### PR TITLE
[Infra] Fix JSON parse error from invalid LLM escape sequences in pairwise judge

### DIFF
--- a/eng/skill-validator/src/judge.ts
+++ b/eng/skill-validator/src/judge.ts
@@ -1,6 +1,7 @@
 import type { JudgeResult, RubricScore, RunMetrics, EvalScenario } from "./types.js";
 import type { PermissionRequest } from "@github/copilot-sdk";
 import { getSharedClient, checkPermission } from "./runner.js";
+import { extractJson, parseLlmJson } from "./llm-json.js";
 
 export interface JudgeOptions {
   model: string;
@@ -206,59 +207,34 @@ function truncateForJudge(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 3) + "..." : s;
 }
 
-function parseJudgeResponse(
+/** @internal Exported for testing only. */
+export function parseJudgeResponse(
   content: string,
   rubric: string[]
 ): JudgeResult {
-  // Try extracting JSON from markdown code block first, then fall back to brace matching
-  const codeBlockMatch = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
-  const jsonStr = codeBlockMatch?.[1] ?? extractOutermostJson(content);
+  const jsonStr = extractJson(content);
 
   if (!jsonStr) {
     throw new Error(`Judge response contained no JSON. Raw response:\n${content.slice(0, 500)}`);
   }
 
-  try {
-    const parsed = JSON.parse(jsonStr);
-    const rubricScores: RubricScore[] = (parsed.rubric_scores || []).map(
-      (s: { criterion: string; score: number; reasoning: string }) => ({
-        criterion: s.criterion,
-        score: Math.round(Math.max(1, Math.min(5, Number(s.score) || 3)) * 10) / 10,
-        reasoning: s.reasoning || "",
-      })
-    );
+  const parsed = parseLlmJson(jsonStr, "judge response");
 
-    return {
-      rubricScores,
-      overallScore: Math.round(
-        Math.max(1, Math.min(5, Number(parsed.overall_score) || 3)) * 10
-      ) / 10,
-      overallReasoning: parsed.overall_reasoning || "",
-    };
-  } catch (error) {
-    throw new Error(`Judge response parsing failed: ${error}\nExtracted JSON:\n${jsonStr.slice(0, 500)}`);
-  }
-}
+  const rubricScores: RubricScore[] = (parsed.rubric_scores || []).map(
+    (s: { criterion: string; score: number; reasoning: string }) => ({
+      criterion: s.criterion,
+      score: Math.round(Math.max(1, Math.min(5, Number(s.score) || 3)) * 10) / 10,
+      reasoning: s.reasoning || "",
+    })
+  );
 
-function extractOutermostJson(text: string): string | null {
-  const start = text.indexOf("{");
-  if (start === -1) return null;
-
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-    if (escape) { escape = false; continue; }
-    if (ch === "\\") { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === "{") depth++;
-    if (ch === "}") { depth--; if (depth === 0) return text.slice(start, i + 1); }
-  }
-
-  return null;
+  return {
+    rubricScores,
+    overallScore: Math.round(
+      Math.max(1, Math.min(5, Number(parsed.overall_score) || 3)) * 10
+    ) / 10,
+    overallReasoning: parsed.overall_reasoning || "",
+  };
 }
 
 

--- a/eng/skill-validator/src/llm-json.ts
+++ b/eng/skill-validator/src/llm-json.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared utilities for parsing JSON from LLM responses.
+ *
+ * LLMs often wrap JSON in markdown code blocks or produce invalid escape
+ * sequences. These helpers handle both cases robustly.
+ */
+
+/**
+ * Extract a JSON string from LLM response text.
+ * Tries markdown code block first, then falls back to brace-matching.
+ */
+export function extractJson(content: string): string | null {
+  const codeBlockMatch = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+  return codeBlockMatch?.[1] ?? extractOutermostJson(content);
+}
+
+/**
+ * Parse a JSON string, tolerating invalid escape sequences that LLMs
+ * sometimes produce (e.g., \' or \a).
+ *
+ * @param jsonStr  The raw JSON string to parse
+ * @param context  A label for error messages (e.g., "pairwise judge (forward)")
+ */
+export function parseLlmJson(jsonStr: string, context: string): any {
+  try {
+    return JSON.parse(jsonStr);
+  } catch (err) {
+    const originalError = err;
+    const hasInvalidEscapes = /\\(?!["\\/bfnrtu])/.test(jsonStr);
+
+    if (!hasInvalidEscapes) {
+      const snippet = jsonStr.slice(0, 200);
+      throw new Error(
+        `Failed to parse ${context} JSON. Original error: ${String(
+          originalError
+        )}. JSON snippet: ${snippet}`
+      );
+    }
+
+    // LLMs sometimes produce invalid JSON escape sequences (e.g., \' or \a).
+    // Retry after removing backslashes before non-JSON-escape characters.
+    try {
+      return JSON.parse(jsonStr.replace(/\\(?!["\\/bfnrtu])/g, ""));
+    } catch (retryErr) {
+      const snippet = jsonStr.slice(0, 200);
+      throw new Error(
+        `Failed to parse ${context} JSON even after sanitizing invalid escapes. ` +
+          `Original error: ${String(originalError)}. Retry error: ${String(
+            retryErr
+          )}. JSON snippet: ${snippet}`
+      );
+    }
+  }
+}
+
+function extractOutermostJson(text: string): string | null {
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { escape = false; continue; }
+    if (ch === "\\") { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    if (ch === "}") { depth--; if (depth === 0) return text.slice(start, i + 1); }
+  }
+
+  return null;
+}

--- a/eng/skill-validator/src/pairwise-judge.ts
+++ b/eng/skill-validator/src/pairwise-judge.ts
@@ -8,6 +8,7 @@ import type {
 import { PAIRWISE_MAGNITUDE_SCORES } from "./types.js";
 import type { PermissionRequest } from "@github/copilot-sdk";
 import { getSharedClient, checkPermission } from "./runner.js";
+import { extractJson, parseLlmJson } from "./llm-json.js";
 
 export interface PairwiseJudgeOptions {
   model: string;
@@ -264,43 +265,13 @@ export function parsePairwiseResponse(
   rubric: string[],
   direction: "forward" | "reverse"
 ): PairwiseJudgeResult {
-  const codeBlockMatch = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
-  const jsonStr = codeBlockMatch?.[1] ?? extractOutermostJson(content);
+  const jsonStr = extractJson(content);
 
   if (!jsonStr) {
     throw new Error(`Pairwise judge response contained no JSON (${direction})`);
   }
 
-  let parsed: any;
-  try {
-    parsed = JSON.parse(jsonStr);
-  } catch (err) {
-    const originalError = err;
-    const hasInvalidEscapes = /\\(?!["\\/bfnrtu])/.test(jsonStr);
-
-    if (!hasInvalidEscapes) {
-      const snippet = jsonStr.slice(0, 200);
-      throw new Error(
-        `Failed to parse pairwise judge JSON (${direction}). Original error: ${String(
-          originalError
-        )}. JSON snippet: ${snippet}`
-      );
-    }
-
-    // LLMs sometimes produce invalid JSON escape sequences (e.g., \' or \a).
-    // Retry after removing backslashes before non-JSON-escape characters.
-    try {
-      parsed = JSON.parse(jsonStr.replace(/\\(?!["\\/bfnrtu])/g, ""));
-    } catch (retryErr) {
-      const snippet = jsonStr.slice(0, 200);
-      throw new Error(
-        `Failed to parse pairwise judge JSON even after sanitizing invalid escapes (${direction}). ` +
-          `Original error: ${String(originalError)}. Retry error: ${String(
-            retryErr
-          )}. JSON snippet: ${snippet}`
-      );
-    }
-  }
+  const parsed = parseLlmJson(jsonStr, `pairwise judge (${direction})`);
 
   const rubricResults: PairwiseRubricResult[] = (parsed.rubric_results || []).map(
     (r: any) => {
@@ -383,27 +354,6 @@ function mergeInconsistentResults(
     overallReasoning: `Position-swap inconsistent (forward: ${forward.overallWinner}, reverse: ${reverse.overallWinner}). Defaulting to tie.`,
     positionSwapConsistent: false,
   };
-}
-
-function extractOutermostJson(text: string): string | null {
-  const start = text.indexOf("{");
-  if (start === -1) return null;
-
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-    if (escape) { escape = false; continue; }
-    if (ch === "\\") { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === "{") depth++;
-    if (ch === "}") { depth--; if (depth === 0) return text.slice(start, i + 1); }
-  }
-
-  return null;
 }
 
 /**

--- a/eng/skill-validator/tests/judge.test.ts
+++ b/eng/skill-validator/tests/judge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parseJudgeResponse } from "../src/judge.js";
+
+const validJson = JSON.stringify({
+  rubric_scores: [
+    { criterion: "Correctness", score: 4, reasoning: "Mostly correct" },
+  ],
+  overall_score: 4,
+  overall_reasoning: "Good work overall",
+});
+
+describe("parseJudgeResponse", () => {
+  it("parses valid JSON in a code block", () => {
+    const content = "```json\n" + validJson + "\n```";
+    const result = parseJudgeResponse(content, ["Correctness"]);
+    expect(result.overallScore).toBe(4);
+    expect(result.rubricScores).toHaveLength(1);
+    expect(result.rubricScores[0].score).toBe(4);
+  });
+
+  it("parses valid JSON without a code block", () => {
+    const content = "Here is my evaluation:\n" + validJson;
+    const result = parseJudgeResponse(content, ["Correctness"]);
+    expect(result.overallScore).toBe(4);
+  });
+
+  it("handles invalid escape sequences like \\' and \\a", () => {
+    const raw = `{
+      "rubric_scores": [
+        {"criterion": "Quality", "score": 5, "reasoning": "It\\'s excellent and has \\a great structure"}
+      ],
+      "overall_score": 5,
+      "overall_reasoning": "The agent\\'s work is outstanding"
+    }`;
+    expect(() => JSON.parse(raw)).toThrow();
+
+    const result = parseJudgeResponse(raw, ["Quality"]);
+    expect(result.overallScore).toBe(5);
+    expect(result.rubricScores[0].reasoning).toContain("excellent");
+  });
+
+  it("throws with context for non-escape JSON errors", () => {
+    const malformed = '{"overall_score": 4, broken}';
+    expect(() => parseJudgeResponse(malformed, [])).toThrow(
+      /Failed to parse judge response JSON/
+    );
+  });
+
+  it("throws with context when sanitized JSON is still invalid", () => {
+    const malformed = '{"overall_score": "4\\x", broken}';
+    expect(() => parseJudgeResponse(malformed, [])).toThrow(
+      /even after sanitizing invalid escapes/
+    );
+  });
+
+  it("throws when content has no JSON", () => {
+    expect(() => parseJudgeResponse("no json here", [])).toThrow(
+      /contained no JSON/
+    );
+  });
+
+  it("clamps scores to 1-5 range", () => {
+    const json = JSON.stringify({
+      rubric_scores: [{ criterion: "Q", score: 10, reasoning: "" }],
+      overall_score: -1,
+      overall_reasoning: "",
+    });
+    const result = parseJudgeResponse(json, ["Q"]);
+    expect(result.rubricScores[0].score).toBe(5);
+    expect(result.overallScore).toBe(1);
+  });
+
+  it("defaults missing scores to 3", () => {
+    const json = JSON.stringify({
+      rubric_scores: [{ criterion: "Q", reasoning: "" }],
+      overall_reasoning: "",
+    });
+    const result = parseJudgeResponse(json, ["Q"]);
+    expect(result.rubricScores[0].score).toBe(3);
+    expect(result.overallScore).toBe(3);
+  });
+});

--- a/eng/skill-validator/tests/llm-json.test.ts
+++ b/eng/skill-validator/tests/llm-json.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { extractJson, parseLlmJson } from "../src/llm-json.js";
+
+describe("extractJson", () => {
+  it("extracts JSON from a markdown code block", () => {
+    const content = 'Some text\n```json\n{"key": "value"}\n```\nMore text';
+    expect(extractJson(content)).toBe('{"key": "value"}');
+  });
+
+  it("extracts JSON from a code block without language tag", () => {
+    const content = '```\n{"key": "value"}\n```';
+    expect(extractJson(content)).toBe('{"key": "value"}');
+  });
+
+  it("extracts JSON by brace-matching when no code block", () => {
+    const content = 'Here is my answer: {"key": "value"} done.';
+    expect(extractJson(content)).toBe('{"key": "value"}');
+  });
+
+  it("handles nested braces", () => {
+    const content = '{"outer": {"inner": 1}}';
+    expect(extractJson(content)).toBe('{"outer": {"inner": 1}}');
+  });
+
+  it("returns null when no JSON present", () => {
+    expect(extractJson("no json here")).toBeNull();
+  });
+
+  it("ignores braces inside strings", () => {
+    const content = '{"key": "a { b } c"}';
+    expect(extractJson(content)).toBe('{"key": "a { b } c"}');
+  });
+});
+
+describe("parseLlmJson", () => {
+  it("parses valid JSON", () => {
+    const result = parseLlmJson('{"a": 1}', "test");
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("sanitizes invalid escape sequences", () => {
+    const raw = `{"reasoning": "It\\'s good and has \\a nice \\x structure"}`;
+    expect(() => JSON.parse(raw)).toThrow();
+
+    const result = parseLlmJson(raw, "test");
+    expect(result.reasoning).toContain("good");
+  });
+
+  it("throws with context for non-escape parse errors", () => {
+    expect(() => parseLlmJson("{broken}", "test context")).toThrow(
+      /Failed to parse test context JSON/
+    );
+  });
+
+  it("throws with both errors when sanitization doesn't help", () => {
+    expect(() => parseLlmJson('{"key\\x": broken}', "test")).toThrow(
+      /even after sanitizing/
+    );
+  });
+
+  it("includes JSON snippet in error messages", () => {
+    expect(() => parseLlmJson("{broken}", "test")).toThrow(
+      /JSON snippet: \{broken\}/
+    );
+  });
+});

--- a/eng/skill-validator/tests/pairwise-judge.test.ts
+++ b/eng/skill-validator/tests/pairwise-judge.test.ts
@@ -177,7 +177,7 @@ describe("parsePairwiseResponse", () => {
   it("throws with context for non-escape JSON errors", () => {
     const malformed = '{"overall_winner": "A", broken}';
     expect(() => parsePairwiseResponse(malformed, [], "forward")).toThrow(
-      /Failed to parse pairwise judge JSON \(forward\)/
+      /Failed to parse pairwise judge \(forward\) JSON/
     );
   });
 
@@ -185,7 +185,7 @@ describe("parsePairwiseResponse", () => {
     // Has invalid escapes AND structural problems
     const malformed = '{"overall_winner": "A\\x", broken}';
     expect(() => parsePairwiseResponse(malformed, [], "forward")).toThrow(
-      /even after sanitizing invalid escapes \(forward\)/
+      /even after sanitizing invalid escapes/
     );
   });
 


### PR DESCRIPTION
Wrap JSON.parse in try/catch and retry after stripping invalid escape sequences (e.g., \' or \a) that LLMs sometimes produce in reasoning text.

Example error: `"Pairwise judge attempt 1 failed (forward): Bad escaped character in JSON at position 1075 (line 13 column 267)"`