### PR TITLE
Disallow eval.yml without scenarios

### DIFF
--- a/eng/skill-validator/src/Services/EvalSchema.cs
+++ b/eng/skill-validator/src/Services/EvalSchema.cs
@@ -16,8 +16,10 @@ public static class EvalSchema
         var raw = YamlDeserializer.Deserialize<RawEvalConfig>(yamlContent)
             ?? throw new InvalidOperationException("Failed to parse eval config YAML");
 
-        var scenarios = raw.Scenarios?.Select(ParseScenario).ToList()
-            ?? throw new InvalidOperationException("Eval config must have scenarios");
+        var scenarios = raw.Scenarios?.Select(ParseScenario).ToList();
+
+        if (scenarios is not { Count: > 0 })
+            throw new InvalidOperationException("Eval config must have at least one scenario");
 
         return new EvalConfig(scenarios);
     }

--- a/eng/skill-validator/tests/EvalSchemaTests.cs
+++ b/eng/skill-validator/tests/EvalSchemaTests.cs
@@ -40,11 +40,11 @@ public class ParseEvalConfigTests
     }
 
     [Fact]
-    public void AcceptsEmptyScenarios()
+    public void RejectsEmptyScenarios()
     {
         var yaml = "scenarios: []";
-        var result = EvalSchema.ParseEvalConfig(yaml);
-        Assert.Empty(result.Scenarios);
+        var ex = Assert.Throws<InvalidOperationException>(() => EvalSchema.ParseEvalConfig(yaml));
+        Assert.Contains("at least one scenario", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
This restores the behavior from two weeks ago that I temporarily disabled when I brought the dotnet-msbuild plugin over.

---

Reject eval configs with an empty scenarios list at parse time, rather than silently accepting them. This ensures authors don't accidentally ship eval files that test nothing.

### Changes
- **EvalSchema.cs**: Added validation that throws if parsed scenarios list is empty
- **EvalSchemaTests.cs**: Changed \AcceptsEmptyScenarios\ → \RejectsEmptyScenarios\ to verify the new behavior

All 195 tests pass.