### PR TITLE
Fix timeout in migrate-mstest-v3-to-v4 eval scenario 9

### DIFF
--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -371,9 +371,13 @@ scenarios:
 
   - name: "Migrate MSTest.Sdk v3 project using ManagedType and TestTimeout"
     prompt: |
-      I have a test project using MSTest.Sdk/3.8.0. The tests use TestContext.ManagedType,
-      TestTimeout.Infinite, and TestContext.Properties.Contains. After upgrading to
-      MSTest.Sdk/4.1.0, I get compilation errors. How do I fix them?
+      I upgraded my test project from MSTest.Sdk/3.8.0 to MSTest.Sdk/4.1.0 and now I get
+      these compilation errors:
+      - CS1061: 'TestContext' does not contain a definition for 'ManagedType'
+      - CS0103: The name 'TestTimeout' does not exist in the current context
+      - CS1061: 'IDictionary<string, object>' does not contain a definition for 'Contains'
+      How do I fix these errors? Also, is there anything else I should know about
+      MSTest.Sdk v4 behavior changes?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -391,7 +395,7 @@ scenarios:
       - "Identifies that TestContext.ManagedType is removed in v4 and recommends FullyQualifiedTestClassName"
       - "Identifies that TestTimeout.Infinite is removed and recommends int.MaxValue"
       - "Identifies that TestContext.Properties.Contains must become ContainsKey"
-      - "Notes the MSTest.Sdk version should be updated to 4.1.0"
+      - "Notes the project is using MSTest.Sdk/4.1.0 or confirms the SDK version upgrade"
       - "Mentions that MSTest.Sdk v4 no longer adds Microsoft.NET.Test.Sdk when using MTP"
     timeout: 240
 

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sdk-project/TestProject.csproj
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sdk-project/TestProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.8.0">
+<Project Sdk="MSTest.Sdk/4.1.0">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
## Problem

The eval scenario "Migrate MSTest.Sdk v3 project using ManagedType and TestTimeout" was timing out on CI.

## Root Cause

The fixture `TestProject.csproj` had `MSTest.Sdk/3.8.0` while the prompt claimed the user already upgraded to `MSTest.Sdk/4.1.0`. This mismatch caused the model to:

1. Notice the project hadn't actually been upgraded yet
2. Edit the csproj to change the SDK version to 4.1.0
3. Run `dotnet build` to reproduce the compilation errors
4. MSTest.Sdk requires downloading the SDK package from NuGet during restore (unlike regular `PackageReference` used by all other fixtures), which is very slow on CI with a cold NuGet cache
5. Multiple `powershell` (build) invocations easily exceeded the 240s timeout

## Fix

- **Fixture csproj**: Updated from `MSTest.Sdk/3.8.0` → `MSTest.Sdk/4.1.0` to match the prompt (user says they already upgraded)
- **Prompt**: Reworded to include specific CS error codes (`CS1061`, `CS0103`), making it a clear "focused fix request" — the model should read the code and provide fixes rather than building
- **Rubric**: Updated item 4 to reflect the project already being on 4.1.0