### PR TITLE
GHA to validate ownership

### DIFF
--- a/.github/workflows/codeowners-folder-validation.yml
+++ b/.github/workflows/codeowners-folder-validation.yml
@@ -176,7 +176,10 @@ jobs:
       - name: Fail when CODEOWNERS entries are missing
         if: steps.audit.outputs.has_missing == 'true'
         shell: pwsh
+        env:
+          MISSING_JSON: ${{ steps.audit.outputs.missing_json }}
         run: |
+          Write-Host "missing_json: $env:MISSING_JSON"
           Write-Error 'Missing required CODEOWNERS folder entries. See issue for details.'
           exit 1
  


### PR DESCRIPTION
Part of our contribution policy is that every skill / plugin has an associated owner with it. This GHA is designed to block PRs that produce content that violates this.