### PR TITLE
Reduce scheduled evaluation from every 3h to daily, skip if no changes

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 8 * * *'  # Once daily at 08:00 UTC (reduced from every 3h)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
@@ -34,13 +34,41 @@ jobs:
       plugins: ${{ steps.find.outputs.plugins }}
       has_plugins: ${{ steps.find.outputs.has_plugins }}
     steps:
+      - name: Check for new commits since last evaluation
+        if: github.event_name == 'schedule'
+        id: check-changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find the HEAD SHA of the last successful scheduled evaluation run.
+          LAST_SHA=$(gh api "repos/${{ github.repository }}/actions/workflows/evaluation.yml/runs?event=schedule&status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // empty')
+
+          if [ -z "$LAST_SHA" ]; then
+            echo "No previous successful scheduled run found — proceeding"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_SHA="${{ github.sha }}"
+          if [ "$LAST_SHA" = "$CURRENT_SHA" ]; then
+            echo "No new commits since last successful evaluation ($LAST_SHA) — skipping"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            COUNT=$(gh api "repos/${{ github.repository }}/compare/${LAST_SHA}...${CURRENT_SHA}" --jq '.total_commits')
+            echo "$COUNT new commit(s) since last successful evaluation ($LAST_SHA)"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: github.event_name != 'schedule' || steps.check-changes.outputs.has_changes == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Find skills to evaluate
+        if: github.event_name != 'schedule' || steps.check-changes.outputs.has_changes == 'true'
         id: find
         run: |
           $entries = @()


### PR DESCRIPTION
## Reduce scheduled evaluation frequency to save tokens

### Problem

Scheduled evaluation runs are the dominant cost driver, consuming ~67% of all
AI token usage. A

Additionally, many scheduled runs on days with no commits re-evaluate
identical code, producing no new signal while consuming the same tokens.


### Changes

1. **Cron reduced from every 3h to once daily** (08:00 UTC). This saves ~87%
   of scheduled evaluation cost while still providing daily benchmark data.

2. **Skip-if-no-changes guard**: Before checkout/discovery, scheduled runs
   query the GitHub API for the last successful scheduled evaluation's HEAD SHA.
   If it matches the current SHA, the run exits early with no token consumption.
   This handles weekends and quiet days gracefully.


PR evaluation behavior is completely unchanged.
