### PR TITLE
Add 'dotnet sln add' step to code-testing-implementer

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -34,7 +34,11 @@ For each file in your phase:
 - Note dependencies and how to mock them
 - **Validate project references**: Read the test project file and verify it references the source project(s) you'll test. Add missing references before creating test files
 
-### 3. Write Test Files
+### 3. Register Test Project with Solution
+
+If the test project is new (just created by you or a previous phase), find the `.sln`/`.slnx` file and run `dotnet sln <solution> add <test-project.csproj>` so that `dotnet test <solution>` discovers the tests. Skip this if the project is already in the solution.
+
+### 4. Write Test Files
 
 For each test file in your phase:
 
@@ -43,13 +47,13 @@ For each test file in your phase:
 - Include tests for: happy path, edge cases (empty, null, boundary), error conditions
 - Mock all external dependencies — never call external URLs, bind ports, or depend on timing
 
-### 4. Verify with Build
+### 5. Verify with Build
 
 Call the `code-testing-builder` sub-agent to compile. Build only the specific test project, not the full solution.
 
 If build fails: call `code-testing-fixer`, rebuild, retry up to 3 times.
 
-### 5. Verify with Tests
+### 6. Verify with Tests
 
 Call the `code-testing-tester` sub-agent to run tests.
 
@@ -65,11 +69,11 @@ If tests fail:
 - Never mark a test `[Ignore]`, `[Skip]`, or `[Inconclusive]`
 - Retry the fix-test cycle up to 5 times
 
-### 6. Format Code (Optional)
+### 7. Format Code (Optional)
 
 If a lint command is available, call the `code-testing-linter` sub-agent.
 
-### 7. Report Results
+### 8. Report Results
 
 ```text
 PHASE: [N]

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -36,7 +36,7 @@ For each file in your phase:
 
 ### 3. Register Test Project with Solution
 
-If the test project is new (just created by you or a previous phase), find the `.sln`/`.slnx` file and run `dotnet sln <solution> add <test-project.csproj>` so that `dotnet test <solution>` discovers the tests. Skip this if the project is already in the solution.
+If the test project is new (just created by you or a previous phase), use the exact solution target already identified in `.testagent/research.md` or `.testagent/plan.md` rather than searching for any `.sln`/`.slnx` file. If that target is a `.sln` or `.slnx`, add the test project to that solution with `dotnet sln <solution> add <test-project.csproj>` so the planned test command can discover it. If the target is a `.slnf` (solution filter), make sure the new test project is included in the active test target as well as in the underlying solution if needed; adding only to the underlying `.sln` may not be enough for test discovery. Skip this if the project is already included in the solution/solution filter used for testing. When referring to test execution, prefer the researched command or `dotnet test --solution <solution>` over `dotnet test <solution>`.
 
 ### 4. Write Test Files
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -34,9 +34,9 @@ For each file in your phase:
 - Note dependencies and how to mock them
 - **Validate project references**: Read the test project file and verify it references the source project(s) you'll test. Add missing references before creating test files
 
-### 3. Register Test Project with Solution
+### 3. Register Test Project with Build System
 
-If the test project is new (just created by you or a previous phase), use the exact solution target already identified in `.testagent/research.md` or `.testagent/plan.md` rather than searching for any `.sln`/`.slnx` file. If that target is a `.sln` or `.slnx`, add the test project to that solution with `dotnet sln <solution> add <test-project.csproj>` so the planned test command can discover it. If the target is a `.slnf` (solution filter), make sure the new test project is included in the active test target as well as in the underlying solution if needed; adding only to the underlying `.sln` may not be enough for test discovery. Skip this if the project is already included in the solution/solution filter used for testing. When referring to test execution, prefer the researched command or `dotnet test --solution <solution>` over `dotnet test <solution>`.
+If the test project is new, register it with the project's build system so the test command can discover it. See `extensions/` for language-specific instructions (e.g., `extensions/dotnet.md` for .NET solution registration).
 
 ### 4. Write Test Files
 

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
@@ -65,11 +65,11 @@ This prevents CS0234 ("namespace not found") and CS0246 ("type not found") error
 
 If a new test project was created, register it with the solution so `dotnet test` can discover it:
 
-1. Use the exact solution target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for any `.sln`/`.slnx` file.
+1. Use the exact solution or solution-filter target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
 2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
 3. If the target is a `.slnf` (solution filter), also ensure the new project is included in the filter; adding only to the underlying `.sln` may not be enough for test discovery.
 4. Skip this if the project is already included in the solution or solution filter used for testing.
-5. Prefer the researched test command or `dotnet test --solution <solution>` over `dotnet test <solution>`.
+5. Prefer the researched test command. If you need to run the solution directly, use `dotnet test --solution <solution>` only for repos on .NET SDK 10+ with MTP-style syntax; otherwise use the standard positional form `dotnet test <solution>`.
 
 ## MSTest Template
 

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
@@ -61,6 +61,16 @@ This prevents CS0234 ("namespace not found") and CS0246 ("type not found") error
 - For the final validation, build the full `.sln` with `--no-incremental`
 - Full-solution builds catch cross-project reference errors invisible in scoped builds
 
+### Registering a new test project
+
+If a new test project was created, register it with the solution so `dotnet test` can discover it:
+
+1. Use the exact solution target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for any `.sln`/`.slnx` file.
+2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
+3. If the target is a `.slnf` (solution filter), also ensure the new project is included in the filter; adding only to the underlying `.sln` may not be enough for test discovery.
+4. Skip this if the project is already included in the solution or solution filter used for testing.
+5. Prefer the researched test command or `dotnet test --solution <solution>` over `dotnet test <solution>`.
+
 ## MSTest Template
 
 ```csharp


### PR DESCRIPTION
When a new test project is created, register it with the solution file using 'dotnet sln add' so that 'dotnet test <solution>' discovers the tests.