### PR TITLE
Support checking skills and agents at single invocation

### DIFF
--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -33,15 +33,18 @@ public static class CheckCommand
             var skillPaths = parseResult.GetValue(skillsOpt) ?? [];
             var agentPaths = parseResult.GetValue(agentsOpt) ?? [];
 
-            int modeCount = (pluginPaths.Length > 0 ? 1 : 0) + (skillPaths.Length > 0 ? 1 : 0) + (agentPaths.Length > 0 ? 1 : 0);
-            if (modeCount == 0)
+            bool hasPlugin = pluginPaths.Length > 0;
+            bool hasSkills = skillPaths.Length > 0;
+            bool hasAgents = agentPaths.Length > 0;
+
+            if (!hasPlugin && !hasSkills && !hasAgents)
             {
                 Console.Error.WriteLine("Specify one of --plugin, --skills, or --agents. Use --plugin to check an entire plugin directory.");
                 return 1;
             }
-            if (modeCount > 1)
+            if (hasPlugin && (hasSkills || hasAgents))
             {
-                Console.Error.WriteLine("Only one of --plugin, --skills, or --agents can be used at a time.");
+                Console.Error.WriteLine("--plugin cannot be combined with --skills or --agents. Use --plugin alone to check an entire plugin directory.");
                 return 1;
             }
 
@@ -75,6 +78,9 @@ public static class CheckCommand
     {
         if (config.PluginPaths.Count > 0)
             return await RunPluginCheck(config);
+
+        if (config.SkillPaths.Count > 0 && config.AgentPaths.Count > 0)
+            return await RunSkillsAndAgentsCheck(config);
 
         if (config.SkillPaths.Count > 0)
             return await RunSkillsCheck(config);
@@ -250,6 +256,26 @@ public static class CheckCommand
             return 1;
 
         Console.WriteLine($"{Ansi.Green}✅ All checks passed ({agents.Count} agent(s)){Ansi.Reset}");
+        return 0;
+    }
+
+    private static async Task<int> RunSkillsAndAgentsCheck(CheckConfig config)
+    {
+        var (skills, skillResult) = await RunSkillsCheckCore(config.SkillPaths, config.Verbose, config.CheckOptions);
+        var (agents, agentResult) = await RunAgentsCheckCore(config.AgentPaths);
+
+        if (skills.Count == 0 && agents.Count == 0)
+            return 1; // errors already printed
+
+        if (skillResult != 0 || agentResult != 0)
+            return 1;
+
+        // Run reference scanner on all directories
+        var allDirs = config.SkillPaths.Concat(config.AgentPaths).ToList();
+        if (RunReferenceScanner(config.KnownDomainsFile, allDirs))
+            return 1;
+
+        Console.WriteLine($"{Ansi.Green}✅ All checks passed ({skills.Count} skill(s), {agents.Count} agent(s)){Ansi.Reset}");
         return 0;
     }
 

--- a/eng/skill-validator/src/README.md
+++ b/eng/skill-validator/src/README.md
@@ -119,7 +119,7 @@ skill-validator check --verbose --plugin ./plugins/my-plugin
 | `--known-domains <path>` | *(none)* | Path to known-domains.txt for reference scanning; when omitted the reference scan is skipped |
 | `--verbose` | `false` | Show detailed output |
 
-> Exactly one of `--plugin`, `--skills`, or `--agents` must be provided.
+> `--plugin` must be used alone. `--skills` and `--agents` can be combined.
 
 ## `evaluate` flags
 

--- a/eng/skill-validator/src/Shared/AgentDiscovery.cs
+++ b/eng/skill-validator/src/Shared/AgentDiscovery.cs
@@ -75,10 +75,17 @@ public static class AgentDiscovery
     }
 
     /// <summary>
-    /// Discover agent files (.agent.md) directly in the given directory.
+    /// Discover agent files (.agent.md) in the given directory, or a single agent if a file path is provided.
     /// </summary>
     public static async Task<IReadOnlyList<AgentInfo>> DiscoverAgentsInDirectory(string agentsDir)
     {
+        // If the path is a file, try to discover it directly
+        if (File.Exists(agentsDir))
+        {
+            var agent = await DiscoverAgentAt(agentsDir);
+            return agent is not null ? [agent] : [];
+        }
+
         if (!Directory.Exists(agentsDir))
             return [];
 

--- a/eng/skill-validator/src/Shared/SkillDiscovery.cs
+++ b/eng/skill-validator/src/Shared/SkillDiscovery.cs
@@ -8,6 +8,10 @@ public static class SkillDiscovery
 
     public static async Task<IReadOnlyList<SkillInfo>> DiscoverSkills(string targetPath)
     {
+        // If pointing at a SKILL.md file, use its parent directory
+        if (File.Exists(targetPath) && Path.GetFileName(targetPath).Equals("SKILL.md", StringComparison.OrdinalIgnoreCase))
+            targetPath = Path.GetDirectoryName(targetPath)!;
+
         // Check if the target itself is a skill
         var directSkill = await DiscoverSkillAt(targetPath);
         if (directSkill is not null)

--- a/eng/skill-validator/tests/Check/CheckCommandTests.cs
+++ b/eng/skill-validator/tests/Check/CheckCommandTests.cs
@@ -203,3 +203,122 @@ public class DuplicateSkillNameTests
         }
     }
 }
+
+public class CheckCommandFilePathTests
+{
+    private static string CreateSkillFixture(string skillName, string description)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"file-test-{Guid.NewGuid():N}");
+        var skillDir = Path.Combine(root, skillName);
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            $"---\nname: {skillName}\ndescription: {description}\n---\n# {skillName}\n\nContent.\n");
+        return root;
+    }
+
+    private static string CreateAgentFixture(string agentName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"file-test-{Guid.NewGuid():N}");
+        var agentsDir = Path.Combine(root, "agents");
+        Directory.CreateDirectory(agentsDir);
+        File.WriteAllText(Path.Combine(agentsDir, $"{agentName}.agent.md"),
+            $"---\nname: {agentName}\ndescription: A test agent.\n---\n# {agentName}\n\nAgent content.\n");
+        return root;
+    }
+
+    [Fact]
+    public async Task SkillsArg_WithSkillDirectoryPath_Passes()
+    {
+        var root = CreateSkillFixture("my-skill", "A short description.");
+        try
+        {
+            var config = new CheckConfig { SkillPaths = [Path.Combine(root, "my-skill")] };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task SkillsArg_WithSkillMdFilePath_Passes()
+    {
+        var root = CreateSkillFixture("my-skill", "A short description.");
+        try
+        {
+            var config = new CheckConfig { SkillPaths = [Path.Combine(root, "my-skill", "SKILL.md")] };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task AgentsArg_WithAgentFilePath_Passes()
+    {
+        var root = CreateAgentFixture("test-agent");
+        try
+        {
+            var config = new CheckConfig { AgentPaths = [Path.Combine(root, "agents", "test-agent.agent.md")] };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task AgentsArg_WithDirectoryPath_Passes()
+    {
+        var root = CreateAgentFixture("test-agent");
+        try
+        {
+            var config = new CheckConfig { AgentPaths = [Path.Combine(root, "agents")] };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task CombinedSkillsAndAgents_Passes()
+    {
+        var skillRoot = CreateSkillFixture("my-skill", "A short description.");
+        var agentRoot = CreateAgentFixture("test-agent");
+        try
+        {
+            var config = new CheckConfig
+            {
+                SkillPaths = [Path.Combine(skillRoot, "my-skill")],
+                AgentPaths = [Path.Combine(agentRoot, "agents")],
+            };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally
+        {
+            Directory.Delete(skillRoot, true);
+            Directory.Delete(agentRoot, true);
+        }
+    }
+
+    [Fact]
+    public async Task CombinedSkillsAndAgents_WithFilePaths_Passes()
+    {
+        var skillRoot = CreateSkillFixture("my-skill", "A short description.");
+        var agentRoot = CreateAgentFixture("test-agent");
+        try
+        {
+            var config = new CheckConfig
+            {
+                SkillPaths = [Path.Combine(skillRoot, "my-skill", "SKILL.md")],
+                AgentPaths = [Path.Combine(agentRoot, "agents", "test-agent.agent.md")],
+            };
+            var result = await CheckCommand.Run(config);
+            Assert.Equal(0, result);
+        }
+        finally
+        {
+            Directory.Delete(skillRoot, true);
+            Directory.Delete(agentRoot, true);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Skill-validator integration in other repos might need to check skills and agents - let's support that within a single invocation. Also it might need to specify them more granularly (especially agents)

### Changes done
- --skills and --agents can be specified simultaneously
- both options supports dirs and files
- tests added