### PR TITLE
Add Cursor plugin marketplace support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,66 @@
+{
+  "name": "dotnet-agent-skills",
+  "owner": {
+    "name": ".NET Team at Microsoft"
+  },
+  "metadata": {
+    "description": "Curated .NET agent skills and custom agents from the .NET team at Microsoft."
+  },
+  "plugins": [
+    {
+      "name": "dotnet",
+      "source": "plugins/dotnet",
+      "description": "Collection of core .NET skills for handling common .NET coding tasks."
+    },
+    {
+      "name": "dotnet-data",
+      "source": "plugins/dotnet-data",
+      "description": "Skills for .NET data access and Entity Framework related tasks."
+    },
+    {
+      "name": "dotnet-diag",
+      "source": "plugins/dotnet-diag",
+      "description": "Skills for .NET performance investigations, debugging, and incident analysis."
+    },
+    {
+      "name": "dotnet-msbuild",
+      "source": "plugins/dotnet-msbuild",
+      "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization."
+    },
+    {
+      "name": "dotnet-nuget",
+      "source": "plugins/dotnet-nuget",
+      "description": "NuGet and .NET package management: dependency management and modernization."
+    },
+    {
+      "name": "dotnet-upgrade",
+      "source": "plugins/dotnet-upgrade",
+      "description": "Skills for migrating and upgrading .NET projects across framework versions, language features, and compatibility targets."
+    },
+    {
+      "name": "dotnet-maui",
+      "source": "plugins/dotnet-maui",
+      "description": "Skills for .NET MAUI development: environment setup, diagnostics, troubleshooting, navigation, data binding, dependency injection, layout, and theming."
+    },
+    {
+      "name": "dotnet-ai",
+      "source": "plugins/dotnet-ai",
+      "description": "AI and ML skills for .NET: technology selection, LLM integration, agentic workflows, RAG pipelines, MCP, and classic ML with ML.NET."
+    },
+    {
+      "name": "dotnet-template-engine",
+      "source": "plugins/dotnet-template-engine",
+      "description": ".NET Template Engine skills: template discovery, project scaffolding, and template authoring."
+    },
+    {
+      "name": "dotnet-test",
+      "source": "plugins/dotnet-test",
+      "description": "Skills for running, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, and MSTest workflows."
+    },
+    {
+      "name": "dotnet-aspnet",
+      "source": "plugins/dotnet-aspnet",
+      "description": "ASP.NET Core web development skills including middleware, endpoints, real-time communication, and API patterns."
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,57 +9,57 @@
   "plugins": [
     {
       "name": "dotnet",
-      "source": "plugins/dotnet",
+      "source": "./plugins/dotnet",
       "description": "Collection of core .NET skills for handling common .NET coding tasks."
     },
     {
       "name": "dotnet-data",
-      "source": "plugins/dotnet-data",
+      "source": "./plugins/dotnet-data",
       "description": "Skills for .NET data access and Entity Framework related tasks."
     },
     {
       "name": "dotnet-diag",
-      "source": "plugins/dotnet-diag",
+      "source": "./plugins/dotnet-diag",
       "description": "Skills for .NET performance investigations, debugging, and incident analysis."
     },
     {
       "name": "dotnet-msbuild",
-      "source": "plugins/dotnet-msbuild",
+      "source": "./plugins/dotnet-msbuild",
       "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization."
     },
     {
       "name": "dotnet-nuget",
-      "source": "plugins/dotnet-nuget",
+      "source": "./plugins/dotnet-nuget",
       "description": "NuGet and .NET package management: dependency management and modernization."
     },
     {
       "name": "dotnet-upgrade",
-      "source": "plugins/dotnet-upgrade",
+      "source": "./plugins/dotnet-upgrade",
       "description": "Skills for migrating and upgrading .NET projects across framework versions, language features, and compatibility targets."
     },
     {
       "name": "dotnet-maui",
-      "source": "plugins/dotnet-maui",
+      "source": "./plugins/dotnet-maui",
       "description": "Skills for .NET MAUI development: environment setup, diagnostics, troubleshooting, navigation, data binding, dependency injection, layout, and theming."
     },
     {
       "name": "dotnet-ai",
-      "source": "plugins/dotnet-ai",
+      "source": "./plugins/dotnet-ai",
       "description": "AI and ML skills for .NET: technology selection, LLM integration, agentic workflows, RAG pipelines, MCP, and classic ML with ML.NET."
     },
     {
       "name": "dotnet-template-engine",
-      "source": "plugins/dotnet-template-engine",
+      "source": "./plugins/dotnet-template-engine",
       "description": ".NET Template Engine skills: template discovery, project scaffolding, and template authoring."
     },
     {
       "name": "dotnet-test",
-      "source": "plugins/dotnet-test",
+      "source": "./plugins/dotnet-test",
       "description": "Skills for running, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, and MSTest workflows."
     },
     {
       "name": "dotnet-aspnet",
-      "source": "plugins/dotnet-aspnet",
+      "source": "./plugins/dotnet-aspnet",
       "description": "ASP.NET Core web development skills including middleware, endpoints, real-time communication, and API patterns."
     }
   ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If your skill does not fit any existing plugin, consider creating a new one.
 To create a new plugin:
 
 1. Add `plugins/<plugin-name>/plugin.json` and a `skills/` directory beneath it.
-2. Add a matching entry in both `.github/plugin/marketplace.json` and `.claude-plugin/marketplace.json`. The `.claude-plugin/marketplace.json` file must remain an exact copy of `.github/plugin/marketplace.json`, so any change to one file (adding, removing, or editing a plugin entry) must be applied to the other in the same way.
+2. Add a matching entry in `.github/plugin/marketplace.json`, `.claude-plugin/marketplace.json`, and `.cursor-plugin/marketplace.json`. Keep plugin entries consistent across all marketplace manifests (including `plugins[].source` format) to reduce drift and make future updates safer.
 3. Add a CODEOWNERS entry for the new plugin and its tests (see [Code ownership](#code-ownership)).
 4. Add the plugin to the **What's Included** table in the root `README.md`.
 5. Create a `tests/<plugin-name>/` directory for skill tests.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ This repository contains the .NET team's curated set of core skills and custom a
 
 Once configured, type `/plugins` in Copilot Chat or use the `@agentPlugins` filter in Extensions to browse and install plugins from the marketplace.
 
+### Cursor
+
+This repository is a [Cursor plugin marketplace](https://cursor.com/docs/plugins). Install plugins directly from the Cursor IDE:
+
+1. Open the marketplace panel in Cursor
+2. Search for `.NET` or browse [cursor.com/marketplace](https://cursor.com/marketplace)
+3. Install the desired plugins
+
+Alternatively, load plugins locally:
+
+1. Clone this repository
+2. Copy or symlink to `~/.cursor/plugins/local/dotnet-agent-skills`
+3. Restart Cursor or run **Developer: Reload Window**
+
 ### Codex CLI
 
 Skills in this repository follow the [agentskills.io](https://agentskills.io) open standard

--- a/README.md
+++ b/README.md
@@ -64,17 +64,16 @@ Once configured, type `/plugins` in Copilot Chat or use the `@agentPlugins` filt
 
 ### Cursor
 
-This repository is a [Cursor plugin marketplace](https://cursor.com/docs/plugins). Install plugins directly from the Cursor IDE:
+This repository is a [Cursor plugin marketplace](https://cursor.com/docs/plugins). You can discover and install published plugins directly in Cursor:
 
 1. Open the marketplace panel in Cursor
 2. Search for `.NET` or browse [cursor.com/marketplace](https://cursor.com/marketplace)
 3. Install the desired plugins
 
-Alternatively, load plugins locally:
+For local development or unpublished changes, import plugins from a local checkout:
 
-1. Clone this repository
-2. Copy or symlink to `~/.cursor/plugins/local/dotnet-agent-skills`
-3. Restart Cursor or run **Developer: Reload Window**
+1. Copy or symlink your local checkout to `~/.cursor/plugins/local/dotnet-agent-skills`
+2. Restart Cursor or run **Developer: Reload Window**
 
 ### Codex CLI
 


### PR DESCRIPTION
## Summary

Adds [Cursor IDE](https://cursor.com) plugin marketplace support, similar to the existing Claude Code integration.

Fixes #523

## Changes

- **`.cursor-plugin/marketplace.json`**: Cursor marketplace manifest listing all 11 published plugins. Cursor discovers plugins via [folder-based auto-discovery](https://cursor.com/docs/reference/plugins#component-discovery) — existing `skills/` and `agents/` directory structures with YAML frontmatter (`name` + `description`) are already compatible.
- **`README.md`**: Added Cursor installation instructions.

## Notes

- Symlinks from `.cursor-plugin` → `.claude-plugin` don't work in current Cursor versions (per issue discussion), so this is a standalone copy of the marketplace manifest.
- No per-plugin `.cursor-plugin/plugin.json` files are needed — Cursor's auto-discovery finds `SKILL.md` files in `skills/` subdirectories and `.md` agent files in `agents/` directories automatically.
- All existing skill and agent frontmatter is already Cursor-compatible.