### PR TITLE
Fix the devops health workflows after gh-aw update

### DIFF
--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -473,6 +473,7 @@ Replace the entire issue body with the following structure:
 {For each finding dispatched in the current run:}
 | {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | [Workflow Run]({workflow_actions_url}) |
 {Preserve any rows from the previous issue body that already show ✅ Done or ✅ Resolved — do not remove them}
+{If no findings were dispatched AND no previous rows exist, render the table header with zero rows — the section MUST still appear in the output}
 
 ---
 
@@ -598,6 +599,7 @@ Before finishing, verify:
 - **Time budget**: You have a 60-minute timeout. Prioritize reaching Steps 4 and 5 (issue update + dispatch). Do NOT write intermediate scripts or analysis files. Work through each check, collect findings in memory, and proceed directly to output. Aim to complete data collection (Step 1) within 30 minutes.
 - **Efficiency**: Process API responses in memory. Do NOT create Python/bash scripts to analyze data — parse JSON directly using `jq` or inline analysis. Do NOT write intermediate files unless explicitly required by the output format.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **complete, literal issue body text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. Pass the body directly as the string value.
+- **CRITICAL — Investigation Results section is MANDATORY**: The `## 🔍 Investigation Results` section MUST always appear in the issue body, even if no investigations were dispatched (in that case, render the section with the table header and zero data rows). The downstream grooming workflow depends on this section to link investigation results. Never omit it. Never inline investigation status elsewhere (e.g., inside the New Findings section). The section must appear **exactly** between the `## 🆕 New Findings` section and the `## ✅ Resolved` section.
 - **Be data-driven**: Include specific numbers, durations, percentages, and links.
 - **Be precise with fingerprints**: Use the exact fingerprint formulas from the knowledge file. Consistency is critical — the same finding MUST produce the same fingerprint across runs.
 - **First run handling**: If `cache-memory` has no previous state, note: "⚠️ This is the first health check run. All findings appear as new. Diff will resume from next run."

--- a/.github/workflows/devops-health-groom.md
+++ b/.github/workflows/devops-health-groom.md
@@ -160,15 +160,21 @@ For each **Daily overview** comment, extract:
 
 ### 3.1 Parse the Current Issue Body
 
-Find the `## 🔍 Investigation Results` section in the issue body. This section contains a markdown table with rows like:
+Look for the `## 🔍 Investigation Results` section in the issue body. This section, when present, contains a markdown table with rows like:
 
 ```
 | {finding_title} | {severity} | 🔄 Dispatched | [Workflow Run]({url}) |
 ```
 
+**If the section is missing** (the health check agent sometimes omits it), you MUST
+create it. Do NOT skip this step — creating the section is the primary purpose of
+this workflow. Proceed to Step 3.2 with an empty table.
+
 ### 3.2 Build the Updated Table
 
-For each row in the Investigation Results table:
+**If the Investigation Results section already exists** in the issue body:
+
+For each row in the existing Investigation Results table:
 1. Determine the `finding_id` for this row. Match by finding title or by checking the fingerprint from the current health check state in `cache-memory`.
 2. Look up the `finding_id` in the investigation comments collected in Step 2.
 3. If a matching investigation comment exists:
@@ -176,7 +182,35 @@ For each row in the Investigation Results table:
    - Replace the Result cell with `[{executive_summary}]({comment_url})`
 4. If no matching investigation comment exists yet, leave the row unchanged.
 
-Also check for investigation comments that correspond to findings in the **📌 Existing Findings** or **🆕 New Findings** sections (from previous runs). Add rows for those too if they aren't already in the table.
+**If the Investigation Results section does NOT exist** in the issue body:
+
+You must INSERT it. Build the section from scratch using the investigation
+comments collected in Step 2:
+
+1. For each investigation comment, create a table row:
+   ```
+   | {finding_title from comment heading} | {severity from comment} | ✅ Done | [{executive_summary}]({comment_url}) |
+   ```
+2. Wrap the rows in the standard section structure:
+   ```markdown
+   ## 🔍 Investigation Results
+
+   > Deep investigations are dispatched for new critical/warning findings.
+   > The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
+
+   | Finding | Severity | Status | Result |
+   |---------|----------|--------|--------|
+   {rows}
+   ```
+3. Insert this section into the issue body **immediately before** the first of
+   these sections (whichever appears first): `## ✅ Resolved`, `## 📌 Existing`,
+   `## 📊 Trends`. If none of those headings are found, append the section at
+   the end of the body (before the `<sub>` footer if present).
+
+**In both cases** (section existed or was created), also check for investigation
+comments that correspond to findings in the **📌 Existing Findings** or **🆕 New
+Findings** sections (from previous runs). Add rows for those too if they aren't
+already in the table.
 
 ### 3.3 Hold Changes (Do Not Update Yet)
 
@@ -286,5 +320,5 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 - **Preserve the issue body structure**: When updating the issue body, keep ALL sections intact. Only modify the Investigation Results table rows and any resolved-finding annotations. Do not rewrite sections you don't need to change.
 - **Don't hide "Other" comments**: Only hide comments that match the Investigation or Daily overview patterns. Human comments, bot reactions, etc. must be preserved.
 - **Idempotent**: Running this workflow twice should produce the same result. If investigation results are already linked, don't re-link them. If comments are already hidden, they won't appear in the API results (collapsed).
-- **Graceful degradation**: If the issue body doesn't contain an Investigation Results section (e.g., first run before any investigations), skip Step 3 and proceed to hiding stale comments.
+- **Create missing sections**: If the issue body doesn't contain a `## 🔍 Investigation Results` section, **create it** from investigation comments (see Step 3). Do NOT silently skip linking — this is the groomer's primary job. Only skip Step 3 if there are zero investigation comments to link.
 - **No intermediate files**: Do all work in memory. Do NOT write intermediate scripts, JSON files, or body text files. Parse API responses with `jq` inline and hold the issue body as a string variable.


### PR DESCRIPTION

The detailed investigations info was not properly posted and hence groomer completely skipped updating the table