### PR TITLE
Clarify that when-to-use guidance belongs in description frontmatter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,14 +101,14 @@ Create the file with required YAML frontmatter:
 ```yaml
 ---
 name: <skill-name>
-description: <description of what the skill does and when to use it>
+description: <description of what the skill does, when to use it, and when not to use it>
 ---
 ```
 
 > **Tip:** The `description` field is used by the agent runtime to decide whether to load the full skill.
 > Include **when to use** and **when not to use** guidance directly in the description so the agent can
-> select or skip skills without reading the entire `SKILL.md`. This avoids unnecessary token load.
-> See [`thread-abort-migration/SKILL.md`](plugins/dotnet/skills/thread-abort-migration/SKILL.md#L3-L15) for a good example.
+> select or skip skills without reading the entire `SKILL.md`. This avoids unnecessary token usage.
+> See [`thread-abort-migration/SKILL.md`](plugins/dotnet/skills/thread-abort-migration/SKILL.md) for a good example.
 
 ### Recommended `SKILL.md` sections
 


### PR DESCRIPTION
The `description` frontmatter field is what the agent runtime reads to decide whether to load a skill. If when-to-use/not-use guidance lives only in the SKILL.md body, the agent must load the entire file just to decide relevance, wasting tokens.

This updates CONTRIBUTING.md to:

- Add a tip callout explaining that when-to-use/not-use belongs in the `description` frontmatter
- Link to `thread-abort-migration/SKILL.md` as a good example of this pattern
- Annotate the recommended sections and checklist to clarify the body is for expanded detail only
