### PR TITLE
Fix the repo path traversal check

### DIFF
--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -120,9 +120,13 @@ public static partial class SkillProfiler
             var segments = refPath.Split('/');
 
             // Reject parent-directory traversals
-            if (!allowRepoTraversal && segments.Any(s => s == ".."))
+            if (segments.Any(s => s == ".."))
             {
-                errors.Add($"File reference '{refMatch.Groups[1].Value}' uses parent-directory traversal — references must stay within the skill directory.");
+                if (!allowRepoTraversal)
+                {
+                    errors.Add($"File reference '{refMatch.Groups[1].Value}' uses parent-directory traversal — references must stay within the skill directory.");
+                }
+                // When repo traversal is allowed, external refs have no depth constraint.
                 continue;
             }
 

--- a/eng/skill-validator/tests/Check/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/Check/SkillProfileTests.cs
@@ -321,9 +321,18 @@ public class AnalyzeSkillTests
     }
 
     [Fact]
-    public void AllowRepoTraversalStillChecksDepth()
+    public void AllowRepoTraversalAllowsDeepExternalRefs()
     {
-        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](deep/nested/file.md)\n" + new string('x', 4000);
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](../../../documentation/guides/setup.md)\n" + new string('x', 4000);
+        var options = new CheckOptions { AllowRepoTraversal = true };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        Assert.DoesNotContain(profile.Errors, e => e.Contains("traversal") || e.Contains("directories deep"));
+    }
+
+    [Fact]
+    public void AllowRepoTraversalStillChecksDepthForInternalRefs()
+    {
+        var content = "---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref](refs/utils/foo/readme.md)\n" + new string('x', 4000);
         var options = new CheckOptions { AllowRepoTraversal = true };
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
         Assert.Contains(profile.Errors, e => e.Contains("directories deep"));


### PR DESCRIPTION
Followup of https://github.com/dotnet/skills/pull/524

### Motivation

When we want to allow traversal of paths outside of the skill folder (in case of repo specific skills, that are not meant to be shareable) - we should not check for the depth of the path, unless it is in the current skill folder - otherwise the depth check would snap