### PR TITLE
[Infra] Add run label to distinguish output

### DIFF
--- a/eng/skill-validator/src/cli.ts
+++ b/eng/skill-validator/src/cli.ts
@@ -268,7 +268,6 @@ export async function run(config: ValidatorConfig): Promise<number> {
         withSkill: RunResult;
         pairwise: PairwiseJudgeResult | undefined;
       }> => {
-        const runLabel = `run ${runIndex + 1}/${config.runs}`;
         const runTag = config.runs > 1
           ? (singleScenario ? `[${skill.name}/${runIndex + 1}]` : `[${skill.name}/${scenario.name}/${runIndex + 1}]`)
           : tag;
@@ -373,7 +372,7 @@ export async function run(config: ValidatorConfig): Promise<number> {
               judgeOpts
             );
           } catch (error) {
-            runLog(`⚠️  Pairwise judge failed for ${runLabel}: ${error}`);
+            runLog(`⚠️  Pairwise judge failed: ${error}`);
             pairwise = undefined;
           }
         }


### PR DESCRIPTION
Example output:

```
[check-bin-obj-clash/2]       📂 Work dir: C:\Users\vihofer\AppData\Local\Temp\skill-validator-stt0KM (baseline)
[check-bin-obj-clash/2]       📂 Work dir: C:\Users\vihofer\AppData\Local\Temp\skill-validator-BEZnp2 (skilled)
[check-bin-obj-clash/1]       📂 Work dir: C:\Users\vihofer\AppData\Local\Temp\skill-validator-KxE2sp (baseline)
[check-bin-obj-clash/1]       📂 Work dir: C:\Users\vihofer\AppData\Local\Temp\skill-validator-F6EC4c (skilled)
```