### PR TITLE
Fix reference scanner silently passing when git diff fails

### DIFF
--- a/.github/workflows/reference-validation.yml
+++ b/.github/workflows/reference-validation.yml
@@ -42,9 +42,18 @@ jobs:
           }
 
           # On PRs, scan only changed files to avoid failing on pre-existing issues
-          git fetch origin $env:GITHUB_BASE_REF --depth=1
-          $changedFiles = @(git diff --name-only "origin/$env:GITHUB_BASE_REF"...HEAD |
-            Where-Object { $_ -match '\.(md|html)$' })
+          git fetch origin $env:GITHUB_BASE_REF
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to fetch base branch '$env:GITHUB_BASE_REF'"
+            exit 1
+          }
+
+          $diffOutput = @(git diff --name-only "origin/$env:GITHUB_BASE_REF"...HEAD)
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::git diff failed -- cannot determine changed files"
+            exit 1
+          }
+          $changedFiles = @($diffOutput | Where-Object { $_ -match '\.(md|html)$' })
 
           if ($changedFiles.Count -eq 0) {
             Write-Host "No changed .md or .html files in this PR. Nothing to scan."


### PR DESCRIPTION
Fix reference scanner silently passing when git diff fails

The PR-mode code path in the reference validation workflow (#336) had two bugs:

1. **`--depth=1` on `git fetch`** prevented the three-dot diff (`origin/main...HEAD`) from finding a merge-base, causing `git diff` to fail
2. **No `$LASTEXITCODE` check** after `git diff` -- the failure output was piped through `Where-Object`, filtered out, and the scanner reported "No changed files" and exited successfully without scanning anything

This was observed on PR #331 where the scanner [passed without scanning](https://github.com/dotnet/skills/actions/runs/23013415854/job/66830052704?pr=331).

### Fix
- Remove `--depth=1` from `git fetch` (checkout already uses `fetch-depth: 0`)
- Add `$LASTEXITCODE` checks after both `git fetch` and `git diff`
- Separate `git diff` from the `Where-Object` filter so exit code is captured
