### PR TITLE
Enable NativeAOT publishing for SkillValidator

### DIFF
--- a/eng/skill-validator/src/Commands/ConsolidateCommand.cs
+++ b/eng/skill-validator/src/Commands/ConsolidateCommand.cs
@@ -45,8 +45,8 @@ public static class ConsolidateCommand
             try
             {
                 var content = await File.ReadAllTextAsync(file);
-                var data = System.Text.Json.JsonSerializer.Deserialize<ConsolidateData>(content,
-                    new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var data = System.Text.Json.JsonSerializer.Deserialize(content,
+                    SkillValidatorJsonContext.Default.ConsolidateData);
                 if (data?.Verdicts is not null)
                     allVerdicts.AddRange(data.Verdicts);
                 if (data?.Model is not null && model is null) model = data.Model;
@@ -62,12 +62,5 @@ public static class ConsolidateCommand
         await File.WriteAllTextAsync(outputPath, output);
         Console.WriteLine($"Consolidated {files.Length} result file(s) into {outputPath}");
         return 0;
-    }
-
-    private sealed class ConsolidateData
-    {
-        public string? Model { get; set; }
-        public string? JudgeModel { get; set; }
-        public List<SkillVerdict>? Verdicts { get; set; }
     }
 }

--- a/eng/skill-validator/src/Models/Models.cs
+++ b/eng/skill-validator/src/Models/Models.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace SkillValidator.Models;
@@ -88,7 +89,7 @@ public sealed record SkillInfo(
 public sealed record AgentEvent(
     string Type,
     long Timestamp,
-    Dictionary<string, object?> Data);
+    Dictionary<string, JsonNode?> Data);
 
 // --- Judge results ---
 
@@ -229,7 +230,7 @@ public sealed class SkillVerdict
 
 // --- Overfitting assessment ---
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<OverfittingSeverity>))]
 public enum OverfittingSeverity
 {
     Low,
@@ -313,4 +314,21 @@ public static class DefaultWeights
         ["OverallJudgmentImprovement"] = 0.30,
         ["ErrorReduction"] = 0.05,
     };
+}
+
+// --- JSON transport types ---
+
+internal sealed class ConsolidateData
+{
+    public string? Model { get; set; }
+    public string? JudgeModel { get; set; }
+    public List<SkillVerdict>? Verdicts { get; set; }
+}
+
+internal sealed class ResultsOutput
+{
+    public required string Model { get; init; }
+    public required string JudgeModel { get; init; }
+    public required string Timestamp { get; init; }
+    public required IReadOnlyList<SkillVerdict> Verdicts { get; init; }
 }

--- a/eng/skill-validator/src/Services/AgentRunner.cs
+++ b/eng/skill-validator/src/Services/AgentRunner.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using SkillValidator.Models;
 using GitHub.Copilot.SDK;
 
@@ -190,17 +191,17 @@ public static class AgentRunner
                 switch (evt)
                 {
                     case AssistantMessageDeltaEvent delta:
-                        agentEvent.Data["deltaContent"] = delta.Data.DeltaContent;
+                        agentEvent.Data["deltaContent"] = JsonValue.Create(delta.Data.DeltaContent);
                         agentOutput += delta.Data.DeltaContent ?? "";
                         break;
                     case AssistantMessageEvent msg:
-                        agentEvent.Data["content"] = msg.Data.Content;
+                        agentEvent.Data["content"] = JsonValue.Create(msg.Data.Content);
                         if (!string.IsNullOrEmpty(msg.Data.Content))
                             agentOutput = msg.Data.Content;
                         break;
                     case ToolExecutionStartEvent toolStart:
-                        agentEvent.Data["toolName"] = toolStart.Data.ToolName;
-                        agentEvent.Data["arguments"] = toolStart.Data.Arguments?.ToString();
+                        agentEvent.Data["toolName"] = JsonValue.Create(toolStart.Data.ToolName);
+                        agentEvent.Data["arguments"] = JsonValue.Create(toolStart.Data.Arguments?.ToString());
                         if (options.Verbose)
                         {
                             var write = options.Log ?? (m => Console.Error.WriteLine(m));
@@ -208,14 +209,19 @@ public static class AgentRunner
                         }
                         break;
                     case ToolExecutionCompleteEvent toolComplete:
-                        agentEvent.Data["success"] = toolComplete.Data.Success.ToString();
-                        agentEvent.Data["result"] = toolComplete.Data.Result?.Content ?? toolComplete.Data.Error?.Message ?? "";
+                        agentEvent.Data["success"] = JsonValue.Create(toolComplete.Data.Success.ToString());
+                        agentEvent.Data["result"] = JsonValue.Create(toolComplete.Data.Result?.Content ?? toolComplete.Data.Error?.Message ?? "");
                         break;
                     case SkillInvokedEvent skillInvoked:
-                        agentEvent.Data["name"] = skillInvoked.Data.Name;
-                        agentEvent.Data["path"] = skillInvoked.Data.Path;
+                        agentEvent.Data["name"] = JsonValue.Create(skillInvoked.Data.Name);
+                        agentEvent.Data["path"] = JsonValue.Create(skillInvoked.Data.Path);
                         if (skillInvoked.Data.AllowedTools is { } allowedTools)
-                            agentEvent.Data["allowedTools"] = allowedTools;
+                        {
+                            var arr = new JsonArray();
+                            foreach (var tool in allowedTools)
+                                arr.Add((JsonNode?)JsonValue.Create(tool));
+                            agentEvent.Data["allowedTools"] = arr;
+                        }
                         if (options.Verbose)
                         {
                             var write = options.Log ?? (m => Console.Error.WriteLine(m));
@@ -223,18 +229,18 @@ public static class AgentRunner
                         }
                         break;
                     case AssistantUsageEvent usage:
-                        agentEvent.Data["inputTokens"] = usage.Data.InputTokens;
-                        agentEvent.Data["outputTokens"] = usage.Data.OutputTokens;
-                        agentEvent.Data["model"] = usage.Data.Model;
+                        agentEvent.Data["inputTokens"] = JsonValue.Create(usage.Data.InputTokens);
+                        agentEvent.Data["outputTokens"] = JsonValue.Create(usage.Data.OutputTokens);
+                        agentEvent.Data["model"] = JsonValue.Create(usage.Data.Model);
                         break;
                     case UserMessageEvent userMsg:
-                        agentEvent.Data["content"] = userMsg.Data.Content;
+                        agentEvent.Data["content"] = JsonValue.Create(userMsg.Data.Content);
                         break;
                     case SessionIdleEvent:
                         done.TrySetResult();
                         break;
                     case SessionErrorEvent err:
-                        agentEvent.Data["message"] = err.Data.Message;
+                        agentEvent.Data["message"] = JsonValue.Create(err.Data.Message);
                         done.TrySetException(new InvalidOperationException(err.Data.Message ?? "Session error"));
                         break;
                 }
@@ -251,7 +257,7 @@ public static class AgentRunner
             events.Add(new AgentEvent(
                 "runner.error",
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                new Dictionary<string, object?> { ["message"] = te.ToString() }));
+                new Dictionary<string, JsonNode?> { ["message"] = JsonValue.Create(te.ToString()) }));
         }
         catch (Exception error)
         {
@@ -263,7 +269,7 @@ public static class AgentRunner
                 events.Add(new AgentEvent(
                     "runner.timeout",
                     DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    new Dictionary<string, object?> { ["message"] = msg }));
+                    new Dictionary<string, JsonNode?> { ["message"] = JsonValue.Create(msg) }));
             }
             else if (!events.Any(e => e.Type == "session.error"))
             {
@@ -271,7 +277,7 @@ public static class AgentRunner
                 events.Add(new AgentEvent(
                     "runner.error",
                     DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    new Dictionary<string, object?> { ["message"] = msg }));
+                    new Dictionary<string, JsonNode?> { ["message"] = JsonValue.Create(msg) }));
             }
         }
 

--- a/eng/skill-validator/src/Services/EvalSchema.cs
+++ b/eng/skill-validator/src/Services/EvalSchema.cs
@@ -6,7 +6,7 @@ namespace SkillValidator.Services;
 
 public static class EvalSchema
 {
-    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+    private static readonly IDeserializer YamlDeserializer = new StaticDeserializerBuilder(new SkillValidatorYamlContext())
         .WithNamingConvention(UnderscoredNamingConvention.Instance)
         .IgnoreUnmatchedProperties()
         .Build();
@@ -112,12 +112,18 @@ public static class EvalSchema
 
     // Raw YAML deserialization models
 
-    private sealed class RawEvalConfig
+    internal sealed class RawFrontmatter
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+    }
+
+    internal sealed class RawEvalConfig
     {
         public List<RawScenario>? Scenarios { get; set; }
     }
 
-    private sealed class RawScenario
+    internal sealed class RawScenario
     {
         public string Name { get; set; } = "";
         public string Prompt { get; set; } = "";
@@ -132,21 +138,21 @@ public static class EvalSchema
         public bool? ExpectActivation { get; set; }
     }
 
-    private sealed class RawSetup
+    internal sealed class RawSetup
     {
         public bool CopyTestFiles { get; set; }
         public List<RawSetupFile>? Files { get; set; }
         public List<string>? Commands { get; set; }
     }
 
-    private sealed class RawSetupFile
+    internal sealed class RawSetupFile
     {
         public string Path { get; set; } = "";
         public string? Source { get; set; }
         public string? Content { get; set; }
     }
 
-    private sealed class RawAssertion
+    internal sealed class RawAssertion
     {
         public string Type { get; set; } = "";
         public string? Path { get; set; }

--- a/eng/skill-validator/src/Services/Judge.cs
+++ b/eng/skill-validator/src/Services/Judge.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using SkillValidator.Models;
 using SkillValidator.Utilities;
 using GitHub.Copilot.SDK;
@@ -204,7 +205,7 @@ public static class Judge
             relevant.Insert(headCount, new AgentEvent(
                 "summary",
                 0,
-                new Dictionary<string, object?> { ["message"] = $"... ({omitted} events omitted for brevity) ..." }));
+                new Dictionary<string, JsonNode?> { ["message"] = JsonValue.Create($"... ({omitted} events omitted for brevity) ...") }));
         }
 
         var sb = new System.Text.StringBuilder();
@@ -242,10 +243,10 @@ public static class Judge
         var parts = new List<string>();
         if (content.Length > 0) parts.Add(Truncate(content, 500));
 
-        if (e.Data.TryGetValue("toolRequests", out var toolReqs) && toolReqs is JsonElement el && el.ValueKind == JsonValueKind.Array)
+        if (e.Data.TryGetValue("toolRequests", out var toolReqs) && toolReqs is JsonArray toolArr)
         {
-            var tools = string.Join(", ", el.EnumerateArray()
-                .Select(t => t.GetProperty("name").GetString() ?? ""));
+            var tools = string.Join(", ", toolArr
+                .Select(t => t?["name"]?.GetValue<string>() ?? ""));
             if (tools.Length > 0) parts.Add($"(called tools: {tools})");
         }
         return $"[ASSISTANT] {string.Join(" ", parts)}";
@@ -289,6 +290,6 @@ public static class Judge
     private static string Truncate(string s, int max) =>
         s.Length > max ? s[..(max - 3)] + "..." : s;
 
-    private static string GetStr(Dictionary<string, object?> data, string key) =>
+    private static string GetStr(Dictionary<string, JsonNode?> data, string key) =>
         data.TryGetValue(key, out var v) && v is not null ? v.ToString() ?? "" : "";
 }

--- a/eng/skill-validator/src/Services/MetricsCollector.cs
+++ b/eng/skill-validator/src/Services/MetricsCollector.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using SkillValidator.Models;
 
 namespace SkillValidator.Services;
@@ -131,20 +132,20 @@ public static class MetricsCollector
         };
     }
 
-    private static string? GetStringValue(Dictionary<string, object?> data, string key)
+    private static string? GetStringValue(Dictionary<string, JsonNode?> data, string key)
     {
         if (data.TryGetValue(key, out var value) && value is not null)
             return value.ToString();
         return null;
     }
 
-    private static int GetIntValue(Dictionary<string, object?> data, string key)
+    private static int GetIntValue(Dictionary<string, JsonNode?> data, string key)
     {
         if (data.TryGetValue(key, out var value) && value is not null)
         {
-            if (value is int i) return i;
-            if (value is long l) return (int)l;
-            if (value is double d) return (int)d;
+            try { return value.GetValue<int>(); } catch { }
+            try { return (int)value.GetValue<long>(); } catch { }
+            try { return (int)value.GetValue<double>(); } catch { }
             if (int.TryParse(value.ToString(), out var parsed)) return parsed;
         }
         return 0;

--- a/eng/skill-validator/src/Services/PairwiseJudge.cs
+++ b/eng/skill-validator/src/Services/PairwiseJudge.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using SkillValidator.Models;
 using SkillValidator.Utilities;
 using GitHub.Copilot.SDK;
@@ -235,7 +236,7 @@ public static class PairwiseJudge
             relevant = [..head, ..tail];
             relevant.Insert(headCount, new AgentEvent(
                 "summary", 0,
-                new Dictionary<string, object?> { ["message"] = $"... ({omitted} events omitted for brevity) ..." }));
+                new Dictionary<string, JsonNode?> { ["message"] = JsonValue.Create($"... ({omitted} events omitted for brevity) ...") }));
         }
 
         var sb = new System.Text.StringBuilder();
@@ -271,10 +272,10 @@ public static class PairwiseJudge
         var parts = new List<string>();
         if (content.Length > 0) parts.Add(Trunc(content, 400));
 
-        if (e.Data.TryGetValue("toolRequests", out var toolReqs) && toolReqs is JsonElement el && el.ValueKind == JsonValueKind.Array)
+        if (e.Data.TryGetValue("toolRequests", out var toolReqs) && toolReqs is JsonArray toolArr)
         {
-            var tools = string.Join(", ", el.EnumerateArray()
-                .Select(t => t.GetProperty("name").GetString() ?? ""));
+            var tools = string.Join(", ", toolArr
+                .Select(t => t?["name"]?.GetValue<string>() ?? ""));
             if (tools.Length > 0) parts.Add($"(called tools: {tools})");
         }
         return $"[ASSISTANT] {string.Join(" ", parts)}";
@@ -408,6 +409,6 @@ public static class PairwiseJudge
     private static string Trunc(string s, int max) =>
         s.Length > max ? s[..(max - 3)] + "..." : s;
 
-    private static string GetStr(Dictionary<string, object?> data, string key) =>
+    private static string GetStr(Dictionary<string, JsonNode?> data, string key) =>
         data.TryGetValue(key, out var v) && v is not null ? v.ToString() ?? "" : "";
 }

--- a/eng/skill-validator/src/Services/Reporter.cs
+++ b/eng/skill-validator/src/Services/Reporter.cs
@@ -423,34 +423,25 @@ public static class Reporter
         string? model,
         string? judgeModel)
     {
-        var output = new
+        var output = new ResultsOutput
         {
-            model = model ?? "unknown",
-            judgeModel = judgeModel ?? model ?? "unknown",
-            timestamp = DateTime.UtcNow.ToString("o"),
-            verdicts,
+            Model = model ?? "unknown",
+            JudgeModel = judgeModel ?? model ?? "unknown",
+            Timestamp = DateTime.UtcNow.ToString("o"),
+            Verdicts = verdicts,
         };
 
-        var json = JsonSerializer.Serialize(output, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        });
+        var json = JsonSerializer.Serialize(output, SkillValidatorJsonContext.Default.ResultsOutput);
 
         await File.WriteAllTextAsync(Path.Combine(resultsDir, "results.json"), json);
         Console.WriteLine($"JSON results written to {Path.Combine(resultsDir, "results.json")}");
 
         // Write per-skill verdict.json files for downstream consumers (e.g. dashboard)
-        var jsonOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
         foreach (var verdict in verdicts)
         {
             var skillDir = Path.Combine(resultsDir, SafeDirName(verdict.SkillName));
             Directory.CreateDirectory(skillDir);
-            var verdictJson = JsonSerializer.Serialize(verdict, jsonOptions);
+            var verdictJson = JsonSerializer.Serialize(verdict, SkillValidatorJsonContext.Default.SkillVerdict);
             await File.WriteAllTextAsync(Path.Combine(skillDir, "verdict.json"), verdictJson);
         }
     }

--- a/eng/skill-validator/src/Services/SkillDiscovery.cs
+++ b/eng/skill-validator/src/Services/SkillDiscovery.cs
@@ -42,8 +42,8 @@ public static partial class SkillDiscovery
         var skillMdContent = await File.ReadAllTextAsync(skillMdPath);
         var (metadata, _) = ParseFrontmatter(skillMdContent);
 
-        var name = metadata.GetValueOrDefault("name") ?? Path.GetFileName(dirPath);
-        var description = metadata.GetValueOrDefault("description") ?? "";
+        var name = metadata.Name ?? Path.GetFileName(dirPath);
+        var description = metadata.Description ?? "";
 
         string? evalPath = null;
         EvalConfig? evalConfig = null;
@@ -85,17 +85,18 @@ public static partial class SkillDiscovery
             {
                 try
                 {
-                    var raw = JsonSerializer.Deserialize<JsonElement>(
-                        await File.ReadAllTextAsync(candidate));
+                    var raw = JsonSerializer.Deserialize(
+                        await File.ReadAllTextAsync(candidate),
+                        SkillValidatorJsonContext.Default.JsonElement);
                     if (raw.TryGetProperty("mcpServers", out var serversEl)
                         && serversEl.ValueKind == JsonValueKind.Object)
                     {
                         var result = new Dictionary<string, MCPServerDef>();
                         foreach (var prop in serversEl.EnumerateObject())
                         {
-                            var def = JsonSerializer.Deserialize<MCPServerDef>(
+                            var def = JsonSerializer.Deserialize(
                                 prop.Value.GetRawText(),
-                                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                                SkillValidatorJsonContext.Default.MCPServerDef);
                             if (def is not null)
                                 result[prop.Name] = def;
                         }
@@ -116,19 +117,19 @@ public static partial class SkillDiscovery
         return null;
     }
 
-    internal static (Dictionary<string, string> Metadata, string Body) ParseFrontmatter(string content)
+    private static readonly IDeserializer FrontmatterDeserializer = new StaticDeserializerBuilder(new SkillValidatorYamlContext())
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    internal static (EvalSchema.RawFrontmatter Metadata, string Body) ParseFrontmatter(string content)
     {
         var match = FrontmatterRegex().Match(content);
         if (!match.Success)
-            return (new Dictionary<string, string>(), content);
+            return (new EvalSchema.RawFrontmatter(), content);
 
-        var yamlDeserializer = new DeserializerBuilder()
-            .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
-
-        var metadata = yamlDeserializer.Deserialize<Dictionary<string, string>>(match.Groups[1].Value)
-            ?? new Dictionary<string, string>();
+        var metadata = FrontmatterDeserializer.Deserialize<EvalSchema.RawFrontmatter>(match.Groups[1].Value)
+            ?? new EvalSchema.RawFrontmatter();
 
         return (metadata, match.Groups[2].Value);
     }

--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -3,10 +3,18 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>skill-validator</AssemblyName>
-    <PublishSelfContained>true</PublishSelfContained>
-    <PublishRelease>true</PublishRelease>
+
+    <!-- Packaging -->
+    <PackageId>Microsoft.DotNet.SkillValidator</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <ToolCommandName>skillvalidator</ToolCommandName>
     <Version>1.0.0</Version>
     <Description>Validate that agent skills meaningfully improve agent performance</Description>
+
+    <!-- Publishing -->
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
+    <PublishAot>true</PublishAot>
 
     <!-- dotnet run args for local invocation -->
     <RunArguments>--results-dir &quot;$([MSBuild]::NormalizePath('$(ArtifactsPath)', 'TestResults', '$(AssemblyName)'))&quot; --parallel-skills 3 --parallel-scenarios 3 --parallel-runs 3</RunArguments>
@@ -22,6 +30,7 @@
     <!-- external -->
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.30" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/skill-validator/src/SkillValidatorJsonContext.cs
+++ b/eng/skill-validator/src/SkillValidatorJsonContext.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using SkillValidator.Models;
+
+namespace SkillValidator;
+
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ResultsOutput))]
+[JsonSerializable(typeof(ConsolidateData))]
+[JsonSerializable(typeof(SkillVerdict))]
+[JsonSerializable(typeof(ScenarioComparison))]
+[JsonSerializable(typeof(RunResult))]
+[JsonSerializable(typeof(RunMetrics))]
+[JsonSerializable(typeof(JudgeResult))]
+[JsonSerializable(typeof(RubricScore))]
+[JsonSerializable(typeof(AssertionResult))]
+[JsonSerializable(typeof(Assertion))]
+[JsonSerializable(typeof(AgentEvent))]
+[JsonSerializable(typeof(MetricBreakdown))]
+[JsonSerializable(typeof(ConfidenceInterval))]
+[JsonSerializable(typeof(PairwiseJudgeResult))]
+[JsonSerializable(typeof(PairwiseRubricResult))]
+[JsonSerializable(typeof(SkillActivationInfo))]
+[JsonSerializable(typeof(OverfittingResult))]
+[JsonSerializable(typeof(RubricOverfitAssessment))]
+[JsonSerializable(typeof(AssertionOverfitAssessment))]
+[JsonSerializable(typeof(OverfittingSeverity))]
+[JsonSerializable(typeof(PairwiseMagnitude))]
+[JsonSerializable(typeof(AssertionType))]
+[JsonSerializable(typeof(MCPServerDef))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(Dictionary<string, int>))]
+[JsonSerializable(typeof(Dictionary<string, JsonNode?>))]
+[JsonSerializable(typeof(List<SkillVerdict>))]
+[JsonSerializable(typeof(IReadOnlyList<SkillVerdict>))]
+internal partial class SkillValidatorJsonContext : JsonSerializerContext;

--- a/eng/skill-validator/src/SkillValidatorYamlContext.cs
+++ b/eng/skill-validator/src/SkillValidatorYamlContext.cs
@@ -1,0 +1,13 @@
+using SkillValidator.Services;
+using YamlDotNet.Serialization;
+
+namespace SkillValidator;
+
+[YamlStaticContext]
+[YamlSerializable(typeof(EvalSchema.RawFrontmatter))]
+[YamlSerializable(typeof(EvalSchema.RawEvalConfig))]
+[YamlSerializable(typeof(EvalSchema.RawScenario))]
+[YamlSerializable(typeof(EvalSchema.RawSetup))]
+[YamlSerializable(typeof(EvalSchema.RawSetupFile))]
+[YamlSerializable(typeof(EvalSchema.RawAssertion))]
+public partial class SkillValidatorYamlContext : StaticContext;

--- a/eng/skill-validator/tests/MetricsTests.cs
+++ b/eng/skill-validator/tests/MetricsTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using SkillValidator.Models;
 using SkillValidator.Services;
 
@@ -5,9 +6,17 @@ namespace SkillValidator.Tests;
 
 public class ExtractSkillActivationTests
 {
-    private static AgentEvent MakeEvent(string type, Dictionary<string, object?>? data = null)
+    private static AgentEvent MakeEvent(string type, Dictionary<string, JsonNode?>? data = null)
     {
-        return new AgentEvent(type, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), data ?? new Dictionary<string, object?>());
+        return new AgentEvent(type, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), data ?? new Dictionary<string, JsonNode?>());
+    }
+
+    private static Dictionary<string, JsonNode?> D(params (string Key, JsonNode? Value)[] entries)
+    {
+        var dict = new Dictionary<string, JsonNode?>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
     }
 
     [Fact]
@@ -15,9 +24,9 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("skill.loaded", new() { ["skillName"] = "my-skill" }),
-            MakeEvent("assistant.message", new() { ["content"] = "hello" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
+            MakeEvent("skill.loaded", D(("skillName", JsonValue.Create("my-skill")))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("hello")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 1 });
@@ -33,8 +42,8 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("instruction.attached", new() { ["name"] = "build-helper" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "read" }),
+            MakeEvent("instruction.attached", D(("name", JsonValue.Create("build-helper")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("read")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["read"] = 1 });
@@ -49,9 +58,9 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "msbuild_analyze" }),
-            MakeEvent("assistant.message", new() { ["content"] = "done" }),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("msbuild_analyze")))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("done")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 3 });
@@ -67,8 +76,8 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("assistant.message", new() { ["content"] = "done" }),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("done")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 1 });
@@ -95,7 +104,7 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int>());
@@ -109,9 +118,9 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("skill.loaded", new() { ["skillName"] = "my-skill" }),
-            MakeEvent("skill.activated", new() { ["skillName"] = "my-skill" }),
-            MakeEvent("skill.loaded", new() { ["skillName"] = "other-skill" }),
+            MakeEvent("skill.loaded", D(("skillName", JsonValue.Create("my-skill")))),
+            MakeEvent("skill.activated", D(("skillName", JsonValue.Create("my-skill")))),
+            MakeEvent("skill.loaded", D(("skillName", JsonValue.Create("other-skill")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int>());
@@ -125,8 +134,8 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("skill.loaded", new()),
-            MakeEvent("skill.loaded", new() { ["skillName"] = "" }),
+            MakeEvent("skill.loaded"),
+            MakeEvent("skill.loaded", D(("skillName", JsonValue.Create("")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int>());
@@ -141,9 +150,9 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("skill.loaded", new() { ["skillName"] = "build-cache" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "msbuild_diag" }),
+            MakeEvent("skill.loaded", D(("skillName", JsonValue.Create("build-cache")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("msbuild_diag")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 2 });
@@ -159,10 +168,10 @@ public class ExtractSkillActivationTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.message", new() { ["content"] = "I used a skill" }),
-            MakeEvent("session.idle", new()),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("session.error", new() { ["message"] = "failed" }),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("I used a skill")))),
+            MakeEvent("session.idle"),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("session.error", D(("message", JsonValue.Create("failed")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 1 });
@@ -177,8 +186,8 @@ public class ExtractSkillActivationTests
         // SkillInvokedEvent has type "skill.invoked" and Data with "name" property
         var events = new List<AgentEvent>
         {
-            MakeEvent("skill.invoked", new() { ["name"] = "binlog-failure-analysis", ["path"] = "/skills/binlog-failure-analysis" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
+            MakeEvent("skill.invoked", D(("name", JsonValue.Create("binlog-failure-analysis")), ("path", JsonValue.Create("/skills/binlog-failure-analysis")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
         };
 
         var result = MetricsCollector.ExtractSkillActivation(events, new Dictionary<string, int> { ["bash"] = 1 });
@@ -191,9 +200,17 @@ public class ExtractSkillActivationTests
 
 public class CollectMetricsTests
 {
-    private static AgentEvent MakeEvent(string type, Dictionary<string, object?>? data = null)
+    private static AgentEvent MakeEvent(string type, Dictionary<string, JsonNode?>? data = null)
     {
-        return new AgentEvent(type, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), data ?? new Dictionary<string, object?>());
+        return new AgentEvent(type, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), data ?? new Dictionary<string, JsonNode?>());
+    }
+
+    private static Dictionary<string, JsonNode?> D(params (string Key, JsonNode? Value)[] entries)
+    {
+        var dict = new Dictionary<string, JsonNode?>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
     }
 
     [Fact]
@@ -201,10 +218,10 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "view" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
-            MakeEvent("assistant.message", new() { ["content"] = "done" }),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("view")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("done")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "done", 1000, "/tmp/work");
@@ -219,9 +236,9 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.usage", new() { ["inputTokens"] = 500, ["outputTokens"] = 200 }),
-            MakeEvent("assistant.message", new() { ["content"] = "hello world" }),
-            MakeEvent("assistant.usage", new() { ["inputTokens"] = 300, ["outputTokens"] = 100 }),
+            MakeEvent("assistant.usage", D(("inputTokens", JsonValue.Create(500)), ("outputTokens", JsonValue.Create(200)))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("hello world")))),
+            MakeEvent("assistant.usage", D(("inputTokens", JsonValue.Create(300)), ("outputTokens", JsonValue.Create(100)))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "hello world", 5000, "/tmp/work");
@@ -235,7 +252,7 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.message", new() { ["content"] = "hello world!!" }), // 13 chars -> ceil(13/4) = 4
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("hello world!!")))), // 13 chars -> ceil(13/4) = 4
         };
 
         var result = MetricsCollector.CollectMetrics(events, "hello world!!", 5000, "/tmp/work");
@@ -248,8 +265,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.message", new() { ["content"] = "turn 1" }),
-            MakeEvent("assistant.message", new() { ["content"] = "turn 2" }),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("turn 1")))),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("turn 2")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "turn 2", 1000, "/tmp/work");
@@ -262,8 +279,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("session.error", new() { ["message"] = "something went wrong" }),
-            MakeEvent("runner.error", new() { ["message"] = "timeout" }),
+            MakeEvent("session.error", D(("message", JsonValue.Create("something went wrong")))),
+            MakeEvent("runner.error", D(("message", JsonValue.Create("timeout")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "", 1000, "/tmp/work");
@@ -286,8 +303,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("user.message", new() { ["content"] = "test" }), // 4 chars -> ceil(4/4) = 1
-            MakeEvent("assistant.message", new() { ["content"] = "response" }), // 8 chars -> ceil(8/4) = 2
+            MakeEvent("user.message", D(("content", JsonValue.Create("test")))), // 4 chars -> ceil(4/4) = 1
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("response")))), // 8 chars -> ceil(8/4) = 2
         };
 
         var result = MetricsCollector.CollectMetrics(events, "response", 1000, "/tmp/work");
@@ -301,8 +318,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.message", new() { ["content"] = "working..." }),
-            MakeEvent("runner.timeout", new() { ["message"] = "Scenario timed out after 120s" }),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("working...")))),
+            MakeEvent("runner.timeout", D(("message", JsonValue.Create("Scenario timed out after 120s")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "", 120000, "/tmp/work");
@@ -316,8 +333,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("assistant.message", new() { ["content"] = "done" }),
-            MakeEvent("tool.execution_start", new() { ["toolName"] = "bash" }),
+            MakeEvent("assistant.message", D(("content", JsonValue.Create("done")))),
+            MakeEvent("tool.execution_start", D(("toolName", JsonValue.Create("bash")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "", 5000, "/tmp/work");
@@ -331,7 +348,7 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("runner.error", new() { ["message"] = "Something went wrong" }),
+            MakeEvent("runner.error", D(("message", JsonValue.Create("Something went wrong")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "", 3000, "/tmp/work");
@@ -345,8 +362,8 @@ public class CollectMetricsTests
     {
         var events = new List<AgentEvent>
         {
-            MakeEvent("runner.error", new() { ["message"] = "file not found" }),
-            MakeEvent("runner.timeout", new() { ["message"] = "Scenario timed out after 120s" }),
+            MakeEvent("runner.error", D(("message", JsonValue.Create("file not found")))),
+            MakeEvent("runner.timeout", D(("message", JsonValue.Create("Scenario timed out after 120s")))),
         };
 
         var result = MetricsCollector.CollectMetrics(events, "", 120000, "/tmp/work");


### PR DESCRIPTION
## Summary

Migrate SkillValidator (\ng/skill-validator\) to publish as a NativeAOT binary, producing a single ~15 MB native executable with fast startup and no JIT dependency.

## Changes

### Source-generated JSON serialization
- New \SkillValidatorJsonContext\ with \[JsonSerializable]\ for all 25+ serialized types
- All \JsonSerializer.Serialize/Deserialize\ call sites updated to use context-based overloads
- Replaced anonymous type in \Reporter.cs\ with named \ResultsOutput\ record
- Fixed \JsonStringEnumConverter\ to generic AOT-safe \JsonStringEnumConverter<OverfittingSeverity>\

### Source-generated YAML deserialization
- Added \Vecc.YamlDotNet.Analyzers.StaticGenerator\ package
- New \SkillValidatorYamlContext\ with \[YamlSerializable]\ for eval config and frontmatter types
- Switched \DeserializerBuilder\ to \StaticDeserializerBuilder\ in \EvalSchema.cs\ and \SkillDiscovery.cs\
- Added \RawFrontmatter\ strongly-typed model for YAML frontmatter (replaces \Dictionary<string, string>\)

### AOT-safe AgentEvent data
- Changed \AgentEvent.Data\ from \Dictionary<string, object?>\ to \Dictionary<string, JsonNode?>\
- Updated all construction sites (\AgentRunner.cs\, \Judge.cs\, \PairwiseJudge.cs\) and reading sites (\MetricsCollector.cs\)

## Validation
- \dotnet publish -c Release\ produces a clean NativeAOT binary with **zero trim/AOT warnings**
- All **198 existing tests pass**
