### PR TITLE
Load only skill that is pointed by test

### DIFF
--- a/eng/skill-validator/src/runner.ts
+++ b/eng/skill-validator/src/runner.ts
@@ -109,7 +109,7 @@ export function buildSessionConfig(
   model: string,
   workDir: string
 ): SessionConfig {
-  const skillPath = skill ? dirname(skill.path) : undefined;
+  const skillPath = skill ? skill.path : undefined;
   return {
     model,
     streaming: true,

--- a/eng/skill-validator/tests/runner.test.ts
+++ b/eng/skill-validator/tests/runner.test.ts
@@ -13,9 +13,9 @@ describe("buildSessionConfig", () => {
     evalConfig: null,
   };
 
-  it("sets skillDirectories to parent of skill path", () => {
+  it("sets skillDirectories to the skill path itself", () => {
     const config = buildSessionConfig(mockSkill, "gpt-4.1", "/tmp/work");
-    expect(config.skillDirectories).toEqual(["/home/user/skills"]);
+    expect(config.skillDirectories).toEqual(["/home/user/skills/test-skill"]);
   });
 
   it("sets workingDirectory to the workDir", () => {


### PR DESCRIPTION
### Context

Running test for a specific skill loaded all the skills from under parent folder - so there could be unwanted interactions