### PR TITLE
Update SDK to .NET 11 preview

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "11.0.100-preview.3.26207.106",
     "rollForward": "latestMajor"
   },
   "test": {


### PR DESCRIPTION
Based on suggestion by @ViktorHofer 

Update global.json SDK version to 11.0.100-preview.3.26207.106 so that the evaluation workflow installs .NET 11 preview SDK via the existing `actions/setup-dotnet` step that reads from global.json.

Ref: https://github.com/dotnet/skills/pull/535 (discussion around .NET 11 SDK availability in eval)

FYI: @ManishJayaswal 