### PR TITLE
Skip token randomization on forked PRs

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -278,7 +278,6 @@ jobs:
           echo "token=${TOKENS[$IDX]}" >> $GITHUB_OUTPUT
 
       - name: Run skill-validator
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token || secrets.COPILOT_GITHUB_TOKEN }}
           RESULTS_PATH: artifacts/TestResults/skill-validator/${{ matrix.entry.name }}


### PR DESCRIPTION
On forked PRs, the token randomization step is skipped and the workflow falls back to the \COPILOT_GITHUB_TOKEN\ secret directly. Forked repositories must set this secret with **Copilot Requests** permissions to run evaluations.

### Changes
- Added \if\ condition to skip the randomization step on forked PRs
- Fall back to \secrets.COPILOT_GITHUB_TOKEN\ when the step is skipped (\steps.select-token.outputs.token || secrets.COPILOT_GITHUB_TOKEN\)
- Added a comment at the top of the workflow documenting the fork secret requirement