### PR TITLE
feat(dotnet-test): add handoffs between orchestrator agents

### DIFF
--- a/plugins/dotnet-test/agents/test-migration.agent.md
+++ b/plugins/dotnet-test/agents/test-migration.agent.md
@@ -9,6 +9,13 @@ description: >-
 tools: ['read', 'search', 'edit', 'terminal', 'skill']
 user-invokable: true
 disable-model-invocation: false
+handoffs:
+  - label: Audit Test Quality
+    agent: test-quality-auditor
+    prompt: >-
+      The test framework migration is complete. Please audit the migrated
+      test suite for quality issues, anti-patterns, and coverage gaps.
+    send: false
 ---
 
 # Test Migration Agent

--- a/plugins/dotnet-test/agents/test-quality-auditor.agent.md
+++ b/plugins/dotnet-test/agents/test-quality-auditor.agent.md
@@ -9,6 +9,19 @@ description: >-
 tools: ['read', 'search', 'edit', 'terminal', 'skill']
 user-invokable: true
 disable-model-invocation: false
+handoffs:
+  - label: Generate Missing Tests
+    agent: code-testing-generator
+    prompt: >-
+      Based on the audit findings above, generate tests to fill the identified
+      coverage gaps and address the weak test areas.
+    send: false
+  - label: Fix Testability Issues
+    agent: testability-migration
+    prompt: >-
+      The audit found untestable code with static dependencies. Please run
+      the detect-generate-migrate pipeline on the flagged areas.
+    send: false
 ---
 
 # Test Quality Auditor Agent

--- a/plugins/dotnet-test/agents/testability-migration.agent.md
+++ b/plugins/dotnet-test/agents/testability-migration.agent.md
@@ -7,6 +7,14 @@ description: >-
   TimeProvider, adopt IFileSystem, or improve testability of a legacy codebase.
 name: testability-migration
 tools: ['read', 'search', 'edit', 'terminal', 'skill']
+handoffs:
+  - label: Generate Tests for Migrated Code
+    agent: code-testing-generator
+    prompt: >-
+      The code has been migrated to use injectable abstractions. Please
+      generate unit tests for the migrated classes, using test doubles for
+      the new wrapper interfaces.
+    send: false
 ---
 
 # Testability Migration Agent


### PR DESCRIPTION
## Summary

Adds [handoffs](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_handoffs) between the dotnet-test orchestrator agents, enabling guided sequential workflows where users can transition between agents with a single click after each step completes.

## Workflow Diagram

```
test-migration ──── "Audit Test Quality" ────► test-quality-auditor
                                                  │
                                    ┌─────────────┼─────────────────┐
                                    │             │                 │
                          "Generate Missing    "Fix Testability
                              Tests"             Issues"
                                    │                               │
                                    ▼                               ▼
                          code-testing-generator    testability-migration
                                    ▲                               │
                                    │         "Generate Tests       │
                                    │       for Migrated Code"      │
                                    └───────────────────────────────┘
```

## Handoffs Added

| Agent | Handoff Label | Target | Scenario |
|-------|--------------|--------|----------|
| `test-quality-auditor` | Generate Missing Tests | `code-testing-generator` | Audit found coverage gaps → generate tests to fill them |
| `test-quality-auditor` | Fix Testability Issues | `testability-migration` | Audit found untestable static dependencies → migrate to injectable abstractions |
| `testability-migration` | Generate Tests for Migrated Code | `code-testing-generator` | Code now uses injectable abstractions → generate tests using test doubles |
| `test-migration` | Audit Test Quality | `test-quality-auditor` | Framework migration complete → audit the migrated test suite |

All handoffs use `send: false` so the user can review and edit the prompt before submitting.