### PR TITLE
Fix session visualisation storing

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1229,8 +1229,8 @@ jobs:
       - name: Check if AGENTVIZ SPA needs update
         id: check-replay
         run: |
-          AGENTVIZ_REPO="https://github.com/JanKrivanek/agentviz.git"
-          AGENTVIZ_BRANCH="dev/jankrivanek/static-manifest-mode"
+          AGENTVIZ_REPO="https://github.com/jayparikh/agentviz.git"
+          AGENTVIZ_BRANCH="main"
 
           # Resolve the latest commit on the AGENTVIZ branch (no clone needed)
           TARGET_SHA=$(git ls-remote "$AGENTVIZ_REPO" "refs/heads/$AGENTVIZ_BRANCH" | cut -f1)
@@ -1269,7 +1269,7 @@ jobs:
         run: |
           TARGET_SHA="${{ steps.check-replay.outputs.target_sha }}"
 
-          git clone https://github.com/JanKrivanek/agentviz.git /tmp/agentviz-src
+          git clone https://github.com/jayparikh/agentviz.git /tmp/agentviz-src
           cd /tmp/agentviz-src
 
           # Check out the exact resolved commit for deterministic builds

--- a/eng/dashboard/build-replay-sessions.ps1
+++ b/eng/dashboard/build-replay-sessions.ps1
@@ -234,7 +234,7 @@ foreach ($artifactDir in $artifactDirs) {
         $displayName = "$pluginName / $scenarioName ($roleTag, run $runIndex)"
         $id = "$subDir/$pluginName/$safeScenario--$roleTag--run$runIndex"
 
-        $tags = @($Source, $pluginName, $roleTag, $safeScenario)
+        $tags = @($Source, $pluginName, $roleTag)
         if ($Source -eq 'pr' -and $PrNumber -gt 0) {
             $tags += "pr-$PrNumber"
         }

--- a/eng/dashboard/purge-replay-sessions.ps1
+++ b/eng/dashboard/purge-replay-sessions.ps1
@@ -31,6 +31,17 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Resolve all parameter paths to absolute so that FullName.Substring() comparisons
+# produce correct relative paths. Get-ChildItem returns items whose FullName is
+# always absolute; if the base path used for Substring is relative, the computed
+# relative path will be garbage (e.g., on a CI runner whose workspace is
+# /home/runner/work/skills/skills, a relative "staging/sessions" (16 chars) would
+# chop the first 16 chars of the absolute FullName, yielding
+# "k/skills/skills/staging/sessions/..." instead of the intended relative path).
+$ExistingDir = [System.IO.Path]::GetFullPath($ExistingDir)
+$NewDir      = [System.IO.Path]::GetFullPath($NewDir)
+$OutputDir   = [System.IO.Path]::GetFullPath($OutputDir)
+
 $cutoffDate = (Get-Date).ToUniversalTime().AddDays(-$RetentionDays)
 
 # Use a temp directory if OutputDir == ExistingDir to avoid read/write conflicts


### PR DESCRIPTION
### Motivation

We have been storing sessions at garbled paths due to a relative-vs-absolute path mismatch in `purge-replay-sessions.ps1`. The `FullName.Substring()` calls used to compute relative paths were comparing absolute `FullName` values against relative parameter paths (e.g.,`staging`), producing garbled paths like `k/skills/skills/staging/sessions/...` instead of the intended `scheduled/2026-04-04/...`.

### Changes

- **purge-replay-sessions.ps1**: Resolve all parameter paths (`ExistingDir`, `NewDir`, `OutputDir`) to absolute via `[System.IO.Path]::GetFullPath()` before any `Substring` arithmetic. This is the root cause fix.

- **build-replay-sessions.ps1**: Remove `\` from the manifest `tags` array. The per-scenario slug was too granular for tag-based filtering (with hundreds of unique scenario names, the AGENTVIZ tag bar rendered 296 tag buttons that overflowed the UI and pushed the session list out of view). Scenario names remain searchable through the session `name` field.