### PR TITLE
Add implementing-server-sent-events skill

### DIFF
--- a/PR-264-description.md
+++ b/PR-264-description.md
@@ -1,0 +1,21 @@
+## Summary
+Adds the **minimal-api-file-upload** skill for handling file uploads in ASP.NET Core 8 minimal APIs.
+
+> **Note:** Replaces #134 (migrated from skills-old repo). Skill moved to `aspnetcore` plugin per repo restructuring.
+
+## What the Skill Teaches
+- `IFormFile` binding in minimal APIs (when `[FromForm]` is needed vs automatic)
+- `IFormFileCollection` for multiple file uploads
+- Security: file size limits, content type allowlists, magic byte validation
+- Safe file naming with `Guid` + validated extension (never trust client filename)
+- Streaming uploads with `MultipartReader` for large files
+- Antiforgery considerations
+- Path traversal prevention
+
+## Eval Scenarios
+- (eval.yaml needs scenarios — currently empty)
+
+## Files
+- `plugins/aspnetcore/plugin.json` — ASP.NET Core plugin
+- `plugins/aspnetcore/skills/minimal-api-file-upload/SKILL.md` — skill instructions
+- `tests/aspnetcore/minimal-api-file-upload/eval.yaml` — eval scenarios (to be added)

--- a/PR-265-description.md
+++ b/PR-265-description.md
@@ -1,0 +1,23 @@
+## Summary
+Adds the **implementing-server-sent-events** skill for building SSE endpoints in ASP.NET Core 8 minimal APIs.
+
+> **Note:** Replaces #139 (migrated from skills-old repo). Skill moved to `aspnetcore` plugin per repo restructuring.
+
+## What the Skill Teaches
+- Manual SSE protocol implementation (no built-in `MapSSE` — doesn't exist)
+- Required headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`
+- Correct SSE event framing with `\n\n` terminators
+- `Response.Body.FlushAsync()` for immediate delivery
+- Event IDs + `Last-Event-ID` header for reconnection support
+- `retry:` field for controlling client reconnection interval
+- `X-Accel-Buffering: no` for reverse proxy compatibility
+- `HttpContext.RequestAborted` / `CancellationToken` for client disconnect detection
+- `Channel<T>` for background service → endpoint communication
+
+## Eval Scenarios
+1. Implement SSE notification endpoint in ASP.NET Core 8 minimal API
+
+## Files
+- `plugins/aspnetcore/plugin.json` — ASP.NET Core plugin
+- `plugins/aspnetcore/skills/implementing-server-sent-events/SKILL.md` — skill instructions
+- `tests/aspnetcore/implementing-server-sent-events/eval.yaml` — 1 eval scenario (needs expansion)

--- a/PR-266-description.md
+++ b/PR-266-description.md
@@ -1,0 +1,25 @@
+## Summary
+Adds the **implementing-websocket-endpoints** skill for building WebSocket endpoints in ASP.NET Core 8.
+
+> **Note:** Replaces #142 (migrated from skills-old repo). Skill moved to `aspnetcore` plugin per repo restructuring.
+
+## What the Skill Teaches
+- `UseWebSockets()` middleware setup (no `MapWebSocket` — doesn't exist)
+- Manual WebSocket upgrade via `AcceptWebSocketAsync`
+- Proper receive loop with `EndOfMessage` fragment handling
+- **Critical:** Use `CloseOutputAsync` (not `CloseAsync`) when responding to client-initiated close to avoid deadlock
+- `ConcurrentDictionary`-based connection manager for broadcast
+- `KeepAliveInterval` and `KeepAliveTimeout` configuration
+- `AllowedOrigins` for cross-origin protection
+- Query string token authentication (browser WebSocket API cannot send custom headers)
+
+## Eval Scenarios
+1. Implement WebSocket chat endpoint in ASP.NET Core 8
+2. Fix WebSocket CloseAsync deadlock
+3. WebSocket should not be used for server-to-client streaming (negative test)
+4. Handle fragmented WebSocket messages correctly
+
+## Files
+- `plugins/aspnetcore/plugin.json` — ASP.NET Core plugin
+- `plugins/aspnetcore/skills/implementing-websocket-endpoints/SKILL.md` — skill instructions
+- `tests/aspnetcore/implementing-websocket-endpoints/eval.yaml` — 4 eval scenarios

--- a/PR-267-description.md
+++ b/PR-267-description.md
@@ -1,0 +1,31 @@
+## Summary
+Adds the **implementing-rate-limiting** skill for ASP.NET Core's built-in rate limiting middleware (.NET 7+).
+
+> **Note:** Replaces #131 (migrated from skills-old repo). Skill moved to `aspnetcore` plugin per repo restructuring.
+
+## What the Skill Teaches
+- Algorithm selection: fixed window vs sliding window vs token bucket vs concurrency limiter
+- **Critical:** Setting `RejectionStatusCode = 429` (default is 503!)
+- Per-IP and per-user partitioned rate limiting
+- Middleware pipeline ordering (`UseRateLimiter()` after `UseRouting()`)
+- `OnRejected` callback with `Retry-After` header
+- `DisableRateLimiting()` for health check endpoints
+- Named policies with `RequireRateLimiting`
+
+## Eval Results (3-run, `claude-opus-4.6`)
+
+| Scenario | Baseline | With Skill | Verdict |
+|----------|----------|------------|---------|
+| Add per-client rate limiting to an ASP.NET Core API | 4.0/5 | **4.7/5** | ❌ [1] |
+| Rate limiting silently inactive without UseRateLimiter | 4.3/5 | 2.7/5 | ❌ |
+| Fix rate limiter returning 503 instead of 429 | 2.3/5 | 2.3/5 | ❌ [2] |
+| Rate limiting should not apply to authentication scenarios | 4.0/5 | **4.7/5** | ✅ |
+| Choose correct rate limiting algorithm | 4.0/5 | **5.0/5** | ✅ |
+
+[1] Quality improved but weighted score penalized by token/tool/time overhead.
+[2] Timeouts impacted scoring. Will iterate with increased timeouts.
+
+## Files
+- `plugins/aspnetcore/plugin.json` — new ASP.NET Core plugin
+- `plugins/aspnetcore/skills/implementing-rate-limiting/SKILL.md` — skill instructions
+- `tests/aspnetcore/implementing-rate-limiting/eval.yaml` — 5 eval scenarios

--- a/plugins/aspnetcore/skills/implementing-server-sent-events/SKILL.md
+++ b/plugins/aspnetcore/skills/implementing-server-sent-events/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: implementing-server-sent-events
+description: Implement Server-Sent Events (SSE) endpoints in ASP.NET Core. Use when building real-time streaming from server to client without WebSockets.
+---
+
+# Implementing Server-Sent Events (SSE) in ASP.NET Core
+
+## When to Use
+- Server-to-client real-time push (notifications, live updates, streaming progress)
+- When you DON'T need bidirectional communication (use WebSockets for that)
+- SSE is simpler than WebSockets and works over standard HTTP
+- Automatic reconnection built into EventSource browser API
+
+## When Not to Use
+- Bidirectional communication needed → use WebSockets
+- Binary data streaming → use WebSockets or gRPC streaming
+- Need more than 6 concurrent connections per domain in HTTP/1.1 → use HTTP/2
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Event data source | Yes | The data to stream (IAsyncEnumerable, Channel, timer, etc.) |
+| Event types | No | Named event types for `event:` field |
+| Client reconnection | No | Whether to support Last-Event-ID reconnection |
+
+## Workflow
+
+### Step 1: CRITICAL — There Is No Built-In MapSSE() or MapServerSentEvents()
+
+ASP.NET Core has NO built-in SSE endpoint helper. You must manually write the SSE protocol.
+
+```csharp
+// COMMON MISTAKE: Trying to use a non-existent API
+// app.MapSSE("/events", ...);                    // DOES NOT EXIST
+// app.MapServerSentEvents("/events", ...);       // DOES NOT EXIST
+// app.UseServerSentEvents();                     // DOES NOT EXIST
+
+// CORRECT: Use a standard minimal API endpoint with manual SSE protocol
+app.MapGet("/events", async (HttpContext context, CancellationToken ct) =>
+{
+    // CRITICAL: Set these three headers for SSE
+    context.Response.Headers.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+    context.Response.Headers["Connection"] = "keep-alive";
+
+    // CRITICAL: Disable response buffering for reverse proxies (nginx, etc.)
+    context.Response.Headers["X-Accel-Buffering"] = "no";
+
+    await context.Response.Body.FlushAsync(ct);
+
+    // Stream events...
+});
+```
+
+### Step 2: CRITICAL — SSE Protocol Format
+
+The SSE format has strict rules. Each field ends with `\n`, and each event ends with `\n\n` (double newline).
+
+```csharp
+// CRITICAL: The SSE format is NOT just "send text"
+// Each event MUST end with TWO newlines (\n\n)
+
+// Simple data event:
+await context.Response.WriteAsync($"data: {message}\n\n", ct);
+await context.Response.Body.FlushAsync(ct);
+
+// COMMON MISTAKE: Forgetting the double newline
+// await context.Response.WriteAsync($"data: {message}\n", ct);  // WRONG - event never completes
+
+// Named event with id (for reconnection):
+await context.Response.WriteAsync($"id: {eventId}\n", ct);
+await context.Response.WriteAsync($"event: userJoined\n", ct);
+await context.Response.WriteAsync($"data: {jsonPayload}\n\n", ct);
+await context.Response.Body.FlushAsync(ct);
+
+// Multi-line data (each line needs "data: " prefix):
+await context.Response.WriteAsync($"data: line 1\n", ct);
+await context.Response.WriteAsync($"data: line 2\n", ct);
+await context.Response.WriteAsync($"data: line 3\n\n", ct);  // Only last line gets double \n
+await context.Response.Body.FlushAsync(ct);
+```
+
+### Step 3: CRITICAL — Flush After Every Event
+
+```csharp
+// CRITICAL: You MUST flush after every event, otherwise the client
+// won't receive anything until the buffer fills up
+
+// Option A: Flush manually after each event
+await context.Response.WriteAsync($"data: {msg}\n\n", ct);
+await context.Response.Body.FlushAsync(ct);  // CRITICAL
+
+// Option B: Use StreamWriter with AutoFlush = true
+await using var writer = new StreamWriter(context.Response.Body, leaveOpen: true);
+writer.AutoFlush = true;  // Flushes after every Write
+await writer.WriteLineAsync($"data: {msg}\n");  // Note: WriteLine adds one \n, we add one more
+
+// COMMON MISTAKE: Forgetting FlushAsync — client sees nothing
+// await context.Response.WriteAsync($"data: hello\n\n", ct);
+// // Missing FlushAsync! Client receives nothing until connection closes.
+```
+
+### Step 4: CRITICAL — Handle Client Disconnection with RequestAborted
+
+```csharp
+app.MapGet("/events/stream", async (HttpContext context) =>
+{
+    context.Response.Headers.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+
+    // CRITICAL: Use RequestAborted to detect client disconnect
+    var ct = context.RequestAborted;
+
+    try
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var data = await GetNextEvent(ct);
+            await context.Response.WriteAsync($"data: {data}\n\n", ct);
+            await context.Response.Body.FlushAsync(ct);
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        // Client disconnected — this is normal, not an error
+        // COMMON MISTAKE: Logging this as an error or letting it propagate
+    }
+});
+```
+
+### Step 5: Support Client Reconnection with Last-Event-ID
+
+```csharp
+app.MapGet("/events", async (HttpContext context) =>
+{
+    context.Response.Headers.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+
+    // CRITICAL: When EventSource reconnects, it sends Last-Event-ID header
+    var lastEventId = context.Request.Headers["Last-Event-ID"].FirstOrDefault();
+
+    // Set retry interval (milliseconds) — how long client waits before reconnecting
+    await context.Response.WriteAsync($"retry: 5000\n\n");
+    await context.Response.Body.FlushAsync();
+
+    var startFrom = lastEventId != null ? int.Parse(lastEventId) + 1 : 0;
+
+    var ct = context.RequestAborted;
+    var eventId = startFrom;
+
+    try
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var data = await GetNextEvent(eventId, ct);
+            // CRITICAL: Send id: field so client can reconnect from this point
+            await context.Response.WriteAsync($"id: {eventId}\ndata: {data}\n\n", ct);
+            await context.Response.Body.FlushAsync(ct);
+            eventId++;
+        }
+    }
+    catch (OperationCanceledException) { }
+});
+```
+
+### Step 6: Complete Implementation with IAsyncEnumerable
+
+```csharp
+app.MapGet("/events/notifications", async (
+    HttpContext context,
+    INotificationService notifications) =>
+{
+    context.Response.Headers.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+    context.Response.Headers["Connection"] = "keep-alive";
+    context.Response.Headers["X-Accel-Buffering"] = "no";
+
+    var ct = context.RequestAborted;
+    var eventId = 0;
+
+    try
+    {
+        await foreach (var notification in notifications.StreamAsync(ct))
+        {
+            var json = JsonSerializer.Serialize(notification);
+            await context.Response.WriteAsync(
+                $"id: {eventId++}\nevent: {notification.Type}\ndata: {json}\n\n", ct);
+            await context.Response.Body.FlushAsync(ct);
+        }
+    }
+    catch (OperationCanceledException) { }
+
+    // CRITICAL: Don't return a value — the response is already written to
+    // COMMON MISTAKE: return Results.Ok() after streaming — this corrupts the response
+});
+```
+
+## Common Mistakes
+
+1. **Using a non-existent MapSSE() or MapServerSentEvents() method**: ASP.NET Core has no built-in SSE helper. You must manually set headers and write the SSE protocol format.
+2. **Forgetting double newline**: Events MUST end with `\n\n`. A single `\n` means the event is not complete and the client won't process it.
+3. **Not flushing**: Without `FlushAsync()` after each event, the response is buffered and the client receives nothing until disconnect.
+4. **Not handling RequestAborted**: The loop runs forever if you don't check `context.RequestAborted`. `OperationCanceledException` on disconnect is normal.
+5. **Returning a result after streaming**: Don't `return Results.Ok()` after writing SSE events — the response body is already being written.
+6. **Missing Content-Type header**: Must be exactly `text/event-stream`, not `application/json` or `text/plain`.
+7. **Missing X-Accel-Buffering: no**: Reverse proxies (nginx) buffer responses by default, breaking SSE.

--- a/plugins/aspnetcore/skills/minimal-api-file-upload/SKILL.md
+++ b/plugins/aspnetcore/skills/minimal-api-file-upload/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: minimal-api-file-upload
+description: >
+  Implement file upload endpoints in ASP.NET Core minimal APIs (.NET 8+). USE FOR: handling IFormFile
+  and IFormFileCollection parameters, configuring dual size limits (Kestrel + FormOptions), disabling
+  anti-forgery on upload endpoints, validating file content via magic bytes, safe filename generation,
+  streaming large files with MultipartReader. DO NOT USE FOR: MVC controller file uploads ([FromForm]
+  works directly with attributes), simple JSON body endpoints, very large files over 1GB (use streaming
+  with MultipartReader instead of IFormFile).
+---
+
+# Implementing File Uploads in ASP.NET Core Minimal APIs
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| File parameter(s) | Yes | IFormFile or IFormFileCollection |
+| Size limits | Yes | Max file/request size |
+| Allowed types | No | Content type or extension restrictions |
+
+## Workflow
+
+### Step 1: IFormFile Binding in Minimal APIs
+
+```csharp
+// In .NET 8+, IFormFile IS bound automatically from multipart form data
+app.MapPost("/upload", (IFormFile file) => Results.Ok(file.FileName));
+
+// BUT when you mix IFormFile with other parameters, annotate with [FromForm]
+app.MapPost("/upload-with-metadata",
+    ([FromForm] IFormFile file, [FromForm] string description) =>
+{
+    return Results.Ok(new { file.FileName, Description = description });
+});
+
+// For multiple files, use IFormFileCollection
+app.MapPost("/upload-multiple", (IFormFileCollection files) =>
+{
+    return Results.Ok(files.Select(f => new { f.FileName, f.Length }));
+});
+```
+
+### Step 2: CRITICAL — File Size Limits Are Separate from Request Size Limits
+
+```csharp
+// CRITICAL: There are TWO different size limits and you need to configure BOTH
+
+// 1. Request body size limit (Kestrel level) — default is 30MB
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB — match your per-endpoint limit
+});
+
+// 2. Form options — multipart body length limit — default is 128MB
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = 10 * 1024 * 1024; // 10 MB
+    options.ValueLengthLimit = 1024 * 1024; // 1 MB for form values
+    options.MultipartHeadersLengthLimit = 16384; // 16 KB for section headers
+});
+
+// COMMON MISTAKE: Only increasing Kestrel MaxRequestBodySize
+// upload still fails because FormOptions.MultipartBodyLengthLimit is exceeded
+
+// COMMON MISTAKE: Only increasing FormOptions
+// upload fails with "Request body too large" from Kestrel before reaching form parsing
+
+// CRITICAL: Per-endpoint override with RequestSizeLimit attribute
+app.MapPost("/upload-large", [RequestSizeLimit(200_000_000)] (IFormFile file) =>
+{
+    return Results.Ok(new { file.FileName, file.Length });
+});
+
+// CRITICAL: To disable the limit entirely (for streaming):
+app.MapPost("/upload-unlimited", [DisableRequestSizeLimit] async (HttpContext context) =>
+{
+    // Handle manually
+});
+```
+
+### Step 3: CRITICAL — Anti-Forgery Auto-Validates Form Uploads in .NET 8
+
+```csharp
+// CRITICAL: In .NET 8 with UseAntiforgery(), ALL form-bound endpoints
+// automatically validate anti-forgery tokens, INCLUDING file uploads
+
+builder.Services.AddAntiforgery();
+var app = builder.Build();
+app.UseAntiforgery();
+
+// This endpoint now REQUIRES an anti-forgery token:
+app.MapPost("/upload", (IFormFile file) => Results.Ok(file.FileName));
+// Without the token → 400 Bad Request
+
+// CRITICAL: For API-only file uploads (no anti-forgery needed), opt out:
+// ⚠️ WARNING: Only disable anti-forgery for endpoints NOT authenticated with cookies.
+// For cookie-authenticated endpoints, disabling anti-forgery opens CSRF attacks.
+// JWT bearer auth and unauthenticated endpoints are safe to disable.
+app.MapPost("/api/upload", (IFormFile file) => Results.Ok(file.FileName))
+    .DisableAntiforgery();  // Safe for JWT/unauthenticated; UNSAFE for cookie auth
+
+// COMMON MISTAKE: Getting 400 errors on file uploads and not realizing
+// it's because UseAntiforgery() is in the pipeline
+```
+
+### Step 4: CRITICAL — Validate File Content, Not Just Extension
+
+```csharp
+app.MapPost("/upload", async (IFormFile file) =>
+{
+    // CRITICAL: Check content type AND file signature (magic bytes)
+    // NEVER trust file extension alone — it can be spoofed
+
+    var allowedTypes = new[] { "image/jpeg", "image/png" };
+    if (!allowedTypes.Contains(file.ContentType))
+        return Results.BadRequest("File type not allowed");
+
+    // CRITICAL: Check magic bytes for file type verification
+    // ContentType alone is client-provided and can be spoofed
+    using var stream = file.OpenReadStream();
+    var header = new byte[8];
+    var bytesRead = await stream.ReadAsync(header, 0, 8);
+    stream.Position = 0;
+
+    if (bytesRead < 4)
+        return Results.BadRequest("File too small to verify");
+
+    // JPEG: FF D8 FF
+    // PNG: 89 50 4E 47
+    var isJpeg = header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF;
+    var isPng = header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47;
+
+    if (!isJpeg && !isPng)
+        return Results.BadRequest("File content doesn't match declared type");
+
+    // CRITICAL: Generate a safe filename — NEVER use user-provided filename directly
+    // Derive extension from validated magic bytes, not from user-controlled file.FileName
+    var extension = isJpeg ? ".jpg" : ".png";
+    var safeFileName = $"{Guid.NewGuid()}{extension}";
+
+    var filePath = Path.Combine("uploads", safeFileName);
+    Directory.CreateDirectory("uploads");
+    using var fileStream = File.Create(filePath);
+    await file.CopyToAsync(fileStream);
+
+    return Results.Ok(new { FileName = safeFileName, file.Length });
+});
+```
+
+### Step 5: Streaming Large Files Without Buffering
+
+```csharp
+// NOTE: IFormFile buffers uploads to a temp file (not purely in-memory),
+// but for very large files, use MultipartReader for true streaming
+// to avoid excessive disk/memory usage during parsing.
+
+app.MapPost("/upload-stream",
+    [DisableRequestSizeLimit]
+    async (HttpContext context) =>
+{
+    // Parse the multipart boundary from Content-Type header
+    var contentType = context.Request.ContentType;
+    if (contentType == null || !contentType.Contains("multipart/"))
+        return Results.BadRequest("Not a multipart request");
+
+    var boundary = HeaderUtilities.RemoveQuotes(
+        MediaTypeHeaderValue.Parse(contentType).Boundary).Value;
+    if (string.IsNullOrEmpty(boundary))
+        return Results.BadRequest("Missing boundary");
+
+    var reader = new MultipartReader(boundary, context.Request.Body);
+
+    while (await reader.ReadNextSectionAsync() is { } section)
+    {
+        // Check if this section has a Content-Disposition with a filename
+        if (!ContentDispositionHeaderValue.TryParse(
+                section.ContentDisposition, out var disposition) ||
+            !disposition.IsFileDisposition())
+            continue;
+
+        var fileName = disposition.FileName.Value;
+        var safeFile = $"{Guid.NewGuid()}{Path.GetExtension(fileName)}";
+
+        // Stream directly to disk — never buffer in memory
+        Directory.CreateDirectory("uploads");
+        using var fileStream = File.Create(Path.Combine("uploads", safeFile));
+        await section.Body.CopyToAsync(fileStream);
+    }
+
+    return Results.Ok("Uploaded");
+}).DisableAntiforgery();
+
+// COMMON MISTAKE: Using file.CopyToAsync for very large files
+// IFormFile buffers everything in memory first — can cause OutOfMemoryException
+```
+
+## Common Mistakes
+
+1. **Only configuring one size limit**: Must configure BOTH Kestrel `MaxRequestBodySize` AND `FormOptions.MultipartBodyLengthLimit`.
+2. **400 errors from anti-forgery**: In .NET 8, `UseAntiforgery()` auto-validates form uploads. Use `.DisableAntiforgery()` for API endpoints.
+3. **Trusting file.FileName**: User-provided filename can contain path traversal. Always generate a safe filename.
+4. **Trusting Content-Type only**: Content type can be spoofed. Check magic bytes for actual file type.
+5. **Using IFormFile for very large files**: IFormFile buffers to a temp file during parsing. Use `MultipartReader` for true streaming.
+6. **Using non-existent helper methods**: `GetMultipartBoundary()` and `GetContentDispositionHeader()` are NOT built-in ASP.NET Core APIs. Parse boundary from `MediaTypeHeaderValue` and use `ContentDispositionHeaderValue.TryParse()` directly.

--- a/tests/aspnetcore/implementing-server-sent-events/eval.yaml
+++ b/tests/aspnetcore/implementing-server-sent-events/eval.yaml
@@ -16,13 +16,72 @@ scenarios:
       Use a simple background service that generates a notification every 2 seconds to simulate a real event source. Use Channel<T> to communicate between the background service and the SSE endpoint.
 
       Create a complete working project with Program.cs and any needed service files.
+    assertions:
+      - type: "output_matches"
+        pattern: "(text/event-stream)"
+      - type: "output_matches"
+        pattern: "(FlushAsync|AutoFlush)"
+      - type: "output_matches"
+        pattern: "(RequestAborted|CancellationToken)"
     rubric:
-      - "Uses manual SSE protocol (Response.WriteAsync with text/event-stream content type), NOT a non-existent MapSSE(), MapServerSentEvents(), or UseServerSentEvents() helper method"
-      - "Sets all required SSE headers: Content-Type text/event-stream, Cache-Control no-cache, and Connection keep-alive"
-      - "Uses correct SSE format with double newline (\\n\\n) to terminate each event, not single newline"
-      - "Calls Response.Body.FlushAsync() after each event write (or uses equivalent auto-flush mechanism) so client receives events immediately"
-      - "Uses HttpContext.RequestAborted or CancellationToken to detect client disconnection and handles OperationCanceledException gracefully"
-      - "Includes id: field in SSE events and reads Last-Event-ID header from request for reconnection support"
+      - "Uses manual SSE protocol (Response.WriteAsync with text/event-stream content type), NOT a non-existent MapSSE() or UseServerSentEvents() helper"
+      - "Sets required SSE headers: Content-Type text/event-stream, Cache-Control no-cache"
+      - "Uses correct SSE format with double newline to terminate each event"
+      - "Calls FlushAsync after each event write so client receives events immediately"
+      - "Uses HttpContext.RequestAborted or CancellationToken to detect client disconnection"
+      - "Includes id: field in SSE events for reconnection support"
       - "Sets retry: field to control client reconnection interval"
-      - "Sets X-Accel-Buffering: no header for reverse proxy compatibility"
-      - "Does NOT return Results.Ok() or any IResult after writing SSE events to the response body"
+    timeout: 120
+
+  - name: "SSE should not be used for bidirectional communication"
+    prompt: |
+      I need to build a real-time chat feature where users send and receive messages. Should I use Server-Sent Events for this?
+    expect_activation: false
+    assertions:
+      - type: "output_matches"
+        pattern: "(WebSocket|SignalR|bidirectional)"
+    rubric:
+      - "Identified that SSE is server-to-client only and does not support bidirectional communication"
+      - "Recommended WebSocket or SignalR for bidirectional real-time messaging"
+      - "Did NOT suggest SSE as the primary solution for this use case"
+    timeout: 60
+
+  - name: "Fix SSE events not arriving in browser until connection closes"
+    prompt: |
+      My ASP.NET Core SSE endpoint works — I can see the events in the response body when I curl it — but in the browser, no events arrive until the connection closes. Then they all appear at once. What's wrong?
+    setup:
+      files:
+        - path: "Program.cs"
+          content: |
+            var builder = WebApplication.CreateBuilder(args);
+            var app = builder.Build();
+
+            app.MapGet("/events", async (HttpContext context) =>
+            {
+                context.Response.ContentType = "text/event-stream";
+                for (int i = 0; i < 10; i++)
+                {
+                    await context.Response.WriteAsync($"data: Event {i}\n\n");
+                    await Task.Delay(1000);
+                }
+            });
+
+            app.Run();
+        - path: "SSEBug.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+    assertions:
+      - type: "output_matches"
+        pattern: "(FlushAsync|Flush)"
+      - type: "output_matches"
+        pattern: "(Cache-Control|no-cache|X-Accel-Buffering)"
+    rubric:
+      - "Identified the root cause: missing FlushAsync() after each WriteAsync — the response is buffered"
+      - "Added Response.Body.FlushAsync() after each event write"
+      - "Added Cache-Control: no-cache header to prevent proxy/browser caching"
+      - "Mentioned X-Accel-Buffering: no for nginx reverse proxy compatibility"
+    timeout: 120

--- a/tests/aspnetcore/implementing-server-sent-events/eval.yaml
+++ b/tests/aspnetcore/implementing-server-sent-events/eval.yaml
@@ -1,0 +1,28 @@
+scenarios:
+  - name: "Implement SSE notification endpoint in ASP.NET Core 8 minimal API"
+    prompt: |
+      I need to implement a Server-Sent Events (SSE) endpoint in an ASP.NET Core 8 minimal API project.
+
+      The endpoint should be at GET /api/events/notifications and should:
+      1. Stream real-time notifications to connected clients
+      2. Support named event types (e.g., "message", "alert", "update")
+      3. Include event IDs so clients can reconnect and resume from where they left off
+      4. Handle client disconnection gracefully
+      5. Set a 5-second retry interval for client reconnection
+      6. Work correctly behind reverse proxies like nginx
+
+      The notification data should be JSON objects with properties: Id, Type, Message, Timestamp.
+
+      Use a simple background service that generates a notification every 2 seconds to simulate a real event source. Use Channel<T> to communicate between the background service and the SSE endpoint.
+
+      Create a complete working project with Program.cs and any needed service files.
+    rubric:
+      - "Uses manual SSE protocol (Response.WriteAsync with text/event-stream content type), NOT a non-existent MapSSE(), MapServerSentEvents(), or UseServerSentEvents() helper method"
+      - "Sets all required SSE headers: Content-Type text/event-stream, Cache-Control no-cache, and Connection keep-alive"
+      - "Uses correct SSE format with double newline (\\n\\n) to terminate each event, not single newline"
+      - "Calls Response.Body.FlushAsync() after each event write (or uses equivalent auto-flush mechanism) so client receives events immediately"
+      - "Uses HttpContext.RequestAborted or CancellationToken to detect client disconnection and handles OperationCanceledException gracefully"
+      - "Includes id: field in SSE events and reads Last-Event-ID header from request for reconnection support"
+      - "Sets retry: field to control client reconnection interval"
+      - "Sets X-Accel-Buffering: no header for reverse proxy compatibility"
+      - "Does NOT return Results.Ok() or any IResult after writing SSE events to the response body"

--- a/tests/aspnetcore/minimal-api-file-upload/eval.yaml
+++ b/tests/aspnetcore/minimal-api-file-upload/eval.yaml
@@ -1,0 +1,80 @@
+scenarios:
+  - name: "Implement file upload endpoint with validation"
+    prompt: >
+      I need to implement a file upload endpoint in my ASP.NET Core 8 minimal API.
+      The endpoint should accept image files (JPEG and PNG only), reject files over 10MB,
+      and save them to an "uploads" folder. My app already has UseAntiforgery() in the pipeline.
+      Show me the complete implementation including size limits configuration and the endpoint.
+    assertions:
+      - type: "output_matches"
+        pattern: "(IFormFile|IFormFileCollection)"
+      - type: "output_matches"
+        pattern: "(MaxRequestBodySize|MultipartBodyLengthLimit|RequestSizeLimit)"
+    rubric:
+      - "Configures BOTH Kestrel MaxRequestBodySize AND FormOptions.MultipartBodyLengthLimit — configuring only one is INCORRECT"
+      - "Uses .DisableAntiforgery() on the file upload endpoint to prevent 400 errors from the anti-forgery middleware"
+      - "Generates a safe filename (e.g., Guid.NewGuid()) instead of using user-provided IFormFile.FileName directly"
+      - "Validates file content via magic bytes/file signatures, not just file extension or ContentType (which are client-spoofable)"
+      - "Correctly uses IFormFile parameter binding in the minimal API endpoint"
+      - "Uses [RequestSizeLimit] or global config for the 10MB limit"
+    expect_tools: ["bash"]
+    timeout: 120
+
+  - name: "Fix 400 error on file upload with UseAntiforgery"
+    prompt: |
+      My ASP.NET Core 8 minimal API file upload endpoint keeps returning 400 Bad Request, but only after I added authentication. The endpoint worked fine before. Here's my code:
+
+      ```csharp
+      builder.Services.AddAntiforgery();
+      var app = builder.Build();
+      app.UseAntiforgery();
+
+      app.MapPost("/api/upload", (IFormFile file) =>
+      {
+          return Results.Ok(new { file.FileName, file.Length });
+      });
+      ```
+
+      What's wrong?
+    assertions:
+      - type: "output_matches"
+        pattern: "(DisableAntiforgery|antiforgery|anti-forgery)"
+    rubric:
+      - "Identified the root cause: UseAntiforgery() auto-validates anti-forgery tokens on all form-bound endpoints including file uploads"
+      - "Recommended .DisableAntiforgery() on the endpoint for API-only (non-cookie-auth) scenarios"
+      - "Warned about CSRF risk if the endpoint uses cookie authentication — do NOT disable antiforgery for cookie-auth endpoints"
+    timeout: 60
+
+  - name: "Dual size limit configuration"
+    prompt: |
+      My ASP.NET Core 8 file upload endpoint rejects files over 30MB even though I configured the limit to 100MB. Here's my config:
+
+      ```csharp
+      builder.WebHost.ConfigureKestrel(options =>
+      {
+          options.Limits.MaxRequestBodySize = 100 * 1024 * 1024;
+      });
+      ```
+
+      Smaller files work fine. What am I missing?
+    assertions:
+      - type: "output_matches"
+        pattern: "(FormOptions|MultipartBodyLengthLimit)"
+    rubric:
+      - "Identified that Kestrel MaxRequestBodySize is only ONE of TWO limits — FormOptions.MultipartBodyLengthLimit also needs to be configured"
+      - "Showed how to configure both limits: builder.WebHost.ConfigureKestrel for request body AND builder.Services.Configure<FormOptions> for multipart"
+      - "Explained that the default MultipartBodyLengthLimit is 128MB but the default MaxRequestBodySize is 30MB, causing the mismatch"
+    timeout: 60
+
+  - name: "File upload should not use magic bytes for JSON API"
+    prompt: |
+      I'm building a REST API in ASP.NET Core that accepts JSON payloads with base64-encoded file data. Should I use IFormFile?
+    expect_activation: false
+    assertions:
+      - type: "output_not_matches"
+        pattern: "(IFormFile.*base64|base64.*IFormFile)"
+    rubric:
+      - "Recommended against IFormFile for base64-encoded JSON payloads — IFormFile is for multipart/form-data"
+      - "Suggested reading the base64 string from the JSON body and decoding with Convert.FromBase64String"
+      - "Mentioned that multipart/form-data (IFormFile) is more efficient for actual file uploads than base64 in JSON (33% overhead)"
+    timeout: 60


### PR DESCRIPTION
## Summary
Adds a skill for implementing Server-Sent Events endpoints in ASP.NET Core 8 minimal APIs.

> **Note:** Replaces #147 (migrated from skills-old repo to new plugins/ structure).

### Eval Results (3-run)
- **Overall: +13.6%** improvement (BL=4.0, SK=4.7)

## Files
- plugins/dotnet/skills/implementing-server-sent-events/SKILL.md
- tests/dotnet/implementing-server-sent-events/eval.yaml