### PR TITLE
[Infra] Fix MCP discovery

### DIFF
--- a/eng/skill-validator/src/Services/SkillDiscovery.cs
+++ b/eng/skill-validator/src/Services/SkillDiscovery.cs
@@ -75,7 +75,7 @@ public static partial class SkillDiscovery
     /// extract its mcpServers map (if any).
     /// </summary>
     internal static async Task<IReadOnlyDictionary<string, MCPServerDef>?> FindPluginMcpServers(
-        string skillDir, int maxLevels = 2)
+        string skillDir, int maxLevels = 3)
     {
         var dir = Path.GetFullPath(skillDir);
         for (var i = 0; i < maxLevels; i++)

--- a/eng/skill-validator/tests/DiscoveryTests.cs
+++ b/eng/skill-validator/tests/DiscoveryTests.cs
@@ -76,6 +76,40 @@ public class DiscoverSkillsTests
     }
 
     [Fact]
+    public async Task FindsPluginMcpServersInGrandparentDirectory()
+    {
+        // Simulates the real layout: plugin.json is at dotnet-msbuild/,
+        // skill dir is at dotnet-msbuild/skills/my-skill/
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"skill-test-{Guid.NewGuid():N}");
+        var skillDir = Path.Combine(tmpDir, "skills", "my-skill");
+        Directory.CreateDirectory(skillDir);
+        try
+        {
+            var pluginJson = """
+                {
+                    "mcpServers": {
+                        "binlog-mcp": {
+                            "command": "dotnet",
+                            "args": ["run"],
+                            "tools": ["load_binlog"]
+                        }
+                    }
+                }
+                """;
+            await File.WriteAllTextAsync(Path.Combine(tmpDir, "plugin.json"), pluginJson);
+
+            var result = await SkillDiscovery.FindPluginMcpServers(skillDir);
+            Assert.NotNull(result);
+            Assert.True(result!.ContainsKey("binlog-mcp"));
+            Assert.Equal("dotnet", result["binlog-mcp"].Command);
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, true);
+        }
+    }
+
+    [Fact]
     public async Task ReturnsNullWhenNoPluginJson()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), $"skill-test-{Guid.NewGuid():N}");


### PR DESCRIPTION
### Details

Discovering the plugin.json with MCP definition actually needs to traverse 3 levels up (was limited to 2):

```
src/dotnet-msbuild/plugin.json                                ← target (grandparent)
src/dotnet-msbuild/skills/                                         ← parent  
src/dotnet-msbuild/skills/binlog-failure-analysis/    ← skill dir (start)
```