### PR TITLE
Add CODEOWNERS entries for dotnet-aot-compat

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,7 @@
 /plugins/dotnet/skills/microbenchmarking/ @dotnet/dotnet-perf-team
 /tests/dotnet/microbenchmarking/ @dotnet/dotnet-perf-team
 
-/plugins/dotnet/skills/dotnet-aot-compat/ @agocke
-/tests/dotnet/dotnet-aot-compat/ @agocke
+/plugins/dotnet/skills/dotnet-aot-compat/ @agocke @dotnet/appmodel
+/tests/dotnet/dotnet-aot-compat/ @agocke @dotnet/appmodel
 
 /plugins/dotnet/agents/optimizing-dotnet-performance.agent.md @dotnet/appmodel


### PR DESCRIPTION
Fixes https://github.com/dotnet/skills/issues/173

Add CODEOWNERS entries for the `dotnet-aot-compat` skill and its tests, with @agocke as owner.

This resolves the CODEOWNERS folder validation failure for:
- `/plugins/dotnet/skills/dotnet-aot-compat/`
- `/tests/dotnet/dotnet-aot-compat/`
