### PR TITLE
Change 'skill-validator' to 'sv' in temp directory name to reduce bias during evaluation

### DIFF
--- a/eng/skill-validator/src/Services/AgentRunner.cs
+++ b/eng/skill-validator/src/Services/AgentRunner.cs
@@ -109,7 +109,7 @@ public static class AgentRunner
         var skillPath = skill is not null ? Path.GetDirectoryName(skill.Path) : null;
 
         // Create a unique temporary config directory for this session to not share any data
-        var configDir = Path.Combine(Path.GetTempPath(), $"skill-validator-cfg-{Guid.NewGuid():N}");
+        var configDir = Path.Combine(Path.GetTempPath(), $"sv-cfg-{Guid.NewGuid():N}");
         Directory.CreateDirectory(configDir);
         _workDirs.Add(configDir);
 
@@ -289,7 +289,7 @@ public static class AgentRunner
 
     private static async Task<string> SetupWorkDir(EvalScenario scenario, string? skillPath, string? evalPath)
     {
-        var workDir = Path.Combine(Path.GetTempPath(), $"skill-validator-{Guid.NewGuid():N}");
+        var workDir = Path.Combine(Path.GetTempPath(), $"sv-{Guid.NewGuid():N}");
         Directory.CreateDirectory(workDir);
         _workDirs.Add(workDir);
 


### PR DESCRIPTION
Currently `skill-validator` has agents perform their work in unique directories in the user's temp directory with the name `skill-validator-{guid}`. When the agent is running, it sees the full path to the working directory it is running in, and so the directory name leaks to the AI that it is being evaluated rather than performing real work on a realistic scenario. This means our evaluations are subject to alignment faking or sandbagging in which it may behave differently when it knows it is being evaluated.

This PR changes the prefix for the temp directories from `skill-validator` to `sv` so that it is not as obvious that the work is being done for the purposes of skill validation. A more comprehensive solution to this might be to build upon the work in the PR to add [docker isolation](https://github.com/dotnet/skills/pull/176) and ensure that evaluation scenarios feel as similar as possible to a real development environment through the use of bind mounts (e.g. developing inside of `/src/project-name` instead of a temp directory).