### PR TITLE
Improve the build-perf-diag scenario test

### DIFF
--- a/tests/dotnet-msbuild/build-perf-diagnostics/Contoso.WebApi.csproj
+++ b/tests/dotnet-msbuild/build-perf-diagnostics/Contoso.WebApi.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <RootNamespace>Contoso.WebApi</RootNamespace>
   </PropertyGroup>
 
-  <!-- Additional project-specific analyzers (on top of 2 global analyzers from Directory.Build.props) -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.7.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.16.0.82469" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.127" />

--- a/tests/dotnet-msbuild/build-perf-diagnostics/DataService.cs
+++ b/tests/dotnet-msbuild/build-perf-diagnostics/DataService.cs
@@ -1,10 +1,16 @@
-namespace AnalyzerHeavy;
+using Microsoft.Extensions.Logging;
 
-/// <summary>
-/// A class with enough code to make analyzers do meaningful work.
-/// </summary>
-public class HeavyClass
+namespace Contoso.WebApi;
+
+public class DataService
 {
+    private readonly ILogger<DataService> _logger;
+
+    public DataService(ILogger<DataService> logger)
+    {
+        _logger = logger;
+    }
+
     private readonly Dictionary<string, List<int>> _data = new();
 
     public void AddValues(string key, params int[] values)
@@ -28,6 +34,7 @@ public class HeavyClass
 
     public string GenerateReport()
     {
+        _logger.LogInformation("Generating report for {Count} keys", _data.Count);
         var sb = new System.Text.StringBuilder();
         foreach (var (key, values) in _data)
         {

--- a/tests/dotnet-msbuild/build-perf-diagnostics/Directory.Build.props
+++ b/tests/dotnet-msbuild/build-perf-diagnostics/Directory.Build.props
@@ -3,15 +3,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
-  <!-- Enforce code style analysis for every project in the repo -->
-  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>
 
-  <!-- Global analyzers — applied to ALL projects, including tests -->
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/tests/dotnet-msbuild/build-perf-diagnostics/eval.yaml
+++ b/tests/dotnet-msbuild/build-perf-diagnostics/eval.yaml
@@ -1,17 +1,17 @@
 scenarios:
-  - name: "Analyze analyzer performance impact on builds"
-    prompt: "Build this project and analyze its build performance. Review the full build infrastructure including Directory.Build.props. Identify bottlenecks and suggest specific MSBuild property configurations to improve dev inner loop build times while preserving CI quality enforcement."
+  - name: "Diagnose slow build for a small project"
+    prompt: >-
+      This .NET project's build time is unacceptable for its size.
+      Systematically diagnose where build time is being spent and recommend
+      targeted fixes.
     setup:
       copy_test_files: true
     assertions:
-      - type: "output_contains"
-        value: "RunAnalyzers"
       - type: "output_matches"
-        pattern: "(analyzer|Analyzer)"
+        pattern: "(RunAnalyzers|analyzer|Analyzer)"
     rubric:
-      - "Identified all analyzer packages including those from GlobalPackageReference in Directory.Build.props"
-      - "Explained that analyzers significantly increase Csc compilation time"
-      - "Suggested using RunAnalyzers property to conditionally disable analyzers during dev inner loop"
-      - "Identified EnforceCodeStyleInBuild should be conditional on CI, not always true"
-      - "Solution preserves full analyzer enforcement in CI pipelines while speeding dev builds"
-    timeout: 160
+      - "Identified that Roslyn analyzers are consuming a disproportionate share of build time"
+      - "Found analyzer packages in both Directory.Build.props (GlobalPackageReference) and the project file"
+      - "Recommended using RunAnalyzers property to conditionally disable analyzers in the dev inner loop"
+      - "Proposed making EnforceCodeStyleInBuild conditional on CI environment while preserving enforcement in CI pipelines"
+    timeout: 360


### PR DESCRIPTION
### Context

build-perf-diag  consistently scoring low with skill.
The health analyzer analyzsis: https://github.com/dotnet/skills/issues/288#issuecomment-4079556422

tl;dr; The test was too obvious to be solvable without skill