### PR TITLE
Move agentic-workflows doc under docs/

### DIFF
--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -8,8 +8,8 @@ The workflow source files live in `.github/workflows/` and are compiled with `gh
 
 | Workflow | Description | Trigger |
 |----------|-------------|---------|
-| [devops-health-check](../../.github/workflows/devops-health-check.md) | Daily orchestrator that collects repo health signals (pipelines, skill quality, PRs, infrastructure), computes a fingerprint-based diff against the previous run, and updates a pinned health dashboard issue | `schedule: daily` (fuzzy daily), `workflow_dispatch` |
-| [devops-health-investigate](../../.github/workflows/devops-health-investigate.md) | Worker agent dispatched by the health check orchestrator to perform deep root-cause analysis on individual findings | `workflow_dispatch` (dispatched by orchestrator via `dispatch-workflow`) |
+| [devops-health-check](../.github/workflows/devops-health-check.md) | Daily orchestrator that collects repo health signals (pipelines, skill quality, PRs, infrastructure), computes a fingerprint-based diff against the previous run, and updates a pinned health dashboard issue | `schedule: daily` (fuzzy daily), `workflow_dispatch` |
+| [devops-health-investigate](../.github/workflows/devops-health-investigate.md) | Worker agent dispatched by the health check orchestrator to perform deep root-cause analysis on individual findings | `workflow_dispatch` (dispatched by orchestrator via `dispatch-workflow`) |
 
 ## Architecture
 


### PR DESCRIPTION
We will need a docs folder eventually anyways. Move the rep specific aw doc out from the eng folder.