### PR TITLE
[TEST] Clarify workload and timing for ResolveProjectReferences

### DIFF
--- a/plugins/dotnet-msbuild/skills/resolve-project-references/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/resolve-project-references/SKILL.md
@@ -13,7 +13,7 @@ When reviewing the **Target Performance Summary** from a diagnostic build log, `
 
 The reported time for `ResolveProjectReferences` includes **waiting for dependent projects to build** while the MSBuild node is yielded (see dotnet/msbuild#3135). During this wait, the node may be doing useful work on other projects.
 
-The target itself does very little work — it just triggers the build of referenced projects and waits for them to complete. The "time" attributed to it is wall-clock wait time, not CPU work.
+The target itself does little work — it just triggers the build of referenced projects and waits for them to complete. The "time" attributed to it is wall-clock wait time, not CPU work.
 
 ### Correct Diagnosis
 


### PR DESCRIPTION
Clarify the workload of the ResolveProjectReferences target and emphasize the distinction between wall-clock wait time and CPU work.