### PR TITLE
Remove shell tool restrictions from agentic workflows

### DIFF
--- a/src/dotnet-msbuild/agentic-workflows/build-failure-analysis.md
+++ b/src/dotnet-msbuild/agentic-workflows/build-failure-analysis.md
@@ -42,9 +42,6 @@ You are an MSBuild build failure analysis agent. You build the repository locall
    - Check for build instructions in `AGENTS.md`, `.github/copilot-instructions.md`, or `README.md` in the repo root
    - If instructions specify a build command, use it but **append `/bl:{}`** to produce a binary log
    - If no instructions are found, run: `dotnet build /bl:{}` from the repo root
-   - **IMPORTANT: Shell tool restrictions**:
-     - Each shell command must start with the tool name directly. Do NOT use `cd ... &&`, compound commands (`&&`, `||`, `;`), `for` loops, or subshells. The working directory is already the repository root.
-     - If `dotnet` as a command is denied, use `env dotnet build /bl:{}` instead — the `env` prefix is always allowed.
    - **Binlog location**: Always write binlogs to the **repository root directory** (current working directory). Do NOT write them to `/tmp` or other paths, because the binlog-mcp server can only access files under the workspace directory.
    - Builds may fail — that is expected. Do not stop on build errors.
 

--- a/src/dotnet-msbuild/agentic-workflows/build-perf-audit.md
+++ b/src/dotnet-msbuild/agentic-workflows/build-perf-audit.md
@@ -38,7 +38,7 @@ You are a build performance auditing agent. Each week, you analyze the repositor
 
 ## Workflow
 
-1. **Build with binlog**: Run `dotnet build /bl:perf-audit.binlog -m` to generate a performance baseline. If `dotnet` is denied by the sandbox, use `env dotnet build /bl:perf-audit.binlog -m` instead. Do NOT use compound commands (`cd ... &&`), `for` loops, or full paths — the working directory is already the repository root.
+1. **Build with binlog**: Run `dotnet build /bl:perf-audit.binlog -m` to generate a performance baseline.
 
 2. **Analyze performance** using binlog-mcp tools:
    - Load the binlog with `load_binlog`


### PR DESCRIPTION
The shell tool restrictions (no compound commands, \nv dotnet\ workaround) in the agentic workflow definitions are no longer needed as of gh aw 0.56.0 which fixed these limitations.

### Changes
- **build-failure-analysis.md**: Removed the 3-line 'Shell tool restrictions' bullet
- **build-perf-audit.md**: Removed inline sandbox/compound-command caveats from the build step