### PR TITLE
Fix pr-number input type: use string instead of number

### DIFF
--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -50,10 +50,10 @@ on:
         type: boolean
         default: false
       pr-number:
-        description: 'PR number for commenting (0 = skip)'
+        description: 'PR number for commenting (empty = skip)'
         required: false
-        type: number
-        default: 0
+        type: string
+        default: ''
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: false
@@ -206,7 +206,7 @@ jobs:
 
   comment-on-pr:
     needs: evaluate
-    if: always() && needs.evaluate.result != 'cancelled' && needs.evaluate.result != 'skipped' && inputs.pr-number != 0
+    if: always() && needs.evaluate.result != 'cancelled' && needs.evaluate.result != 'skipped' && inputs.pr-number != ''
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -135,7 +135,7 @@ jobs:
     with:
       entries: ${{ needs.discover.outputs.entries }}
       runs: ${{ needs.discover.outputs.is_infra == 'true' && '2' || (github.ref == 'refs/heads/main' && '5' || '3') }}
-      pr-number: ${{ github.event.pull_request.number || 0 }}
+      pr-number: ${{ github.event.pull_request.number || '' }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}


### PR DESCRIPTION
Reusable workflow inputs typed as \
umber\ reject string values from job outputs (which are always strings). This caused the \un-evaluation\ reusable workflow call to fail immediately in the fork PR evaluation workflow.

**Changes:**
- \valuation-run.yml\: Change \pr-number\ input from \	ype: number\ to \	ype: string\, update default and skip condition
- \valuation.yml\: Update fallback from \