### PR TITLE
Move token usage data into separate branch

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -805,8 +805,7 @@ jobs:
               $params.PRNumber = ${{ needs.gate.outputs.pr_number }}
               $params.PRTitle = $env:PR_TITLE
             }
-            # Script also writes <plugin>.json to OutputDir — we ignore it,
-            # only token-usage.json is pushed to the branch.
+            $params.SkipBenchmarkData = $true
             & ./eng/dashboard/generate-benchmark-data.ps1 @params
           }
         shell: pwsh
@@ -828,6 +827,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Remove any stale files so this branch stays token-only
+          git rm -rf data/ --ignore-unmatch --quiet 2>/dev/null || true
           mkdir -p data
           # Ensure token-usage.json exists; create an empty fallback if missing
           if [ ! -f /tmp/token-data/data/token-usage.json ]; then
@@ -956,6 +957,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Remove stale files so this branch only contains current eval data
+          git rm -rf data/ --ignore-unmatch --quiet 2>/dev/null || true
           mkdir -p data
           # Copy only eval data files (not token-usage.json)
           cp /tmp/eval-data/data/components.json data/

--- a/eng/dashboard/generate-benchmark-data.ps1
+++ b/eng/dashboard/generate-benchmark-data.ps1
@@ -34,6 +34,10 @@
 .PARAMETER DataDir
     Directory containing plugin JSON files to purge. Required with -PurgeStaleFiles.
 
+.PARAMETER SkipBenchmarkData
+    When set, skips generation of benchmark <PluginName>.json entries. Use this when
+    only token-usage data is needed, such as in the publish-token-data job.
+
 .PARAMETER SkipTokenUsage
     When set, skips generation of token-usage.json entries. Use this when only
     benchmark data (<PluginName>.json) is needed, such as in the publish-eval-data job.
@@ -68,6 +72,9 @@ param(
 
     [Parameter(ParameterSetName = 'Generate')]
     [string]$PRTitle,
+
+    [Parameter(ParameterSetName = 'Generate')]
+    [switch]$SkipBenchmarkData,
 
     [Parameter(ParameterSetName = 'Generate')]
     [switch]$SkipTokenUsage,
@@ -376,7 +383,8 @@ $efficiencyKey = "Efficiency"
 
 # PR evaluations only collect token-usage data — skip benchmark history so PR
 # runs don't contaminate the nightly benchmark results in <PluginName>.json.
-if ($Source -ne 'pr') {
+# -SkipBenchmarkData also skips this section (used by publish-token-data).
+if ($Source -ne 'pr' -and -not $SkipBenchmarkData) {
     # Load existing data or create new structure
     $benchmarkData = @{
         lastUpdate = $now
@@ -440,7 +448,7 @@ if ($Source -ne 'pr') {
 } else {
     # Ensure OutputDir exists even in PR mode (needed for token-usage.json)
     New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
-    Write-Host "[OK] PR mode — skipping benchmark $PluginName.json generation, collecting token usage only"
+    Write-Host "[OK] Skipping benchmark $PluginName.json generation, collecting token usage only"
 }
 
 # --- Generate token-usage entries ---


### PR DESCRIPTION
### Motivation

- Keep collecting token usage for PRs
- Prevent PRs from publishing to the dashboard

### Important!

Do not merge - a one time migration script needs to be run (to move the existing token usage data) before this is merged