### PR TITLE
Add concrete pipeline examples for code-testing-agent

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -111,13 +111,11 @@ Run tests from the **full workspace scope** with a fresh build (never use `--no-
 
 After the previous phases complete, check for uncovered source files:
 
-1. List **all** source files in scope (controllers, services, models, helpers, data layer — everything).
+1. List all source files in scope.
 2. List all test files created.
 3. Identify source files with no corresponding test file.
 4. Generate tests for each uncovered file, build, test, and fix.
-5. Repeat until every source file has tests or all reasonable targets are exhausted.
-
-**Do not skip model/DTO classes.** Models with properties, validation attributes, enums, navigation properties, computed fields, or constructors all contribute to line coverage and should have basic tests (property round-trips, enum value coverage, validation attribute behavior).
+5. Repeat until every non-trivial source file has tests or all reasonable targets are exhausted.
 
 ### Step 9: Report Results
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -46,7 +46,8 @@ Based on the request scope, pick exactly one strategy and follow it:
 | "Generate tests for the billing module" | Single pass | Moderate scope (handful of files), one R→P→I cycle covers it |
 | "Achieve 80% coverage across the whole solution" | Iterative | Large scope, first pass covers the obvious gaps, subsequent passes target remaining uncovered code |
 | "Add tests for this function" (with file open) | Direct | Single function is trivially small scope |
-| "Generate comprehensive tests for my ASP.NET app" | Single pass or Iterative | Depends on how many controllers/services exist — use single pass for <10 files, iterative for more |
+| "Generate comprehensive tests for my ASP.NET app" | Single pass | If the app has fewer than 10 controllers/services/files in scope, one R→P→I cycle should cover it |
+| "Generate comprehensive tests for my large ASP.NET app" | Iterative | If the app has 10 or more controllers/services/files in scope, use repeated passes to close remaining gaps |
 
 **All strategies MUST execute Steps 6-9** (final build validation, final test validation, coverage gap iteration, and reporting). These steps are never skipped.
 
@@ -110,11 +111,13 @@ Run tests from the **full workspace scope** with a fresh build (never use `--no-
 
 After the previous phases complete, check for uncovered source files:
 
-1. List all source files in scope.
+1. List **all** source files in scope (controllers, services, models, helpers, data layer — everything).
 2. List all test files created.
 3. Identify source files with no corresponding test file.
 4. Generate tests for each uncovered file, build, test, and fix.
-5. Repeat until every non-trivial source file has tests or all reasonable targets are exhausted.
+5. Repeat until every source file has tests or all reasonable targets are exhausted.
+
+**Do not skip model/DTO classes.** Models with properties, validation attributes, enums, navigation properties, computed fields, or constructors all contribute to line coverage and should have basic tests (property round-trips, enum value coverage, validation attribute behavior).
 
 ### Step 9: Report Results
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -38,6 +38,16 @@ Based on the request scope, pick exactly one strategy and follow it:
 | **Single pass** | A moderate scope (couple projects or modules) that a single Research → Plan → Implement cycle can cover | Execute Steps 3-8 once, then proceed to Step 9. |
 | **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's `.testagent/` documents (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
 
+**Strategy decision examples:**
+
+| User request | Strategy | Reasoning |
+|---|---|---|
+| "Write tests for `src/InvoiceService.cs`" | Direct | Single file, can write tests immediately without sub-agents |
+| "Generate tests for the billing module" | Single pass | Moderate scope (handful of files), one R→P→I cycle covers it |
+| "Achieve 80% coverage across the whole solution" | Iterative | Large scope, first pass covers the obvious gaps, subsequent passes target remaining uncovered code |
+| "Add tests for this function" (with file open) | Direct | Single function is trivially small scope |
+| "Generate comprehensive tests for my ASP.NET app" | Single pass or Iterative | Depends on how many controllers/services exist — use single pass for <10 files, iterative for more |
+
 **All strategies MUST execute Steps 6-9** (final build validation, final test validation, coverage gap iteration, and reporting). These steps are never skipped.
 
 ### Step 3: Research Phase
@@ -109,6 +119,37 @@ After the previous phases complete, check for uncovered source files:
 ### Step 9: Report Results
 
 Summarize tests created, report any failures or issues, suggest next steps if needed.
+
+**Example final report:**
+
+```
+## Test Generation Report
+
+**Project**: MyProject
+**Strategy**: Single pass
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 24    |
+| Tests passing  | 24    |
+| Tests failing  | 0     |
+| Files created  | 3     |
+
+### Files Created
+- tests/MyProject.Tests/ServiceATests.cs (10 tests)
+- tests/MyProject.Tests/ServiceBTests.cs (8 tests)
+- tests/MyProject.Tests/HelperTests.cs (6 tests)
+
+### Build Validation
+- Scoped build: ✅ passed
+- Full solution build: ✅ passed
+
+### Next Steps
+- Consider adding integration tests for database layer
+```
+
+> **Language-specific examples**: For a complete end-to-end walkthrough including sample source code, research output, plan, generated tests, and fix cycles, see the `extensions/` folder (e.g., `extensions/dotnet-examples.md` for .NET).
 
 ## State Management
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -89,6 +89,8 @@ ISSUES:
 - [Any unresolved issues]
 ```
 
+> **Concrete example**: For a complete generated test file and build-error fix cycle walkthrough, see `extensions/dotnet-examples.md` ("Sample Generated Test File" and "Sample Fix Cycle" sections).
+
 ## Rules
 
 1. **Complete the phase** — don't stop partway through

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -124,6 +124,8 @@ What this phase accomplishes and why it's first.
 ...
 ```
 
+> **Concrete example**: For a filled-in plan with real method names, specific test scenarios, and phase structure, see `extensions/dotnet-examples.md` ("Sample Plan Output" section).
+
 ## Rules
 
 1. **Be specific** — include exact file paths and method names

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -35,11 +35,11 @@ Check the **Coverage Baseline** section:
 
 **Broad strategy** (coverage <60% or unknown):
 
-- Generate tests for **all** source files systematically — services, controllers, models, helpers, data layer
+- Generate tests for **all** source files systematically
 - Organize into phases by priority and complexity (2-5 phases)
-- Every public class and method must have at least one test, including model/DTO classes (property round-trips, validation attributes, enum values)
+- Every public class and method must have at least one test
 - If >15 source files, use more phases (up to 8-10)
-- List ALL source files and assign each to a phase — no file should be left unassigned
+- List ALL source files and assign each to a phase
 
 **Targeted strategy** (coverage >60%):
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -35,11 +35,11 @@ Check the **Coverage Baseline** section:
 
 **Broad strategy** (coverage <60% or unknown):
 
-- Generate tests for **all** source files systematically
+- Generate tests for **all** source files systematically — services, controllers, models, helpers, data layer
 - Organize into phases by priority and complexity (2-5 phases)
-- Every public class and method must have at least one test
+- Every public class and method must have at least one test, including model/DTO classes (property round-trips, validation attributes, enum values)
 - If >15 source files, use more phases (up to 8-10)
-- List ALL source files and assign each to a phase
+- List ALL source files and assign each to a phase — no file should be left unassigned
 
 **Targeted strategy** (coverage >60%):
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -155,3 +155,5 @@ For each test project found, list:
 ## Output
 
 Write the research document to `.testagent/research.md` in the workspace root.
+
+> **Concrete example**: For a filled-in research document showing real file paths, detected frameworks, and prioritized file tables, see `extensions/dotnet-examples.md` ("Sample Research Output" section).

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -128,10 +128,15 @@ Create `.testagent/research.md` with this structure:
 | File | Classes/Functions | Testability | Notes |
 |------|-------------------|-------------|-------|
 
+### Medium Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| path/to/model.ext | Properties, enums, validation | Medium | Models with properties, validation attributes, or enums still need basic tests for coverage |
+
 ### Low Priority / Skip
 | File | Reason |
 |------|--------|
-| path/to/file.ext | Auto-generated |
+| path/to/file.ext | Auto-generated, no testable logic (e.g., pure interfaces, empty Program.cs) |
 
 ## Existing Tests
 - [List existing test files and what they cover]

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -128,15 +128,10 @@ Create `.testagent/research.md` with this structure:
 | File | Classes/Functions | Testability | Notes |
 |------|-------------------|-------------|-------|
 
-### Medium Priority
-| File | Classes/Functions | Testability | Notes |
-|------|-------------------|-------------|-------|
-| path/to/model.ext | Properties, enums, validation | Medium | Models with properties, validation attributes, or enums still need basic tests for coverage |
-
 ### Low Priority / Skip
 | File | Reason |
 |------|--------|
-| path/to/file.ext | Auto-generated, no testable logic (e.g., pure interfaces, empty Program.cs) |
+| path/to/file.ext | Auto-generated |
 
 ## Existing Tests
 - [List existing test files and what they cover]

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -136,23 +136,31 @@ All pipeline state is stored in `.testagent/` folder:
 
 ## Examples
 
-### Example 1: Full Project Testing
+### Strategy Selection
 
-```text
-Generate unit tests for my Calculator project at C:\src\Calculator
-```
+The generator picks a strategy based on request scope:
 
-### Example 2: Specific File Testing
+| User Request | Strategy | Why |
+|---|---|---|
+| "Generate tests for `src/services/UserService.ts`" | **Direct** | Single file, small scope — write tests immediately, skip sub-agents |
+| "Add unit tests for my billing project" | **Single pass** | Moderate scope — one Research → Plan → Implement cycle covers it |
+| "Achieve 80% coverage across the entire solution" | **Iterative** | Large scope — multiple R→P→I cycles, each narrowing remaining gaps |
 
-```text
-Generate unit tests for src/services/UserService.ts
-```
+### Pipeline Walkthrough
 
-### Example 3: Targeted Coverage
+Given a request like *"Generate unit tests for my InvoiceService"*, the pipeline produces:
 
-```text
-Add tests for the authentication module with focus on edge cases
-```
+1. **Research** → `.testagent/research.md` containing detected language/framework, build commands, files to test ranked by priority, and existing test inventory
+2. **Plan** → `.testagent/plan.md` containing phased approach with specific methods and test scenarios (happy path, edge cases, error cases) for each file
+3. **Implement** → Test files written, built, and verified per phase. Fix cycle runs automatically if build/test errors occur
+4. **Validate** → Full workspace build + full test run to catch cross-project issues
+5. **Report** → Summary of tests created, pass/fail counts, coverage notes, and next steps
+
+### Language-Specific Examples
+
+The `extensions/` folder contains concrete, filled-in examples for each pipeline phase showing real source code, real research output, real plans, and real generated tests:
+
+- **[.NET/C#](extensions/dotnet-examples.md)** — MSTest example with InvoiceService: research output, plan output, generated test file, fix cycle walkthrough, and final report
 
 ## Agent Reference
 

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
@@ -88,14 +88,10 @@ What `code-testing-researcher` produces in `.testagent/research.md`:
 |------|-------------------|-------------|-------|
 | src/Contoso.Billing/InvoiceService.cs | InvoiceService: CalculateTotal, GetByIdAsync, MarkAsPaidAsync | High | Core business logic, repository dependency needs mocking |
 
-### Medium Priority
-| File | Classes/Functions | Testability | Notes |
-|------|-------------------|-------------|-------|
-| src/Contoso.Billing/Invoice.cs | Invoice: properties, LineItems, TaxRate, Status, InvoiceStatus enum | Medium | Model with enum, properties, and collection — test property defaults, enum values, validation |
-
 ### Low Priority / Skip
 | File | Reason |
 |------|--------|
+| src/Contoso.Billing/Invoice.cs | Data model, no logic |
 | src/Contoso.Billing/IInvoiceRepository.cs | Interface, no implementation |
 
 ## Existing Tests

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
@@ -88,10 +88,14 @@ What `code-testing-researcher` produces in `.testagent/research.md`:
 |------|-------------------|-------------|-------|
 | src/Contoso.Billing/InvoiceService.cs | InvoiceService: CalculateTotal, GetByIdAsync, MarkAsPaidAsync | High | Core business logic, repository dependency needs mocking |
 
+### Medium Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| src/Contoso.Billing/Invoice.cs | Invoice: properties, LineItems, TaxRate, Status, InvoiceStatus enum | Medium | Model with enum, properties, and collection — test property defaults, enum values, validation |
+
 ### Low Priority / Skip
 | File | Reason |
 |------|--------|
-| src/Contoso.Billing/Invoice.cs | Data model, no logic |
 | src/Contoso.Billing/IInvoiceRepository.cs | Interface, no implementation |
 
 ## Existing Tests
@@ -342,7 +346,7 @@ What `code-testing-generator` produces at Step 9:
 ## Test Generation Report
 
 **Project**: Contoso.Billing
-**Strategy**: Direct (single source file)
+**Strategy**: Single pass
 
 ### Results
 | Metric         | Value |

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet-examples.md
@@ -1,0 +1,370 @@
+# .NET Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a .NET/C# codebase. These show what each pipeline phase produces for a small project.
+
+## Source Under Test
+
+A simple `InvoiceService` in a .NET 9 project using MSTest:
+
+```text
+src/
+  Contoso.Billing/
+    Contoso.Billing.csproj
+    InvoiceService.cs
+    Invoice.cs
+    IInvoiceRepository.cs
+tests/
+  Contoso.Billing.Tests/
+    Contoso.Billing.Tests.csproj    (exists, references Contoso.Billing)
+Contoso.Billing.sln
+```
+
+```csharp
+// InvoiceService.cs
+namespace Contoso.Billing;
+
+public class InvoiceService(IInvoiceRepository repository)
+{
+    public decimal CalculateTotal(Invoice invoice)
+    {
+        if (invoice is null) throw new ArgumentNullException(nameof(invoice));
+        if (invoice.LineItems.Count == 0) throw new InvalidOperationException("Invoice has no line items.");
+
+        var subtotal = invoice.LineItems.Sum(li => li.Quantity * li.UnitPrice);
+        var tax = subtotal * invoice.TaxRate;
+        return Math.Round(subtotal + tax, 2);
+    }
+
+    public async Task<Invoice> GetByIdAsync(int id)
+    {
+        var invoice = await repository.FindAsync(id);
+        return invoice ?? throw new KeyNotFoundException($"Invoice {id} not found.");
+    }
+
+    public async Task MarkAsPaidAsync(int id)
+    {
+        var invoice = await repository.FindAsync(id)
+            ?? throw new KeyNotFoundException($"Invoice {id} not found.");
+        if (invoice.Status == InvoiceStatus.Paid)
+            throw new InvalidOperationException("Invoice is already paid.");
+        invoice.Status = InvoiceStatus.Paid;
+        invoice.PaidDate = DateTime.UtcNow;
+        await repository.UpdateAsync(invoice);
+    }
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: C:\src\Contoso.Billing
+- **Language**: C# (.NET 9)
+- **Framework**: .NET 9 (net9.0)
+- **Test Framework**: MSTest 3.8
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Build**: `dotnet build Contoso.Billing.sln`
+- **Test**: `dotnet test Contoso.Billing.sln`
+- **Lint**: `dotnet format Contoso.Billing.sln`
+
+## Project Structure
+- Source: `src/Contoso.Billing/`
+- Tests: `tests/Contoso.Billing.Tests/` (exists, empty)
+
+## Files to Test
+
+### High Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| src/Contoso.Billing/InvoiceService.cs | InvoiceService: CalculateTotal, GetByIdAsync, MarkAsPaidAsync | High | Core business logic, repository dependency needs mocking |
+
+### Low Priority / Skip
+| File | Reason |
+|------|--------|
+| src/Contoso.Billing/Invoice.cs | Data model, no logic |
+| src/Contoso.Billing/IInvoiceRepository.cs | Interface, no implementation |
+
+## Existing Tests
+- No existing tests found
+
+## Existing Test Projects
+- **Project file**: `tests/Contoso.Billing.Tests/Contoso.Billing.Tests.csproj`
+- **Target source project**: `src/Contoso.Billing/Contoso.Billing.csproj`
+- **Test files**: none
+
+## Testing Patterns
+- No existing patterns; recommend sealed test classes, AAA structure, `Moq` for mocking IInvoiceRepository
+
+## Recommendations
+- Start with InvoiceService.CalculateTotal (pure logic, easy to test)
+- Then async methods (require mocking IInvoiceRepository)
+```
+
+## Sample Plan Output
+
+What `code-testing-planner` produces in `.testagent/plan.md`:
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate MSTest tests for the Contoso.Billing InvoiceService, covering all three
+public methods across happy path, edge case, and error scenarios. Single phase
+since there is only one source file.
+
+## Commands
+- **Build**: `dotnet build tests/Contoso.Billing.Tests/Contoso.Billing.Tests.csproj`
+- **Test**: `dotnet test tests/Contoso.Billing.Tests/Contoso.Billing.Tests.csproj`
+- **Lint**: `dotnet format --include tests/Contoso.Billing.Tests/`
+
+## Phase Summary
+| Phase | Focus | Files | Est. Tests |
+|-------|-------|-------|------------|
+| 1 | InvoiceService | 1 | 9-12 |
+
+---
+
+## Phase 1: InvoiceService
+
+### Overview
+Cover all public methods of InvoiceService. CalculateTotal is pure logic tested
+with DataRow. Async methods require a mocked IInvoiceRepository.
+
+### Files to Test
+
+#### 1. InvoiceService.cs
+- **Source**: `src/Contoso.Billing/InvoiceService.cs`
+- **Test File**: `tests/Contoso.Billing.Tests/InvoiceServiceTests.cs`
+- **Test Class**: `InvoiceServiceTests`
+
+**Methods to Test**:
+1. `CalculateTotal` — Pure calculation logic
+   - Happy path: single line item returns quantity × price + tax
+   - Happy path: multiple line items summed correctly
+   - Edge case: zero tax rate returns subtotal only
+   - Error case: null invoice throws ArgumentNullException
+   - Error case: empty line items throws InvalidOperationException
+
+2. `GetByIdAsync` — Repository lookup
+   - Happy path: existing ID returns invoice
+   - Error case: non-existent ID throws KeyNotFoundException
+
+3. `MarkAsPaidAsync` — State transition
+   - Happy path: unpaid invoice transitions to Paid with PaidDate set
+   - Error case: already paid throws InvalidOperationException
+   - Error case: non-existent ID throws KeyNotFoundException
+
+### Success Criteria
+- [ ] All test files created
+- [ ] Tests compile with `dotnet build`
+- [ ] All tests pass with `dotnet test`
+```
+
+## Sample Generated Test File
+
+What `code-testing-implementer` produces:
+
+```csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Contoso.Billing;
+
+namespace Contoso.Billing.Tests;
+
+[TestClass]
+public sealed class InvoiceServiceTests
+{
+    private readonly Mock<IInvoiceRepository> _repositoryMock = new();
+    private readonly InvoiceService _sut;
+
+    public InvoiceServiceTests()
+    {
+        _sut = new InvoiceService(_repositoryMock.Object);
+    }
+
+    // --- CalculateTotal ---
+
+    [TestMethod]
+    [DataRow(1, 100.00, 0.10, 110.00, DisplayName = "Single item with 10% tax")]
+    [DataRow(3, 25.00, 0.0, 75.00, DisplayName = "Multiple quantity, zero tax")]
+    public void CalculateTotal_ValidLineItems_ReturnsExpectedTotal(
+        int quantity, double unitPrice, double taxRate, double expected)
+    {
+        // Arrange
+        var invoice = new Invoice
+        {
+            TaxRate = (decimal)taxRate,
+            LineItems = [new LineItem { Quantity = quantity, UnitPrice = (decimal)unitPrice }]
+        };
+
+        // Act
+        var total = _sut.CalculateTotal(invoice);
+
+        // Assert
+        Assert.AreEqual((decimal)expected, total);
+    }
+
+    [TestMethod]
+    public void CalculateTotal_NullInvoice_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => _sut.CalculateTotal(null!));
+    }
+
+    [TestMethod]
+    public void CalculateTotal_EmptyLineItems_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var invoice = new Invoice { LineItems = [] };
+
+        // Act & Assert
+        Assert.ThrowsExactly<InvalidOperationException>(() => _sut.CalculateTotal(invoice));
+    }
+
+    // --- GetByIdAsync ---
+
+    [TestMethod]
+    public async Task GetByIdAsync_ExistingId_ReturnsInvoice()
+    {
+        // Arrange
+        var expected = new Invoice { Id = 42 };
+        _repositoryMock.Setup(r => r.FindAsync(42)).ReturnsAsync(expected);
+
+        // Act
+        var result = await _sut.GetByIdAsync(42);
+
+        // Assert
+        Assert.AreSame(expected, result);
+    }
+
+    [TestMethod]
+    public async Task GetByIdAsync_NonExistentId_ThrowsKeyNotFoundException()
+    {
+        // Arrange
+        _repositoryMock.Setup(r => r.FindAsync(999)).ReturnsAsync((Invoice?)null);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(
+            () => _sut.GetByIdAsync(999));
+    }
+
+    // --- MarkAsPaidAsync ---
+
+    [TestMethod]
+    public async Task MarkAsPaidAsync_UnpaidInvoice_SetsStatusAndDate()
+    {
+        // Arrange
+        var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Pending };
+        _repositoryMock.Setup(r => r.FindAsync(1)).ReturnsAsync(invoice);
+
+        // Act
+        await _sut.MarkAsPaidAsync(1);
+
+        // Assert
+        Assert.AreEqual(InvoiceStatus.Paid, invoice.Status);
+        Assert.IsNotNull(invoice.PaidDate);
+        _repositoryMock.Verify(r => r.UpdateAsync(invoice), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task MarkAsPaidAsync_AlreadyPaid_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Paid };
+        _repositoryMock.Setup(r => r.FindAsync(1)).ReturnsAsync(invoice);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => _sut.MarkAsPaidAsync(1));
+    }
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer encounters a build error, the fixer agent diagnoses and resolves it:
+
+**Build output:**
+
+```text
+error CS0246: The type or namespace name 'Moq' could not be found (are you missing a using directive or an assembly reference?)
+```
+
+**Fixer diagnosis:** The test project is missing the Moq NuGet package.
+
+**Fix applied:**
+
+```bash
+dotnet add tests/Contoso.Billing.Tests/Contoso.Billing.Tests.csproj package Moq
+```
+
+**Rebuild:** `dotnet build tests/Contoso.Billing.Tests/Contoso.Billing.Tests.csproj` → SUCCESS
+
+---
+
+**Another common cycle:**
+
+**Build output:**
+
+```text
+error CS7036: There is no argument given that corresponds to the required parameter 'repository' of 'InvoiceService.InvoiceService(IInvoiceRepository)'
+```
+
+**Fixer diagnosis:** Test code instantiated `new InvoiceService()` without passing the required constructor parameter. The source uses a primary constructor with an `IInvoiceRepository` dependency.
+
+**Fix applied:**
+
+```csharp
+// Before (wrong)
+var sut = new InvoiceService();
+
+// After (fixed)
+var repositoryMock = new Mock<IInvoiceRepository>();
+var sut = new InvoiceService(repositoryMock.Object);
+```
+
+**Rebuild:** SUCCESS
+
+## Sample Final Report
+
+What `code-testing-generator` produces at Step 9:
+
+```markdown
+## Test Generation Report
+
+**Project**: Contoso.Billing
+**Strategy**: Direct (single source file)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 9     |
+| Tests passing  | 9     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `tests/Contoso.Billing.Tests/InvoiceServiceTests.cs` (9 tests)
+
+### Coverage
+- InvoiceService.CalculateTotal — 3 happy path, 2 error cases
+- InvoiceService.GetByIdAsync — 1 happy path, 1 error case
+- InvoiceService.MarkAsPaidAsync — 1 happy path, 1 error case
+
+### Build Validation
+- Scoped build: ✅ passed
+- Full solution build (`dotnet build --no-incremental`): ✅ passed
+
+### Next Steps
+- Add integration tests for repository layer if needed
+- Consider testing with multiple line items for CalculateTotal
+```

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
@@ -108,6 +108,49 @@ public sealed class ClassNameTests
 }
 ```
 
+## ASP.NET MVC Controller Testing
+
+For ASP.NET Core MVC apps using EF Core, test controllers with an InMemory database instead of mocking DbContext:
+
+```csharp
+[TestClass]
+public sealed class StudentsControllerTests
+{
+    private SchoolContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<SchoolContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new SchoolContext(options);
+    }
+
+    [TestMethod]
+    public async Task Index_ReturnsStudentsList()
+    {
+        // Arrange
+        using var context = CreateContext();
+        context.Students.Add(new Student { FirstMidName = "Alice", LastName = "Smith", EnrollmentDate = DateTime.Now });
+        await context.SaveChangesAsync();
+        var controller = new StudentsController(context);
+
+        // Act
+        var result = await controller.Index(null, null, null, null) as ViewResult;
+
+        // Assert
+        Assert.IsNotNull(result);
+        var model = result.Model as PaginatedList<Student>;
+        Assert.IsNotNull(model);
+        Assert.AreEqual(1, model.Count);
+    }
+}
+```
+
+Key patterns:
+- Use `Guid.NewGuid().ToString()` as the InMemory database name so each test gets an isolated database
+- Seed data in Arrange, then verify controller actions in Act/Assert
+- Test sorting, filtering, pagination, and CRUD operations for each controller
+- Cover both GET and POST actions, including validation error paths
+
 ## Coverage XML Parsing
 
 If `.testagent/initial_coverage.xml` exists, it uses Cobertura/VS format:

--- a/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/extensions/dotnet.md
@@ -108,49 +108,6 @@ public sealed class ClassNameTests
 }
 ```
 
-## ASP.NET MVC Controller Testing
-
-For ASP.NET Core MVC apps using EF Core, test controllers with an InMemory database instead of mocking DbContext:
-
-```csharp
-[TestClass]
-public sealed class StudentsControllerTests
-{
-    private SchoolContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<SchoolContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        return new SchoolContext(options);
-    }
-
-    [TestMethod]
-    public async Task Index_ReturnsStudentsList()
-    {
-        // Arrange
-        using var context = CreateContext();
-        context.Students.Add(new Student { FirstMidName = "Alice", LastName = "Smith", EnrollmentDate = DateTime.Now });
-        await context.SaveChangesAsync();
-        var controller = new StudentsController(context);
-
-        // Act
-        var result = await controller.Index(null, null, null, null) as ViewResult;
-
-        // Assert
-        Assert.IsNotNull(result);
-        var model = result.Model as PaginatedList<Student>;
-        Assert.IsNotNull(model);
-        Assert.AreEqual(1, model.Count);
-    }
-}
-```
-
-Key patterns:
-- Use `Guid.NewGuid().ToString()` as the InMemory database name so each test gets an isolated database
-- Seed data in Arrange, then verify controller actions in Act/Assert
-- Test sorting, filtering, pagination, and CRUD operations for each controller
-- Cover both GET and POST actions, including validation error paths
-
 ## Coverage XML Parsing
 
 If `.testagent/initial_coverage.xml` exists, it uses Cobertura/VS format:


### PR DESCRIPTION
## Summary

Addresses the **Example Quality (2/5)** feedback from the internal review for the code-testing-agent skill. The core issue was that there were no concrete input/output examples, walkthroughs, or sample outputs — making expected behavior unanchored for the LLM.

## Changes

### New file
- **\xtensions/dotnet-examples.md\** — Complete .NET-specific end-to-end examples:
  - Sample source code (\InvoiceService\) used as the test target
  - Filled-in research output (\.testagent/research.md\)
  - Filled-in plan output (\.testagent/plan.md\)
  - Complete generated test file (MSTest with Moq)
  - Fix cycle walkthroughs (CS0246 missing package, CS7036 missing constructor arg)
  - Sample final report

### Updated files (language-agnostic)
- **\SKILL.md\** — Examples section replaced with strategy selection table, pipeline walkthrough, and pointer to language-specific extensions
- **\code-testing-generator.agent.md\** — Added strategy decision examples (5 concrete scenarios) and sample final report
- **\code-testing-researcher.agent.md\** — Added reference to dotnet-examples.md
- **\code-testing-planner.agent.md\** — Added reference to dotnet-examples.md
- **\code-testing-implementer.agent.md\** — Added reference to dotnet-examples.md

## Architecture

All language-specific examples live in the \xtensions/\ folder, keeping core agents language-agnostic. Adding examples for other languages (Python, TypeScript, Go) is just creating additional \xtensions/<lang>-examples.md\ files.