### PR TITLE
Fall back to rubric scores when pairwise judge is position-swap-inconsistent

### DIFF
--- a/eng/skill-validator/InvestigatingResults.md
+++ b/eng/skill-validator/InvestigatingResults.md
@@ -221,11 +221,12 @@ Several scenario-level options in `eval.yaml` are relevant when diagnosing failu
 - `overallJudgmentImprovement` is -0.4 even though quality scores are similar
 - Pairwise judge is inconsistent between position-swapped runs
 
-**Cause:** When outputs are nearly equal, the judge's position bias can dominate. The position-swap mitigation defaults to "tie" on inconsistency, but the weighted scoring still penalizes.
+**Cause:** When outputs are nearly equal, the judge's position bias can dominate. The position-swap mitigation defaults to "tie" on inconsistency. When this happens, the Comparator falls back to rubric-based quality scores instead of using the (zeroed-out) pairwise scores.
 
 **Fixes:**
 - This is usually noise — re-run the eval to see if it persists
 - If it consistently happens, improve the skill to produce clearly differentiated output
+- Check `pairwiseResult.positionSwapConsistent` — when `false`, the quality/overall scores come from rubric scoring, not pairwise
 
 ### 8. Baseline already good (no headroom)
 

--- a/eng/skill-validator/src/Evaluate/Comparator.cs
+++ b/eng/skill-validator/src/Evaluate/Comparator.cs
@@ -21,8 +21,11 @@ public static class Comparator
             OverallJudgmentImprovement: NormalizeScoreImprovement(baseline.JudgeResult.OverallScore, withSkill.JudgeResult.OverallScore),
             ErrorReduction: ComputeReduction(baseline.Metrics.ErrorCount, withSkill.Metrics.ErrorCount));
 
-        // Override quality scores with pairwise results when available
-        if (pairwiseResult is not null)
+        // Override quality scores with pairwise results when consistent.
+        // When position-swap-inconsistent, keep the rubric-based scores —
+        // zeroing out 70% of the score on a noisy comparison is worse than
+        // using the (noisier but non-zero) rubric-based quality signal.
+        if (pairwiseResult is not null && pairwiseResult.PositionSwapConsistent)
         {
             var pairwiseScores = PairwiseJudge.PairwiseToQualityScore(pairwiseResult);
             breakdown = breakdown with

--- a/eng/skill-validator/tests/Evaluate/ComparatorTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ComparatorTests.cs
@@ -279,4 +279,29 @@ public class CompareScenarioWithPairwiseTests
         Assert.Equal(1.0, withPairwise.Breakdown.OverallJudgmentImprovement);
         Assert.Equal(pairwise, withPairwise.PairwiseResult);
     }
+
+    [Fact]
+    public void KeepsRubricScoresWhenPairwiseIsInconsistent()
+    {
+        var baseline = MakeRunResult(overallScore: 2, rubricScores: [new RubricScore("Q", 2, "")]);
+        var withSkill = MakeRunResult(overallScore: 4, rubricScores: [new RubricScore("Q", 4, "")]);
+
+        // Without pairwise, rubric-based quality should show improvement
+        var noPairwise = Comparator.CompareScenario("test", baseline, withSkill);
+        Assert.True(noPairwise.Breakdown.QualityImprovement > 0);
+        Assert.True(noPairwise.Breakdown.OverallJudgmentImprovement > 0);
+        double rubricQuality = noPairwise.Breakdown.QualityImprovement;
+        double rubricOverall = noPairwise.Breakdown.OverallJudgmentImprovement;
+
+        // With position-swap-inconsistent pairwise, should keep rubric scores (not zero them)
+        var inconsistentPairwise = new PairwiseJudgeResult(
+            [new PairwiseRubricResult("Q", "tie", PairwiseMagnitude.Equal, "inconsistent")],
+            "tie",
+            PairwiseMagnitude.Equal,
+            "Position-swap inconsistent",
+            PositionSwapConsistent: false);
+        var withInconsistent = Comparator.CompareScenario("test", baseline, withSkill, inconsistentPairwise);
+        Assert.Equal(rubricQuality, withInconsistent.Breakdown.QualityImprovement);
+        Assert.Equal(rubricOverall, withInconsistent.Breakdown.OverallJudgmentImprovement);
+    }
 }


### PR DESCRIPTION
## Problem

When the pairwise judge is position-swap-inconsistent (disagrees with itself when A/B positions are swapped), `MergeInconsistentResults` defaults everything to `tie`, which `PairwiseToQualityScore` converts to **0**. Since pairwise results override both `QualityImprovement` (40%) and `OverallJudgmentImprovement` (30%), this zeros out **70% of the weighted score**.

For action-oriented skills that do real work (download symbols, run tools), rubric scoring may show genuine quality improvement (e.g., 2.3/5 → 3.0/5), but the pairwise comparison is noisy enough to flip on position swap. The result: quality credit gets discarded and the overhead penalties from doing valuable work push the score negative.

### Concrete example

From the apple-crash-symbolication skill eval on PR #201:
- Rubric scored MAUI scenario: baseline 2.3/5, skilled 3.0/5 (+0.7)
- Pairwise judge: position-swap-inconsistent → forced to tie → quality = **0**
- Only the efficiency penalties remained → final score **-1.4%**
- The skill's output actually symbolicated frames the baseline couldn't

## Fix

Only override rubric-based scores when the pairwise comparison is position-swap-consistent. When inconsistent, keep the rubric-based quality signal — it's noisier than a consistent pairwise result, but non-zero.

One-line guard: `if (pairwiseResult is not null && pairwiseResult.PositionSwapConsistent)`

## Changes

- `Comparator.cs`: Skip pairwise override when `PositionSwapConsistent == false`
- `ComparatorTests.cs`: New test `KeepsRubricScoresWhenPairwiseIsInconsistent`
- `InvestigatingResults.md`: Updated pairwise inconsistency guidance to reflect new behavior

## Validation

- 497/497 tests pass
- Ran apple-crash-symbolication eval before/after: MAUI scenario went from -0.014 to +0.217 on a run where pairwise happened to be consistent; the fix provides insurance for runs where it isn't

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>