### PR TITLE
Warn when eval prompt explicitly references skill name

### DIFF
--- a/eng/skill-validator/src/Services/SkillProfiler.cs
+++ b/eng/skill-validator/src/Services/SkillProfiler.cs
@@ -86,7 +86,7 @@ public static partial class SkillProfiler
         // Check if eval prompts explicitly reference the skill by name — this biases
         // baseline runs (agent wastes time searching) and forces activation instead of
         // testing organic discovery.
-        if (skill.EvalConfig is not null)
+        if (skill.EvalConfig is not null && !string.IsNullOrWhiteSpace(skill.Name))
         {
             foreach (var scenario in skill.EvalConfig.Scenarios)
             {

--- a/eng/skill-validator/tests/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/SkillProfileTests.cs
@@ -114,6 +114,57 @@ public class AnalyzeSkillTests
         Assert.Equal("detailed", profile.ComplexityTier);
         Assert.Empty(profile.Warnings);
     }
+
+    private static SkillInfo MakeSkillWithEval(string content, string name, List<EvalScenario> scenarios)
+    {
+        return new SkillInfo(
+            Name: name,
+            Description: "Test skill",
+            Path: "/tmp/test-skill",
+            SkillMdPath: "/tmp/test-skill/SKILL.md",
+            SkillMdContent: content,
+            EvalPath: "/tmp/test-skill/eval.yaml",
+            EvalConfig: new EvalConfig(scenarios));
+    }
+
+    [Fact]
+    public void WarnsWhenEvalPromptMentionsSkillName()
+    {
+        var content = "---\nname: migrate-app\n---\n# Title\n1. Step\n```bash\necho\n```\n" + new string('x', 4000);
+        var scenarios = new List<EvalScenario>
+        {
+            new("basic", "Use the migrate-app skill to help me migrate my project")
+        };
+        var skill = MakeSkillWithEval(content, "migrate-app", scenarios);
+        var profile = SkillProfiler.AnalyzeSkill(skill);
+        Assert.Contains(profile.Warnings, w => w.Contains("mentions skill name") && w.Contains("migrate-app"));
+    }
+
+    [Fact]
+    public void NoWarningWhenEvalPromptDoesNotMentionSkillName()
+    {
+        var content = "---\nname: migrate-app\n---\n# Title\n1. Step\n```bash\necho\n```\n" + new string('x', 4000);
+        var scenarios = new List<EvalScenario>
+        {
+            new("basic", "Help me migrate my project to the latest framework")
+        };
+        var skill = MakeSkillWithEval(content, "migrate-app", scenarios);
+        var profile = SkillProfiler.AnalyzeSkill(skill);
+        Assert.DoesNotContain(profile.Warnings, w => w.Contains("mentions skill name"));
+    }
+
+    [Fact]
+    public void NoWarningWhenSkillNameIsEmpty()
+    {
+        var content = "---\nname: \n---\n# Title\n1. Step\n```bash\necho\n```\n" + new string('x', 4000);
+        var scenarios = new List<EvalScenario>
+        {
+            new("basic", "Help me migrate my project")
+        };
+        var skill = MakeSkillWithEval(content, "", scenarios);
+        var profile = SkillProfiler.AnalyzeSkill(skill);
+        Assert.DoesNotContain(profile.Warnings, w => w.Contains("mentions skill name"));
+    }
 }
 
 public class FormatProfileLineTests


### PR DESCRIPTION
   Add a profile warning when an eval scenario prompt contains the skill name (e.g. "Use the migrate-dotnet10-to-dotnet11 skill to help me").

This pattern biases eval results in two ways:

1. Baseline penalty — the agent wastes time searching for a skill file that doesn't exist in the empty workspace, often hitting timeouts
2. Forced activation — the skill activates because the user explicitly asked for it, not because the agent organically discovered it was relevant

Example of the problem: https://github.com/dotnet/skills/pull/181/files/a60090859407b19b9794959531ab41f319f32d08#diff-1f871bb9e52c41b2a481da2bfc6e8d7f25b7b1b1d2f0de28b4b8ee43e8f67b07L5

The warning flows through the existing ProfileWarnings pipeline so it surfaces in console output, JSON results, and the "Possible causes from skill analysis" section when a verdict fails.