### PR TITLE
Include actionable guidance in scenario timeout warnings

### DIFF
--- a/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
@@ -571,7 +571,8 @@ public static class EvaluateCommand
             r.SkilledIsolated.Metrics.TimedOut ||
             r.SkilledPlugin.Metrics.TimedOut);
 
-        // Propagate expect_activation from scenario config
+        // Propagate timeout and expect_activation from scenario config
+        comparison.TimeoutSeconds = scenario.Timeout;
         comparison.ExpectActivation = scenario.ExpectActivation;
 
         return comparison;

--- a/eng/skill-validator/src/Evaluate/Models.cs
+++ b/eng/skill-validator/src/Evaluate/Models.cs
@@ -242,6 +242,8 @@ public sealed class ScenarioComparison
     public SubagentActivationInfo? SubagentActivationIsolated { get; set; }
     public SubagentActivationInfo? SubagentActivationPlugin { get; set; }
     public bool TimedOut { get; set; }
+    /// <summary>The scenario timeout in seconds (from eval.yaml or the 120s default).</summary>
+    public int TimeoutSeconds { get; set; } = 120;
     /// <summary>When false, non-activation is expected (negative test) and should not flag the verdict.</summary>
     public bool ExpectActivation { get; set; } = true;
 

--- a/eng/skill-validator/src/Evaluate/Reporter.cs
+++ b/eng/skill-validator/src/Evaluate/Reporter.cs
@@ -168,7 +168,7 @@ public static class Reporter
         if (anyTimeout)
         {
             Console.WriteLine();
-            Console.WriteLine("{Ansi.Yellow}⏰ timeout — run hit the scenario timeout limit; scoring may be impacted by aborting model execution before it could produce its full output{Ansi.Reset}");
+            Console.WriteLine("{Ansi.Yellow}⏰ timeout — run hit the scenario timeout limit; scoring may be impacted by aborting model execution before it could produce its full output (increase via 'timeout' in eval.yaml; default: 120s){Ansi.Reset}");
         }
 
         Console.WriteLine();
@@ -229,7 +229,7 @@ public static class Reporter
             if (b.TimedOut) parts.Add("baseline");
             if (s.TimedOut) parts.Add("isolated");
             if (p?.TimedOut == true) parts.Add("plugin");
-            Console.WriteLine($"      {Ansi.BoldRed}⏰ TIMEOUT{Ansi.Reset} — {string.Join(" and ", parts)} run(s) hit the scenario timeout limit");
+            Console.WriteLine($"      {Ansi.BoldRed}⏰ TIMEOUT{Ansi.Reset} — {string.Join(" and ", parts)} run(s) hit the {scenario.TimeoutSeconds}s scenario timeout limit (increase via 'timeout' in eval.yaml)");
         }
 
         foreach (var (label, baseline, isolated, plugin) in metricRows)
@@ -570,7 +570,7 @@ public static class Reporter
         bool anyTimeout = verdicts.Any(v => v.Scenarios.Any(s =>
             (s.Baseline?.Metrics?.TimedOut == true) || (s.SkilledIsolated?.Metrics?.TimedOut == true) || (s.SkilledPlugin?.Metrics?.TimedOut == true)));
         if (anyTimeout)
-            sb.AppendLine("\n> ⏰ **timeout** — run hit the scenario timeout limit; scoring may be impacted by aborting model execution before it could produce its full output");
+            sb.AppendLine("\n> ⏰ **timeout** — run hit the scenario timeout limit; scoring may be impacted by aborting model execution before it could produce its full output (increase via `timeout` in eval.yaml; default: 120s)");
 
         // Noise test results
         var withNoise = verdicts.Where(v => v.NoiseTestResult is not null).ToList();


### PR DESCRIPTION
Include actionable guidance in scenario timeout warnings

When a scenario hits the timeout limit, the warning messages now tell users how to fix it: the actual timeout value and that it can be increased via the `timeout` field in `eval.yaml`.

### Changes

- **Per-scenario console output** shows the actual timeout value, e.g. `hit the 120s scenario timeout limit (increase via 'timeout' in eval.yaml)`
- **Console summary** and **markdown/PR comment** append `(increase via 'timeout' in eval.yaml; default: 120s)`
- Added `TimeoutSeconds` property to `ScenarioComparison` to thread the value through to the reporter

This brings scenario timeout messages to parity with judge timeout messages, which already include `Try --judge-timeout with a higher value`.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
