### PR TITLE
Add stale PRs agentic workflow

### DIFF
--- a/.github/workflows/close-stale-prs.agent.lock.yml
+++ b/.github/workflows/close-stale-prs.agent.lock.yml
@@ -23,7 +23,7 @@
 #
 # Automatically warn about and close pull requests that have been open for more than 30 days with no recent activity.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"26c29da8563f50fa88b69cd7b52eab22106b8f2241b02078f3ca1ba7683caefe","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f67eaac1209744cbaaff884133820e2cf3c3c1eb835cd689372dff342e22f316","compiler_version":"v0.59.0","strict":true}
 
 name: "Close Stale Pull Requests"
 "on":
@@ -41,6 +41,7 @@ run-name: "Close Stale Pull Requests"
 
 jobs:
   activation:
+    if: ${{ !(github.event_name == 'schedule' && github.event.repository.fork) }}
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/close-stale-prs.agent.md
+++ b/.github/workflows/close-stale-prs.agent.md
@@ -4,6 +4,12 @@ description: "Automatically warn about and close pull requests that have been op
 on:
   schedule: weekly on monday
   workflow_dispatch: # Allow manual triggering
+
+# Don't run scheduled triggers on forked repositories — forks lack the
+# secrets and context required, and scheduled runs would consume the
+# fork owner's minutes.
+if: ${{ !(github.event_name == 'schedule' && github.event.repository.fork) }}
+
 safe-outputs:
   close-pull-request:
     max: 25


### PR DESCRIPTION
## Summary

Adds a GitHub Agentic Workflow that automatically manages stale pull requests by warning authors and eventually closing inactive PRs.

## Policy

- **Warning** after **30 days** of inactivity (no non-bot comments/reviews) — posts a comment giving the author 7 days to respond.
- **Auto-close** after **37 days** of inactivity (30 + 7 day grace period).
- PRs labeled `no-stale` are exempt.
- PRs authored by `dotnet-maestro[bot]` / `dotnet-maestro` are skipped (managed separately).
- Bot activity is excluded when computing last activity date to prevent the bot's own comments from resetting the timer.

## Schedule

Runs weekly on Monday via `schedule` trigger, with `workflow_dispatch` for manual runs. Includes a fork-guard to skip scheduled runs on forked repositories.

## Safe outputs

| Tool | Max | Purpose |
|------|-----|---------|
| `close_pull_request` | 25 | Close stale PRs |
| `add_comment` | 30 | Post stale warnings |

## Files

- `.github/workflows/close-stale-prs.agent.md` — Agent prompt defining the stale PR policy and instructions.
- `.github/workflows/close-stale-prs.agent.lock.yml` — Compiled workflow (auto-generated by `gh aw compile`).