### PR TITLE
[Infra] Fix benchmark generation: match timestamp dirs instead of run-*

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -402,7 +402,10 @@ jobs:
           $components = '${{ needs.discover.outputs.components }}' | ConvertFrom-Json
           foreach ($component in $components) {
             $artifactDir = "all-results/skill-validator-results-$component"
-            $runDir = Get-ChildItem -Path $artifactDir -Directory -Filter "run-*" -ErrorAction SilentlyContinue | Select-Object -First 1
+            $runDir = Get-ChildItem -Path $artifactDir -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -match '^\d{8}-\d{6}$' } |
+              Sort-Object Name -Descending |
+              Select-Object -First 1
             if (-not $runDir) {
               Write-Warning "No run results found for $component, skipping benchmark generation"
               continue


### PR DESCRIPTION
The skill-validator reporter creates timestamped subdirectories (YYYYMMDD-HHMMSS format), not run-* directories. The benchmark step was looking for run-* and never finding results. Also sort descending to pick the latest run when multiple exist.