### PR TITLE
Add completion comments and emoji cleanup to fork PR evaluation workflow

### DIFF
--- a/.github/workflows/evaluation-fork-pr.yml
+++ b/.github/workflows/evaluation-fork-pr.yml
@@ -185,7 +185,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      pull-requests: write
     steps:
+      - name: Remove eyes reaction from trigger comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REACTION_ID=$(gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --jq '.[] | select(.content == "eyes" and .user.login == "github-actions[bot]") | .id' | head -1 || echo "")
+          if [[ -n "$REACTION_ID" && "$REACTION_ID" != "null" ]]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions/${REACTION_ID}" \
+              -X DELETE || true
+          fi
+
       - name: Set final commit status
         env:
           GH_TOKEN: ${{ github.token }}
@@ -208,3 +220,45 @@ jobs:
             -f context="evaluation (fork PRs)" \
             -f description="$DESC" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Post completion comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ needs.gate.outputs.pr_number }}
+          EVAL_RESULT="${{ needs.run-evaluation.result }}"
+          MARKER="<!-- skill-validator-results -->"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Post a note when skipped — distinguish "no skills" from upstream failure
+          if [[ "$EVAL_RESULT" == "skipped" ]]; then
+            if [[ "${{ needs.discover.result }}" == "success" && "${{ needs.discover.outputs.has_entries }}" != "true" ]]; then
+              BODY="⏭️ No skills to evaluate — no changed skills with tests were found in this PR. [View workflow run](${RUN_URL})"
+            else
+              BODY="❌ Evaluation did not complete (upstream job failed or was skipped). [View workflow run](${RUN_URL})"
+            fi
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
+            exit 0
+          fi
+
+          # Handle failure — always post, no table check needed
+          if [[ "$EVAL_RESULT" != "success" ]]; then
+            BODY="❌ Evaluation failed. [View workflow run](${RUN_URL})"
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
+            exit 0
+          fi
+
+          # Success path — only post if the evaluation table was updated (not newly created)
+          # to avoid posting a duplicate comment alongside the new table
+          if [[ "${{ needs.run-evaluation.outputs.comment_action }}" != "updated" ]]; then
+            echo "Evaluation table was newly created or not posted; skipping completion comment."
+            exit 0
+          fi
+
+          TABLE_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1 || echo "")
+
+          TABLE_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}#issuecomment-${TABLE_COMMENT_ID}"
+          BODY="✅ Evaluation completed. [View results](${TABLE_URL}) | [View workflow run](${RUN_URL})"
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -71,6 +71,10 @@ on:
         required: false
       COPILOT_GITHUB_TOKEN_8:
         required: false
+    outputs:
+      comment_action:
+        description: 'Whether the PR comment was created, updated, or not posted'
+        value: ${{ jobs.comment-on-pr.outputs.comment_action }}
 
 jobs:
   build-validator:
@@ -214,6 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    outputs:
+      comment_action: ${{ steps.post-comment.outputs.comment_action }}
     steps:
       - name: Download all result artifacts
         uses: actions/download-artifact@v8
@@ -253,6 +259,7 @@ jobs:
           cat consolidated-comment.md >> $GITHUB_STEP_SUMMARY
 
       - name: Post or update PR comment
+        id: post-comment
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -267,7 +274,9 @@ jobs:
           if [ -n "$COMMENT_ID" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
               -X PATCH -F "body=@consolidated-comment.md"
+            echo "comment_action=updated" >> $GITHUB_OUTPUT
           else
             gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
               -X POST -F "body=@consolidated-comment.md"
+            echo "comment_action=created" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Updates the \eport-status\ job in the fork PR evaluation workflow to provide better feedback:

- **Remove eyes reaction** from the \/evaluate\ trigger comment when the workflow finishes
- **Post a status comment** indicating the outcome:
  - ✅ Success (with link to the evaluation summary table)
  - ❌ Failure (with link to the workflow run)
  - ⏭️ Skipped (when no changed skills with tests are found)
- **Avoid duplicate comments**: on success, only posts if the evaluation summary table comment already existed (i.e., was updated in-place rather than newly created)