### PR TITLE
Improve dotnet-pinvoke skill: stop signals, routing, inline anti-patterns

### DIFF
--- a/plugins/dotnet/skills/dotnet-pinvoke/SKILL.md
+++ b/plugins/dotnet/skills/dotnet-pinvoke/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: dotnet-pinvoke
-description: Correctly call native (C/C++) libraries from .NET using P/Invoke and LibraryImport. Covers function signatures, string marshalling, memory lifetime, SafeHandle, and cross-platform patterns. USE FOR: writing new P/Invoke or LibraryImport declarations, reviewing or debugging existing native interop code, wrapping a C or C++ library for use in .NET, diagnosing crashes, memory leaks, or corruption at the managed/native boundary. DO NOT USE FOR: COM interop, C++/CLI mixed-mode assemblies, or pure managed code with no native dependencies.
+description: >
+  Correctly call native (C/C++) libraries from .NET using P/Invoke and LibraryImport.
+  Covers function signatures, string marshalling, memory lifetime, SafeHandle, and
+  cross-platform patterns.
+  USE FOR: writing new P/Invoke or LibraryImport declarations, reviewing or debugging
+  existing native interop code, wrapping a C or C++ library for use in .NET, diagnosing
+  crashes, memory leaks, or corruption at the managed/native boundary.
+  DO NOT USE FOR: COM interop, C++/CLI mixed-mode assemblies, or pure managed code with
+  no native dependencies.
 ---
 
 # .NET P/Invoke


### PR DESCRIPTION
## Builds on PR #54

This PR stacks on #54 (Add .NET P/Invoke skill by @AaronRobinsonMSFT) — it should be reviewed/merged after #54 lands.

## Changes

Improvements based on multi-model evaluation against [skill-builder patterns](https://github.com/lewing/agent-plugins/tree/main/plugins/skill-trainer/skills/skill-builder).

### What changed
- **Structured description keywords** — Reformatted to \USE FOR:\ / \DO NOT USE FOR:\ for better routing
- **When to Use section** — 6 concrete trigger scenarios  
- **Stop Signals section** — Prevents agents from marching through all 8 steps on simple tasks
- **Inline anti-patterns** — 4 \❌ NEVER\ callouts near Steps 2, 4, and 5

### Why
Without stop signals, an agent asked to 'write a P/Invoke for CreateFile' would go through all 8 steps including migration and tooling — now it knows to stop at Step 3 for single-function tasks.

### Evidence
Multi-model eval (3 models, 2 families) scored **4.8/5 average**:

| Model | Score |
|-------|-------|
| Claude Sonnet 4 | 4.8/5 |
| GPT-5.1 | 5.0/5 |
| Claude Haiku 4.5 | 4.6/5 |

- [Assessment gist](https://gist.github.com/lewing/859ab56b0c37601804c03a5c601cfd8d)
- [Training log gist](https://gist.github.com/lewing/e272e71dca0f4d1036a02a65796b5e1c)