### PR TITLE
Fix jsonl sessions attaching

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -998,6 +998,21 @@ jobs:
           merge-multiple: false
         continue-on-error: ${{ needs.evaluate.result != 'success' }}
 
+      - name: Inspect downloaded artifacts
+        if: always()
+        run: |
+          echo "=== all-results/ directory listing (3 levels) ==="
+          if [ -d all-results ]; then
+            find all-results -maxdepth 3 -ls 2>/dev/null | head -80
+            echo "---"
+            echo "sessions.db files:"
+            find all-results -name 'sessions.db' -ls 2>/dev/null
+            echo "events.jsonl files:"
+            find all-results -name 'events.jsonl' 2>/dev/null | head -20
+          else
+            echo "all-results/ directory does not exist!"
+          fi
+
       - name: Determine source metadata
         id: meta
         run: |

--- a/eng/skill-validator/src/Evaluate/AgentRunner.cs
+++ b/eng/skill-validator/src/Evaluate/AgentRunner.cs
@@ -69,6 +69,14 @@ public static class AgentRunner
             var options = new CopilotClientOptions
             {
                 LogLevel = verbose ? "info" : "none",
+                SessionFs = new SessionFsConfig
+                {
+                    InitialCwd = Environment.CurrentDirectory,
+                    SessionStatePath = "session-state",
+                    Conventions = OperatingSystem.IsWindows()
+                        ? GitHub.Copilot.SDK.Rpc.SessionFsSetProviderRequestConventions.Windows
+                        : GitHub.Copilot.SDK.Rpc.SessionFsSetProviderRequestConventions.Posix,
+                },
             };
 
             if (!string.IsNullOrEmpty(_capturedGitHubToken))

--- a/eng/skill-validator/src/Evaluate/LlmSession.cs
+++ b/eng/skill-validator/src/Evaluate/LlmSession.cs
@@ -35,6 +35,12 @@ internal static class LlmSession
     {
         var client = await AgentRunner.GetSharedClient(verbose);
 
+        // Judge/analyzer sessions don't persist data, but SessionFs on the client
+        // requires every session to provide a CreateSessionFsHandler.
+        var tempConfigDir = Path.Combine(Path.GetTempPath(), $"sv-judge-{Guid.NewGuid():N}");
+        try
+        {
+
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
             Model = model,
@@ -46,6 +52,7 @@ internal static class LlmSession
                 Content = systemPrompt,
             },
             InfiniteSessions = new InfiniteSessionConfig { Enabled = false },
+            CreateSessionFsHandler = _ => new LocalSessionFsHandler(tempConfigDir),
             OnPermissionRequest = onPermissionRequest ?? ((_, _) => Task.FromResult(new PermissionRequestResult
             {
                 Kind = PermissionRequestResultKind.DeniedByRules,
@@ -92,5 +99,10 @@ internal static class LlmSession
             throw new InvalidOperationException($"{timeoutLabel} returned no content");
 
         return new LlmResponse(content, new TokenUsage(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens));
+        } // try
+        finally
+        {
+            try { Directory.Delete(tempConfigDir, true); } catch { }
+        }
     }
 }


### PR DESCRIPTION
### Context

The jsonl sessions attaching wasn't working properly since the last copilot.sdk update - we need to explicitly opt into a having custom config FS handler.