### PR TITLE
Add Vanilla efficiency metrics to dashboard benchmark data

### DIFF
--- a/eng/dashboard/generate-benchmark-data.ps1
+++ b/eng/dashboard/generate-benchmark-data.ps1
@@ -349,6 +349,22 @@ foreach ($verdict in $results.verdicts) {
             }
             $efficiencyBenches.Add($pluginTokenBench)
         }
+
+        # Efficiency metrics (from vanilla/baseline run)
+        if ($null -ne $scenario.baseline.metrics.wallTimeMs) {
+            $efficiencyBenches.Add(@{
+                name  = "$testName - Vanilla Time"
+                unit  = "seconds"
+                value = [math]::Round([float]$scenario.baseline.metrics.wallTimeMs / 1000, 1)
+            })
+        }
+        if ($null -ne $scenario.baseline.metrics.tokenEstimate) {
+            $efficiencyBenches.Add(@{
+                name  = "$testName - Vanilla Tokens In"
+                unit  = "tokens"
+                value = [float]$scenario.baseline.metrics.tokenEstimate
+            })
+        }
     }
 }
 


### PR DESCRIPTION
The "Efficiency Over Time" charts on the [Skills dashboard](https://dotnet.github.io/skills/) were missing Vanilla (baseline) data. The dashboard JS already had logic to detect and render `Vanilla Time` and `Vanilla Tokens In` series, but `generate-benchmark-data.ps1` never emitted those bench entries from `$scenario.baseline.metrics`.

This adds the missing Vanilla efficiency bench entries (`Vanilla Time` and `Vanilla Tokens In`) from `$scenario.baseline.metrics`, matching the same pattern used for Skilled and Plugin efficiency metrics.