### PR TITLE
improve(dotnet-test): enhance agent descriptions for subagent discovery

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Runs build/compile commands for any language and reports results.
+
   Use when: compiling code, running dotnet build, checking for compilation
   errors, verifying project builds successfully.
 name: code-testing-builder

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Runs build/compile commands for any language and reports
-  results. Discovers build command from project files if not specified.
+  Runs build/compile commands for any language and reports results.
+  Use when: compiling code, running dotnet build, checking for compilation
+  errors, verifying project builds successfully.
 name: code-testing-builder
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Fixes compilation errors in source or test files.
+
   Use when: resolving build errors, fixing CS/TS error codes, adding missing
   imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Fixes compilation errors in source or test files. Analyzes
-  error messages and applies corrections.
+  Fixes compilation errors in source or test files.
+  Use when: resolving build errors, fixing CS/TS error codes, adding missing
+  imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -123,3 +123,4 @@ All state is stored in `.testagent/` folder:
 6. **Scoped builds during phases, full build at the end** — build specific test projects during implementation for speed; run a full-workspace non-incremental build after all phases to catch cross-project errors
 7. **No environment-dependent tests** — mock all external dependencies; never call external URLs, bind ports, or depend on timing
 8. **Fix assertions, don't skip tests** — when tests fail, read production code and fix the expected value; never `[Ignore]` or `[Skip]`
+9. **Clean up `.testagent/`** — after pipeline completion, delete the `.testagent/` folder or advise the user to add it to `.gitignore` so ephemeral state is not committed

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -1,7 +1,9 @@
 ---
 description: >-
   Implements a single phase from the test plan. Writes test files and verifies
-  they compile and pass. Use when: executing a plan phase, writing test files,
+  they compile and pass.
+
+  Use when: executing a plan phase, writing test files,
   running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Implements a single phase from the test plan. Writes test
-  files and verifies they compile and pass. Calls builder, tester, and fixer agents as
-  needed.
+  Implements a single phase from the test plan. Writes test files and verifies
+  they compile and pass. Use when: executing a plan phase, writing test files,
+  running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Runs code formatting/linting for any language. Discovers lint
-  command from project files if not specified.
+  Runs code formatting and linting for any language.
+  Use when: formatting code, running dotnet format, fixing style issues,
+  applying lint fixes.
 name: code-testing-linter
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Runs code formatting and linting for any language.
+
   Use when: formatting code, running dotnet format, fixing style issues,
   applying lint fixes.
 name: code-testing-linter

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Creates structured test implementation plans from research
-  findings. Organizes tests into phases by priority and complexity. Works with any
-  language.
+  Creates structured test implementation plans from research findings.
+  Use when: organizing tests into phases, prioritizing test generation,
+  creating .testagent/plan.md from research.
 name: code-testing-planner
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Creates structured test implementation plans from research findings.
+
   Use when: organizing tests into phases, prioritizing test generation,
   creating .testagent/plan.md from research.
 name: code-testing-planner

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Analyzes codebases to understand structure, testing patterns, and testability.
+
   Use when: researching project structure, identifying source files to test,
   discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Analyzes codebases to understand structure, testing patterns,
-  and testability. Identifies source files, existing tests, build commands, and
-  testing framework. Works with any language.
+  Analyzes codebases to understand structure, testing patterns, and testability.
+  Use when: researching project structure, identifying source files to test,
+  discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher
 user-invocable: false
 ---

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -1,6 +1,7 @@
 ---
 description: >-
   Runs test commands for any language and reports pass/fail results.
+
   Use when: running dotnet test, executing tests, verifying tests pass,
   checking test results and failures.
 name: code-testing-tester

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Runs test commands for any language and reports results.
-  Discovers test command from project files if not specified.
+  Runs test commands for any language and reports pass/fail results.
+  Use when: running dotnet test, executing tests, verifying tests pass,
+  checking test results and failures.
 name: code-testing-tester
 user-invocable: false
 ---


### PR DESCRIPTION
## Summary

Improves sub-agent descriptions with trigger phrases so parent agents can reliably discover and delegate to them, following the [VS Code agent customization best practice](https://code.visualstudio.com/docs/copilot/customization/custom-agents): *"The `description` field is how the agent decides whether to load a skill, instruction, or agent."*

## Changes

### Add trigger phrases to 7 sub-agent descriptions

Each sub-agent description now includes a `Use when:` section with specific keywords that parent agents match against when deciding which sub-agent to invoke.

| Agent | Added triggers |
|-------|---------------|
| `code-testing-builder` | compiling code, running dotnet build, checking compilation errors |
| `code-testing-tester` | running dotnet test, executing tests, verifying tests pass |
| `code-testing-linter` | formatting code, running dotnet format, fixing style issues |
| `code-testing-fixer` | resolving build errors, fixing CS/TS error codes, adding missing imports |
| `code-testing-researcher` | researching project structure, discovering test frameworks |
| `code-testing-planner` | organizing tests into phases, prioritizing test generation |
| `code-testing-implementer` | executing a plan phase, writing test files, build-test-fix cycle |

### Add `.testagent/` cleanup rule to generator

Added rule #9 to the generator agent: after pipeline completion, delete `.testagent/` or advise adding it to `.gitignore`. This prevents ephemeral pipeline state (research.md, plan.md) from being accidentally committed.