### PR TITLE
Fix infra change detection to use merge-base instead of base tip

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -52,7 +52,8 @@ jobs:
             # PR: detect individual changed skills
             $base = "${{ github.event.pull_request.base.sha }}"
             $head = "${{ github.event.pull_request.head.sha }}"
-            $changedFiles = git diff --name-only --diff-filter=ACMR $base $head
+            $mergeBase = git merge-base $base $head
+            $changedFiles = git diff --name-only --diff-filter=ACMR $mergeBase $head
 
             # Check if any changed files are in infrastructure paths (evaluation workflows or eng/skill-validator/)
             $hasInfraChanges = $changedFiles |


### PR DESCRIPTION
The evaluation workflow was using a two-point diff (`base_sha..head_sha`) to detect changed files in PRs. This includes files changed on `main` that the PR branch hasn't merged yet, causing false **Infrastructure changes detected** triggers.

For example, [this run on PR #75](https://github.com/dotnet/skills/actions/runs/22839946355/job/66243990714) triggered infra detection because `evaluation-run.yml` was modified on `main` (by PR #284) after the PR branch diverged — even though the PR itself never touched any evaluation workflow files.

**Fix:** compute the merge-base between the base branch tip and the PR head, then diff against that. This ensures only changes actually introduced by the PR are considered.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>