### PR TITLE
Add testability migration skills and agent for dotnet-test

### DIFF
--- a/plugins/dotnet-test/agents/testability-migration.agent.md
+++ b/plugins/dotnet-test/agents/testability-migration.agent.md
@@ -1,0 +1,121 @@
+---
+description: >-
+  Orchestrates end-to-end testability migration for .NET codebases: detects
+  untestable static dependencies, generates wrapper abstractions or guides
+  built-in adoption, and performs mechanical bulk migration of call sites.
+  Use when asked to make code testable, remove static coupling, migrate to
+  TimeProvider, adopt IFileSystem, or improve testability of a legacy codebase.
+name: testability-migration
+tools: ['read', 'search', 'edit', 'terminal', 'skill']
+---
+
+# Testability Migration Agent
+
+You are a testability migration agent for .NET codebases. Your mission is to help developers incrementally replace hard-to-test static dependencies with injectable abstractions, making their code unit-testable without requiring a risky big-bang rewrite.
+
+## Pipeline Overview
+
+You operate a three-phase pipeline: **Detect → Generate → Migrate**. Each phase uses a specialized skill. You orchestrate them in order, confirming with the user between phases.
+
+```
+┌─────────────────────┐     ┌──────────────────────────┐     ┌─────────────────────────┐
+│  1. DETECT           │ ──▶ │  2. GENERATE              │ ──▶ │  3. MIGRATE              │
+│                      │     │                           │     │                          │
+│  Scan for statics    │     │  Create wrappers or       │     │  Bulk-replace call sites │
+│  Rank by frequency   │     │  adopt built-in abstractions│   │  Add constructor injection│
+│  Identify scope      │     │  Register in DI            │     │  Update tests            │
+│                      │     │                           │     │                          │
+│  detect-static-      │     │  generate-testability-     │     │  migrate-static-to-      │
+│  dependencies        │     │  wrappers                  │     │  wrapper                 │
+└─────────────────────┘     └──────────────────────────┘     └─────────────────────────┘
+```
+
+## Workflow
+
+### Phase 1: Detect
+
+Use the `detect-static-dependencies` skill to:
+1. Scan the user's target (file, project, solution)
+2. Identify all static dependency call sites
+3. Rank by frequency and group by category
+4. Present the report to the user
+
+After presenting results, ask the user:
+- Which category to tackle first (recommend the highest-frequency one with best built-in support)
+- What scope to migrate (single project? namespace? whole solution?)
+
+### Phase 2: Generate
+
+Use the `generate-testability-wrappers` skill to:
+1. Determine the appropriate abstraction (built-in vs. custom)
+2. For built-in (`TimeProvider`, `IHttpClientFactory`): provide adoption instructions
+3. For custom (`IEnvironmentProvider`, `IConsole`, `IProcessRunner`): generate interface + implementation
+4. Add DI registration or ambient context setup
+5. Verify the project builds with the new abstraction
+
+Present the generated code to the user and confirm before proceeding to migration.
+
+### Phase 3: Migrate
+
+Use the `migrate-static-to-wrapper` skill to:
+1. Plan the migration for the agreed scope
+2. Replace static call sites with wrapper calls
+3. Add constructor injection to affected classes
+4. Update existing test files with test doubles
+5. Verify the project builds
+6. Report what was changed and what remains
+
+## Decision Rules
+
+### When to skip Phase 2 (Generate)
+
+Skip wrapper generation if the user's codebase already has:
+- `TimeProvider` registered in DI → go straight to migration
+- `System.IO.Abstractions` referenced → go straight to migration
+- Existing custom wrappers for the target statics
+
+### When to recommend ambient context over DI
+
+Use the ambient context pattern when:
+- The class is `static` and cannot accept constructor injection
+- The codebase has no DI container (e.g., a class library)
+- The user explicitly asks for it
+- The migration scope is small (< 5 call sites) and adding DI would be heavy
+
+### When to stop and warn
+
+- If the codebase uses .NET Framework < 4.6 and `TimeProvider` is not available
+- If the static is in generated code (`*.Designer.cs`, `*.g.cs`) — skip, do not modify
+- If the class is sealed and the user wants to mock it — suggest wrapping the sealed class, not the static
+
+## Response Guidelines
+
+### Full pipeline request
+
+When the user asks something like "make my code testable" or "help me get rid of static dependencies":
+1. Start with Phase 1 (detection)
+2. Present the report
+3. Ask for confirmation on scope and priority
+4. Proceed through Phase 2 and Phase 3
+
+### Targeted request
+
+When the user asks something specific like "replace DateTime.Now with TimeProvider":
+1. Skip or abbreviate Phase 1 (only scan for the specific pattern)
+2. Determine if Phase 2 is needed (is `TimeProvider` already registered?)
+3. Proceed directly to Phase 3 (migration)
+
+### Scope control
+
+Always respect scope boundaries:
+- One project or namespace per migration pass
+- Present a "Remaining" section showing what was not migrated
+- Offer to continue with the next scope
+
+## Safety Rules
+
+1. **Never modify generated code** — skip `*.Designer.cs`, `*.g.cs`, files in `obj/`, `bin/`
+2. **Never modify test code during detection** — tests should be updated during migration only
+3. **Always build after changes** — run `dotnet build` and fix any errors before reporting success
+4. **Preserve behavior** — the wrapper must delegate directly to the static; no logic changes
+5. **Incremental only** — migrate one scope at a time, never the entire solution in one pass unless it's small (< 20 files)

--- a/plugins/dotnet-test/plugin.json
+++ b/plugins/dotnet-test/plugin.json
@@ -11,6 +11,7 @@
     "./agents/code-testing-builder.agent.md",
     "./agents/code-testing-tester.agent.md",
     "./agents/code-testing-fixer.agent.md",
-    "./agents/code-testing-linter.agent.md"
+    "./agents/code-testing-linter.agent.md",
+    "./agents/testability-migration.agent.md"
   ]
 }

--- a/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
+++ b/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: detect-static-dependencies
+description: >
+  Scan C# source files for hard-to-test static dependencies — DateTime.Now/UtcNow,
+  File.*, Directory.*, Environment.*, HttpClient, Console.*, Process.*, and other
+  untestable statics. Produces a ranked report of static call sites by frequency.
+  USE FOR: find untestable statics, scan for static dependencies, testability audit,
+  identify hard-to-mock code, find DateTime.Now usage, detect static coupling,
+  testability report, static analysis for testability.
+  DO NOT USE FOR: generating wrappers (use generate-testability-wrappers),
+  migrating code (use migrate-static-to-wrapper), general code review,
+  or finding statics that are already behind abstractions.
+---
+
+# Detect Static Dependencies
+
+Scan a C# codebase for calls to hard-to-test static APIs and produce a ranked report showing which statics appear most frequently, which files are most affected, and which abstractions already exist in the .NET ecosystem to replace them.
+
+## When to Use
+
+- Auditing a project's testability before adding unit tests
+- Understanding the scope of static coupling in a legacy codebase
+- Prioritizing which statics to wrap first (highest-frequency wins)
+- Creating a migration plan for incremental testability improvements
+
+## When Not to Use
+
+- The user wants wrappers generated (hand off to `generate-testability-wrappers`)
+- The user wants mechanical migration done (hand off to `migrate-static-to-wrapper`)
+- The statics are already behind interfaces or `TimeProvider`
+- The code is not C# / .NET
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Target path | Yes | A file, directory, project (.csproj), or solution (.sln) to scan |
+| Exclusion patterns | No | Glob patterns to skip (e.g., `**/obj/**`, `**/Migrations/**`) |
+| Category filter | No | Limit to specific categories: `time`, `filesystem`, `environment`, `network`, `console`, `process` |
+
+## Workflow
+
+### Step 1: Determine scan scope
+
+Resolve the target to a set of `.cs` files:
+- If a `.cs` file, scan that single file.
+- If a directory, scan all `.cs` files recursively (excluding `obj/`, `bin/`).
+- If a `.csproj`, find its directory and scan `.cs` files within.
+- If a `.sln`, parse it, find all project directories, and scan `.cs` files across all projects.
+
+Always exclude `obj/`, `bin/`, and any user-specified exclusion patterns.
+
+### Step 2: Search for static dependency patterns
+
+Scan each file for calls matching these categories:
+
+#### Time
+| Pattern | Replacement |
+|---------|-------------|
+| `DateTime.Now` | `TimeProvider.GetLocalNow()` |
+| `DateTime.UtcNow` | `TimeProvider.GetUtcNow()` |
+| `DateTime.Today` | `TimeProvider.GetLocalNow().Date` |
+| `DateTimeOffset.Now` | `TimeProvider.GetLocalNow()` |
+| `DateTimeOffset.UtcNow` | `TimeProvider.GetUtcNow()` |
+| `Task.Delay(` | `TimeProvider.Delay()` |
+| `new CancellationTokenSource(TimeSpan` | `TimeProvider.CreateCancellationTokenSource()` |
+
+#### File System
+| Pattern | Replacement |
+|---------|-------------|
+| `File.ReadAllText(` | `IFileSystem` (System.IO.Abstractions) |
+| `File.WriteAllText(` | `IFileSystem` |
+| `File.Exists(` | `IFileSystem` |
+| `File.Delete(` | `IFileSystem` |
+| `File.Copy(` | `IFileSystem` |
+| `File.Move(` | `IFileSystem` |
+| `Directory.Exists(` | `IFileSystem` |
+| `Directory.CreateDirectory(` | `IFileSystem` |
+| `Directory.GetFiles(` | `IFileSystem` |
+| `Directory.Delete(` | `IFileSystem` |
+| `Path.Combine(` | `IFileSystem.Path` |
+| `Path.GetTempPath(` | `IFileSystem.Path` |
+
+#### Environment
+| Pattern | Replacement |
+|---------|-------------|
+| `Environment.GetEnvironmentVariable(` | `IEnvironmentProvider` wrapper |
+| `Environment.SetEnvironmentVariable(` | `IEnvironmentProvider` wrapper |
+| `Environment.MachineName` | `IEnvironmentProvider` wrapper |
+| `Environment.UserName` | `IEnvironmentProvider` wrapper |
+| `Environment.CurrentDirectory` | `IEnvironmentProvider` wrapper |
+| `Environment.Exit(` | `IEnvironmentProvider` wrapper |
+
+#### Network
+| Pattern | Replacement |
+|---------|-------------|
+| `new HttpClient(` | `IHttpClientFactory` |
+| `HttpClient.GetAsync(` | `IHttpClientFactory` |
+| `HttpClient.PostAsync(` | `IHttpClientFactory` |
+| `HttpClient.SendAsync(` | `IHttpClientFactory` |
+| `Dns.GetHostEntry(` | Custom wrapper |
+| `Dns.GetHostAddresses(` | Custom wrapper |
+
+#### Console
+| Pattern | Replacement |
+|---------|-------------|
+| `Console.WriteLine(` | `IConsole` wrapper or `ILogger` |
+| `Console.ReadLine(` | `IConsole` wrapper |
+| `Console.Write(` | `IConsole` wrapper |
+| `Console.ReadKey(` | `IConsole` wrapper |
+
+#### Process
+| Pattern | Replacement |
+|---------|-------------|
+| `Process.Start(` | `IProcessRunner` wrapper |
+| `Process.GetCurrentProcess(` | `IProcessRunner` wrapper |
+| `Process.GetProcessesByName(` | `IProcessRunner` wrapper |
+
+### Step 3: Aggregate and rank results
+
+Count each static call pattern across the entire scan scope. Produce a summary with:
+
+1. **Category summary** — total call sites per category (time, filesystem, env, etc.)
+2. **Top patterns** — the 10 most frequent individual patterns ranked by count
+3. **Most affected files** — files with the highest number of static dependencies
+4. **Existing abstractions available** — for each category, note the recommended .NET abstraction:
+   - Time → `TimeProvider` (built-in since .NET 8)
+   - File system → `System.IO.Abstractions` (NuGet package)
+   - HTTP → `IHttpClientFactory` (built-in)
+   - Environment → custom `IEnvironmentProvider`
+   - Console → custom `IConsole` or `ILogger`
+   - Process → custom `IProcessRunner`
+
+### Step 4: Present the report
+
+Format the output as a structured report:
+
+```
+## Static Dependency Report
+
+**Scope**: <project/solution name>
+**Files scanned**: <count>
+**Total static call sites**: <count>
+
+### Category Summary
+| Category     | Call Sites | Recommended Abstraction |
+|-------------|-----------|------------------------|
+| Time         | 42        | TimeProvider (.NET 8+) |
+| File System  | 31        | System.IO.Abstractions |
+| Environment  | 12        | IEnvironmentProvider   |
+| ...          | ...       | ...                    |
+
+### Top 10 Patterns
+| # | Pattern             | Count | Files |
+|---|---------------------|-------|-------|
+| 1 | DateTime.UtcNow     | 28    | 14    |
+| 2 | File.ReadAllText    | 18    | 9     |
+| ...                                      |
+
+### Most Affected Files
+| File                          | Static Calls | Categories          |
+|-------------------------------|-------------|---------------------|
+| Services/OrderProcessor.cs    | 12          | Time, FileSystem    |
+| ...                                                               |
+
+### Migration Priority
+1. **Time** (42 sites) — Use `TimeProvider`, zero NuGet dependencies on .NET 8+
+2. **File System** (31 sites) — Use `System.IO.Abstractions` NuGet package
+3. ...
+```
+
+### Step 5: Suggest next steps
+
+Based on the report, recommend:
+- Which category to tackle first (fewest dependencies, best built-in support)
+- Whether to use `generate-testability-wrappers` for custom wrapper generation
+- Whether to use `migrate-static-to-wrapper` for mechanical bulk migration
+
+## Validation
+
+- [ ] All `.cs` files in scope were scanned (check count)
+- [ ] Report includes category totals, top patterns, and affected files
+- [ ] Each detected pattern has a recommended replacement listed
+- [ ] `obj/` and `bin/` directories were excluded
+- [ ] Migration priority is ordered by impact (count × ease of replacement)
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Scanning `obj/` or generated code | Always exclude `obj/`, `bin/`, and `*.Designer.cs` |
+| Counting wrapped calls as statics | Check if the call is behind an interface or injected service before counting |
+| Missing statics inside lambdas/LINQ | Search covers all code within `.cs` files, including lambdas |
+| Recommending `TimeProvider` on < .NET 8 | Check `TargetFramework` in `.csproj` — if < net8.0, recommend `NodaTime.IClock` or custom `ISystemClock` |
+| Ignoring test projects | Only scan production code — exclude `*.Tests.csproj` projects from the scan |

--- a/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
+++ b/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
@@ -54,67 +54,14 @@ Always exclude `obj/`, `bin/`, and any user-specified exclusion patterns.
 
 Scan each file for calls matching these categories:
 
-#### Time
-| Pattern | Replacement |
-|---------|-------------|
-| `DateTime.Now` | `TimeProvider.GetLocalNow()` |
-| `DateTime.UtcNow` | `TimeProvider.GetUtcNow()` |
-| `DateTime.Today` | `TimeProvider.GetLocalNow().Date` |
-| `DateTimeOffset.Now` | `TimeProvider.GetLocalNow()` |
-| `DateTimeOffset.UtcNow` | `TimeProvider.GetUtcNow()` |
-| `Task.Delay(` | `TimeProvider.Delay()` |
-| `new CancellationTokenSource(TimeSpan` | `TimeProvider.CreateCancellationTokenSource()` |
-
-#### File System
-| Pattern | Replacement |
-|---------|-------------|
-| `File.ReadAllText(` | `IFileSystem` (System.IO.Abstractions) |
-| `File.WriteAllText(` | `IFileSystem` |
-| `File.Exists(` | `IFileSystem` |
-| `File.Delete(` | `IFileSystem` |
-| `File.Copy(` | `IFileSystem` |
-| `File.Move(` | `IFileSystem` |
-| `Directory.Exists(` | `IFileSystem` |
-| `Directory.CreateDirectory(` | `IFileSystem` |
-| `Directory.GetFiles(` | `IFileSystem` |
-| `Directory.Delete(` | `IFileSystem` |
-| `Path.Combine(` | `IFileSystem.Path` |
-| `Path.GetTempPath(` | `IFileSystem.Path` |
-
-#### Environment
-| Pattern | Replacement |
-|---------|-------------|
-| `Environment.GetEnvironmentVariable(` | `IEnvironmentProvider` wrapper |
-| `Environment.SetEnvironmentVariable(` | `IEnvironmentProvider` wrapper |
-| `Environment.MachineName` | `IEnvironmentProvider` wrapper |
-| `Environment.UserName` | `IEnvironmentProvider` wrapper |
-| `Environment.CurrentDirectory` | `IEnvironmentProvider` wrapper |
-| `Environment.Exit(` | `IEnvironmentProvider` wrapper |
-
-#### Network
-| Pattern | Replacement |
-|---------|-------------|
-| `new HttpClient(` | `IHttpClientFactory` |
-| `HttpClient.GetAsync(` | `IHttpClientFactory` |
-| `HttpClient.PostAsync(` | `IHttpClientFactory` |
-| `HttpClient.SendAsync(` | `IHttpClientFactory` |
-| `Dns.GetHostEntry(` | Custom wrapper |
-| `Dns.GetHostAddresses(` | Custom wrapper |
-
-#### Console
-| Pattern | Replacement |
-|---------|-------------|
-| `Console.WriteLine(` | `IConsole` wrapper or `ILogger` |
-| `Console.ReadLine(` | `IConsole` wrapper |
-| `Console.Write(` | `IConsole` wrapper |
-| `Console.ReadKey(` | `IConsole` wrapper |
-
-#### Process
-| Pattern | Replacement |
-|---------|-------------|
-| `Process.Start(` | `IProcessRunner` wrapper |
-| `Process.GetCurrentProcess(` | `IProcessRunner` wrapper |
-| `Process.GetProcessesByName(` | `IProcessRunner` wrapper |
+| Category | Patterns to search for | Recommended replacement |
+|----------|----------------------|------------------------|
+| **Time** | `DateTime.Now`, `DateTime.UtcNow`, `DateTime.Today`, `DateTimeOffset.Now`, `DateTimeOffset.UtcNow`, `Task.Delay(`, `new CancellationTokenSource(TimeSpan` | `TimeProvider` (.NET 8+) |
+| **File System** | `File.ReadAllText(`, `File.WriteAllText(`, `File.Exists(`, `File.Delete(`, `File.Copy(`, `File.Move(`, `Directory.Exists(`, `Directory.CreateDirectory(`, `Directory.GetFiles(`, `Directory.Delete(`, `Path.Combine(`, `Path.GetTempPath(` | `IFileSystem` (System.IO.Abstractions NuGet) |
+| **Environment** | `Environment.GetEnvironmentVariable(`, `Environment.SetEnvironmentVariable(`, `Environment.MachineName`, `Environment.UserName`, `Environment.CurrentDirectory`, `Environment.Exit(` | Custom `IEnvironmentProvider` |
+| **Network** | `new HttpClient(`, `HttpClient.GetAsync(`, `HttpClient.PostAsync(`, `HttpClient.SendAsync(` | `IHttpClientFactory` (built-in) |
+| **Console** | `Console.WriteLine(`, `Console.ReadLine(`, `Console.Write(`, `Console.ReadKey(` | `IConsole` wrapper or `ILogger` |
+| **Process** | `Process.Start(`, `Process.GetCurrentProcess(`, `Process.GetProcessesByName(` | Custom `IProcessRunner` |
 
 ### Step 3: Aggregate and rank results
 

--- a/plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md
+++ b/plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: generate-testability-wrappers
+description: >
+  Generate wrapper interfaces, default implementations, and DI registration for
+  hard-to-test static dependencies in C# code. Produces IFileSystem, IEnvironmentProvider,
+  IConsole, IProcessRunner wrappers, or guides adoption of built-in abstractions like
+  TimeProvider and IHttpClientFactory.
+  USE FOR: generate wrapper for static, create IFileSystem wrapper, wrap DateTime.Now,
+  make static testable, create abstraction for File.*, generate DI registration,
+  TimeProvider adoption, IHttpClientFactory setup, testability wrapper, mock-friendly interface.
+  DO NOT USE FOR: detecting statics (use detect-static-dependencies), migrating call
+  sites (use migrate-static-to-wrapper), general interface design that is not about testability.
+---
+
+# Generate Testability Wrappers
+
+Generate wrapper interfaces, default implementations, and DI service registration code for untestable static dependencies. For statics that already have .NET built-in abstractions (`TimeProvider`, `IHttpClientFactory`), guide adoption of the built-in. For statics without built-in alternatives, generate custom minimal wrappers.
+
+## When to Use
+
+- After running `detect-static-dependencies` and identifying which statics to wrap
+- When the user asks to make a class testable by replacing statics with injected abstractions
+- When adopting `TimeProvider` (.NET 8+) or `System.IO.Abstractions`
+- When creating a custom wrapper for `Environment.*`, `Console.*`, or `Process.*`
+
+## When Not to Use
+
+- The user wants to find statics first (use `detect-static-dependencies`)
+- The user wants to bulk-replace call sites (use `migrate-static-to-wrapper`)
+- The static is already behind an interface
+- The project does not use dependency injection and the user does not want to add it
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Static category | Yes | Which category: `time`, `filesystem`, `environment`, `network`, `console`, `process` |
+| Target framework | Yes | The `TargetFramework` from `.csproj` (affects which built-in abstractions exist) |
+| DI container | No | Which DI framework: `microsoft` (default), `autofac`, `none` (ambient context) |
+| Namespace | No | Target namespace for generated wrapper code |
+
+## Workflow
+
+### Step 1: Determine the abstraction strategy
+
+Based on the category and target framework:
+
+| Category | .NET 8+ | .NET 6-7 | .NET Framework |
+|----------|---------|----------|----------------|
+| Time | `TimeProvider` (built-in) | `TimeProvider` via `Microsoft.Bcl.TimeProvider` NuGet | Custom `ISystemClock` |
+| File system | `System.IO.Abstractions` (NuGet) | Same | Same |
+| HTTP | `IHttpClientFactory` (built-in) | Same | Same |
+| Environment | Custom `IEnvironmentProvider` | Same | Same |
+| Console | Custom `IConsole` | Same | Same |
+| Process | Custom `IProcessRunner` | Same | Same |
+
+### Step 2: Generate built-in abstraction adoption (Time, HTTP)
+
+#### TimeProvider (.NET 8+)
+
+No wrapper code needed — guide the user:
+
+1. Register in DI:
+```csharp
+builder.Services.AddSingleton(TimeProvider.System);
+```
+
+2. Inject into classes:
+```csharp
+public class OrderProcessor(TimeProvider timeProvider)
+{
+    public bool IsExpired(Order order)
+        => timeProvider.GetUtcNow() > order.ExpiresAt;
+}
+```
+
+3. Test with `FakeTimeProvider`:
+```csharp
+// Requires Microsoft.Extensions.TimeProvider.Testing NuGet
+var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero));
+var processor = new OrderProcessor(fakeTime);
+fakeTime.Advance(TimeSpan.FromDays(1));
+Assert.True(processor.IsExpired(order));
+```
+
+#### TimeProvider (pre-.NET 8)
+
+Guide: install `Microsoft.Bcl.TimeProvider` NuGet. Same API as above.
+
+#### IHttpClientFactory
+
+No wrapper code needed — guide the user:
+
+1. Register in DI:
+```csharp
+builder.Services.AddHttpClient<MyService>(client =>
+{
+    client.BaseAddress = new Uri("https://api.example.com");
+});
+```
+
+2. Inject into classes:
+```csharp
+public class MyService(HttpClient httpClient)
+{
+    public Task<string> GetDataAsync()
+        => httpClient.GetStringAsync("/data");
+}
+```
+
+### Step 3: Generate custom wrappers (Environment, Console, Process)
+
+For categories without built-in abstractions, follow this template:
+
+#### Interface — define the minimal surface
+
+Only include methods that were actually detected in the codebase. Do NOT generate a wrapper for every possible member — wrap only what is used.
+
+```csharp
+namespace <Namespace>;
+
+/// <summary>
+/// Abstraction over <static class> for testability. 
+/// </summary>
+public interface I<WrapperName>
+{
+    // One method per detected static call
+    <return type> <MethodName>(<parameters>);
+}
+```
+
+#### Default implementation — delegate to the real static
+
+```csharp
+namespace <Namespace>;
+
+/// <summary>
+/// Default implementation that delegates to <static class>.
+/// </summary>
+public sealed class <WrapperName> : I<WrapperName>
+{
+    public <return type> <MethodName>(<parameters>)
+        => <StaticClass>.<Method>(<arguments>);
+}
+```
+
+#### DI registration
+
+```csharp
+// In Program.cs or Startup.cs:
+builder.Services.AddSingleton<I<WrapperName>, <WrapperName>>();
+```
+
+### Step 4: Generate file system wrapper adoption
+
+Prefer the established `System.IO.Abstractions` NuGet package over custom wrappers:
+
+1. Install the package:
+```
+dotnet add package System.IO.Abstractions
+```
+
+2. Register in DI:
+```csharp
+builder.Services.AddSingleton<IFileSystem, FileSystem>();
+```
+
+3. Inject `IFileSystem` into classes:
+```csharp
+public class ConfigLoader(IFileSystem fileSystem)
+{
+    public string LoadConfig(string path)
+        => fileSystem.File.ReadAllText(path);
+}
+```
+
+4. Test with `MockFileSystem`:
+```
+dotnet add <TestProject> package System.IO.Abstractions.TestingHelpers
+```
+```csharp
+var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+{
+    { "/config.json", new MockFileData("{\"key\": \"value\"}") }
+});
+var loader = new ConfigLoader(mockFs);
+Assert.Equal("{\"key\": \"value\"}", loader.LoadConfig("/config.json"));
+```
+
+### Step 5: Generate ambient context alternative (when DI is not available)
+
+If the codebase does not use DI (e.g., old console app, library code), offer the ambient context pattern instead:
+
+```csharp
+public static class Clock
+{
+    private static readonly AsyncLocal<Func<DateTimeOffset>?> s_override = new();
+
+    public static DateTimeOffset UtcNow
+        => s_override.Value?.Invoke() ?? TimeProvider.System.GetUtcNow();
+
+    /// <summary>Test helper — pins the clock to a fixed time in the current async scope.</summary>
+    public static IDisposable Override(DateTimeOffset fixedTime)
+    {
+        s_override.Value = () => fixedTime;
+        return new Scope();
+    }
+
+    public static IDisposable Override(Func<DateTimeOffset> factory)
+    {
+        s_override.Value = factory;
+        return new Scope();
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        public void Dispose() => s_override.Value = null;
+    }
+}
+```
+
+Explain the trade-offs:
+- **Production cost**: one static `readonly` field + one null check per call (negligible)
+- **Thread safety**: `AsyncLocal<T>` scopes per async flow — parallel tests don't interfere
+- **Limitation**: does not propagate to `Task.Run` unless the execution context is captured
+
+### Step 6: Place generated files
+
+Generate files following the project's existing conventions:
+- If there is an `Abstractions/` or `Interfaces/` folder, place the interface there
+- If there is an `Infrastructure/` or `Services/` folder, place the implementation there
+- Otherwise, create files next to the code that uses the static
+
+Always generate:
+1. The interface file (or adoption instructions for built-in abstractions)
+2. The default implementation file
+3. The DI registration snippet (as a code comment at the bottom of the implementation, or as separate instructions)
+
+## Validation
+
+- [ ] Generated interface only wraps statics that were actually detected (not speculative)
+- [ ] Default implementation delegates to the real static with no behavior changes
+- [ ] DI registration uses `AddSingleton` for stateless wrappers, `AddTransient` for stateful ones
+- [ ] NuGet packages are recommended where established libraries exist (System.IO.Abstractions, etc.)
+- [ ] For .NET 8+, `TimeProvider` is recommended over custom `ISystemClock`
+- [ ] Ambient context pattern includes `AsyncLocal<T>`, scoped disposal, and trade-off explanation
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Wrapping ALL members of a static class | Only wrap methods actually called in the codebase |
+| Custom time wrapper on .NET 8+ | Use built-in `TimeProvider` instead |
+| Custom file system wrapper | Prefer `System.IO.Abstractions` NuGet — battle-tested, complete |
+| Registering scoped when singleton suffices | Stateless wrappers should be `AddSingleton` |
+| Forgetting test helper packages | `Microsoft.Extensions.TimeProvider.Testing` for time, `System.IO.Abstractions.TestingHelpers` for filesystem |
+| Ambient context without `AsyncLocal` | Non-async `[ThreadStatic]` breaks with `async`/`await` — always use `AsyncLocal<T>` |

--- a/plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md
+++ b/plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: generate-testability-wrappers
 description: >
-  Generate wrapper interfaces, default implementations, and DI registration for
-  hard-to-test static dependencies in C# code. Produces IFileSystem, IEnvironmentProvider,
-  IConsole, IProcessRunner wrappers, or guides adoption of built-in abstractions like
-  TimeProvider and IHttpClientFactory.
+  Generate wrapper interfaces and DI registration for hard-to-test static dependencies in C#.
+  Produces IFileSystem, IEnvironmentProvider, IConsole, IProcessRunner wrappers, or guides adoption
+  of TimeProvider and IHttpClientFactory.
   USE FOR: generate wrapper for static, create IFileSystem wrapper, wrap DateTime.Now,
-  make static testable, create abstraction for File.*, generate DI registration,
-  TimeProvider adoption, IHttpClientFactory setup, testability wrapper, mock-friendly interface.
+  make static testable, make class testable, create abstraction for File.*, generate
+  DI registration, TimeProvider adoption, IHttpClientFactory setup, testability wrapper,
+  mock-friendly interface, mock time in tests, create the right abstraction to mock,
+  how to mock DateTime, test code using File.ReadAllText, what abstraction for Environment,
+  how to make statics injectable, adopt System.IO.Abstractions, make file calls testable.
   DO NOT USE FOR: detecting statics (use detect-static-dependencies), migrating call
-  sites (use migrate-static-to-wrapper), general interface design that is not about testability.
+  sites (use migrate-static-to-wrapper), general interface design not about testability.
 ---
 
 # Generate Testability Wrappers
@@ -89,24 +91,7 @@ Guide: install `Microsoft.Bcl.TimeProvider` NuGet. Same API as above.
 
 #### IHttpClientFactory
 
-No wrapper code needed — guide the user:
-
-1. Register in DI:
-```csharp
-builder.Services.AddHttpClient<MyService>(client =>
-{
-    client.BaseAddress = new Uri("https://api.example.com");
-});
-```
-
-2. Inject into classes:
-```csharp
-public class MyService(HttpClient httpClient)
-{
-    public Task<string> GetDataAsync()
-        => httpClient.GetStringAsync("/data");
-}
-```
+No wrapper code needed — register typed clients via `builder.Services.AddHttpClient<MyService>()` and inject `HttpClient` directly into the class constructor.
 
 ### Step 3: Generate custom wrappers (Environment, Console, Process)
 
@@ -189,29 +174,20 @@ Assert.Equal("{\"key\": \"value\"}", loader.LoadConfig("/config.json"));
 
 ### Step 5: Generate ambient context alternative (when DI is not available)
 
-If the codebase does not use DI (e.g., old console app, library code), offer the ambient context pattern instead:
+If the codebase does not use DI (e.g., old console app, library code), offer the ambient context pattern:
 
 ```csharp
 public static class Clock
 {
     private static readonly AsyncLocal<Func<DateTimeOffset>?> s_override = new();
-
     public static DateTimeOffset UtcNow
         => s_override.Value?.Invoke() ?? TimeProvider.System.GetUtcNow();
 
-    /// <summary>Test helper — pins the clock to a fixed time in the current async scope.</summary>
     public static IDisposable Override(DateTimeOffset fixedTime)
     {
         s_override.Value = () => fixedTime;
         return new Scope();
     }
-
-    public static IDisposable Override(Func<DateTimeOffset> factory)
-    {
-        s_override.Value = factory;
-        return new Scope();
-    }
-
     private sealed class Scope : IDisposable
     {
         public void Dispose() => s_override.Value = null;
@@ -219,10 +195,7 @@ public static class Clock
 }
 ```
 
-Explain the trade-offs:
-- **Production cost**: one static `readonly` field + one null check per call (negligible)
-- **Thread safety**: `AsyncLocal<T>` scopes per async flow — parallel tests don't interfere
-- **Limitation**: does not propagate to `Task.Run` unless the execution context is captured
+Key trade-offs: `AsyncLocal<T>` ensures parallel tests don't interfere; production cost is one null check per call; the `static readonly` field is essentially free.
 
 ### Step 6: Place generated files
 
@@ -255,3 +228,4 @@ Always generate:
 | Registering scoped when singleton suffices | Stateless wrappers should be `AddSingleton` |
 | Forgetting test helper packages | `Microsoft.Extensions.TimeProvider.Testing` for time, `System.IO.Abstractions.TestingHelpers` for filesystem |
 | Ambient context without `AsyncLocal` | Non-async `[ThreadStatic]` breaks with `async`/`await` — always use `AsyncLocal<T>` |
+

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -6,9 +6,12 @@ description: >
   Performs codemod-style bulk replacement of DateTime.UtcNow to TimeProvider.GetUtcNow(),
   File.ReadAllText to IFileSystem, and similar transformations. Adds constructor
   injection parameters and updates DI registration.
-  USE FOR: replace DateTime.Now with TimeProvider, migrate static calls to wrapper,
-  bulk replace File.* with IFileSystem, codemod static to injectable, add constructor
-  injection for time provider, mechanical migration of statics.
+  USE FOR: replace DateTime.UtcNow with TimeProvider, replace DateTime.Now with
+  TimeProvider, migrate static calls to wrapper, bulk replace File.* with IFileSystem,
+  codemod static to injectable, add constructor injection for time provider,
+  mechanical migration of statics, refactor DateTime to TimeProvider, swap static
+  for injected dependency, convert static calls to use abstraction, replace statics
+  in a class, migrate one file to TimeProvider, scoped migration, update call sites.
   DO NOT USE FOR: detecting statics (use detect-static-dependencies), generating
   wrappers (use generate-testability-wrappers), migrating between test frameworks.
 ---
@@ -63,71 +66,28 @@ For each file containing the static pattern, determine:
 
 #### Replacement mapping
 
-| Original Call | Replacement (DI) | Replacement (ambient) |
-|---------------|-------------------|-----------------------|
-| `DateTime.Now` | `_timeProvider.GetLocalNow().DateTime` | `Clock.Now` |
-| `DateTime.UtcNow` | `_timeProvider.GetUtcNow().DateTime` | `Clock.UtcNow` |
-| `DateTime.Today` | `_timeProvider.GetLocalNow().Date` | `Clock.Today` |
-| `DateTimeOffset.Now` | `_timeProvider.GetLocalNow()` | `Clock.Now` |
-| `DateTimeOffset.UtcNow` | `_timeProvider.GetUtcNow()` | `Clock.UtcNow` |
-| `Task.Delay(duration)` | `_timeProvider.Delay(duration)` | N/A |
-| `File.ReadAllText(path)` | `_fileSystem.File.ReadAllText(path)` | N/A |
-| `File.WriteAllText(path, text)` | `_fileSystem.File.WriteAllText(path, text)` | N/A |
-| `File.Exists(path)` | `_fileSystem.File.Exists(path)` | N/A |
-| `Directory.Exists(path)` | `_fileSystem.Directory.Exists(path)` | N/A |
-| `Directory.CreateDirectory(path)` | `_fileSystem.Directory.CreateDirectory(path)` | N/A |
-| `Environment.GetEnvironmentVariable(name)` | `_env.GetEnvironmentVariable(name)` | N/A |
-| `Console.WriteLine(msg)` | `_console.WriteLine(msg)` | N/A |
-| `Process.Start(info)` | `_processRunner.Start(info)` | N/A |
+| Category | Original | DI replacement |
+|----------|----------|----------------|
+| Time | `DateTime.Now` | `_timeProvider.GetLocalNow().DateTime` |
+| Time | `DateTime.UtcNow` | `_timeProvider.GetUtcNow().DateTime` |
+| Time | `DateTime.Today` | `_timeProvider.GetLocalNow().Date` |
+| Time | `DateTimeOffset.UtcNow` | `_timeProvider.GetUtcNow()` |
+| File | `File.ReadAllText(path)` | `_fileSystem.File.ReadAllText(path)` |
+| File | `File.WriteAllText(path, text)` | `_fileSystem.File.WriteAllText(path, text)` |
+| File | `File.Exists(path)` | `_fileSystem.File.Exists(path)` |
+| File | `Directory.Exists(path)` | `_fileSystem.Directory.Exists(path)` |
+| Env | `Environment.GetEnvironmentVariable(name)` | `_env.GetEnvironmentVariable(name)` |
+| Console | `Console.WriteLine(msg)` | `_console.WriteLine(msg)` |
+| Process | `Process.Start(info)` | `_processRunner.Start(info)` |
+
+Apply the same pattern for other members in each category.
 
 ### Step 3: Add constructor injection
 
-For each class that needs the new dependency:
+Add the new dependency following the class's existing pattern:
 
-#### Primary constructor (C# 12+ / .NET 8+, preferred if class already uses primary constructor)
-
-```csharp
-// Before:
-public class OrderProcessor(ILogger<OrderProcessor> logger)
-
-// After:
-public class OrderProcessor(ILogger<OrderProcessor> logger, TimeProvider timeProvider)
-```
-
-#### Traditional constructor
-
-```csharp
-// Before:
-public class OrderProcessor
-{
-    private readonly ILogger<OrderProcessor> _logger;
-
-    public OrderProcessor(ILogger<OrderProcessor> logger)
-    {
-        _logger = logger;
-    }
-}
-
-// After:
-public class OrderProcessor
-{
-    private readonly ILogger<OrderProcessor> _logger;
-    private readonly TimeProvider _timeProvider;
-
-    public OrderProcessor(ILogger<OrderProcessor> logger, TimeProvider timeProvider)
-    {
-        _logger = logger;
-        _timeProvider = timeProvider;
-    }
-}
-```
-
-#### Field naming convention
-
-Follow the existing convention in the class:
-- If other fields use `_camelCase`, use `_timeProvider`
-- If other fields use `m_camelCase`, use `m_timeProvider`
-- If primary constructor, use the parameter name directly
+- **Primary constructor** (C# 12+): Add parameter to primary constructor: `public class OrderProcessor(ILogger<OrderProcessor> logger, TimeProvider timeProvider)`
+- **Traditional constructor**: Add `private readonly` field + constructor parameter, matching the existing field naming convention (`_camelCase` or `m_camelCase`)
 
 ### Step 4: Replace call sites
 

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: migrate-static-to-wrapper
+description: >
+  Mechanically replace static dependency call sites with wrapper or built-in
+  abstraction calls across a bounded scope (file, project, or namespace).
+  Performs codemod-style bulk replacement of DateTime.UtcNow to TimeProvider.GetUtcNow(),
+  File.ReadAllText to IFileSystem, and similar transformations. Adds constructor
+  injection parameters and updates DI registration.
+  USE FOR: replace DateTime.Now with TimeProvider, migrate static calls to wrapper,
+  bulk replace File.* with IFileSystem, codemod static to injectable, add constructor
+  injection for time provider, mechanical migration of statics.
+  DO NOT USE FOR: detecting statics (use detect-static-dependencies), generating
+  wrappers (use generate-testability-wrappers), migrating between test frameworks.
+---
+
+# Migrate Static to Wrapper
+
+Perform mechanical, codemod-style replacement of static dependency call sites with calls to injected wrapper interfaces or built-in abstractions. Operates on a bounded scope (single file, project, or namespace) so migrations can be done incrementally.
+
+## When to Use
+
+- After wrappers have been generated (via `generate-testability-wrappers`) or built-in abstractions identified
+- Migrating `DateTime.UtcNow` → `TimeProvider.GetUtcNow()` across a project
+- Migrating `File.*` → `IFileSystem.File.*` across a namespace
+- Adding constructor injection for the new abstraction to affected classes
+- Incremental migration: one project or namespace at a time
+
+## When Not to Use
+
+- No wrapper or abstraction exists yet (use `generate-testability-wrappers` first)
+- The user wants to detect statics, not migrate them (use `detect-static-dependencies`)
+- The code does not use dependency injection and the user hasn't chosen ambient context
+- Migrating between test frameworks (use the appropriate migration skill)
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Static pattern | Yes | What to replace (e.g., `DateTime.UtcNow`, `File.ReadAllText`) |
+| Replacement abstraction | Yes | What to use instead (e.g., `TimeProvider`, `IFileSystem`) |
+| Scope | Yes | File path, project (.csproj), namespace, or directory to migrate |
+| Injection strategy | No | `constructor` (default), `primary-constructor`, or `ambient` |
+
+## Workflow
+
+### Step 1: Verify prerequisites
+
+Before modifying any code:
+
+1. **Confirm the wrapper/abstraction exists**: Check that the interface or built-in abstraction is available in the project. For `TimeProvider`, verify the target framework is .NET 8+ or `Microsoft.Bcl.TimeProvider` is referenced. For `System.IO.Abstractions`, verify the NuGet package is referenced.
+
+2. **Confirm DI registration exists**: Check `Program.cs` or `Startup.cs` for the service registration. If missing, add it before proceeding.
+
+3. **Identify all files in scope**: List the `.cs` files that will be modified. Exclude test projects, `obj/`, `bin/`, and generated code.
+
+### Step 2: Plan the migration for each file
+
+For each file containing the static pattern, determine:
+
+1. **Which class(es) contain the call sites** — identify the class declarations
+2. **Whether the class already has the dependency injected** — check constructors for existing `TimeProvider`, `IFileSystem`, etc. parameters
+3. **The replacement expression** for each call site
+
+#### Replacement mapping
+
+| Original Call | Replacement (DI) | Replacement (ambient) |
+|---------------|-------------------|-----------------------|
+| `DateTime.Now` | `_timeProvider.GetLocalNow().DateTime` | `Clock.Now` |
+| `DateTime.UtcNow` | `_timeProvider.GetUtcNow().DateTime` | `Clock.UtcNow` |
+| `DateTime.Today` | `_timeProvider.GetLocalNow().Date` | `Clock.Today` |
+| `DateTimeOffset.Now` | `_timeProvider.GetLocalNow()` | `Clock.Now` |
+| `DateTimeOffset.UtcNow` | `_timeProvider.GetUtcNow()` | `Clock.UtcNow` |
+| `Task.Delay(duration)` | `_timeProvider.Delay(duration)` | N/A |
+| `File.ReadAllText(path)` | `_fileSystem.File.ReadAllText(path)` | N/A |
+| `File.WriteAllText(path, text)` | `_fileSystem.File.WriteAllText(path, text)` | N/A |
+| `File.Exists(path)` | `_fileSystem.File.Exists(path)` | N/A |
+| `Directory.Exists(path)` | `_fileSystem.Directory.Exists(path)` | N/A |
+| `Directory.CreateDirectory(path)` | `_fileSystem.Directory.CreateDirectory(path)` | N/A |
+| `Environment.GetEnvironmentVariable(name)` | `_env.GetEnvironmentVariable(name)` | N/A |
+| `Console.WriteLine(msg)` | `_console.WriteLine(msg)` | N/A |
+| `Process.Start(info)` | `_processRunner.Start(info)` | N/A |
+
+### Step 3: Add constructor injection
+
+For each class that needs the new dependency:
+
+#### Primary constructor (C# 12+ / .NET 8+, preferred if class already uses primary constructor)
+
+```csharp
+// Before:
+public class OrderProcessor(ILogger<OrderProcessor> logger)
+
+// After:
+public class OrderProcessor(ILogger<OrderProcessor> logger, TimeProvider timeProvider)
+```
+
+#### Traditional constructor
+
+```csharp
+// Before:
+public class OrderProcessor
+{
+    private readonly ILogger<OrderProcessor> _logger;
+
+    public OrderProcessor(ILogger<OrderProcessor> logger)
+    {
+        _logger = logger;
+    }
+}
+
+// After:
+public class OrderProcessor
+{
+    private readonly ILogger<OrderProcessor> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public OrderProcessor(ILogger<OrderProcessor> logger, TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+}
+```
+
+#### Field naming convention
+
+Follow the existing convention in the class:
+- If other fields use `_camelCase`, use `_timeProvider`
+- If other fields use `m_camelCase`, use `m_timeProvider`
+- If primary constructor, use the parameter name directly
+
+### Step 4: Replace call sites
+
+Perform each replacement mechanically. For each call site:
+
+1. Replace the static call with the wrapper call
+2. Preserve the surrounding code structure (whitespace, comments, chaining)
+3. Add required `using` directives if not already present
+
+#### Adding using directives
+
+| Abstraction | Using directive |
+|------------|-----------------|
+| `TimeProvider` | None (in `System` namespace) |
+| `IFileSystem` | `using System.IO.Abstractions;` |
+| `IHttpClientFactory` | `using System.Net.Http;` (usually already present) |
+| Custom wrappers | `using <wrapper namespace>;` |
+
+### Step 5: Update affected test files
+
+If test files exist for the migrated classes:
+
+1. **Update constructor calls** — add the new parameter to test class instantiation
+2. **Use test doubles**:
+   - `TimeProvider` → `new FakeTimeProvider()` from `Microsoft.Extensions.TimeProvider.Testing`
+   - `IFileSystem` → `new MockFileSystem()` from `System.IO.Abstractions.TestingHelpers`
+   - Custom wrappers → `new Mock<IWrapperName>()` or hand-rolled fake
+
+### Step 6: Build verification
+
+After all changes in the current scope:
+
+```bash
+dotnet build <project.csproj>
+```
+
+If the build fails:
+- **Missing using**: Add the required `using` directive
+- **Missing NuGet package**: Run `dotnet add package <name>`
+- **Constructor mismatch in tests**: Update test instantiation (Step 5)
+- **Ambiguous call**: Fully qualify the wrapper call
+
+### Step 7: Report changes
+
+Summarize what was done:
+
+```
+## Migration Summary
+
+**Pattern**: DateTime.UtcNow → TimeProvider.GetUtcNow()
+**Scope**: MyProject/Services/
+
+### Files Modified (production)
+| File | Call Sites Replaced | Injection Added |
+|------|--------------------:|:----------------|
+| OrderProcessor.cs | 3 | Yes (constructor) |
+| NotificationService.cs | 1 | Yes (primary ctor) |
+
+### Files Modified (tests)
+| File | Change |
+|------|--------|
+| OrderProcessorTests.cs | Added FakeTimeProvider parameter |
+
+### Remaining (out of scope)
+- MyProject/Legacy/ — 8 call sites not migrated (different namespace)
+```
+
+## Validation
+
+- [ ] All call sites in scope were replaced (none missed)
+- [ ] Constructor injection added to all affected classes
+- [ ] Field naming follows existing class conventions
+- [ ] Required `using` directives added
+- [ ] Required NuGet packages referenced
+- [ ] Build succeeds after migration
+- [ ] Test files updated with appropriate test doubles
+- [ ] No behavioral changes introduced (wrapper delegates directly to the static)
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Replacing statics in test code | Only replace in production code; tests should use fakes/mocks |
+| Breaking static classes | Static classes can't have constructors — use ambient context for these |
+| Missing `FakeTimeProvider` NuGet | Add `Microsoft.Extensions.TimeProvider.Testing` to test project |
+| Replacing in expression-bodied members without updating return type | `DateTime` → `DateTimeOffset` when using `TimeProvider.GetUtcNow()` — verify type compatibility |
+| Migrating too much at once | Stick to the defined scope — one project or namespace per run |
+| Forgetting DI registration | Always verify `Program.cs`/`Startup.cs` has the registration before replacing call sites |

--- a/tests/dotnet-test/agent.testability-migration/eval.yaml
+++ b/tests/dotnet-test/agent.testability-migration/eval.yaml
@@ -1,0 +1,50 @@
+scenarios:
+  - name: "Full pipeline: detect statics and recommend migration plan"
+    prompt: |
+      I have a SubscriptionManager class that's impossible to unit test because it
+      uses DateTime.UtcNow, File.*, Directory.*, Environment.*, and Console.* all
+      directly. Can you analyze it and help me make it testable?
+    setup:
+      copy_test_files: true
+      additional_required_skills:
+        - detect-static-dependencies
+        - generate-testability-wrappers
+        - migrate-static-to-wrapper
+    assertions:
+      - type: "output_matches"
+        pattern: "(DateTime\\.UtcNow|DateTime\\.Now|time)"
+      - type: "output_matches"
+        pattern: "(File\\.|Directory\\.|file system|filesystem)"
+      - type: "output_matches"
+        pattern: "(TimeProvider|IFileSystem|System\\.IO\\.Abstractions|wrapper|abstraction)"
+      - type: "exit_success"
+    rubric:
+      - "Identified the static dependencies in SubscriptionManager (time, filesystem, environment, console)"
+      - "Recommended TimeProvider for replacing DateTime.UtcNow calls"
+      - "Recommended System.IO.Abstractions or a wrapper for File/Directory calls"
+      - "Proposed an incremental migration plan rather than changing everything at once"
+      - "Produced concrete code changes or clear next steps"
+    timeout: 300
+
+  - name: "Targeted request: just migrate DateTime to TimeProvider"
+    prompt: |
+      I only care about making the time calls testable right now. Replace DateTime.UtcNow
+      with TimeProvider in my SubscriptionManager class. I'm on .NET 10.
+    setup:
+      copy_test_files: true
+      additional_required_skills:
+        - migrate-static-to-wrapper
+    assertions:
+      - type: "file_contains"
+        path: "**/SubscriptionManager.cs"
+        value: "TimeProvider"
+      - type: "file_not_contains"
+        path: "**/SubscriptionManager.cs"
+        value: "DateTime.UtcNow"
+      - type: "exit_success"
+    rubric:
+      - "Replaced all DateTime.UtcNow calls in SubscriptionManager with TimeProvider equivalents"
+      - "Added TimeProvider as a dependency to SubscriptionManager via constructor injection"
+      - "Registered TimeProvider.System in the DI container in Program.cs"
+      - "Did not modify the File.*, Directory.*, Environment.*, or Console.* calls — stayed focused"
+    timeout: 300

--- a/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/FullPipeline.csproj
+++ b/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/FullPipeline.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/Program.cs
+++ b/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/Program.cs
@@ -1,0 +1,4 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/", () => "Hello World");
+app.Run();

--- a/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/Services/SubscriptionManager.cs
+++ b/tests/dotnet-test/agent.testability-migration/fixtures/full-pipeline/Services/SubscriptionManager.cs
@@ -1,0 +1,41 @@
+namespace FullPipeline.Services;
+
+public class SubscriptionManager
+{
+    public Subscription CreateTrial(string userId)
+    {
+        return new Subscription
+        {
+            UserId = userId,
+            StartedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(14),
+            Plan = "trial"
+        };
+    }
+
+    public bool IsActive(Subscription sub)
+    {
+        return DateTime.UtcNow < sub.ExpiresAt;
+    }
+
+    public void ExportSubscription(Subscription sub)
+    {
+        var exportDir = Environment.GetEnvironmentVariable("EXPORT_DIR") ?? "/tmp/exports";
+        if (!Directory.Exists(exportDir))
+        {
+            Directory.CreateDirectory(exportDir);
+        }
+
+        var json = System.Text.Json.JsonSerializer.Serialize(sub);
+        File.WriteAllText(Path.Combine(exportDir, $"{sub.UserId}.json"), json);
+        Console.WriteLine($"Exported subscription for {sub.UserId}");
+    }
+}
+
+public class Subscription
+{
+    public string UserId { get; set; } = "";
+    public DateTime StartedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public string Plan { get; set; } = "";
+}

--- a/tests/dotnet-test/detect-static-dependencies/eval.yaml
+++ b/tests/dotnet-test/detect-static-dependencies/eval.yaml
@@ -41,10 +41,10 @@ scenarios:
         pattern: "(TimeProvider|time provider|ISystemClock|abstraction)"
       - type: "exit_success"
     rubric:
-      - "Found all DateTime.UtcNow and DateTime.Now call sites across multiple files"
-      - "Identified OrderProcessor.cs and NotificationService.cs as files with time dependencies"
-      - "Recommended TimeProvider as the replacement abstraction for .NET 8+"
-      - "Explained that the static calls make tests non-deterministic"
+      - "Found DateTime.UtcNow and/or DateTime.Now call sites in the project"
+      - "Identified specific files containing time-related static dependencies"
+      - "Recommended TimeProvider or a similar abstraction as the replacement for .NET 8+"
+      - "Explained that the static calls make tests non-deterministic or hard to test"
     timeout: 120
 
   - name: "Decline scan for non-C# project"

--- a/tests/dotnet-test/detect-static-dependencies/eval.yaml
+++ b/tests/dotnet-test/detect-static-dependencies/eval.yaml
@@ -1,0 +1,70 @@
+scenarios:
+  - name: "Identify static dependencies in a multi-class project"
+    prompt: |
+      I have a .NET project at StaticHeavy/ that I suspect has a lot of hard-to-test
+      static calls. Can you scan it and tell me what's making it hard to unit test?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "output_matches"
+        pattern: "(DateTime\\.UtcNow|DateTime\\.Now)"
+      - type: "output_matches"
+        pattern: "(File\\.|file system|filesystem|IFileSystem)"
+      - type: "output_matches"
+        pattern: "(Environment\\.|environment variable)"
+      - type: "output_matches"
+        pattern: "(Console\\.|console)"
+      - type: "output_matches"
+        pattern: "(HttpClient|http client)"
+      - type: "exit_success"
+    rubric:
+      - "Identified DateTime.UtcNow and DateTime.Now as frequently used static dependencies"
+      - "Identified File.WriteAllText, File.ReadAllText, File.Exists, and File.AppendAllText as file system statics"
+      - "Identified Environment.GetEnvironmentVariable as environment static usage"
+      - "Identified Console.WriteLine as untestable console output"
+      - "Identified new HttpClient() as a hard-to-test network dependency"
+      - "Ranked or prioritized the static categories by frequency or migration ease"
+      - "Recommended a concrete next step such as wrapping the statics or adopting TimeProvider"
+    timeout: 120
+
+  - name: "Detect time-related statics and recommend TimeProvider"
+    prompt: |
+      My OrderProcessor.cs uses DateTime.UtcNow in several places and it's impossible
+      to write deterministic tests. Can you find all the time-related static calls in
+      my project and tell me what to do about them?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "output_matches"
+        pattern: "(DateTime\\.UtcNow|DateTime\\.Now)"
+      - type: "output_matches"
+        pattern: "(TimeProvider|time provider|ISystemClock|abstraction)"
+      - type: "exit_success"
+    rubric:
+      - "Found all DateTime.UtcNow and DateTime.Now call sites across multiple files"
+      - "Identified OrderProcessor.cs and NotificationService.cs as files with time dependencies"
+      - "Recommended TimeProvider as the replacement abstraction for .NET 8+"
+      - "Explained that the static calls make tests non-deterministic"
+    timeout: 120
+
+  - name: "Decline scan for non-C# project"
+    prompt: |
+      I have a Python Django project at my_app/ that has lots of datetime.now() calls.
+      Can you scan it for untestable statics?
+    expect_activation: false
+    setup:
+      files:
+        - path: "my_app/views.py"
+          content: |
+            from datetime import datetime
+            def index(request):
+                now = datetime.now()
+                return render(request, 'index.html', {'time': now})
+    assertions:
+      - type: "output_matches"
+        pattern: "(Python|not.*(C#|\\.NET)|different|unsupported)"
+    rubric:
+      - "Recognized that the project is Python, not C#/.NET"
+      - "Did not attempt to scan for .NET static patterns"
+      - "Suggested an alternative approach or clarified it only supports .NET"
+    timeout: 60

--- a/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Program.cs
+++ b/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Program.cs
@@ -1,0 +1,9 @@
+namespace StaticHeavy;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("Static Heavy Application");
+    }
+}

--- a/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/ConfigLoader.cs
+++ b/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/ConfigLoader.cs
@@ -1,0 +1,40 @@
+namespace StaticHeavy.Services;
+
+public class ConfigLoader
+{
+    public Dictionary<string, string> LoadConfig(string configPath)
+    {
+        if (!File.Exists(configPath))
+        {
+            throw new FileNotFoundException($"Config file not found: {configPath}");
+        }
+
+        var content = File.ReadAllText(configPath);
+        var lines = content.Split('\n');
+        var config = new Dictionary<string, string>();
+
+        foreach (var line in lines)
+        {
+            var parts = line.Split('=', 2);
+            if (parts.Length == 2)
+            {
+                config[parts[0].Trim()] = parts[1].Trim();
+            }
+        }
+
+        Console.WriteLine($"Loaded {config.Count} config entries from {configPath}");
+        return config;
+    }
+
+    public void SaveConfig(string configPath, Dictionary<string, string> config)
+    {
+        var dir = Path.GetDirectoryName(configPath);
+        if (dir != null && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var lines = config.Select(kv => $"{kv.Key}={kv.Value}");
+        File.WriteAllText(configPath, string.Join('\n', lines));
+    }
+}

--- a/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/NotificationService.cs
+++ b/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/NotificationService.cs
@@ -1,0 +1,37 @@
+namespace StaticHeavy.Services;
+
+public class NotificationService
+{
+    public void SendReminder(Order order)
+    {
+        var daysUntilExpiry = (order.ExpiresAt - DateTime.UtcNow).TotalDays;
+
+        if (daysUntilExpiry <= 7 && daysUntilExpiry > 0)
+        {
+            var message = $"Order {order.Id} expires in {daysUntilExpiry:F0} days";
+            Console.WriteLine(message);
+
+            var logPath = Path.Combine(
+                Environment.GetEnvironmentVariable("LOG_PATH") ?? "/tmp/logs",
+                $"reminder_{DateTime.UtcNow:yyyyMMdd}.log");
+
+            File.AppendAllText(logPath, $"{DateTime.UtcNow:O} - {message}\n");
+        }
+    }
+
+    public async Task<bool> CheckServiceHealthAsync(string healthUrl)
+    {
+        using var client = new HttpClient();
+        client.Timeout = TimeSpan.FromSeconds(5);
+
+        try
+        {
+            var response = await client.GetAsync(healthUrl);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/OrderProcessor.cs
+++ b/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/Services/OrderProcessor.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+
+namespace StaticHeavy.Services;
+
+public class OrderProcessor
+{
+    private readonly ILogger<OrderProcessor> _logger;
+
+    public OrderProcessor(ILogger<OrderProcessor> logger)
+    {
+        _logger = logger;
+    }
+
+    public Order CreateOrder(string customerId, decimal amount)
+    {
+        var order = new Order
+        {
+            Id = Guid.NewGuid().ToString(),
+            CustomerId = customerId,
+            Amount = amount,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(30)
+        };
+
+        var receipt = $"Order {order.Id} created at {DateTime.Now}";
+        File.WriteAllText(Path.Combine(Path.GetTempPath(), $"{order.Id}.txt"), receipt);
+
+        _logger.LogInformation("Order created: {OrderId}", order.Id);
+        return order;
+    }
+
+    public bool IsExpired(Order order)
+    {
+        return DateTime.UtcNow > order.ExpiresAt;
+    }
+
+    public void ArchiveOrder(Order order)
+    {
+        var archiveDir = Path.Combine(Environment.GetEnvironmentVariable("ARCHIVE_PATH") ?? "/tmp/archive", "orders");
+        if (!Directory.Exists(archiveDir))
+        {
+            Directory.CreateDirectory(archiveDir);
+        }
+
+        var json = System.Text.Json.JsonSerializer.Serialize(order);
+        File.WriteAllText(Path.Combine(archiveDir, $"{order.Id}.json"), json);
+
+        Console.WriteLine($"Archived order {order.Id}");
+    }
+}
+
+public class Order
+{
+    public string Id { get; set; } = "";
+    public string CustomerId { get; set; } = "";
+    public decimal Amount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}

--- a/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/StaticHeavy.csproj
+++ b/tests/dotnet-test/detect-static-dependencies/fixtures/static-heavy-project/StaticHeavy.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/generate-testability-wrappers/eval.yaml
+++ b/tests/dotnet-test/generate-testability-wrappers/eval.yaml
@@ -20,7 +20,7 @@ scenarios:
       - "Showed how to inject TimeProvider into the ReportGenerator class"
       - "Showed how to use FakeTimeProvider in tests to pin time"
       - "Mentioned the Microsoft.Extensions.TimeProvider.Testing NuGet package for testing"
-    timeout: 120
+    timeout: 240
 
   - name: "Generate custom Environment wrapper"
     prompt: |
@@ -40,7 +40,7 @@ scenarios:
       - "Generated a default implementation that delegates to the real Environment static class"
       - "Provided DI registration code for the wrapper"
       - "Only wrapped the two members actually used in the code, not every Environment member"
-    timeout: 120
+    timeout: 240
 
   - name: "Recommend System.IO.Abstractions for file system calls"
     prompt: |
@@ -59,7 +59,7 @@ scenarios:
       - "Showed how to register IFileSystem in DI"
       - "Showed how to use MockFileSystem in tests"
       - "Did not generate a custom file system wrapper when the established package exists"
-    timeout: 120
+    timeout: 240
 
   - name: "Decline wrapper generation for already-abstracted code"
     prompt: |
@@ -83,4 +83,4 @@ scenarios:
       - "Recognized that IFileSystem is already in use and no wrapper generation is needed"
       - "Did not generate a redundant wrapper interface"
       - "May have suggested other improvements but did not create duplicate abstractions"
-    timeout: 60
+    timeout: 120

--- a/tests/dotnet-test/generate-testability-wrappers/eval.yaml
+++ b/tests/dotnet-test/generate-testability-wrappers/eval.yaml
@@ -1,0 +1,86 @@
+scenarios:
+  - name: "Generate TimeProvider adoption for DateTime.UtcNow"
+    prompt: |
+      My ReportGenerator class uses DateTime.UtcNow and I can't write deterministic
+      unit tests for it. I'm on .NET 10. Can you create the right abstraction so
+      I can mock time in tests?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "output_matches"
+        pattern: "(TimeProvider|time provider)"
+      - type: "output_matches"
+        pattern: "(FakeTimeProvider|fake.*time|mock.*time|test.*time)"
+      - type: "output_matches"
+        pattern: "(AddSingleton|Register|services\\.Add)"
+      - type: "exit_success"
+    rubric:
+      - "Recommended TimeProvider as the built-in abstraction since the project targets .NET 10"
+      - "Showed how to register TimeProvider.System in the DI container"
+      - "Showed how to inject TimeProvider into the ReportGenerator class"
+      - "Showed how to use FakeTimeProvider in tests to pin time"
+      - "Mentioned the Microsoft.Extensions.TimeProvider.Testing NuGet package for testing"
+    timeout: 120
+
+  - name: "Generate custom Environment wrapper"
+    prompt: |
+      My code calls Environment.GetEnvironmentVariable and Environment.MachineName
+      directly. I need to make these testable. Can you generate a wrapper interface
+      and implementation I can inject?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "output_matches"
+        pattern: "(interface|IEnvironment)"
+      - type: "output_matches"
+        pattern: "(GetEnvironmentVariable|MachineName)"
+      - type: "exit_success"
+    rubric:
+      - "Generated an interface with methods for GetEnvironmentVariable and MachineName"
+      - "Generated a default implementation that delegates to the real Environment static class"
+      - "Provided DI registration code for the wrapper"
+      - "Only wrapped the two members actually used in the code, not every Environment member"
+    timeout: 120
+
+  - name: "Recommend System.IO.Abstractions for file system calls"
+    prompt: |
+      I've got File.WriteAllText, File.ReadAllText, and Directory.Exists scattered
+      across my project. What's the best way to make these testable?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "output_matches"
+        pattern: "(System\\.IO\\.Abstractions|IFileSystem)"
+      - type: "output_matches"
+        pattern: "(MockFileSystem|mock.*file)"
+      - type: "exit_success"
+    rubric:
+      - "Recommended System.IO.Abstractions NuGet package instead of writing a custom wrapper"
+      - "Showed how to register IFileSystem in DI"
+      - "Showed how to use MockFileSystem in tests"
+      - "Did not generate a custom file system wrapper when the established package exists"
+    timeout: 120
+
+  - name: "Decline wrapper generation for already-abstracted code"
+    prompt: |
+      My code already uses IFileSystem from System.IO.Abstractions everywhere.
+      Can you generate a file system wrapper for me?
+    expect_activation: false
+    setup:
+      files:
+        - path: "Services/DataService.cs"
+          content: |
+            using System.IO.Abstractions;
+            namespace MyApp.Services;
+            public class DataService(IFileSystem fileSystem)
+            {
+                public string ReadData(string path) => fileSystem.File.ReadAllText(path);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(already|exists|abstracted|no need|unnecessary)"
+    rubric:
+      - "Recognized that IFileSystem is already in use and no wrapper generation is needed"
+      - "Did not generate a redundant wrapper interface"
+      - "May have suggested other improvements but did not create duplicate abstractions"
+    timeout: 60

--- a/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/NeedsWrappers.csproj
+++ b/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/NeedsWrappers.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/Program.cs
+++ b/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/Program.cs
@@ -1,0 +1,9 @@
+namespace NeedsWrappers;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("NeedsWrappers");
+    }
+}

--- a/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/Services/ReportGenerator.cs
+++ b/tests/dotnet-test/generate-testability-wrappers/fixtures/needs-wrappers/Services/ReportGenerator.cs
@@ -1,0 +1,23 @@
+namespace NeedsWrappers.Services;
+
+public class ReportGenerator
+{
+    public string GenerateReport(string reportName)
+    {
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+        var outputDir = Environment.GetEnvironmentVariable("REPORT_OUTPUT_DIR") ?? "/tmp/reports";
+
+        if (!Directory.Exists(outputDir))
+        {
+            Directory.CreateDirectory(outputDir);
+        }
+
+        var reportPath = Path.Combine(outputDir, $"{reportName}_{timestamp}.txt");
+        var content = $"Report: {reportName}\nGenerated: {DateTime.UtcNow:O}\nMachine: {Environment.MachineName}";
+
+        File.WriteAllText(reportPath, content);
+        Console.WriteLine($"Report written to {reportPath}");
+
+        return reportPath;
+    }
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -1,0 +1,75 @@
+scenarios:
+  - name: "Migrate DateTime.UtcNow to TimeProvider in a service class"
+    prompt: |
+      I have a CouponService that uses DateTime.UtcNow in several places. TimeProvider
+      is already registered in my DI container. Can you replace all the DateTime.UtcNow
+      calls with TimeProvider and add the constructor parameter?
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "file_contains"
+        path: "**/CouponService.cs"
+        value: "TimeProvider"
+      - type: "file_not_contains"
+        path: "**/CouponService.cs"
+        value: "DateTime.UtcNow"
+      - type: "exit_success"
+    rubric:
+      - "Replaced all DateTime.UtcNow calls in CouponService.cs with TimeProvider calls"
+      - "Added TimeProvider as a constructor parameter to CouponService"
+      - "Stored TimeProvider in a readonly field following the class's existing naming convention"
+      - "Did not change the behavior of any method — only the time source changed"
+      - "Did not modify Program.cs DI registration since TimeProvider was already registered"
+    timeout: 180
+
+  - name: "Migrate only in scoped files, leaving others untouched"
+    prompt: |
+      I want to migrate DateTime.UtcNow to TimeProvider, but only in CouponService.cs
+      for now. Don't touch AuditLogger.cs yet — I'll do that in a separate pass.
+      TimeProvider is already in my DI container.
+    setup:
+      copy_test_files: true
+    assertions:
+      - type: "file_contains"
+        path: "**/CouponService.cs"
+        value: "TimeProvider"
+      - type: "file_contains"
+        path: "**/AuditLogger.cs"
+        value: "DateTime.UtcNow"
+      - type: "exit_success"
+    rubric:
+      - "Migrated DateTime.UtcNow to TimeProvider in CouponService.cs"
+      - "Left AuditLogger.cs completely untouched with DateTime.UtcNow calls still present"
+      - "Respected the scope boundary the user specified"
+      - "Reported what was migrated and what remains to be done"
+    timeout: 180
+
+  - name: "Decline migration when wrapper does not exist yet"
+    prompt: |
+      Replace all File.ReadAllText calls in my project with IFileSystem. Just do
+      the bulk replacement across all files.
+    expect_activation: false
+    setup:
+      files:
+        - path: "MyProject/MyProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+        - path: "MyProject/DataLoader.cs"
+          content: |
+            namespace MyProject;
+            public class DataLoader
+            {
+                public string Load(string path) => File.ReadAllText(path);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(System\\.IO\\.Abstractions|package|install|not.*registered|not.*referenced|add.*package)"
+    rubric:
+      - "Identified that System.IO.Abstractions NuGet package is not referenced in the project"
+      - "Did not blindly replace File.ReadAllText with IFileSystem calls that would not compile"
+      - "Recommended installing the package and registering IFileSystem before migrating"
+    timeout: 120

--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -72,4 +72,4 @@ scenarios:
       - "Identified that System.IO.Abstractions NuGet package is not referenced in the project"
       - "Did not blindly replace File.ReadAllText with IFileSystem calls that would not compile"
       - "Recommended installing the package and registering IFileSystem before migrating"
-    timeout: 120
+    timeout: 180

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Program.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton(TimeProvider.System);
+
+var app = builder.Build();
+app.Run();

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/ReadyToMigrate.csproj
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/ReadyToMigrate.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Services/AuditLogger.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Services/AuditLogger.cs
@@ -1,0 +1,11 @@
+namespace ReadyToMigrate.Services;
+
+public class AuditLogger
+{
+    public void LogAction(string userId, string action)
+    {
+        var timestamp = DateTime.UtcNow;
+        var entry = $"[{timestamp:O}] User={userId} Action={action}";
+        Console.WriteLine(entry);
+    }
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Services/CouponService.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/ready-to-migrate/Services/CouponService.cs
@@ -1,0 +1,44 @@
+namespace ReadyToMigrate.Services;
+
+public class CouponService
+{
+    private readonly ILogger<CouponService> _logger;
+
+    public CouponService(ILogger<CouponService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Coupon CreateCoupon(string code, int validDays)
+    {
+        return new Coupon
+        {
+            Code = code,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddDays(validDays)
+        };
+    }
+
+    public bool IsValid(Coupon coupon)
+    {
+        if (DateTime.UtcNow > coupon.ExpiresAt)
+        {
+            _logger.LogInformation("Coupon {Code} expired at {Expiry}", coupon.Code, coupon.ExpiresAt);
+            return false;
+        }
+        return true;
+    }
+
+    public TimeSpan TimeUntilExpiry(Coupon coupon)
+    {
+        var remaining = coupon.ExpiresAt - DateTime.UtcNow;
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
+}
+
+public class Coupon
+{
+    public string Code { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}


### PR DESCRIPTION
Introduces three skills and one orchestrator agent to help developers incrementally replace hard-to-test static dependencies with injectable abstractions:

- detect-static-dependencies: scans C# code for DateTime.Now, File.*, Environment.*, HttpClient, Console.*, Process.* and ranks by frequency
- generate-testability-wrappers: generates wrapper interfaces or guides adoption of built-in abstractions (TimeProvider, IHttpClientFactory, System.IO.Abstractions)
- migrate-static-to-wrapper: mechanical codemod-style bulk replacement of static call sites with wrapper calls, scoped per project/namespace
- testability-migration agent: orchestrates the Detect-Generate-Migrate pipeline end-to-end

Includes eval.yaml tests and fixture projects for all three skills and the agent.