### PR TITLE
Add migrate-mstest-v3-to-v4 eval scenarios for uncovered patterns

### DIFF
--- a/plugins/dotnet-test/skills/migrate-mstest-v3-to-v4/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-mstest-v3-to-v4/SKILL.md
@@ -1,21 +1,19 @@
 ---
 name: migrate-mstest-v3-to-v4
 description: >
-  Migrate an MSTest v3 test project to MSTest v4. Use when user says
-  "upgrade to MSTest v4", "update to latest MSTest", "MSTest 4 migration",
-  "MSTest v4 breaking changes", "MSTest v4 compatibility", or has build errors
-  after updating MSTest packages from 3.x to 4.x. Also use for target
-  framework compatibility (e.g. net6.0/net7.0 support with MSTest v4).
-  USE FOR: upgrading MSTest packages from 3.x to 4.x, fixing source breaking
-  changes (Execute -> ExecuteAsync, CallerInfo constructor, ClassCleanupBehavior
-  removal, TestContext.Properties, Assert API changes, ExpectedExceptionAttribute
-  removal, TestTimeout enum removal), resolving behavioral changes
-  (TreatDiscoveryWarningsAsErrors, TestContext lifecycle, TestCase.Id changes,
-  MSTest.Sdk MTP changes), handling dropped TFMs (net5.0-net7.0 dropped,
-  only net8.0+, net462, uap10.0 supported).
+  Fix build errors and breaking changes after upgrading MSTest from v3 to v4,
+  or plan a complete MSTest v3-to-v4 migration. Use when user says "upgrade to
+  MSTest v4", "MSTest 4 migration", "MSTest v4 breaking changes", "tests don't
+  compile after upgrading MSTest", or has errors CS0507, CS0103, CS1061, CS1615 after updating MSTest packages from 3.x to 4.x.
+  USE FOR: Execute to ExecuteAsync, CallerInfo constructor on TestMethodAttribute,
+  sealed custom attributes, ClassCleanupBehavior removal, TestContext.Properties
+  Contains to ContainsKey, Assert.ThrowsException to ThrowsExactly,
+  Assert.IsInstanceOfType out parameter removal, ExpectedExceptionAttribute
+  removal, TestTimeout enum removal, [TestMethod("name")] to DisplayName syntax,
+  TreatDiscoveryWarningsAsErrors, TestContext.TestName in ClassInitialize,
+  MSTest.Sdk MTP changes, dropped TFMs (net6.0/net7.0 to net8.0+).
   DO NOT USE FOR: migrating from MSTest v1/v2 to v3 (use migrate-mstest-v1v2-to-v3
-  first), migrating between test frameworks, or general .NET upgrades unrelated
-  to MSTest.
+  first), migrating between test frameworks, or general .NET upgrades.
 ---
 
 # MSTest v3 -> v4 Migration

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -400,6 +400,181 @@ scenarios:
     timeout: 240
 
   # ============================================================================
+  # Goal 10: Verified package update with build and test validation
+  # ============================================================================
+
+  - name: "Verified MSTest v3 to v4 package update with build and test"
+    prompt: |
+      I need to upgrade my test project from MSTest 3.8.0 to MSTest 4.x.
+      Please update the package references, fix any breaking changes, then
+      build the project and run the tests to make sure everything works.
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          source: "fixtures/v3-verified-migration/TestProject.csproj"
+        - path: "OrderServiceTests.cs"
+          source: "fixtures/v3-verified-migration/OrderServiceTests.cs"
+    assertions:
+      - type: "file_contains"
+        path: "TestProject.csproj"
+        value: "4."
+      - type: "output_matches"
+        pattern: "(dotnet build|dotnet test|build.*succeed|test.*pass)"
+      - type: "output_matches"
+        pattern: "(TestTimeout|int\\.MaxValue|Timeout)"
+    rubric:
+      - "Updated MSTest package references from 3.8.0 to a 4.x version"
+      - "Fixed the TestTimeout.Infinite breaking change to int.MaxValue"
+      - "Built the project and confirmed zero compilation errors"
+      - "Ran the tests with dotnet test and confirmed all tests pass"
+    timeout: 300
+
+  # ============================================================================
+  # Goal 11: Sealed custom TestMethodAttribute with Timeout migration
+  # ============================================================================
+
+  - name: "Fix sealed custom TestMethodAttribute with Timeout changes"
+    prompt: |
+      After upgrading to MSTest 4.1.0, my test project fails to compile. I have a
+      sealed TimedTestMethodAttribute that overrides Execute, and several tests use
+      [Timeout(TestTimeout.Infinite)]. Here are the errors:
+      - error CS0507: cannot change access modifiers when overriding 'Execute'
+      - error CS0103: The name 'TestTimeout' does not exist in the current context
+      How do I fix these?
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          source: "fixtures/v3-sealed-timeout/TestProject.csproj"
+        - path: "PerformanceTests.cs"
+          source: "fixtures/v3-sealed-timeout/PerformanceTests.cs"
+    assertions:
+      - type: "output_matches"
+        pattern: "ExecuteAsync"
+      - type: "output_matches"
+        pattern: "(int\\.MaxValue|TestTimeout)"
+      - type: "output_matches"
+        pattern: "(sealed|TimedTestMethod)"
+    rubric:
+      - "Identifies that Execute must be changed to ExecuteAsync returning Task<TestResult[]> in the sealed attribute class"
+      - "Shows that [Timeout(TestTimeout.Infinite)] must become [Timeout(int.MaxValue)]"
+      - "Provides corrected code for the sealed TimedTestMethodAttribute class"
+      - "Addresses both the Execute and Timeout breaking changes together"
+    timeout: 180
+
+  # ============================================================================
+  # Goal 12: TestMethodAttribute and TestMethod display name syntax
+  # ============================================================================
+
+  - name: "Fix TestMethodAttribute and TestMethod display name constructor"
+    prompt: |
+      My MSTest v3 project uses [TestMethod("display name")] and
+      [TestMethodAttribute("display name")] to set custom display names on tests.
+      After upgrading to MSTest v4, these constructors no longer work because of
+      CallerInfo parameter changes. How should I update them?
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          source: "fixtures/v3-testmethod-displayname/TestProject.csproj"
+        - path: "AuthTests.cs"
+          source: "fixtures/v3-testmethod-displayname/AuthTests.cs"
+    assertions:
+      - type: "output_matches"
+        pattern: "(DisplayName|display.?name)"
+      - type: "output_matches"
+        pattern: "(CallerFilePath|CallerLineNumber|caller.?info)"
+    rubric:
+      - "Identifies that TestMethodAttribute constructor now uses CallerInfo parameters"
+      - "Shows the correct syntax: [TestMethod(DisplayName = \"...\")]"
+      - "Applies the fix to both [TestMethod(\"...\")] and [TestMethodAttribute(\"...\")] usages"
+      - "Provides corrected code for all three test methods in the fixture"
+    timeout: 180
+
+  # ============================================================================
+  # Goal 13: Assert.IsInstanceOfType out parameter breaking change
+  # ============================================================================
+
+  - name: "Fix Assert.IsInstanceOfType out parameter removal"
+    prompt: |
+      After upgrading to MSTest 4.x, my tests that use Assert.IsInstanceOfType with
+      an out parameter no longer compile. I get errors like:
+      - CS1615: Argument 2 should not be passed with the 'out' keyword
+      How do I update these assertions?
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          source: "fixtures/v3-instanceoftype/TestProject.csproj"
+        - path: "TypeCheckTests.cs"
+          source: "fixtures/v3-instanceoftype/TypeCheckTests.cs"
+    assertions:
+      - type: "output_matches"
+        pattern: "IsInstanceOfType"
+      - type: "output_matches"
+        pattern: "(return value|var typed|var .* = Assert)"
+    rubric:
+      - "Identifies that Assert.IsInstanceOfType<T> no longer uses an out parameter in MSTest v4"
+      - "Shows the new pattern: var typed = Assert.IsInstanceOfType<T>(obj) using the return value"
+      - "Provides corrected code for all three test methods using IsInstanceOfType"
+      - "Explains the typed variable is now assigned from the return value instead of an out parameter"
+    timeout: 180
+
+  # ============================================================================
+  # Goal 14: Behavioral changes review and remediation
+  # ============================================================================
+
+  - name: "Address TreatDiscoveryWarningsAsErrors and behavioral changes"
+    prompt: |
+      I upgraded my MSTest project to v4 and the code compiles fine. But when I run
+      dotnet test, some tests that used to be discovered are now failing with discovery
+      errors. I also noticed that my [ClassInitialize] method crashes when it tries to
+      access TestContext.TestName. The project compiled cleanly — are these runtime
+      behavioral changes in v4? How do I fix them?
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="MSTest" Version="4.1.0" />
+              </ItemGroup>
+            </Project>
+        - path: "DiscoveryTests.cs"
+          content: |
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace MyApp.Tests;
+
+            [TestClass]
+            public class DiscoveryTests
+            {
+                public TestContext TestContext { get; set; }
+
+                [ClassInitialize]
+                public static void ClassSetup(TestContext context)
+                {
+                    var name = context.TestName;
+                    System.Console.WriteLine($"Setting up for: {name}");
+                }
+
+                [TestMethod]
+                public void DiscoverMe() => Assert.IsTrue(true);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(TreatDiscoveryWarningsAsErrors|discovery.*(warning|error))"
+      - type: "output_matches"
+        pattern: "(TestName|ClassInitialize|TestInitialize)"
+    rubric:
+      - "Identifies that TreatDiscoveryWarningsAsErrors defaults to true in MSTest v4, causing previously-ignored warnings to fail"
+      - "Recommends fixing discovery warnings or setting TreatDiscoveryWarningsAsErrors to false in .runsettings"
+      - "Identifies that accessing TestContext.TestName in ClassInitialize throws in v4"
+      - "Recommends moving TestName access to TestInitialize or individual test methods"
+      - "Mentions other behavioral changes the user should watch for (AppDomain, TestCase.Id, analyzer severity changes)"
+    timeout: 180
+
+  # ============================================================================
   # Goal 10: Recognize v3 project needs v3→v4 migration, not v1→v3
   # ============================================================================
 

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -417,11 +417,14 @@ scenarios:
     assertions:
       - type: "file_contains"
         path: "TestProject.csproj"
-        value: "4."
+        value: "PackageReference Include=\"MSTest.TestFramework\" Version=\"4."
+      - type: "file_contains"
+        path: "TestProject.csproj"
+        value: "PackageReference Include=\"MSTest.TestAdapter\" Version=\"4."
       - type: "output_matches"
         pattern: "(dotnet build|dotnet test|build.*succeed|test.*pass)"
       - type: "output_matches"
-        pattern: "(TestTimeout|int\\.MaxValue|Timeout)"
+        pattern: "(int\\.MaxValue|int\\.Max)"
     rubric:
       - "Updated MSTest package references from 3.8.0 to a 4.x version"
       - "Fixed the TestTimeout.Infinite breaking change to int.MaxValue"
@@ -438,7 +441,7 @@ scenarios:
       After upgrading to MSTest 4.1.0, my test project fails to compile. I have a
       sealed TimedTestMethodAttribute that overrides Execute, and several tests use
       [Timeout(TestTimeout.Infinite)]. Here are the errors:
-      - error CS0507: cannot change access modifiers when overriding 'Execute'
+      - error CS0115: no suitable method found to override for 'Execute'
       - error CS0103: The name 'TestTimeout' does not exist in the current context
       How do I fix these?
     setup:
@@ -575,7 +578,7 @@ scenarios:
     timeout: 180
 
   # ============================================================================
-  # Goal 10: Recognize v3 project needs v3→v4 migration, not v1→v3
+  # Goal 15: Recognize v3 project needs v3→v4 migration, not v1→v3
   # ============================================================================
 
   - name: "Correctly identify MSTest v3 project and recommend v4 migration"

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -459,7 +459,7 @@ scenarios:
       - "Shows that [Timeout(TestTimeout.Infinite)] must become [Timeout(int.MaxValue)]"
       - "Provides corrected code for the sealed TimedTestMethodAttribute class"
       - "Addresses both the Execute and Timeout breaking changes together"
-    timeout: 180
+    timeout: 240
 
   # ============================================================================
   # Goal 12: TestMethodAttribute and TestMethod display name syntax
@@ -515,7 +515,7 @@ scenarios:
       - "Shows the new pattern: var typed = Assert.IsInstanceOfType<T>(obj) using the return value"
       - "Provides corrected code for all three test methods using IsInstanceOfType"
       - "Explains the typed variable is now assigned from the return value instead of an out parameter"
-    timeout: 180
+    timeout: 240
 
   # ============================================================================
   # Goal 14: Behavioral changes review and remediation

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TestProject.csproj
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TypeCheckTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TypeCheckTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MyApp.Tests;

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TypeCheckTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-instanceoftype/TypeCheckTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyApp.Tests;
+
+public interface IProcessor { string Name { get; } }
+public class FastProcessor : IProcessor { public string Name => "Fast"; }
+public class SlowProcessor : IProcessor { public string Name => "Slow"; }
+
+[TestClass]
+public class TypeCheckTests
+{
+    [TestMethod]
+    public void CreateProcessor_Fast_ReturnsCorrectType()
+    {
+        object processor = new FastProcessor();
+        Assert.IsInstanceOfType<FastProcessor>(processor, out var typed);
+        Assert.AreEqual("Fast", typed.Name);
+    }
+
+    [TestMethod]
+    public void CreateProcessor_Slow_ReturnsCorrectType()
+    {
+        object processor = new SlowProcessor();
+        Assert.IsInstanceOfType<SlowProcessor>(processor, out var typed);
+        Assert.AreEqual("Slow", typed.Name);
+    }
+
+    [TestMethod]
+    public void CreateProcessor_IsInterface()
+    {
+        object processor = new FastProcessor();
+        Assert.IsInstanceOfType<IProcessor>(processor, out var typed);
+        Assert.IsNotNull(typed.Name);
+    }
+}

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sealed-timeout/PerformanceTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sealed-timeout/PerformanceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyApp.Tests;
+
+public sealed class TimedTestMethodAttribute : TestMethodAttribute
+{
+    public override TestResult[] Execute(ITestMethod testMethod)
+    {
+        var sw = Stopwatch.StartNew();
+        var results = base.Execute(testMethod);
+        sw.Stop();
+        Console.WriteLine($"{testMethod.TestMethodName} took {sw.ElapsedMilliseconds}ms");
+        return results;
+    }
+}
+
+[TestClass]
+public class PerformanceTests
+{
+    [TimedTestMethod]
+    [Timeout(TestTimeout.Infinite)]
+    public void HeavyComputation_Completes()
+    {
+        Assert.IsTrue(true);
+    }
+
+    [TimedTestMethod]
+    public void QuickCheck_Succeeds()
+    {
+        Assert.AreEqual(42, 42);
+    }
+
+    [TestMethod]
+    [Timeout(TestTimeout.Infinite)]
+    public void StressTest_DoesNotTimeout()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sealed-timeout/TestProject.csproj
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-sealed-timeout/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-testmethod-displayname/AuthTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-testmethod-displayname/AuthTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyApp.Tests;
+
+[TestClass]
+public class AuthTests
+{
+    [TestMethod("Verify user login works correctly")]
+    public void Login_ValidCredentials_Succeeds()
+    {
+        Assert.IsTrue(true);
+    }
+
+    [TestMethodAttribute("Check admin privileges are enforced")]
+    public void AdminAccess_RequiresElevation()
+    {
+        Assert.IsTrue(true);
+    }
+
+    [TestMethod("Ensure logout clears session")]
+    public void Logout_ClearsSession()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-testmethod-displayname/TestProject.csproj
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-testmethod-displayname/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/OrderServiceTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/OrderServiceTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MyApp.Tests;

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/OrderServiceTests.cs
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/OrderServiceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyApp.Tests;
+
+[TestClass]
+public class OrderServiceTests
+{
+    [TestMethod]
+    public void CreateOrder_ValidInput_ReturnsOrder()
+    {
+        var orderId = 42;
+        Assert.AreEqual(42, orderId);
+    }
+
+    [TestMethod]
+    [Timeout(TestTimeout.Infinite)]
+    public void ProcessOrder_LargePayload_Completes()
+    {
+        Assert.IsTrue(true);
+    }
+
+    [TestMethod]
+    public void GetOrder_ReturnsExpectedType()
+    {
+        object result = "Order-123";
+        Assert.IsInstanceOfType(result, typeof(string));
+    }
+}

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/TestProject.csproj
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/fixtures/v3-verified-migration/TestProject.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add 5 new evaluation scenarios (Goals 10-14) to `migrate-mstest-v3-to-v4` covering previously uncovered validation items and code patterns.

## New scenarios

| # | Scenario | Covers |
|---|---|---|
| 10 | Verified package update with build/test | Packages updated to 4.x, build zero errors, tests pass |
| 11 | Sealed custom TestMethodAttribute + Timeout | `sealed` keyword, `[Timeout(TestTimeout.Infinite)]` |
| 12 | TestMethod/Attribute display name syntax | `[TestMethod("...")]`, `[TestMethodAttribute("...")]` |
| 13 | IsInstanceOfType out parameter removal | `Assert.IsInstanceOfType<T>(obj, out var)` |
| 14 | Behavioral changes review & remediation | `TreatDiscoveryWarningsAsErrors`, `TestContext.TestName` in `ClassInitialize` |

## New fixture directories

- `v3-verified-migration/` — buildable project for end-to-end validation
- `v3-sealed-timeout/` — sealed attribute + TestTimeout.Infinite patterns
- `v3-testmethod-displayname/` — `[TestMethod("name")]` / `[TestMethodAttribute("name")]` patterns
- `v3-instanceoftype/` — `Assert.IsInstanceOfType<T>` out parameter pattern

## Coverage gaps addressed

- **[Validation]** All MSTest packages updated to 4.x (line 449)
- **[Validation]** Project builds with zero errors (line 450)
- **[Validation]** All tests pass with dotnet test (line 451)
- **[Validation]** Behavioral changes reviewed and addressed (line 458)
- **[CodePattern]** `[TestMethod]` (line 266)
- **[CodePattern]** `[Timeout]` (line 213)
- **[CodePattern]** `sealed` (line 119)
- **[CodePattern]** `[TestMethodAttribute]` (line 173)
- **[CodePattern]** `Assert.IsInstanceOfType` (line 252)