### PR TITLE
Add networking investigation support to dotnet-trace-collect skill

### DIFF
--- a/plugins/dotnet/skills/dotnet-trace-collect/SKILL.md
+++ b/plugins/dotnet/skills/dotnet-trace-collect/SKILL.md
@@ -9,7 +9,7 @@ This skill helps developers diagnose production performance issues by recommendi
 
 ## When to Use
 
-- A developer needs to investigate a production performance issue (high CPU, memory leak, slow requests, excessive GC, etc.)
+- A developer needs to investigate a production performance issue (high CPU, memory leak, slow requests, excessive GC, networking errors, etc.)
 - Choosing the right diagnostic tool for a specific runtime, OS, or deployment topology
 - Setting up and running diagnostic tool commands for data collection
 - Understanding trade-offs between available tools (e.g. PerfView vs dotnet-trace)
@@ -25,7 +25,7 @@ This skill helps developers diagnose production performance issues by recommendi
 
 | Input | Required | Description |
 |-------|----------|-------------|
-| Symptom | Yes | What the developer is observing (high CPU, memory growth, slow requests, hangs, excessive GC, etc.) |
+| Symptom | Yes | What the developer is observing (high CPU, memory growth, slow requests, hangs, excessive GC, HTTP 5xx errors, networking timeouts, connection failures, etc.) |
 | Runtime | Yes | .NET Framework or modern .NET (and version, especially whether .NET 10+) |
 | OS | Yes | Windows or Linux |
 | Deployment | Yes | Non-container, container, or Kubernetes |
@@ -38,7 +38,7 @@ This skill helps developers diagnose production performance issues by recommendi
 
 Determine or ask the developer to clarify:
 
-1. **Symptom**: What they are observing (high CPU, memory leak, slow requests, hangs, excessive GC, etc.)
+1. **Symptom**: What they are observing (high CPU, memory leak, slow requests, hangs, excessive GC, HTTP 5xx errors, networking timeouts, connection failures, etc.)
 2. **Runtime**: .NET Framework or modern .NET? If modern .NET, which version? (Especially whether .NET 10 or later.)
 3. **OS**: Windows or Linux?
 4. **Deployment**: Running directly on the host, in a container, or in Kubernetes?
@@ -141,11 +141,11 @@ Excessive GC requires a **trace** to analyze GC events, pause times, and allocat
 
 #### Slow Requests
 
-Slow requests require a **thread time trace** to see where threads are spending time — waiting on locks, I/O, external calls, etc. Use larger buffers since thread time traces generate more data.
+Slow requests require a **thread time trace** to see where threads are spending time — waiting on locks, I/O, external calls, etc. Use larger buffers since thread time traces generate more data. For ASP.NET Core applications, also enable `Microsoft.AspNetCore.Hosting` and `Microsoft-AspNetCore-Server-Kestrel` providers to get server-side request lifecycle timing (when requests arrive, how long they take to process).
 
-- **Windows (PerfView)**: Use `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048`. The `/ThreadTime` argument adds thread-level wait and block detail. Do not include a stop trigger by default — let the user design one based on their specific scenario.
-- **Linux (dotnet-trace)**: `dotnet-trace` captures thread time data by default — no special arguments needed. Use `dotnet-trace collect -p <PID>`.
-- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile thread-time` for richer data with native stacks.
+- **Windows (PerfView)**: Use `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048`. The `/ThreadTime` argument adds thread-level wait and block detail. For ASP.NET Core, add Kestrel providers: `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*Microsoft.AspNetCore.Hosting,*Microsoft-AspNetCore-Server-Kestrel`. Do not include a stop trigger by default — let the user design one based on their specific scenario.
+- **Linux (dotnet-trace)**: `dotnet-trace` captures thread time data by default — no special arguments needed. Use `dotnet-trace collect -p <PID>`. For ASP.NET Core, add Kestrel providers: `dotnet-trace collect -p <PID> --providers Microsoft.AspNetCore.Hosting,Microsoft-AspNetCore-Server-Kestrel`.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile thread-time` for richer data with native stacks. For ASP.NET Core, add: `--providers Microsoft.AspNetCore.Hosting,Microsoft-AspNetCore-Server-Kestrel`.
 - **Containers**: `dotnet-monitor` can capture traces via its REST API (`/trace?pid=<PID>&durationSeconds=30`).
 
 #### Hangs
@@ -158,6 +158,30 @@ Slow requests require a **thread time trace** to see where threads are spending 
 3. **Analyze the dump with a debugger** to inspect thread stacks and identify the lock cycle:
    - **Windows**: Visual Studio or WinDbg with the SOS debugger extension.
    - **Linux**: `lldb` with the SOS debugger extension.
+
+#### Networking Issues
+
+Networking issues (HTTP 5xx errors from downstream services, request timeouts, connection failures, DNS resolution failures, TLS handshake failures, connection pool exhaustion) require **both** a thread-time trace and networking event providers. The thread-time trace shows where threads are blocked (slow downstream calls, thread starvation), while the networking events show the request lifecycle — which requests failed, what status codes came back, how long DNS resolution and TLS handshakes took, and how long requests waited for a connection from the pool.
+
+For **.NET Framework**, `PerfView /ThreadTime` already collects the relevant networking events (from the `System.Net` ETW provider) — no additional providers are needed.
+
+For **modern .NET**, you must explicitly enable the `System.Net.*` EventSource providers:
+
+| Provider | What it covers |
+|----------|---------------|
+| `System.Net.Http` | HttpClient/SocketsHttpHandler — request lifecycle, HTTP status codes, connection pool |
+| `System.Net.NameResolution` | DNS lookups (start/stop, duration) |
+| `System.Net.Security` | TLS/SSL handshakes (SslStream) |
+| `System.Net.Sockets` | Low-level socket connect/disconnect |
+
+Key events from `System.Net.Http`: `RequestStart` (scheme, host, port, path), `RequestStop` (statusCode — `-1` if no response was received), `RequestFailed` (exception message for timeouts, connection refused, etc.), `RequestLeftQueue` (time waiting for a connection from the pool — indicates connection pool exhaustion), `ConnectionEstablished`, `ConnectionClosed`.
+
+Collect a thread-time trace with networking providers enabled (modern .NET only — .NET Framework needs only `PerfView /ThreadTime`):
+
+- **Windows (PerfView)**: Use `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*System.Net.Http,*System.Net.NameResolution,*System.Net.Security,*System.Net.Sockets`. For .NET Framework, omit the `/Providers` flag — `/ThreadTime` already includes the networking events. The thread-time trace shows where threads are blocked while the networking events show what requests are failing and why.
+- **Linux (dotnet-trace)**: `dotnet-trace` captures thread time data by default. Add networking providers: `dotnet-trace collect -p <PID> --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets`.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile thread-time --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets`.
+- **Containers**: `dotnet-monitor` can capture traces with custom providers via its REST API.
 
 Explain the trade-offs when recommending a tool. For example:
 - PerfView gives richer data but needs admin; runs on Windows including Windows containers.
@@ -210,3 +234,5 @@ After data is collected, recommend the appropriate tool for analysis. Do **not**
 | Diagnostic port not accessible in container | Mount `/tmp` as a shared volume between the app container and `dotnet-monitor` sidecar for the diagnostic Unix domain socket. |
 | Forgetting to install tools in container image | Add `dotnet tool install` to your Dockerfile, or use `dotnet-monitor` as a sidecar to avoid modifying the app image. |
 | Exposing `dotnet-monitor` with `--no-auth` in production | Keep auth enabled, bind to localhost, and use `kubectl port-forward` for access. Use `--no-auth` only for short-lived isolated debugging. |
+| Collecting only CPU/thread-time trace for networking issues | CPU and thread-time traces alone do not show HTTP status codes, DNS timing, or connection pool behavior. Add the networking providers (`System.Net.Http`, `System.Net.NameResolution`, `System.Net.Security`, `System.Net.Sockets`) alongside the thread-time trace. |
+| Enabling all networking providers when only one is needed | Each networking provider adds overhead. If the issue is clearly HTTP-level (5xx status codes), `System.Net.Http` alone may be sufficient. Add DNS, TLS, and socket providers when the root cause is unclear. |

--- a/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-monitor.md
+++ b/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-monitor.md
@@ -51,6 +51,9 @@ curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace http://localho
 # Collect GC trace
 curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace "http://localhost:52323/trace?pid=<PID>&profile=gc-verbose&durationSeconds=30"
 
+# Collect trace with networking providers (HTTP status codes, DNS, TLS, sockets)
+curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace "http://localhost:52323/trace?pid=<PID>&durationSeconds=30&providers=System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets"
+
 # Get live metrics
 curl -H "Authorization: Bearer <monitor-token>" http://localhost:52323/livemetrics?pid=<PID>
 ```

--- a/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-trace-collect-linux.md
+++ b/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-trace-collect-linux.md
@@ -38,6 +38,12 @@ sudo dotnet-trace collect-linux --duration 00:00:30
 # Trace with specific providers
 sudo dotnet-trace collect-linux --providers Microsoft-Windows-DotNETRuntime
 
+# Trace with networking providers (HTTP status codes, DNS, TLS, sockets)
+sudo dotnet-trace collect-linux --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
+# Trace with networking providers and thread-time profile
+sudo dotnet-trace collect-linux --profile thread-time --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
 # Trace with specific profiles
 sudo dotnet-trace collect-linux --profile gc-verbose
 sudo dotnet-trace collect-linux --profile thread-time

--- a/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-trace-collect.md
+++ b/plugins/dotnet/skills/dotnet-trace-collect/references/dotnet-trace-collect.md
@@ -49,6 +49,9 @@ dotnet-trace collect -p <PID> --profile gc-verbose
 # Collect with specific providers
 dotnet-trace collect -p <PID> --providers Microsoft-DotNETCore-SampleProfiler,Microsoft-Windows-DotNETRuntime
 
+# Collect with networking providers (HTTP status codes, DNS, TLS, sockets)
+dotnet-trace collect -p <PID> --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
 # Collect for a fixed duration (time span in hh:mm:ss format)
 dotnet-trace collect -p <PID> --duration 00:00:30
 

--- a/plugins/dotnet/skills/dotnet-trace-collect/references/perfview.md
+++ b/plugins/dotnet/skills/dotnet-trace-collect/references/perfview.md
@@ -30,6 +30,12 @@ PerfView collect /GCCollectOnly /BufferSizeMB:1024 /CircularMB:2048
 # Collect with specific providers
 PerfView collect /Providers:Microsoft-Windows-DotNETRuntime /BufferSizeMB:1024 /CircularMB:2048
 
+# Collect with networking providers (HTTP status codes, DNS, TLS, sockets)
+PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*System.Net.Http,*System.Net.NameResolution,*System.Net.Security,*System.Net.Sockets
+
+# Collect with Kestrel/ASP.NET providers for slow inbound requests
+PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*Microsoft.AspNetCore.Hosting,*Microsoft-AspNetCore-Server-Kestrel
+
 # Collect for a specific duration (seconds)
 PerfView collect /MaxCollectSec:30 /BufferSizeMB:1024 /CircularMB:2048
 

--- a/tests/dotnet/dotnet-trace-collect/eval.yaml
+++ b/tests/dotnet/dotnet-trace-collect/eval.yaml
@@ -242,3 +242,41 @@ scenarios:
       - "Explains that this avoids the need for a .NET SDK in the container"
       - "Mentions kubectl cp as an alternative to copy the tool into the container"
     timeout: 60
+
+  - name: "HTTP 500s from downstream service on Linux (.NET 8)"
+    prompt: >-
+      My .NET 8 ASP.NET Core app running on a Linux VM is making HTTP calls to
+      a downstream API using HttpClient, and we're seeing intermittent HTTP 500
+      responses from that downstream service. I need to understand which
+      requests are failing and how long they're taking. What trace should I
+      collect?
+    assertions:
+      - type: "output_matches"
+        pattern: "(dotnet-trace|dotnet trace)"
+      - type: "output_matches"
+        pattern: "System\\.Net\\.Http"
+    rubric:
+      - "Recommends dotnet-trace with networking providers (at minimum System.Net.Http)"
+      - "Explains that System.Net.Http events include HTTP status codes in RequestStop events, allowing identification of 5xx responses"
+      - "Mentions that the trace also captures request timing to correlate slow requests with failures"
+      - "Provides the specific dotnet-trace collect command with --providers for networking"
+      - "Does not recommend dotnet-trace collect-linux since the runtime is .NET 8 (pre-.NET 10)"
+    timeout: 60
+
+  - name: "Networking timeouts on Windows with admin (.NET 8)"
+    prompt: >-
+      My .NET 8 Windows service is experiencing networking timeouts when
+      calling external APIs via HttpClient. Requests are timing out after 30
+      seconds. I have admin access. What's the best way to collect diagnostic
+      data to understand what's happening at the networking level?
+    assertions:
+      - type: "output_contains"
+        value: "PerfView"
+      - type: "output_matches"
+        pattern: "System\\.Net"
+    rubric:
+      - "Recommends PerfView with /ThreadTime and networking providers as Additional Providers"
+      - "Lists the networking providers to enable (System.Net.Http, and optionally System.Net.NameResolution, System.Net.Security, System.Net.Sockets)"
+      - "Explains that combining thread-time traces with networking events shows both where threads are blocked and what networking operations are failing"
+      - "Mentions that RequestFailed events capture exception messages for timed-out requests"
+    timeout: 60


### PR DESCRIPTION
## Skill Validation Results

| Skill | Scenario | Baseline | With Skill | Δ | Skills Loaded | Overfit | Verdict |
|-------|----------|----------|------------|---|---------------|---------|--------|
| dotnet-trace-collect | High CPU in Kubernetes on Linux (.NET 8) | 3.3/5 | 4.7/5 | +1.4 | ✅ dotnet-trace-collect; tools: skill, powershell | ✅ 0.19 | ✅ |
| dotnet-trace-collect | .NET Framework on Windows without admin privileges | 1.7/5 | 5.0/5 | +3.3 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | .NET 10 on Linux with root access and native call stacks | 1.0/5 | 3.7/5 | +2.7 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Memory leak on Linux (.NET 8) | 2.3/5 | 3.0/5 | +0.7 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Slow requests on Windows with PerfView | 4.3/5 | 5.0/5 | +0.7 | ✅ dotnet-trace-collect; tools: skill, report_intent, view | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Excessive GC on Linux (.NET 8) | 4.3/5 | 5.0/5 | +0.7 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Hang or deadlock diagnosis on Linux | 2.7/5 | 4.0/5 | +1.3 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Windows container high CPU with PerfView | 1.0/5 | 4.3/5 | +3.3 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Long-running intermittent issue with PerfView triggers | 2.0/5 | 4.7/5 | +2.7 | ✅ dotnet-trace-collect; tools: skill, report_intent, view | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Linux pre-.NET 10 needing native call stacks | 2.7/5 | 5.0/5 | +2.3 | ✅ dotnet-trace-collect; tools: skill, report_intent, view, glob | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Windows modern .NET with admin high CPU | 2.3/5 | 5.0/5 | +2.7 | ✅ dotnet-trace-collect; tools: skill, report_intent, view, glob, powershell | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Memory leak on .NET Framework Windows | 3.3/5 | 5.0/5 | +1.7 | ✅ dotnet-trace-collect; tools: skill, report_intent, view, glob | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Kubernetes with console access prefers console tools | 4.0/5 | 5.0/5 | +1.0 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Container installation without .NET SDK | 3.0/5 | 3.3/5 | +0.3 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | HTTP 500s from downstream service on Linux (.NET 8) | 3.7/5 | 5.0/5 | +1.3 | ✅ dotnet-trace-collect; tools: skill | ✅ 0.19 | ✅ |
| dotnet-trace-collect | Networking timeouts on Windows with admin (.NET 8) | 2.0/5 | 4.7/5 | +2.7 | ✅ dotnet-trace-collect; tools: skill, report_intent, view | ✅ 0.19 | ✅ |