### PR TITLE
Fix running SkillValidator on Windows locally

### DIFF
--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -9,7 +9,7 @@
     <Description>Validate that agent skills meaningfully improve agent performance</Description>
 
     <!-- dotnet run args for local invocation -->
-    <RunArguments>--results-dir &quot;$([MSBuild]::NormalizeDirectory('$(ArtifactsPath)', 'TestResults', '$(AssemblyName)'))&quot; --parallel-skills 3 --parallel-scenarios 3 --parallel-runs 3</RunArguments>
+    <RunArguments>--results-dir &quot;$([MSBuild]::NormalizePath('$(ArtifactsPath)', 'TestResults', '$(AssemblyName)'))&quot; --parallel-skills 3 --parallel-scenarios 3 --parallel-runs 3</RunArguments>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The NormalizeDirectory function + the quote resulted in the quote getting escaped: `\"`. Use NormalizePath instead as we don't need the trailing slash.

Regressed with https://github.com/dotnet/skills/commit/3e4ba910f0c309e84c702419809dc153384f8499