### PR TITLE
Support skill negative tests

### DIFF
--- a/eng/dashboard/generate-benchmark-data.ps1
+++ b/eng/dashboard/generate-benchmark-data.ps1
@@ -80,7 +80,14 @@ foreach ($verdict in $results.verdicts) {
         # Check per-scenario activation state
         $scenarioNotActivated = $false
         if ($scenario.skillActivation -and -not $scenario.skillActivation.activated) {
-            $scenarioNotActivated = $true
+            # Only flag as not-activated if activation was expected (expect_activation defaults to true)
+            $scenarioExpectActivation = $true
+            if ($scenario.PSObject.Properties['expectActivation'] -and $scenario.expectActivation -eq $false) {
+                $scenarioExpectActivation = $false
+            }
+            if ($scenarioExpectActivation) {
+                $scenarioNotActivated = $true
+            }
         }
         $notActivated = $verdictNotActivated -or $scenarioNotActivated
 

--- a/eng/skill-validator/src/Commands/ValidateCommand.cs
+++ b/eng/skill-validator/src/Commands/ValidateCommand.cs
@@ -266,14 +266,25 @@ public static class ValidateCommand
         verdict.ProfileWarnings = profile.Warnings;
 
         var notActivated = comparisons.Where(c => c.SkillActivation is { Activated: false }).ToList();
-        if (notActivated.Count > 0)
+        // Separate unexpected non-activations (expect_activation defaulting to true)
+        // from expected ones (negative tests with expect_activation: false).
+        var unexpectedNotActivated = notActivated.Where(c => c.ExpectActivation).ToList();
+        var expectedNotActivated = notActivated.Where(c => !c.ExpectActivation).ToList();
+
+        if (expectedNotActivated.Count > 0)
         {
-            var names = string.Join(", ", notActivated.Select(c => c.ScenarioName));
+            var names = string.Join(", ", expectedNotActivated.Select(c => c.ScenarioName));
+            log($"\x1b[36mℹ️  Skill correctly NOT activated in negative-test scenario(s): {names}\x1b[0m");
+        }
+
+        if (unexpectedNotActivated.Count > 0)
+        {
+            var names = string.Join(", ", unexpectedNotActivated.Select(c => c.ScenarioName));
             log($"\x1b[33m\u26a0\ufe0f  Skill was NOT activated in scenario(s): {names}\x1b[0m");
             verdict.SkillNotActivated = true;
             verdict.Passed = false;
             verdict.FailureKind = "skill_not_activated";
-            verdict.Reason += $" [SKILL NOT ACTIVATED in {notActivated.Count} scenario(s): {names}]";
+            verdict.Reason += $" [SKILL NOT ACTIVATED in {unexpectedNotActivated.Count} scenario(s): {names}]";
         }
 
         var timedOutScenarios = comparisons.Where(c => c.TimedOut).ToList();
@@ -337,6 +348,9 @@ public static class ValidateCommand
 
         // Propagate timeout info from any run
         comparison.TimedOut = runResults.Any(r => r.WithSkill.Metrics.TimedOut || r.Baseline.Metrics.TimedOut);
+
+        // Propagate expect_activation from scenario config
+        comparison.ExpectActivation = scenario.ExpectActivation;
 
         return comparison;
     }

--- a/eng/skill-validator/src/Models/Models.cs
+++ b/eng/skill-validator/src/Models/Models.cs
@@ -63,7 +63,8 @@ public sealed record EvalScenario(
     IReadOnlyList<string>? ExpectTools = null,
     IReadOnlyList<string>? RejectTools = null,
     int? MaxTurns = null,
-    int? MaxTokens = null);
+    int? MaxTokens = null,
+    bool ExpectActivation = true);
 
 public sealed record EvalConfig(IReadOnlyList<EvalScenario> Scenarios);
 
@@ -199,6 +200,8 @@ public sealed class ScenarioComparison
     public IReadOnlyList<double>? PerRunScores { get; set; }
     public SkillActivationInfo? SkillActivation { get; set; }
     public bool TimedOut { get; set; }
+    /// <summary>When false, non-activation is expected (negative test) and should not flag the verdict.</summary>
+    public bool ExpectActivation { get; set; } = true;
 }
 
 // --- Verdict ---

--- a/eng/skill-validator/src/Services/EvalSchema.cs
+++ b/eng/skill-validator/src/Services/EvalSchema.cs
@@ -62,7 +62,8 @@ public static class EvalSchema
             ExpectTools: raw.ExpectTools,
             RejectTools: raw.RejectTools,
             MaxTurns: raw.MaxTurns,
-            MaxTokens: raw.MaxTokens);
+            MaxTokens: raw.MaxTokens,
+            ExpectActivation: raw.ExpectActivation ?? true);
     }
 
     private static Assertion ParseAssertion(RawAssertion raw)
@@ -125,6 +126,7 @@ public static class EvalSchema
         public List<string>? RejectTools { get; set; }
         public int? MaxTurns { get; set; }
         public int? MaxTokens { get; set; }
+        public bool? ExpectActivation { get; set; }
     }
 
     private sealed class RawSetup

--- a/eng/skill-validator/src/Services/Reporter.cs
+++ b/eng/skill-validator/src/Services/Reporter.cs
@@ -168,7 +168,10 @@ public static class Reporter
             }
             else
             {
-                Console.WriteLine("      \x1b[33m⚠️  Skill was NOT activated\x1b[0m");
+                if (!scenario.ExpectActivation)
+                    Console.WriteLine("      \x1b[36mℹ️  Skill correctly NOT activated (negative test)\x1b[0m");
+                else
+                    Console.WriteLine("      \x1b[33m⚠️  Skill was NOT activated\x1b[0m");
             }
         }
 
@@ -302,7 +305,7 @@ public static class Reporter
                     }
                     else
                     {
-                        skillsCol = "⚠️ NOT ACTIVATED";
+                        skillsCol = s.ExpectActivation ? "⚠️ NOT ACTIVATED" : "ℹ️ not activated (expected)";
                     }
                 }
                 else if (skillNotActivated)

--- a/src/dotnet/tests/dump-collect/eval.yaml
+++ b/src/dotnet/tests/dump-collect/eval.yaml
@@ -158,6 +158,7 @@ scenarios:
     prompt: |
       I already have a .dmp crash dump file from my .NET app. Can you help
       me analyze it to find the root cause of the crash?
+    expect_activation: false
     assertions:
       - type: "output_matches"
         pattern: "out of scope|not cover|does not|cannot|only.*collect"


### PR DESCRIPTION
Fixes #137 

### Details

We haven't supported tests that intentionaly test skill NOT being activated in specific scenario. This poluted data with false signals