### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- Briefly describe what changed and why. -->
+
+## Related issue
+
+<!-- Link the issue this PR addresses, if applicable. Example: Fixes #123. -->
+
+## Change type
+
+<!-- Check all that apply. -->
+
+- [ ] New or updated skill
+- [ ] New or updated agent
+- [ ] Documentation or metadata
+- [ ] Tests or evaluation
+- [ ] Build, CI, or infrastructure
+- [ ] Other
+
+## Checklist
+
+- [ ] I searched existing issues and pull requests to avoid duplicates.
+- [ ] I kept the change small and focused.
+- [ ] I updated CODEOWNERS if this adds a new plugin, skill, or agent.
+- [ ] I added or updated tests or validation steps where applicable.
+- [ ] I ran the relevant validation and listed the results below.
+
+## Validation
+
+<!-- List commands run, checks performed, or explain why validation is not applicable. -->


### PR DESCRIPTION
## Summary

- Adds a conservative pull request template under `.github/`.
- Prompts contributors for a summary, related issue, change type, checklist, and validation.
- Keeps requirements aligned with the existing contribution guidance without adding new process overhead.

Fixes #594

## Validation

- `git diff --cached --check`
- `npx --yes markdownlint-cli2 .github/PULL_REQUEST_TEMPLATE.md`
