### PR TITLE
Promote skill spec conformance checks from warnings to errors

### DIFF
--- a/eng/skill-validator/src/Services/SkillProfiler.cs
+++ b/eng/skill-validator/src/Services/SkillProfiler.cs
@@ -86,6 +86,10 @@ public static partial class SkillProfiler
         {
             errors.Add($"Compatibility field is {skill.Compatibility.Length} characters — maximum is {MaxCompatibilityLength}.");
         }
+        else if (skill.Compatibility is not null && string.IsNullOrWhiteSpace(skill.Compatibility))
+        {
+            errors.Add("Compatibility field must be 1-500 non-whitespace characters when provided.");
+        }
 
         // --- agentskills.io spec: body line count ---
         var trimmedBody = body.TrimEnd('\r', '\n');
@@ -194,6 +198,12 @@ public static partial class SkillProfiler
     /// </summary>
     internal static void ValidateName(string name, string directoryName, List<string> errors)
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errors.Add("Skill name is empty — must be 1-64 lowercase alphanumeric characters and hyphens.");
+            return;
+        }
+
         if (name.Length > MaxNameLength)
             errors.Add($"Skill name '{name}' is {name.Length} characters — maximum is {MaxNameLength}.");
 

--- a/eng/skill-validator/tests/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/SkillProfileTests.cs
@@ -300,6 +300,16 @@ public class AnalyzeSkillTests
         Assert.DoesNotContain(profile.Errors, e => e.Contains("Compatibility"));
     }
 
+    [Fact]
+    public void CompatibilityEmptyStringErrors()
+    {
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\n" + new string('x', 4000);
+        var skill = new SkillInfo("test-skill", "desc", "/tmp/test-skill", "/tmp/test-skill/SKILL.md",
+            content, null, null, Compatibility: string.Empty);
+        var profile = SkillProfiler.AnalyzeSkill(skill);
+        Assert.Contains(profile.Errors, e => e.Contains("Compatibility"));
+    }
+
     // --- Body line count tests ---
 
     [Fact]


### PR DESCRIPTION
## Promote skill spec conformance checks from warnings to errors

The [agentskills.io specification](https://agentskills.io/specification) uses "Must" for all of the following constraints, but the validator was treating violations as warnings rather than errors:

| Constraint | Spec language | Link |
|---|---|---|
| Name max 64 chars | "Must be 1-64 characters" | [#name-field](https://agentskills.io/specification#name-field) |
| Name format | "May only contain lowercase alphanumeric and hyphens" | [#name-field](https://agentskills.io/specification#name-field) |
| No leading/trailing hyphens | "Must not start or end with `-`" | [#name-field](https://agentskills.io/specification#name-field) |
| No consecutive hyphens | "Must not contain consecutive hyphens (`--`)" | [#name-field](https://agentskills.io/specification#name-field) |
| Name matches directory | "Must match the parent directory name" | [#name-field](https://agentskills.io/specification#name-field) |
| Description non-empty | "Must be 1-1024 characters" | [#description-field](https://agentskills.io/specification#description-field) |
| Compatibility max 500 | "Must be 1-500 characters if provided" | [#compatibility-field](https://agentskills.io/specification#compatibility-field) |

The warnings-not-errors approach was based on the [client implementation guide](https://agentskills.io/client-implementation/adding-skills-support) which recommends lenient loading for client loaders. But the skill-validator is a publishing gate, not a loader. Spec violations should block.

All 25 existing skills already comply with all constraints. No skill changes needed.
