### PR TITLE
Add workflow_dispatch trigger to skill-validator.yml

### DIFF
--- a/.github/workflows/skill-validator.yml
+++ b/.github/workflows/skill-validator.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RETENTION_DAYS: ${{ (github.event_name == 'schedule' || inputs.create_release == true) && 90 || 5 }}
+  RETENTION_DAYS: ${{ (github.event_name == 'schedule' || inputs.create_release == 'true') && 90 || 5 }}
   AGNOSTIC_RID: linux-x64
 
 jobs:
@@ -102,7 +102,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    if: github.event_name == 'schedule' || inputs.create_release == true
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.create_release == 'true')
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Add a \workflow_dispatch\ trigger with an optional \create_release\ boolean input so the workflow can be run manually from the Actions tab.

When \create_release\ is checked, the release job runs and artifact retention is set to 90 days, matching the scheduled nightly behavior. Without it, only the build matrix runs (useful for ad-hoc validation).