### PR TITLE
Add --verdict-warn-only option to skill-validator for non-fatal skill failures

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -285,7 +285,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}
           RESULTS_PATH: artifacts/TestResults/skill-validator/${{ matrix.entry.name }}
         run: |
-          ARGS="--require-evals --threshold-warn-only"
+          # --require-evals: fail if a skill has no tests/eval.yaml
+          # --verdict-warn-only: treat verdict failures (threshold, completion, activation) as warnings (exit 0);
+          #              execution errors and missing evals still fail.
+          ARGS="--require-evals --verdict-warn-only"
           ARGS="$ARGS --results-dir $RESULTS_PATH --reporter console --reporter json --reporter markdown"
           ARGS="$ARGS --model ${{ github.event.inputs.model || env.DEFAULT_MODEL }}"
           ARGS="$ARGS --judge-model ${{ github.event.inputs.judge-model || env.DEFAULT_JUDGE_MODEL }}"
@@ -313,7 +316,7 @@ jobs:
 
   comment-on-pr:
     needs: [discover, evaluate]
-    if: always() && needs.evaluate.result == 'success' && needs.discover.outputs.has_entries == 'true'
+    if: always() && needs.evaluate.result != 'cancelled' && needs.discover.outputs.has_entries == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download all result artifacts

--- a/eng/skill-validator/README.md
+++ b/eng/skill-validator/README.md
@@ -57,8 +57,11 @@ skill-validator --results-dir ./my-results ./skills/
 # File reporters can also be specified explicitly.
 skill-validator --reporter junit ./skills/
 
-# Strict mode (require all skills to have evals)
-skill-validator --strict ./skills/
+# Require all skills to have evals
+skill-validator --require-evals ./skills/
+
+# Verdict-warn-only mode (verdict failures return exit 0, execution errors still fail)
+skill-validator --verdict-warn-only --require-evals ./skills/
 ```
 
 ## Writing eval files
@@ -227,7 +230,7 @@ The default of 5 runs provides sufficient precision for significance testing (va
 | `--judge-timeout <n>` | `300` | Judge LLM timeout in seconds |
 | `--require-completion` | `true` | Fail if skill regresses task completion |
 | `--require-evals` | `false` | Fail if skill has no tests/eval.yaml |
-| `--strict` | `false` | Enable --require-evals and strict checking |
+| `--verdict-warn-only` | `false` | Treat verdict failures as warnings (exit 0). Execution errors and `--require-evals` still fail. |
 | `--verbose` | `false` | Show tool calls and agent events during runs |
 | `--reporter <spec>` | `console`, `json`, `markdown` | Output format: `console`, `json`, `junit`, `markdown`. |
 | `--results-dir <path>` | `.skill-validator-results` | Directory for file reporter output. |
@@ -244,7 +247,7 @@ Results are displayed in the console with color-coded scores and metric deltas. 
 
 ## CI integration
 
-The same CLI works in CI — `--strict` makes it fail on any issue:
+The same CLI works in CI — use `--require-evals` to enforce eval coverage and `--verdict-warn-only` to treat verdict failures as warnings while still failing on execution errors:
 
 ```yaml
 name: Validate Skill Value
@@ -257,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npx skill-validator --strict --require-evals .
+      - run: npx skill-validator --require-evals --verdict-warn-only .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/eng/skill-validator/src/cli.ts
+++ b/eng/skill-validator/src/cli.ts
@@ -132,7 +132,7 @@ export function createProgram(): Command {
       "--tests-dir <path>",
       "Directory containing test subdirectories (resolved as <tests-dir>/<skill-name>/eval.yaml)"
     )
-    .option("--threshold-warn-only", "Return exit code 0 for threshold failures (does not suppress runtime/config errors)", false)
+    .option("--verdict-warn-only", "Treat verdict failures as warnings (exit 0). Execution errors and --require-evals still fail.", false)
     .option(
       "--reporter <spec>",
       "Reporter (console, json, junit, markdown). Can be repeated.",
@@ -159,7 +159,7 @@ export function createProgram(): Command {
         parallelRuns: Math.max(1, parseInt(opts.parallelRuns, 10) || 1),
         judgeTimeout: parseInt(opts.judgeTimeout, 10) * 1000,
         confidenceLevel: parseFloat(opts.confidenceLevel || "0.95"),
-        thresholdWarnOnly: opts.thresholdWarnOnly,
+        verdictWarnOnly: opts.verdictWarnOnly,
         reporters,
         skillPaths: paths,
         resultsDir: opts.resultsDir,
@@ -246,6 +246,7 @@ export async function run(config: ValidatorConfig): Promise<number> {
           scenarios: [],
           overallImprovementScore: 0,
           reason: "No tests/eval.yaml found (required by --require-evals)",
+          failureKind: "missing_eval",
         };
       } else {
         log(`⏭  Skipping (no tests/eval.yaml)`);
@@ -506,6 +507,7 @@ export async function run(config: ValidatorConfig): Promise<number> {
       log(chalk.yellow(`\u26a0\ufe0f  Skill was NOT activated in scenario(s): ${names}`));
       verdict.skillNotActivated = true;
       verdict.passed = false;
+      verdict.failureKind = "skill_not_activated";
       verdict.reason += ` [SKILL NOT ACTIVATED in ${notActivatedScenarios.length} scenario(s): ${names}]`;
     }
     log(`${verdict.passed ? "✅" : "❌"} Done (score: ${(verdict.overallImprovementScore * 100).toFixed(1)}%)`);
@@ -539,11 +541,18 @@ export async function run(config: ValidatorConfig): Promise<number> {
   await stopSharedClient();
   await cleanupWorkDirs();
 
-  // Always fail on execution errors, even in --threshold-warn-only mode
+  // Always fail on execution errors, even in --verdict-warn-only mode
   if (hasRejections) return 1;
 
   const allPassed = verdicts.every((v) => v.passed);
-  if (config.thresholdWarnOnly) return 0;
+  if (config.verdictWarnOnly && !allPassed) {
+    // In --verdict-warn-only mode, suppress verdict failures except missing_eval
+    // (which is controlled by --require-evals and should remain fatal).
+    const onlyWarnableFailures = verdicts.every(
+      (v) => v.passed || v.failureKind !== "missing_eval"
+    );
+    if (onlyWarnableFailures) return 0;
+  }
   return allPassed ? 0 : 1;
 }
 

--- a/eng/skill-validator/src/comparator.ts
+++ b/eng/skill-validator/src/comparator.ts
@@ -113,6 +113,7 @@ export function computeVerdict(
       scenarios: [],
       overallImprovementScore: 0,
       reason: "No scenarios to evaluate",
+      failureKind: "no_scenarios",
     };
   }
 
@@ -147,6 +148,7 @@ export function computeVerdict(
         confidenceInterval: ci,
         isSignificant: significant,
         reason: "Skill regressed on task completion in one or more scenarios",
+        failureKind: "completion_regression",
       };
     }
   }
@@ -171,6 +173,7 @@ export function computeVerdict(
     confidenceInterval: ci,
     isSignificant: significant,
     reason,
+    failureKind: passed ? undefined : "threshold",
   };
 }
 

--- a/eng/skill-validator/src/types.ts
+++ b/eng/skill-validator/src/types.ts
@@ -182,6 +182,8 @@ export interface SkillVerdict {
   confidenceInterval?: ConfidenceInterval;
   isSignificant?: boolean;
   reason: string;
+  /** Categorizes why the verdict failed, if it did. */
+  failureKind?: "threshold" | "completion_regression" | "no_scenarios" | "missing_eval" | "skill_not_activated";
   profileWarnings?: string[];
   skillNotActivated?: boolean;
 }
@@ -202,7 +204,7 @@ export interface ValidatorConfig {
   confidenceLevel: number;
   reporters: ReporterSpec[];
   skillPaths: string[];
-  thresholdWarnOnly: boolean;
+  verdictWarnOnly: boolean;
   resultsDir?: string;
   testsDir?: string;
 }


### PR DESCRIPTION
- This avoids the continue-on-error setting the yml which sometimes hides real issues.
- Remove the `--strict` option which isn't useful at this point.
- Fine tune conditions to not post a comment when the evaluation steps are abandoned.