### PR TITLE
mcp-csharp-create: add tool description quality and naming guidance

### DIFF
--- a/plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md
+++ b/plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md
@@ -94,7 +94,7 @@ using System.ComponentModel;
 public static class MyTools
 {
     [McpServerTool, Description("Get current weather for a city: temperature, conditions, humidity.")]
-    public static async Task<string> GetWeather(
+    public static string GetWeather(
         [Description("City name (e.g., 'Seattle', 'London')")] string city,
         CancellationToken cancellationToken = default)
     {
@@ -108,7 +108,7 @@ public static class MyTools
 - Every tool method **must** have a `[Description]` attribute — LLMs use this to decide when to call the tool
 - Every parameter **must** have a `[Description]` attribute
 - Accept `CancellationToken` in all async tools
-- Use `[McpServerTool(Name = "custom_name")]` only if the default method name is unclear
+- Use `[McpServerTool(Name = "custom_name")]` when the default method name is unclear, you need snake_case, or to avoid collisions
 
 **Writing effective descriptions:**
 
@@ -132,7 +132,7 @@ Tool descriptions are always loaded into the agent's context — they're routing
 ```csharp
 [McpServerTool, Description("Search build logs for error patterns")]
 public static async Task<string> SearchLogs(
-    [Description("AzDO build ID (integer) or full build URL (e.g., https://dev.azure.com/org/project/_build/results?buildId=123)")] string buildId,
+    [Description("AzDO build ID (integer) or full build URL (e.g., https://dev.azure.com/org/project/_build/results?buildId=123)")] string buildRef,
     [Description("Case-insensitive text pattern to search for. Defaults to 'error'")] string pattern = "error")
 ```
 
@@ -148,7 +148,7 @@ When agents load tools from multiple MCP servers, generic names like `GetStatus`
 [McpServerTool(Name = "search_build_logs")]
 ```
 
-By default, the SDK uses the method name as the tool name. Choose method names that are specific enough to stand alone across servers. Use `[McpServerTool(Name = "...")]` when you need snake_case or a name that differs from the method.
+By default, the SDK uses the method name as the tool name. Choose method names that are specific enough to stand alone across servers. Use `[McpServerTool(Name = "...")]` when you need snake_case, when the default method name would be unclear, or when you need to avoid collisions with tools from other servers.
 
 **DI injection patterns** — the SDK supports two styles:
 


### PR DESCRIPTION
I had an agent review this against my personal mcp views and this is the result.  Nothing here should be considered anything other than suggestions based on my experience, feel free to ignore.

## Summary

Adds practical, pattern-based guidance on the two most impactful design choices for agent-facing MCP servers:

### Tool description quality
- Lead with a verb ("Get", "Search", "Create")
- Keep descriptions compact — they're always loaded into agent context
- Put format details and examples in **parameter descriptions** instead (only loaded when agent considers using the tool)
- Good/bad examples with ❌/✅ annotations

### Tool naming for multi-server environments
- Generic names like `Search` collide when agents load multiple servers
- Use specific names that include service context (e.g., `search_build_logs`)
- Guidance on when to use `[McpServerTool(Name = ...)]` vs method name

### Other improvements
- Updated placeholder example to demonstrate good description patterns
- Added description quality and naming checks to validation checklist
- Added multi-server collision to Common Pitfalls table
- Updated existing "LLM doesn't understand" pitfall with actionable fix

Based on empirical patterns from MCP server design training validated across 3 model families (Haiku, GPT-5.1, Sonnet).

Related: PR #317 (MCP C# skills)