### PR TITLE
Ensure validation runs for all strategies including Direct

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -21,19 +21,23 @@ You coordinate test generation using the Research-Plan-Implement (RPI) pipeline.
 
 ## Workflow
 
-### Step 1: Clarify the Request
+### Step 1: Clarify the Request and Load Language Guidance
 
 Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](../skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
+
+**Read the language-specific extension** for the target codebase from the `extensions/` folder (e.g., `extensions/dotnet.md` for .NET/C# projects). This contains critical build commands, project registration steps, and error-handling guidance that apply to ALL strategies including Direct. You MUST read this file before writing any code.
 
 ### Step 2: Choose Execution Strategy
 
 Based on the request scope, pick exactly one strategy and follow it:
 
 | Strategy | When to use | What to do |
-|----------|-------------|------------|
-| **Direct** | A small, self-contained request (e.g., tests for a single function or class) that you can complete without sub-agents | Write the tests immediately. Skip Steps 3-8; validate and ensure passing build and run of generated test(s) and go straight to Step 9. |
+| ---------- | ------------- | ------------ |
+| **Direct** | A small, self-contained request (e.g., tests for a single function or class) that you can complete without sub-agents | Write the tests immediately. Skip Steps 3-5 (research, plan, implement sub-agents). Then proceed to Steps 6-9 for validation and reporting. |
 | **Single pass** | A moderate scope (couple projects or modules) that a single Research → Plan → Implement cycle can cover | Execute Steps 3-8 once, then proceed to Step 9. |
 | **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's `.testagent/` documents (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
+
+**All strategies MUST execute Steps 6-9** (final build validation, final test validation, coverage gap iteration, and reporting). These steps are never skipped.
 
 ### Step 3: Research Phase
 
@@ -74,9 +78,9 @@ runSubagent({
 
 ### Step 6: Final Build Validation
 
-Run a **full workspace build** (not just individual test projects):
+Run a **full workspace build** (not just individual test projects). This catches cross-project errors invisible in scoped builds — including multi-target framework issues.
 
-- **.NET**: `dotnet build MySolution.sln --no-incremental`
+- **.NET**: `dotnet build MySolution.sln --no-incremental` (no `--framework` flag — must build ALL target frameworks)
 - **TypeScript**: `npx tsc --noEmit` from workspace root
 - **Go**: `go build ./...` from module root
 - **Rust**: `cargo build`
@@ -85,7 +89,7 @@ If it fails, call the `code-testing-fixer`, rebuild, retry up to 3 times.
 
 ### Step 7: Final Test Validation
 
-Run tests from the **full workspace scope**. If tests fail:
+Run tests from the **full workspace scope** with a fresh build (never use `--no-build` for final validation). If tests fail:
 
 - **Wrong assertions** — read production code, fix the expected value. Never `[Ignore]` or `[Skip]` a test just to pass.
 - **Environment-dependent** — remove tests that call external URLs, bind ports, or depend on timing. Prefer mocked unit tests.
@@ -124,3 +128,6 @@ All state is stored in `.testagent/` folder:
 7. **No environment-dependent tests** — mock all external dependencies; never call external URLs, bind ports, or depend on timing
 8. **Fix assertions, don't skip tests** — when tests fail, read production code and fix the expected value; never `[Ignore]` or `[Skip]`
 9. **Clean up `.testagent/`** — after pipeline completion, delete the `.testagent/` folder or advise the user to add it to `.gitignore` so ephemeral state is not committed
+10. **Read language extensions first** — always read the relevant `extensions/*.md` file before writing any code; it contains critical project registration and build validation steps
+11. **Always validate** — final build, final test, coverage-gap review, and reporting are mandatory for ALL strategies including Direct; never skip final validation
+12. **Preserve existing tests** — never delete or overwrite existing test files; create new files or append to existing ones


### PR DESCRIPTION
Harden the test generator agent to ensure final build validation, test validation, and git commit always run — even when using the Direct strategy for small requests.

Changes:
- Step 1: Mandate reading language-specific extensions (e.g., dotnet.md) before writing any code. The extension contains critical project registration (dotnet sln add) and build validation guidance.
- Step 2: Direct strategy now skips only Steps 3-5 (research, plan, implement sub-agents), NOT Steps 6-9. Added explicit note that Steps 6-9 are mandatory for ALL strategies.
- Step 6: Clarify full-solution build must use no --framework flag to catch multi-target framework issues (e.g., net472 errors).
- Step 7: Require fresh build for final test validation (no --no-build).
- New Step 9: Explicit git commit with verification that the diff is non-empty.
- New rules 9-11: Read extensions first, always validate+commit, preserve existing tests.

Motivated by MSBench investigation showing:
- Agent used Direct strategy and skipped final validation entirely
- Agent never read extensions/dotnet.md (missing dotnet sln add)
- Agent forgot to git commit (300 tests created, Changes +0 -0)
- Agent deleted pre-existing tests while adding new ones