### PR TITLE
Reduce scheduled evaluation from every 3h to daily, skip if no changes

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -43,6 +43,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Bypass the skip guard on manual reruns so "Re-run jobs" always executes.
+          if [ "${GITHUB_RUN_ATTEMPT}" != "1" ]; then
+            echo "Manual rerun (attempt ${GITHUB_RUN_ATTEMPT}) — bypassing skip guard"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Determine whether a new evaluation is needed by inspecting the most
           # recent completed scheduled run.  We key off the *latest* completed
           # run (not just the latest successful one) so that a transient failure


### PR DESCRIPTION
(This keeps 5 iterations to get "stable" data. If we only wanted to check infrastructure health we would do 1 iteration. I'm assuming we're looking at  https://dotnet.github.io/skills, where all this goes, and it's important to have stable measurements there.)

## Reduce scheduled evaluation frequency to save tokens

### Problem

Scheduled evaluation runs are the dominant consumer of AI tokens. At 8 runs/day
(every 3 hours), each evaluating all plugins and scenarios with 5 iterations,
the schedule generates a very large number of Copilot sessions per day.

Additionally, on quiet days with no commits, every scheduled run re-evaluates
identical code, producing no new signal while consuming the same tokens.

### Changes

1. **Cron reduced from every 3h to once daily** (08:00 UTC). This saves ~87%
   of scheduled evaluation token consumption while still providing daily
   benchmark data on active days.

2. **Skip-if-no-changes guard**: Before checkout/discovery, scheduled runs
   query the GitHub API for the most recent completed scheduled evaluation run.
   The guard only skips when that run was **successful** and at the **same SHA**
   as the current run. If the last run failed or was cancelled, the evaluation
   proceeds (retry). This means on days with no new commits and a prior
   successful run, the evaluation is skipped entirely (no new signal to capture).

   Hardening:
   - `actions: read` scoped to the `discover` job only (least-privilege)
   - All API calls are non-fatal — failures fall back to running the evaluation
   - Compare API call is best-effort (logging only)
   - Manual reruns (run_attempt > 1) bypass the guard

### Impact

- Scheduled runs reduced from ~8/day to ~1/day (87% reduction)
- On days with no commits and a prior successful run, zero tokens consumed
- Transient failures are automatically retried on the next daily run
- PR evaluation behavior is completely unchanged
