### PR TITLE
Increase timeout for evaluation job to 60 minutes

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -202,7 +202,7 @@ jobs:
     needs: [discover, build-validator]
     if: ${{ needs.build-validator.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: evaluate (${{ matrix.entry.name }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
The msbuild component is currently the biggest one and takes just slightly over 30 minutes. Let's bump the timeout to 60 as that's still low enough.