### PR TITLE
Add --allow-repo-traversal and remove body line count checks

### DIFF
--- a/eng/skill-validator/src/Check/AgentProfiler.cs
+++ b/eng/skill-validator/src/Check/AgentProfiler.cs
@@ -9,13 +9,8 @@ namespace SkillValidator.Check;
 /// </summary>
 public static class AgentProfiler
 {
-    // Aligned with SKILL.md body limit from the agentskills.io spec:
-    // https://agentskills.io/specification#progressive-disclosure
-    private const int MaxBodyLines = 500;
-
     public static AgentProfile AnalyzeAgent(AgentInfo agent, CheckOptions? options = null)
     {
-        var effectiveMaxBodyLines = options?.MaxAgentLines ?? options?.MaxDeclarationLines ?? MaxBodyLines;
         var content = agent.AgentMdContent;
         var errors = new List<string>();
         var warnings = new List<string>();
@@ -51,15 +46,6 @@ public static class AgentProfiler
         // --- Description validation (same 1024-char limit as skills) ---
         // https://agentskills.io/specification#description-field
         SkillProfiler.ValidateDescription(agent.Description, "Agent", errors);
-
-        // --- Body line count ---
-        // https://agentskills.io/specification#progressive-disclosure
-        var trimmedBody = body.TrimEnd('\r', '\n');
-        int bodyLineCount = trimmedBody.Length == 0 ? 0 : trimmedBody.Split('\n').Length;
-        if (bodyLineCount > effectiveMaxBodyLines)
-        {
-            errors.Add($"Agent body is {bodyLineCount} lines — maximum is {effectiveMaxBodyLines}. Keep agent instructions concise.");
-        }
 
         return new AgentProfile(profileName, agent.FileName, errors, warnings);
     }

--- a/eng/skill-validator/src/Check/AgentProfiler.cs
+++ b/eng/skill-validator/src/Check/AgentProfiler.cs
@@ -9,7 +9,7 @@ namespace SkillValidator.Check;
 /// </summary>
 public static class AgentProfiler
 {
-    public static AgentProfile AnalyzeAgent(AgentInfo agent, CheckOptions? options = null)
+    public static AgentProfile AnalyzeAgent(AgentInfo agent)
     {
         var content = agent.AgentMdContent;
         var errors = new List<string>();

--- a/eng/skill-validator/src/Check/AgentProfiler.cs
+++ b/eng/skill-validator/src/Check/AgentProfiler.cs
@@ -13,8 +13,9 @@ public static class AgentProfiler
     // https://agentskills.io/specification#progressive-disclosure
     private const int MaxBodyLines = 500;
 
-    public static AgentProfile AnalyzeAgent(AgentInfo agent)
+    public static AgentProfile AnalyzeAgent(AgentInfo agent, CheckOptions? options = null)
     {
+        var effectiveMaxBodyLines = options?.MaxAgentLines ?? options?.MaxDeclarationLines ?? MaxBodyLines;
         var content = agent.AgentMdContent;
         var errors = new List<string>();
         var warnings = new List<string>();
@@ -55,9 +56,9 @@ public static class AgentProfiler
         // https://agentskills.io/specification#progressive-disclosure
         var trimmedBody = body.TrimEnd('\r', '\n');
         int bodyLineCount = trimmedBody.Length == 0 ? 0 : trimmedBody.Split('\n').Length;
-        if (bodyLineCount > MaxBodyLines)
+        if (bodyLineCount > effectiveMaxBodyLines)
         {
-            errors.Add($"Agent body is {bodyLineCount} lines — maximum is {MaxBodyLines}. Keep agent instructions concise.");
+            errors.Add($"Agent body is {bodyLineCount} lines — maximum is {effectiveMaxBodyLines}. Keep agent instructions concise.");
         }
 
         return new AgentProfile(profileName, agent.FileName, errors, warnings);

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -184,7 +184,7 @@ public static class CheckCommand
         }
 
         // Validate agents
-        var (allAgents, agentResult) = await RunAgentsCheckCore(agentDirs.Distinct().ToList(), config.CheckOptions);
+        var (allAgents, agentResult) = await RunAgentsCheckCore(agentDirs.Distinct().ToList());
 
         if (allSkillsList.Count == 0 && allAgents.Count == 0)
         {
@@ -238,7 +238,7 @@ public static class CheckCommand
 
     private static async Task<int> RunAgentsCheck(CheckConfig config)
     {
-        var (agents, result) = await RunAgentsCheckCore(config.AgentPaths, config.CheckOptions);
+        var (agents, result) = await RunAgentsCheckCore(config.AgentPaths);
 
         if (agents.Count == 0)
             return 1; // error already printed
@@ -284,7 +284,7 @@ public static class CheckCommand
         return (allSkills, hasErrors ? 1 : 0);
     }
 
-    private static async Task<(IReadOnlyList<AgentInfo> Agents, int Result)> RunAgentsCheckCore(IReadOnlyList<string> agentPaths, CheckOptions? checkOptions = null)
+    private static async Task<(IReadOnlyList<AgentInfo> Agents, int Result)> RunAgentsCheckCore(IReadOnlyList<string> agentPaths)
     {
         var allAgents = new List<AgentInfo>();
         foreach (var path in agentPaths)
@@ -308,7 +308,7 @@ public static class CheckCommand
         bool hasErrors = false;
         foreach (var agent in allAgents)
         {
-            var profile = AgentProfiler.AnalyzeAgent(agent, checkOptions);
+            var profile = AgentProfiler.AnalyzeAgent(agent);
             foreach (var warning in profile.Warnings)
                 Console.WriteLine($"{Ansi.Yellow}⚠  [agent:{profile.Name}] {warning}{Ansi.Reset}");
             foreach (var error in profile.Errors)

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -14,8 +14,6 @@ public static class CheckCommand
         var allowedExternalDepsOpt = new Option<string?>("--allowed-external-deps") { Description = "Path to allowed-external-deps.txt allow list file" };
         var knownDomainsOpt = new Option<string?>("--known-domains") { Description = "Path to known-domains.txt for reference scanning" };
         var verboseOpt = new Option<bool>("--verbose") { Description = "Show detailed output" };
-        var maxDeclarationLinesOpt = new Option<int?>("--max-declaration-lines") { Description = "Override the maximum allowed body line count for skills and agents (default: 500)" };
-        var maxAgentLinesOpt = new Option<int?>("--max-agent-lines") { Description = "Override the maximum allowed agent body line count (defaults to --max-declaration-lines value)" };
         var allowRepoTraversalOpt = new Option<bool>("--allow-repo-traversal") { Description = "Allow parent-directory traversals in file references" };
 
         var command = new Command("check", "Run static analysis checks on skills, plugins, and agents (no LLM required). Use --plugin to check an entire plugin directory (recommended).")
@@ -26,8 +24,6 @@ public static class CheckCommand
             allowedExternalDepsOpt,
             knownDomainsOpt,
             verboseOpt,
-            maxDeclarationLinesOpt,
-            maxAgentLinesOpt,
             allowRepoTraversalOpt,
         };
 
@@ -59,22 +55,10 @@ public static class CheckCommand
                 Verbose = parseResult.GetValue(verboseOpt),
                 CheckOptions = new CheckOptions
                 {
-                    MaxDeclarationLines = parseResult.GetValue(maxDeclarationLinesOpt),
-                    MaxAgentLines = parseResult.GetValue(maxAgentLinesOpt),
                     AllowRepoTraversal = parseResult.GetValue(allowRepoTraversalOpt),
                 },
             };
 
-            if (config.CheckOptions.MaxDeclarationLines is <= 0)
-            {
-                Console.Error.WriteLine("--max-declaration-lines must be a positive integer.");
-                return 1;
-            }
-            if (config.CheckOptions.MaxAgentLines is <= 0)
-            {
-                Console.Error.WriteLine("--max-agent-lines must be a positive integer.");
-                return 1;
-            }
             if (config.CheckOptions.AllowRepoTraversal && pluginPaths.Length > 0)
             {
                 Console.Error.WriteLine("--allow-repo-traversal cannot be used with --plugin. Plugins must be portable — use --skills or --agents instead.");

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -64,6 +64,23 @@ public static class CheckCommand
                     AllowRepoTraversal = parseResult.GetValue(allowRepoTraversalOpt),
                 },
             };
+
+            if (config.CheckOptions.MaxDeclarationLines is <= 0)
+            {
+                Console.Error.WriteLine("--max-declaration-lines must be a positive integer.");
+                return 1;
+            }
+            if (config.CheckOptions.MaxAgentLines is <= 0)
+            {
+                Console.Error.WriteLine("--max-agent-lines must be a positive integer.");
+                return 1;
+            }
+            if (config.CheckOptions.AllowRepoTraversal && pluginPaths.Length > 0)
+            {
+                Console.Error.WriteLine("--allow-repo-traversal cannot be used with --plugin. Plugins must be portable — use --skills or --agents instead.");
+                return 1;
+            }
+
             return await Run(config);
         });
 

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -14,6 +14,9 @@ public static class CheckCommand
         var allowedExternalDepsOpt = new Option<string?>("--allowed-external-deps") { Description = "Path to allowed-external-deps.txt allow list file" };
         var knownDomainsOpt = new Option<string?>("--known-domains") { Description = "Path to known-domains.txt for reference scanning" };
         var verboseOpt = new Option<bool>("--verbose") { Description = "Show detailed output" };
+        var maxDeclarationLinesOpt = new Option<int?>("--max-declaration-lines") { Description = "Override the maximum allowed body line count for skills and agents (default: 500)" };
+        var maxAgentLinesOpt = new Option<int?>("--max-agent-lines") { Description = "Override the maximum allowed agent body line count (defaults to --max-declaration-lines value)" };
+        var allowRepoTraversalOpt = new Option<bool>("--allow-repo-traversal") { Description = "Allow parent-directory traversals in file references" };
 
         var command = new Command("check", "Run static analysis checks on skills, plugins, and agents (no LLM required). Use --plugin to check an entire plugin directory (recommended).")
         {
@@ -23,6 +26,9 @@ public static class CheckCommand
             allowedExternalDepsOpt,
             knownDomainsOpt,
             verboseOpt,
+            maxDeclarationLinesOpt,
+            maxAgentLinesOpt,
+            allowRepoTraversalOpt,
         };
 
         command.SetAction(async (parseResult, _) =>
@@ -51,6 +57,12 @@ public static class CheckCommand
                 AllowedExternalDepsFile = parseResult.GetValue(allowedExternalDepsOpt),
                 KnownDomainsFile = parseResult.GetValue(knownDomainsOpt),
                 Verbose = parseResult.GetValue(verboseOpt),
+                CheckOptions = new CheckOptions
+                {
+                    MaxDeclarationLines = parseResult.GetValue(maxDeclarationLinesOpt),
+                    MaxAgentLines = parseResult.GetValue(maxAgentLinesOpt),
+                    AllowRepoTraversal = parseResult.GetValue(allowRepoTraversalOpt),
+                },
             };
             return await Run(config);
         });
@@ -162,7 +174,7 @@ public static class CheckCommand
         if (allSkillsList.Count > 0)
         {
             Console.WriteLine($"Found {allSkillsList.Count} skill(s)");
-            if (ValidateSkillProfiles(allSkillsList, config.Verbose))
+            if (ValidateSkillProfiles(allSkillsList, config.Verbose, config.CheckOptions))
                 skillResult = 1;
 
             // Check for duplicate skill names across all skills
@@ -171,7 +183,7 @@ public static class CheckCommand
         }
 
         // Validate agents
-        var (allAgents, agentResult) = await RunAgentsCheckCore(agentDirs.Distinct().ToList());
+        var (allAgents, agentResult) = await RunAgentsCheckCore(agentDirs.Distinct().ToList(), config.CheckOptions);
 
         if (allSkillsList.Count == 0 && allAgents.Count == 0)
         {
@@ -208,7 +220,7 @@ public static class CheckCommand
 
     private static async Task<int> RunSkillsCheck(CheckConfig config)
     {
-        var (skills, result) = await RunSkillsCheckCore(config.SkillPaths, config.Verbose);
+        var (skills, result) = await RunSkillsCheckCore(config.SkillPaths, config.Verbose, config.CheckOptions);
 
         if (skills.Count == 0)
             return 1; // error already printed
@@ -225,7 +237,7 @@ public static class CheckCommand
 
     private static async Task<int> RunAgentsCheck(CheckConfig config)
     {
-        var (agents, result) = await RunAgentsCheckCore(config.AgentPaths);
+        var (agents, result) = await RunAgentsCheckCore(config.AgentPaths, config.CheckOptions);
 
         if (agents.Count == 0)
             return 1; // error already printed
@@ -240,7 +252,7 @@ public static class CheckCommand
         return 0;
     }
 
-    private static async Task<(IReadOnlyList<SkillInfo> Skills, int Result)> RunSkillsCheckCore(IReadOnlyList<string> skillPaths, bool verbose)
+    private static async Task<(IReadOnlyList<SkillInfo> Skills, int Result)> RunSkillsCheckCore(IReadOnlyList<string> skillPaths, bool verbose, CheckOptions? checkOptions = null)
     {
         var allSkills = new List<SkillInfo>();
         foreach (var path in skillPaths)
@@ -262,7 +274,7 @@ public static class CheckCommand
         Console.WriteLine($"Found {allSkills.Count} skill(s)");
 
         bool hasErrors = false;
-        if (ValidateSkillProfiles(allSkills, verbose))
+        if (ValidateSkillProfiles(allSkills, verbose, checkOptions))
             hasErrors = true;
 
         if (CheckDuplicateSkillNames(allSkills))
@@ -271,7 +283,7 @@ public static class CheckCommand
         return (allSkills, hasErrors ? 1 : 0);
     }
 
-    private static async Task<(IReadOnlyList<AgentInfo> Agents, int Result)> RunAgentsCheckCore(IReadOnlyList<string> agentPaths)
+    private static async Task<(IReadOnlyList<AgentInfo> Agents, int Result)> RunAgentsCheckCore(IReadOnlyList<string> agentPaths, CheckOptions? checkOptions = null)
     {
         var allAgents = new List<AgentInfo>();
         foreach (var path in agentPaths)
@@ -295,7 +307,7 @@ public static class CheckCommand
         bool hasErrors = false;
         foreach (var agent in allAgents)
         {
-            var profile = AgentProfiler.AnalyzeAgent(agent);
+            var profile = AgentProfiler.AnalyzeAgent(agent, checkOptions);
             foreach (var warning in profile.Warnings)
                 Console.WriteLine($"{Ansi.Yellow}⚠  [agent:{profile.Name}] {warning}{Ansi.Reset}");
             foreach (var error in profile.Errors)
@@ -336,12 +348,12 @@ public static class CheckCommand
         return hasDuplicates;
     }
 
-    private static bool ValidateSkillProfiles(IReadOnlyList<SkillInfo> skills, bool verbose)
+    private static bool ValidateSkillProfiles(IReadOnlyList<SkillInfo> skills, bool verbose, CheckOptions? checkOptions = null)
     {
         bool hasErrors = false;
         foreach (var skill in skills)
         {
-            var profile = SkillProfiler.AnalyzeSkill(skill);
+            var profile = SkillProfiler.AnalyzeSkill(skill, checkOptions);
 
             if (verbose)
                 Console.WriteLine($"[{skill.Name}] 📊 {SkillProfiler.FormatProfileLine(profile)}");

--- a/eng/skill-validator/src/Check/Models.cs
+++ b/eng/skill-validator/src/Check/Models.cs
@@ -14,8 +14,6 @@ public sealed record PluginValidationResult(
 
 public sealed record CheckOptions
 {
-    public int? MaxDeclarationLines { get; init; }
-    public int? MaxAgentLines { get; init; }
     public bool AllowRepoTraversal { get; init; }
 }
 

--- a/eng/skill-validator/src/Check/Models.cs
+++ b/eng/skill-validator/src/Check/Models.cs
@@ -12,6 +12,13 @@ public sealed record PluginValidationResult(
     IReadOnlyList<string> Errors,
     IReadOnlyList<string> Warnings);
 
+public sealed record CheckOptions
+{
+    public int? MaxDeclarationLines { get; init; }
+    public int? MaxAgentLines { get; init; }
+    public bool AllowRepoTraversal { get; init; }
+}
+
 public sealed record CheckConfig
 {
     public IReadOnlyList<string> PluginPaths { get; init; } = [];
@@ -20,4 +27,5 @@ public sealed record CheckConfig
     public string? AllowedExternalDepsFile { get; init; }
     public string? KnownDomainsFile { get; init; }
     public bool Verbose { get; init; }
+    public CheckOptions CheckOptions { get; init; } = new();
 }

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -38,8 +38,10 @@ public static partial class SkillProfiler
     private const int MaxBodyLines = 500;
     private const long MaxAssetFileSize = 5 * 1024 * 1024; // 5 MB
 
-    public static SkillProfile AnalyzeSkill(SkillInfo skill)
+    public static SkillProfile AnalyzeSkill(SkillInfo skill, CheckOptions? options = null)
     {
+        var effectiveMaxBodyLines = options?.MaxDeclarationLines ?? MaxBodyLines;
+        var allowRepoTraversal = options?.AllowRepoTraversal ?? false;
         var content = skill.SkillMdContent;
         int chars4TokenCount = (int)Math.Ceiling(content.Length / 4.0);
         int bpeTokenCount = s_bpeTokenizer.Value.CountTokens(content);
@@ -102,9 +104,9 @@ public static partial class SkillProfiler
         // --- agentskills.io spec: body line count ---
         var trimmedBody = body.TrimEnd('\r', '\n');
         int bodyLineCount = trimmedBody.Length == 0 ? 0 : trimmedBody.Split('\n').Length;
-        if (bodyLineCount > MaxBodyLines)
+        if (bodyLineCount > effectiveMaxBodyLines)
         {
-            errors.Add($"SKILL.md body is {bodyLineCount} lines — maximum is {MaxBodyLines}. Move detailed reference material to separate files.");
+            errors.Add($"SKILL.md body is {bodyLineCount} lines — maximum is {effectiveMaxBodyLines}. Move detailed reference material to separate files.");
         }
 
         // --- agentskills.io spec: file reference depth ---
@@ -128,7 +130,7 @@ public static partial class SkillProfiler
             var segments = refPath.Split('/');
 
             // Reject parent-directory traversals
-            if (segments.Any(s => s == ".."))
+            if (!allowRepoTraversal && segments.Any(s => s == ".."))
             {
                 errors.Add($"File reference '{refMatch.Groups[1].Value}' uses parent-directory traversal — references must stay within the skill directory.");
                 continue;

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -35,12 +35,10 @@ public static partial class SkillProfiler
     private const int MaxNameLength = 64;
     internal const int MinDescriptionLength = 10;
     private const int MaxCompatibilityLength = 500;
-    private const int MaxBodyLines = 500;
     private const long MaxAssetFileSize = 5 * 1024 * 1024; // 5 MB
 
     public static SkillProfile AnalyzeSkill(SkillInfo skill, CheckOptions? options = null)
     {
-        var effectiveMaxBodyLines = options?.MaxDeclarationLines ?? MaxBodyLines;
         var allowRepoTraversal = options?.AllowRepoTraversal ?? false;
         var content = skill.SkillMdContent;
         int chars4TokenCount = (int)Math.Ceiling(content.Length / 4.0);
@@ -99,14 +97,6 @@ public static partial class SkillProfiler
         else if (skill.Compatibility is not null && string.IsNullOrWhiteSpace(skill.Compatibility))
         {
             errors.Add("Compatibility field must be 1-500 non-whitespace characters when provided.");
-        }
-
-        // --- agentskills.io spec: body line count ---
-        var trimmedBody = body.TrimEnd('\r', '\n');
-        int bodyLineCount = trimmedBody.Length == 0 ? 0 : trimmedBody.Split('\n').Length;
-        if (bodyLineCount > effectiveMaxBodyLines)
-        {
-            errors.Add($"SKILL.md body is {bodyLineCount} lines — maximum is {effectiveMaxBodyLines}. Move detailed reference material to separate files.");
         }
 
         // --- agentskills.io spec: file reference depth ---

--- a/eng/skill-validator/tests/Check/AgentPluginTests.cs
+++ b/eng/skill-validator/tests/Check/AgentPluginTests.cs
@@ -107,33 +107,6 @@ public class AgentProfilerTests
     }
 
     [Fact]
-    public void BodyOver500LinesErrors()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content));
-        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
-    [Fact]
-    public void BodyAt500LinesNoError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 500).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content));
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
-    [Fact]
-    public void BodyAt500LinesWithTrailingNewlineNoError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 500).Select(i => $"Line {i}")) + "\n";
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content));
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
-    [Fact]
     public void NameStartingWithHyphenErrors()
     {
         var content = "---\nname: -my-agent\ndescription: test\n---\n# Test\n";
@@ -164,48 +137,6 @@ public class AgentProfilerTests
         var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content, name: "My-Agent", fileName: "My-Agent.agent.md"));
         Assert.Contains(profile.Errors, e => e.StartsWith("Agent name"));
         Assert.DoesNotContain(profile.Errors, e => e.StartsWith("Skill name"));
-    }
-
-    // --- CheckOptions: MaxAgentLines ---
-
-    [Fact]
-    public void MaxAgentLinesOverridesDefault()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var options = new CheckOptions { MaxAgentLines = 600 };
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
-    }
-
-    [Fact]
-    public void MaxAgentLinesLowerThanDefaultTriggersError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 300).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var options = new CheckOptions { MaxAgentLines = 200 };
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
-        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("200"));
-    }
-
-    [Fact]
-    public void MaxAgentLinesFallsBackToMaxDeclarationLines()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var options = new CheckOptions { MaxDeclarationLines = 600 };
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
-    }
-
-    [Fact]
-    public void MaxAgentLinesTakesPrecedenceOverMaxDeclarationLines()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
-        var options = new CheckOptions { MaxDeclarationLines = 200, MaxAgentLines = 600 };
-        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
     }
 }
 

--- a/eng/skill-validator/tests/Check/AgentPluginTests.cs
+++ b/eng/skill-validator/tests/Check/AgentPluginTests.cs
@@ -165,6 +165,48 @@ public class AgentProfilerTests
         Assert.Contains(profile.Errors, e => e.StartsWith("Agent name"));
         Assert.DoesNotContain(profile.Errors, e => e.StartsWith("Skill name"));
     }
+
+    // --- CheckOptions: MaxAgentLines ---
+
+    [Fact]
+    public void MaxAgentLinesOverridesDefault()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
+        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
+        var options = new CheckOptions { MaxAgentLines = 600 };
+        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
+    }
+
+    [Fact]
+    public void MaxAgentLinesLowerThanDefaultTriggersError()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 300).Select(i => $"Line {i}"));
+        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
+        var options = new CheckOptions { MaxAgentLines = 200 };
+        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
+        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("200"));
+    }
+
+    [Fact]
+    public void MaxAgentLinesFallsBackToMaxDeclarationLines()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
+        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
+        var options = new CheckOptions { MaxDeclarationLines = 600 };
+        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
+    }
+
+    [Fact]
+    public void MaxAgentLinesTakesPrecedenceOverMaxDeclarationLines()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
+        var content = "---\nname: test-agent\ndescription: test\n---\n" + body;
+        var options = new CheckOptions { MaxDeclarationLines = 200, MaxAgentLines = 600 };
+        var profile = AgentProfiler.AnalyzeAgent(MakeAgent(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
+    }
 }
 
 public class PluginProfilerTests

--- a/eng/skill-validator/tests/Check/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/Check/SkillProfileTests.cs
@@ -259,35 +259,6 @@ public class AnalyzeSkillTests
         Assert.Contains(profile.Errors, e => e.Contains("Compatibility"));
     }
 
-    // --- Body line count tests ---
-
-    [Fact]
-    public void BodyOver500LinesErrors()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-skill\n---\n" + body;
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
-        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
-    [Fact]
-    public void BodyAt500LinesNoError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 500).Select(i => $"Line {i}"));
-        var content = "---\nname: test-skill\n---\n" + body;
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
-    [Fact]
-    public void BodyAt500LinesWithTrailingNewlineNoError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 500).Select(i => $"Line {i}")) + "\n";
-        var content = "---\nname: test-skill\n---\n" + body;
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
-    }
-
     // --- File reference depth tests ---
 
     [Fact]
@@ -336,37 +307,6 @@ public class AnalyzeSkillTests
         var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](./references/file.md)\n" + new string('x', 4000);
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
         Assert.DoesNotContain(profile.Errors, e => e.Contains("directories deep") || e.Contains("traversal"));
-    }
-
-    // --- CheckOptions: MaxDeclarationLines ---
-
-    [Fact]
-    public void MaxDeclarationLinesOverridesDefault()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-skill\n---\n" + body;
-        var options = new CheckOptions { MaxDeclarationLines = 600 };
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
-    }
-
-    [Fact]
-    public void MaxDeclarationLinesLowerThanDefaultTriggersError()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 300).Select(i => $"Line {i}"));
-        var content = "---\nname: test-skill\n---\n" + body;
-        var options = new CheckOptions { MaxDeclarationLines = 200 };
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
-        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("200"));
-    }
-
-    [Fact]
-    public void NullOptionsUsesDefaultMaxBodyLines()
-    {
-        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
-        var content = "---\nname: test-skill\n---\n" + body;
-        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), null);
-        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
     }
 
     // --- CheckOptions: AllowRepoTraversal ---

--- a/eng/skill-validator/tests/Check/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/Check/SkillProfileTests.cs
@@ -337,6 +337,57 @@ public class AnalyzeSkillTests
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content));
         Assert.DoesNotContain(profile.Errors, e => e.Contains("directories deep") || e.Contains("traversal"));
     }
+
+    // --- CheckOptions: MaxDeclarationLines ---
+
+    [Fact]
+    public void MaxDeclarationLinesOverridesDefault()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
+        var content = "---\nname: test-skill\n---\n" + body;
+        var options = new CheckOptions { MaxDeclarationLines = 600 };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("lines"));
+    }
+
+    [Fact]
+    public void MaxDeclarationLinesLowerThanDefaultTriggersError()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 300).Select(i => $"Line {i}"));
+        var content = "---\nname: test-skill\n---\n" + body;
+        var options = new CheckOptions { MaxDeclarationLines = 200 };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("200"));
+    }
+
+    [Fact]
+    public void NullOptionsUsesDefaultMaxBodyLines()
+    {
+        var body = string.Join("\n", Enumerable.Range(1, 501).Select(i => $"Line {i}"));
+        var content = "---\nname: test-skill\n---\n" + body;
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), null);
+        Assert.Contains(profile.Errors, e => e.Contains("lines") && e.Contains("500"));
+    }
+
+    // --- CheckOptions: AllowRepoTraversal ---
+
+    [Fact]
+    public void AllowRepoTraversalSuppressesParentTraversalError()
+    {
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](../other-skill/SKILL.md)\n" + new string('x', 4000);
+        var options = new CheckOptions { AllowRepoTraversal = true };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("parent-directory traversal"));
+    }
+
+    [Fact]
+    public void AllowRepoTraversalStillChecksDepth()
+    {
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](deep/nested/file.md)\n" + new string('x', 4000);
+        var options = new CheckOptions { AllowRepoTraversal = true };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        Assert.Contains(profile.Errors, e => e.Contains("directories deep"));
+    }
 }
 
 public class FormatProfileLineTests

--- a/eng/skill-validator/tests/Check/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/Check/SkillProfileTests.cs
@@ -314,10 +314,10 @@ public class AnalyzeSkillTests
     [Fact]
     public void AllowRepoTraversalSuppressesParentTraversalError()
     {
-        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](../other-skill/SKILL.md)\n" + new string('x', 4000);
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](../SKILL.md)\n" + new string('x', 4000);
         var options = new CheckOptions { AllowRepoTraversal = true };
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
-        Assert.DoesNotContain(profile.Errors, e => e.Contains("parent-directory traversal"));
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("traversal") || e.Contains("directories deep"));
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Adding `--allow-repo-traversal` option for checking repo-specific skills/agents. Plugin skills/agents should not traverse past their dirs (they can be distributed in isolation), but repo-specific agents/skills are placed in a folder structure and disallowing them to refer to precise locations of docs, configs, scripts etc. forces an extra discovery turn.
- Removing body line count checks — the BPE token-based complexity classification already provides better size guidance, making the raw line count check redundant.

### Changes

- Introduces `CheckOptions` with `AllowRepoTraversal` and wires it into `CheckConfig`
- Adds `--allow-repo-traversal` CLI flag, rejected in `--plugin` mode (plugins must be portable)
- Updates `SkillProfiler` to respect the traversal option
- Removes body line count validation from both `SkillProfiler` and `AgentProfiler` (superseded by BPE token warnings)
- Adds unit tests for the traversal option

FYI @ViktorHofer, @danmoseley