### PR TITLE
Fix SDK 9.0.200 global.json pinning causing eval timeouts

### DIFF
--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -59,7 +59,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
     assertions:
@@ -218,7 +219,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
     assertions:
@@ -278,7 +280,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
     assertions:
@@ -347,7 +350,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
     assertions:
@@ -485,7 +489,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
     assertions:

--- a/tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-hotreload-installed/global.json
+++ b/tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-hotreload-installed/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200"
+    "version": "9.0.200",
+    "rollForward": "latestFeature"
   }
 }

--- a/tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-sdk9/global.json
+++ b/tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-sdk9/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200"
+    "version": "9.0.200",
+    "rollForward": "latestFeature"
   }
 }

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -317,7 +317,8 @@ scenarios:
           content: |
             {
               "sdk": {
-                "version": "9.0.200"
+                "version": "9.0.200",
+                "rollForward": "latestFeature"
               }
             }
         - path: "ServiceTests.cs"

--- a/tests/dotnet-test/run-tests/fixtures/mtp-mstest-sdk9/global.json
+++ b/tests/dotnet-test/run-tests/fixtures/mtp-mstest-sdk9/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200"
+    "version": "9.0.200",
+    "rollForward": "latestFeature"
   }
 }

--- a/tests/dotnet-test/run-tests/fixtures/mtp-xunit-v3/global.json
+++ b/tests/dotnet-test/run-tests/fixtures/mtp-xunit-v3/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200"
+    "version": "9.0.200",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Problem

The `mtp-hot-reload/Suggest hot reload for failing test in MTP project (SDK 9)` evaluation (and several others) consistently times out because the `global.json` pins to SDK `9.0.200` without a `rollForward` policy.

The default rollForward policy (`latestPatch`) only allows roll-forward within the same feature band (9.0.2xx). When the machine only has a different feature band installed (e.g., `9.0.313` = 9.0.3xx), **every `dotnet` command fails** with:

> A compatible .NET SDK was not found. Requested SDK version: 9.0.200

The model then burns its entire timeout budget (up to 360s) retrying failed bash commands, producing no useful output.

## Fix

Added `"rollForward": "latestFeature"` to all `global.json` entries pinned to `9.0.200` across:

- `tests/dotnet-test/mtp-hot-reload/eval.yaml` — 5 inline global.json blocks
- `tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-sdk9/global.json`
- `tests/dotnet-test/mtp-hot-reload/fixtures/mtp-mstest-hotreload-installed/global.json`
- `tests/dotnet-test/run-tests/eval.yaml` — 1 inline entry
- `tests/dotnet-test/run-tests/fixtures/mtp-mstest-sdk9/global.json`
- `tests/dotnet-test/run-tests/fixtures/mtp-xunit-v3/global.json`

This allows any `9.0.xxx` SDK to satisfy the requirement while still constraining to .NET 9.

## Verification

Tested locally: with `rollForward: latestFeature`, `dotnet --version` resolves to `9.0.313`, `dotnet restore` and `dotnet add package Microsoft.Testing.Extensions.HotReload` both succeed.