### PR TITLE
Honor --allow-repo-traversal for /-prefixed file references

### DIFF
--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -14,7 +14,7 @@ public static class CheckCommand
         var allowedExternalDepsOpt = new Option<string?>("--allowed-external-deps") { Description = "Path to allowed-external-deps.txt allow list file" };
         var knownDomainsOpt = new Option<string?>("--known-domains") { Description = "Path to known-domains.txt for reference scanning" };
         var verboseOpt = new Option<bool>("--verbose") { Description = "Show detailed output" };
-        var allowRepoTraversalOpt = new Option<bool>("--allow-repo-traversal") { Description = "Allow parent-directory traversals in file references" };
+        var allowRepoTraversalOpt = new Option<bool>("--allow-repo-traversal") { Description = "Allow file references that point outside the skill directory: parent-directory paths (../…) and absolute repo-rooted paths (/src/…). Use for skills shipped inside a repo, not standalone." };
 
         var command = new Command("check", "Run static analysis checks on skills, plugins, and agents (no LLM required). Use --plugin to check an entire plugin directory (recommended).")
         {

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -103,7 +103,11 @@ public static partial class SkillProfiler
         foreach (Match refMatch in FileRefRegex().Matches(body))
         {
             var refPath = refMatch.Groups[1].Value;
-            if (refPath.StartsWith("http", StringComparison.OrdinalIgnoreCase) || refPath.StartsWith('#'))
+            // Skip URLs and in-page anchors. "//" is treated as a protocol-relative URL
+            // (not as a repo-rooted path) and is left to the URL/reference scanner.
+            if (refPath.StartsWith("http", StringComparison.OrdinalIgnoreCase) ||
+                refPath.StartsWith("//", StringComparison.Ordinal) ||
+                refPath.StartsWith('#'))
                 continue;
 
             // Strip fragment anchors (e.g. "file.md#section")
@@ -127,6 +131,19 @@ public static partial class SkillProfiler
                     errors.Add($"File reference '{refMatch.Groups[1].Value}' uses parent-directory traversal — references must stay within the skill directory.");
                 }
                 // When repo traversal is allowed, external refs have no depth constraint.
+                continue;
+            }
+
+            // Reject absolute (repo-rooted) paths — e.g. "/src/libraries/...".
+            // GitHub renders these relative to the repo root, but they are non-portable
+            // outside that repo. Treated symmetrically with ".." traversal: allowed only
+            // when the skill opts in via --allow-repo-traversal.
+            if (refPath.StartsWith('/'))
+            {
+                if (!allowRepoTraversal)
+                {
+                    errors.Add($"File reference '{refMatch.Groups[1].Value}' uses an absolute (repo-rooted) path — references must be relative to the skill directory.");
+                }
                 continue;
             }
 

--- a/eng/skill-validator/tests/Check/SkillProfileTests.cs
+++ b/eng/skill-validator/tests/Check/SkillProfileTests.cs
@@ -337,6 +337,90 @@ public class AnalyzeSkillTests
         var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
         Assert.Contains(profile.Errors, e => e.Contains("directories deep"));
     }
+
+    // --- Absolute (repo-rooted) path handling ---
+
+    public enum LinkExpectation
+    {
+        Pass,
+        DepthError,
+        ParentTraversalError,
+        AbsolutePathError,
+    }
+
+    /// <summary>
+    /// Path-classification contract matrix. Locks down the four kinds of file references
+    /// the validator distinguishes, against both flag settings.
+    ///
+    /// Skill-relative forms (always permitted, no flag needed):
+    ///   - sibling files                               file.md, ./file.md
+    ///   - one directory below SKILL.md                references/file.md, references/file.md#anchor
+    /// Skill-relative but too deep (rejected by design, even with the flag — keeps skills self-contained):
+    ///   - more than 1 dir below SKILL.md              deep/nested/file.md
+    /// Repo-root-scoped forms (only valid with --allow-repo-traversal):
+    ///   - leading-slash absolute                      /src/file.md, /src/libraries/Common/Interop/
+    ///   - parent traversal                            ../sibling.md, ../../up/two.md
+    /// Always permitted (orthogonal to the flag):
+    ///   - in-page anchors                             #section
+    ///   - HTTP(S) URLs                                https://example.com/a/b/c
+    ///   - protocol-relative URLs (treated as URL)     //github.com/dotnet/runtime
+    /// </summary>
+    [Theory]
+    // --- Skill-relative (always pass, both flag values) ---
+    [InlineData("file.md",                                false, LinkExpectation.Pass)]
+    [InlineData("file.md",                                true,  LinkExpectation.Pass)]
+    [InlineData("./file.md",                              false, LinkExpectation.Pass)]
+    [InlineData("./file.md",                              true,  LinkExpectation.Pass)]
+    [InlineData("references/file.md",                     false, LinkExpectation.Pass)]
+    [InlineData("references/file.md",                     true,  LinkExpectation.Pass)]
+    [InlineData("references/file.md#section",             false, LinkExpectation.Pass)]
+    [InlineData("references/file.md#section",             true,  LinkExpectation.Pass)]
+    // --- Skill-relative but too deep (rejected regardless of flag — internal-portability rule) ---
+    [InlineData("deep/nested/file.md",                    false, LinkExpectation.DepthError)]
+    [InlineData("deep/nested/file.md",                    true,  LinkExpectation.DepthError)]
+    // --- Parent traversal (allowed iff flag) ---
+    [InlineData("../sibling.md",                          false, LinkExpectation.ParentTraversalError)]
+    [InlineData("../sibling.md",                          true,  LinkExpectation.Pass)]
+    [InlineData("../../deep/file.md",                     false, LinkExpectation.ParentTraversalError)]
+    [InlineData("../../deep/file.md",                     true,  LinkExpectation.Pass)]
+    // --- Absolute repo-rooted (allowed iff flag) ---
+    [InlineData("/src/file.md",                           false, LinkExpectation.AbsolutePathError)]
+    [InlineData("/src/file.md",                           true,  LinkExpectation.Pass)]
+    [InlineData("/src/libraries/Common/src/Interop/",     false, LinkExpectation.AbsolutePathError)]
+    [InlineData("/src/libraries/Common/src/Interop/",     true,  LinkExpectation.Pass)]
+    // --- Always permitted, independent of flag ---
+    [InlineData("#anchor",                                false, LinkExpectation.Pass)]
+    [InlineData("#anchor",                                true,  LinkExpectation.Pass)]
+    [InlineData("https://example.com/a/b/c",              false, LinkExpectation.Pass)]
+    [InlineData("https://example.com/a/b/c",              true,  LinkExpectation.Pass)]
+    [InlineData("//github.com/dotnet/runtime",            false, LinkExpectation.Pass)]
+    [InlineData("//github.com/dotnet/runtime",            true,  LinkExpectation.Pass)]
+    public void PathClassificationMatrix(string refPath, bool allowRepoTraversal, LinkExpectation expected)
+    {
+        var content = $"---\nname: test-skill\n---\n# Title\n1. Step\n```bash\necho\n```\nSee [ref]({refPath})\n" + new string('x', 4000);
+        var options = new CheckOptions { AllowRepoTraversal = allowRepoTraversal };
+        var profile = SkillProfiler.AnalyzeSkill(MakeSkill(content), options);
+        var errorsForThisRef = profile.Errors.Where(e => e.Contains($"'{refPath}'")).ToList();
+
+        switch (expected)
+        {
+            case LinkExpectation.Pass:
+                Assert.Empty(errorsForThisRef);
+                break;
+            case LinkExpectation.DepthError:
+                Assert.Contains(errorsForThisRef, e => e.Contains("directories deep"));
+                Assert.DoesNotContain(errorsForThisRef, e => e.Contains("traversal") || e.Contains("absolute"));
+                break;
+            case LinkExpectation.ParentTraversalError:
+                Assert.Contains(errorsForThisRef, e => e.Contains("parent-directory traversal"));
+                Assert.DoesNotContain(errorsForThisRef, e => e.Contains("directories deep") || e.Contains("absolute"));
+                break;
+            case LinkExpectation.AbsolutePathError:
+                Assert.Contains(errorsForThisRef, e => e.Contains("absolute (repo-rooted) path"));
+                Assert.DoesNotContain(errorsForThisRef, e => e.Contains("directories deep") || e.Contains("parent-directory traversal"));
+                break;
+        }
+    }
 }
 
 public class FormatProfileLineTests


### PR DESCRIPTION
`--allow-repo-traversal` only suppressed `..` traversal. `/`-prefixed paths bypassed the flag and hit a depth check.

Repro: [dotnet/runtime#126607](https://github.com/dotnet/runtime/actions/runs/24806479057/job/72601725029?pr=126607) — 7 errors on `/src/...` refs despite passing the flag.

### Contract

| Path | no flag | `--allow-repo-traversal` |
|---|---|---|
| `file.md`, `./file.md`, `references/file.md`, `references/file.md#x` | ok | ok |
| `deep/nested/file.md` | depth | depth |
| `../sibling.md`, `../../up.md` | parent-traversal | ok |
| `/src/file.md`, `/src/libraries/Common/Interop/` | **absolute** *(new)* | **ok** *(fixes #126607)* |
| `#section`, `https://…`, `//host/path` | ok | ok |

`/`-prefix and `..` are notational equivalents per [GitHub link rules](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links); now treated symmetrically.
