### PR TITLE
Fix PowerShell parsing of three-dot diff range in reference scanner

### DIFF
--- a/.github/workflows/reference-validation.yml
+++ b/.github/workflows/reference-validation.yml
@@ -48,7 +48,8 @@ jobs:
             exit 1
           }
 
-          $diffOutput = @(git diff --name-only "origin/$env:GITHUB_BASE_REF"...HEAD)
+          $range = "origin/$env:GITHUB_BASE_REF...HEAD"
+          $diffOutput = @(git diff --name-only $range)
           if ($LASTEXITCODE -ne 0) {
             Write-Host "::error::git diff failed -- cannot determine changed files"
             exit 1


### PR DESCRIPTION
## Fix PowerShell parsing of three-dot diff range in reference scanner

The `Scan external references` check has been failing on PRs (e.g., #341) since #348 surfaced a pre-existing bug.

### Root cause

PowerShell splits:
```powershell
git diff --name-only "origin/$env:GITHUB_BASE_REF"...HEAD
```
into **three** arguments: `--name-only`, `origin/main`, `...HEAD` — because the closing quote terminates the token and `...HEAD` becomes a separate bare word. Git can't parse this and prints its usage message.

### Fix

Build the range as a single string variable so it passes to git as one token:
```powershell
$range = "origin/$env:GITHUB_BASE_REF...HEAD"
git diff --name-only $range
```

### Verification

Confirmed locally that:
- The original syntax produces 3 args (bug)
- The variable approach produces 2 args (correct)
- Full workflow pattern works end-to-end including `@()` capture and `.md`/`.html` filter
- No other workflows in the repo use the `...` three-dot syntax (all others use two-ref style)

The second commit temporarily touches a plugin `.md` file to trigger the `reference-validation` paths filter on this PR. **Remove before merge.**
