### PR TITLE
Move completion comment into shared evaluation-run workflow

### DIFF
--- a/.github/workflows/evaluation-fork-pr.yml
+++ b/.github/workflows/evaluation-fork-pr.yml
@@ -221,44 +221,18 @@ jobs:
             -f description="$DESC" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      - name: Post completion comment
+      - name: Post completion comment for skipped evaluation
+        if: needs.run-evaluation.result == 'skipped'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ needs.gate.outputs.pr_number }}
-          EVAL_RESULT="${{ needs.run-evaluation.result }}"
-          MARKER="<!-- skill-validator-results -->"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # Post a note when skipped — distinguish "no skills" from upstream failure
-          if [[ "$EVAL_RESULT" == "skipped" ]]; then
-            if [[ "${{ needs.discover.result }}" == "success" && "${{ needs.discover.outputs.has_entries }}" != "true" ]]; then
-              BODY="⏭️ No skills to evaluate — no changed skills with tests were found in this PR. [View workflow run](${RUN_URL})"
-            else
-              BODY="❌ Evaluation did not complete (upstream job failed or was skipped). [View workflow run](${RUN_URL})"
-            fi
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
-            exit 0
+          if [[ "${{ needs.discover.result }}" == "success" && "${{ needs.discover.outputs.has_entries }}" != "true" ]]; then
+            BODY="⏭️ No skills to evaluate — no changed skills with tests were found in this PR. [View workflow run](${RUN_URL})"
+          else
+            BODY="❌ Evaluation did not complete (upstream job failed or was skipped). [View workflow run](${RUN_URL})"
           fi
-
-          # Handle failure — always post, no table check needed
-          if [[ "$EVAL_RESULT" != "success" ]]; then
-            BODY="❌ Evaluation failed. [View workflow run](${RUN_URL})"
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
-            exit 0
-          fi
-
-          # Success path — only post if the evaluation table was updated (not newly created)
-          # to avoid posting a duplicate comment alongside the new table
-          if [[ "${{ needs.run-evaluation.outputs.comment_action }}" != "updated" ]]; then
-            echo "Evaluation table was newly created or not posted; skipping completion comment."
-            exit 0
-          fi
-
-          TABLE_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1 || echo "")
-
-          TABLE_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}#issuecomment-${TABLE_COMMENT_ID}"
-          BODY="✅ Evaluation completed. [View results](${TABLE_URL}) | [View workflow run](${RUN_URL})"
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -76,6 +76,9 @@ on:
         description: 'Whether the PR comment was created, updated, or not posted'
         value: ${{ jobs.comment-on-pr.outputs.comment_action }}
 
+env:
+  PR_COMMENT_MARKER: '<!-- skill-validator-results -->'
+
 jobs:
   build-validator:
     runs-on: ubuntu-latest
@@ -252,11 +255,10 @@ jobs:
             --output summary-body.md \
             $JSON_FILES
 
-          MARKER="<!-- skill-validator-results -->"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           {
-            echo "$MARKER"
+            echo "$PR_COMMENT_MARKER"
             cat summary-body.md
             echo ""
             echo "[Full results]($RUN_URL)"
@@ -271,11 +273,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ inputs.pr-number }}
-          MARKER="<!-- skill-validator-results -->"
 
           # Find existing comment with our marker
           COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1)
+            --paginate --jq ".[] | select(.body | startswith(\"$PR_COMMENT_MARKER\")) | .id" | head -1)
 
           if [ -n "$COMMENT_ID" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
@@ -286,3 +287,46 @@ jobs:
               -X POST -F "body=@consolidated-comment.md"
             echo "comment_action=created" >> $GITHUB_OUTPUT
           fi
+
+  post-completion-comment:
+    needs: [evaluate, comment-on-pr]
+    if: always() && needs.evaluate.result != 'cancelled' && inputs.pr-number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post completion comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ inputs.pr-number }}
+          EVAL_RESULT="${{ needs.evaluate.result }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Handle skipped (build-validator failed) or failure
+          if [[ "$EVAL_RESULT" == "skipped" ]]; then
+            BODY="❌ Evaluation did not complete (upstream job failed or was skipped). [View workflow run](${RUN_URL})"
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
+            exit 0
+          fi
+
+          if [[ "$EVAL_RESULT" != "success" ]]; then
+            BODY="❌ Evaluation failed. [View workflow run](${RUN_URL})"
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
+            exit 0
+          fi
+
+          # Success path — only post if the evaluation table was updated (not newly created)
+          # to avoid posting a duplicate comment alongside the new table
+          if [[ "${{ needs.comment-on-pr.outputs.comment_action }}" != "updated" ]]; then
+            echo "Evaluation table was newly created or not posted; skipping completion comment."
+            exit 0
+          fi
+
+          TABLE_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$PR_COMMENT_MARKER\")) | .id" | head -1 || echo "")
+
+          TABLE_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}#issuecomment-${TABLE_COMMENT_ID}"
+          BODY="✅ Evaluation completed. [View results](${TABLE_URL}) | [View workflow run](${RUN_URL})"
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"


### PR DESCRIPTION
Move the **Post completion comment** step from `evaluation-fork-pr.yml` into `evaluation-run.yml` as a dedicated `post-completion-comment` job, so both `evaluation.yml` and `evaluation-fork-pr.yml` share the same success/failure/skipped notification logic.

### Changes

- **evaluation-run.yml**: Add `post-completion-comment` job (runs after `comment-on-pr`). Extract `PR_COMMENT_MARKER` env var to eliminate the duplicated `<!-- skill-validator-results -->` string.
- **evaluation-fork-pr.yml**: Replace the full completion comment step with a slim one that only handles the skipped case (no entries / discover failed), since `evaluation-run.yml` isn't invoked in that scenario.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>