### PR TITLE
Skip evaluation workflow on forks to prevent Actions quota drain

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -71,6 +71,11 @@ permissions:
 
 jobs:
   discover:
+    # Scheduled runs should only happen in the upstream repo, not in forks.
+    # Without this guard, forks that have activated Actions (e.g. by pushing a
+    # branch for a PR) will run the evaluation schedule indefinitely, consuming
+    # the fork owner's Actions minutes and storage quota.
+    if: github.event_name != 'schedule' || github.repository == 'dotnet/skills'
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.find.outputs.entries }}


### PR DESCRIPTION
## Problem

When a contributor forks this repo and pushes a branch (the normal workflow for submitting a PR), GitHub Actions become active on the fork. This causes the `evaluation` workflow's `schedule` trigger to start running every 2 hours on the fork.

Each scheduled run:
- Builds the skill-validator and uploads a ~95 MB artifact
- Attempts to run evaluations that require `COPILOT_GITHUB_TOKEN` secrets (unavailable in forks)
- **Fails every time**, but still consumes the fork owner's Actions minutes and storage

In my case, this resulted in **1 GB of accumulated artifacts** (11 concurrent ~95 MB artifacts with 1-day retention, replenished every 2 hours) -- over 2x the 500 MB free tier storage quota -- plus ongoing minutes consumption, all from a repo I only forked to submit PRs.

## Fix

Add `if: github.event_name != 'schedule' || github.repository == 'dotnet/skills'` to the `discover` job. All other jobs depend on `discover`, so this gates the entire workflow for scheduled runs on forks while leaving PR CI and manual dispatch unaffected.

## Impact on existing forks

**After this merges**, you can just sync your fork to upstream main (via GitHub's **Sync fork** button or `gh repo sync`) and re-enable the workflow to restore PR CI while the schedule guard prevents the unwanted runs.

Existing forkers who don't want to wait can temporarily disable the evaluation workflow on their fork:

1. Go to your fork → **Actions** tab → select **evaluation** on the left
2. Click the **…** menu → **Disable workflow**

Or via CLI:
```
gh api -X PUT repos/{owner}/skills/actions/workflows/evaluation.yml/disable
```

Note: disabling the workflow also disables PR CI validation so you'll need to enable again after this merges.

Either way existing artifacts do not need manual cleanup — they have a 1-day retention and will auto-expire within 24 hours of the last scheduled run.