### PR TITLE
Increase timeout for evaluation run to 150 minutes

### DIFF
--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 90
+    timeout-minutes: 150
     name: evaluate (${{ matrix.entry.name }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Motivation

Regular timeouts of dotnet-update eval scenarios
Investigation details: https://github.com/dotnet/skills/issues/288#issuecomment-4062179012