### PR TITLE
tokenization: use BPE instead of chars\4 approximation

### DIFF
--- a/eng/skill-validator/src/Services/SkillProfiler.cs
+++ b/eng/skill-validator/src/Services/SkillProfiler.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Microsoft.ML.Tokenizers;
 using SkillValidator.Models;
 
 namespace SkillValidator.Services;
@@ -6,6 +7,7 @@ namespace SkillValidator.Services;
 public sealed record SkillProfile(
     string Name,
     int TokenCount,
+    int BpeTokenCount,
     string ComplexityTier, // "compact" | "detailed" | "standard" | "comprehensive"
     int SectionCount,
     int CodeBlockCount,
@@ -25,6 +27,10 @@ public static partial class SkillProfiler
     private const int TokenSweetHigh = 2500;
     private const int TokenWarnHigh = 5000;
     internal const int MaxDescriptionLength = 1024;
+
+    // Lazy-initialized BPE tokenizer (cl100k_base, same BPE family as GPT-4/Claude)
+    private static readonly Lazy<TiktokenTokenizer> s_bpeTokenizer = new(
+        () => TiktokenTokenizer.CreateForModel("gpt-4"));
     internal const int MaxAggregateDescriptionLength = 15_000;
     private const int MaxNameLength = 64;
     private const int MaxCompatibilityLength = 500;
@@ -33,7 +39,8 @@ public static partial class SkillProfiler
     public static SkillProfile AnalyzeSkill(SkillInfo skill)
     {
         var content = skill.SkillMdContent;
-        int tokenCount = (int)Math.Ceiling(content.Length / 4.0);
+        int chars4TokenCount = (int)Math.Ceiling(content.Length / 4.0);
+        int bpeTokenCount = s_bpeTokenizer.Value.CountTokens(content);
 
         bool hasFrontmatter = FrontmatterRegex().IsMatch(content);
 
@@ -48,7 +55,7 @@ public static partial class SkillProfiler
         bool hasWhenToUse = WhenToUseRegex().IsMatch(body);
         bool hasWhenNotToUse = WhenNotToUseRegex().IsMatch(body);
 
-        string complexityTier = tokenCount switch
+        string complexityTier = bpeTokenCount switch
         {
             < 400 => "compact",
             <= 2500 => "detailed",
@@ -134,21 +141,21 @@ public static partial class SkillProfiler
             }
         }
 
-        // --- Token size warnings ---
-        if (tokenCount > TokenWarnHigh)
+        // --- Token size warnings (based on BPE token count) ---
+        if (bpeTokenCount > TokenWarnHigh)
         {
             warnings.Add(
-                $"Skill is {tokenCount:N0} tokens — \"comprehensive\" skills hurt performance by 2.9pp on average. Consider splitting into 2–3 focused skills.");
+                $"Skill is {bpeTokenCount:N0} BPE tokens (chars/4 estimate: {chars4TokenCount:N0}) — \"comprehensive\" skills hurt performance by 2.9pp on average. Consider splitting into 2–3 focused skills.");
         }
-        else if (tokenCount > TokenSweetHigh)
+        else if (bpeTokenCount > TokenSweetHigh)
         {
             warnings.Add(
-                $"Skill is {tokenCount:N0} tokens — approaching \"comprehensive\" range where gains diminish.");
+                $"Skill is {bpeTokenCount:N0} BPE tokens (chars/4 estimate: {chars4TokenCount:N0}) — approaching \"comprehensive\" range where gains diminish.");
         }
-        else if (tokenCount < TokenSweetLow)
+        else if (bpeTokenCount < TokenSweetLow)
         {
             warnings.Add(
-                $"Skill is only {tokenCount} tokens — may be too sparse to provide actionable guidance.");
+                $"Skill is only {bpeTokenCount} BPE tokens (chars/4 estimate: {chars4TokenCount}) — may be too sparse to provide actionable guidance.");
         }
 
         if (sectionCount == 0)
@@ -177,7 +184,8 @@ public static partial class SkillProfiler
 
         return new SkillProfile(
             Name: skill.Name,
-            TokenCount: tokenCount,
+            TokenCount: chars4TokenCount,
+            BpeTokenCount: bpeTokenCount,
             ComplexityTier: complexityTier,
             SectionCount: sectionCount,
             CodeBlockCount: codeBlockCount,
@@ -230,7 +238,7 @@ public static partial class SkillProfiler
         };
 
         return
-            $"📊 {profile.Name}: {profile.TokenCount:N0} tokens ({profile.ComplexityTier} {tierIndicator}), " +
+            $"📊 {profile.Name}: {profile.BpeTokenCount:N0} BPE tokens [chars/4: {profile.TokenCount:N0}] ({profile.ComplexityTier} {tierIndicator}), " +
             $"{profile.SectionCount} sections, {profile.CodeBlockCount} code blocks";
     }
 

--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -18,7 +18,7 @@
     <PublishAot>true</PublishAot>
 
     <!-- dotnet run args for local invocation -->
-    <RunArguments>--results-dir &quot;$([MSBuild]::NormalizePath('$(ArtifactsPath)', 'TestResults', '$(AssemblyName)'))&quot; --parallel-skills 3 --parallel-scenarios 3 --parallel-runs 3</RunArguments>
+    <RunArguments>--results-dir "$([MSBuild]::NormalizePath('$(ArtifactsPath)', 'TestResults', '$(AssemblyName)'))" --parallel-skills 3 --parallel-scenarios 3 --parallel-runs 3</RunArguments>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.3" />
     <!-- external -->
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.30" />

--- a/eng/skill-validator/tests/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/SkillProfileTests.cs
@@ -70,8 +70,9 @@ public class AnalyzeSkillTests
     [Fact]
     public void ClassifiesComprehensiveSkillsAndWarns()
     {
-        // >5000 tokens = >20000 chars
-        var content = "---\nname: foo\n---\n# Big\n" + new string('x', 25000);
+        // >5000 BPE tokens — use varied text since BPE compresses repeated chars efficiently
+        var content = "---\nname: foo\n---\n# Big\n" + string.Concat(
+            Enumerable.Range(0, 5000).Select(i => $"word{i} "));
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
         Assert.Equal("comprehensive", profile.ComplexityTier);
         Assert.Contains(profile.Warnings, w => w.Contains("comprehensive"));


### PR DESCRIPTION
Today evaluator estimates the token size of the prompt by `chars/4`. I am proposing to use [BPE](https://en.wikipedia.org/wiki/Byte-pair_encoding) instead.

`chars/4` is a rough average that assumes every 4 characters ≈ 1 token. This is only accurate for plain English prose. It systematically misjudges:
- Code-heavy skills: identifiers like MSBuildProjectFullPath are 1-2 tokens but 24 characters. chars/4 says 6 tokens — a 3-4x overcount.
- Markdown structure: headers, bullets, fenced code blocks (\``csharp`) waste characters on syntax that BPE compresses efficiently.
- Repeated patterns: BPE exploits common subword patterns (e.g. dotnet, build, --configuration) that the chars/4 heuristic cannot.
- Whitespace-heavy formatting: indentation in code blocks inflates char count but BPE merges whitespace runs into single tokens.

[cl100k_base](https://github.com/openai/tiktoken) is the right reference: it's the BPE vocabulary used by GPT-4 and closely matches the tokenization of Claude models (and others). Since skills are injected into these models' context windows, counting with the actual tokenizer gives the true cost.

PR still gives the output in `chars\4`, but uses BPE for evaluation.

### BPE vs chars/4 token estimation — all 25 skills

| Skill | Chars | Chars/4 | BPE | Diff% |
|-------|------:|--------:|----:|------:|
| optimizing-ef-core-queries | 5,744 | 1,436 | 1,335 | +7.6% |
| analyzing-dotnet-performance | 11,310 | 2,828 | 2,561 | +10.4% |
| android-tombstone-symbolication | 8,189 | 2,048 | 2,109 | -2.9% |
| clr-activation-debugging | 20,140 | 5,035 | 4,976 | +1.2% |
| dotnet-trace-collect | 22,621 | 5,656 | 5,119 | +10.5% |
| dump-collect | 4,267 | 1,067 | 1,069 | -0.2% |
| microbenchmarking | 13,155 | 3,289 | 2,674 | +23.0% |
| binlog-failure-analysis | 3,761 | 941 | 972 | -3.2% |
| binlog-generation | 2,853 | 714 | 716 | -0.3% |
| build-parallelism | 3,638 | 910 | 820 | +11.0% |
| build-perf-baseline | 12,357 | 3,090 | 2,842 | +8.7% |
| build-perf-diagnostics | 6,595 | 1,649 | 1,560 | +5.7% |
| check-bin-obj-clash | 16,259 | 4,065 | 3,600 | +12.9% |
| directory-build-organization | 9,418 | 2,355 | 2,102 | +12.0% |
| eval-performance | 4,336 | 1,084 | 949 | +14.2% |
| including-generated-files | 6,843 | 1,711 | 1,447 | +18.2% |
| incremental-build | 13,442 | 3,361 | 2,958 | +13.6% |
| msbuild-antipatterns | 14,241 | 3,561 | 3,456 | +3.0% |
| msbuild-modernization | 16,712 | 4,178 | 4,148 | +0.7% |
| dotnet-aot-compat | 16,752 | 4,188 | 3,901 | +7.4% |
| migrate-nullable-references | 35,735 | 8,934 | 7,835 | +14.0% |
| thread-abort-migration | 12,792 | 3,198 | 2,772 | +15.4% |
| csharp-scripts | 5,183 | 1,296 | 1,239 | +4.6% |
| dotnet-pinvoke | 18,866 | 4,717 | 4,521 | +4.3% |
| nuget-trusted-publishing | 9,254 | 2,314 | 2,215 | +4.5% |

> **Diff%** = how much chars/4 overestimates (+) or underestimates (−) relative to BPE.
> chars/4 overestimates for 22/25 skills (up to +23%). Mean overestimate ≈ +8.5%.