### PR TITLE
Add 7 new .NET 11 skills to dotnet11 plugin

### DIFF
--- a/plugins/dotnet11/skills/aspnetcore-blazor-components-net11/SKILL.md
+++ b/plugins/dotnet11/skills/aspnetcore-blazor-components-net11/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: aspnetcore-blazor-components-net11
+description: >
+  Covers new .NET 11 APIs across Microsoft.AspNetCore.Components,
+  Components.Web, and Components.Endpoints. Includes navigation improvements
+  (GetUriWithHash, RelativeToCurrentUri), contravariant RenderFragment<in T>,
+  IComponentPropertyActivator, form components (Label, DisplayName), media
+  components (Image, Video, FileDownload with MediaSource), EnvironmentBoundary,
+  BasePath, ITempData, and TempDataProviderType. Use when building Blazor apps
+  that need navigation, forms, media rendering, environment-conditional content,
+  or cross-request temporary data in .NET 11.
+license: MIT
+---
+
+# ASP.NET Core Blazor Components — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## Navigation Improvements
+Assembly: `Microsoft.AspNetCore.Components`
+
+### GetUriWithHash
+
+Extension method returning the current URI with a hash fragment appended.
+
+```csharp
+public static string GetUriWithHash(this NavigationManager nav, string hash);
+```
+
+```razor
+@inject NavigationManager Nav
+
+<button @onclick="GoToSection">Jump to Section</button>
+
+@code {
+    private void GoToSection()
+    {
+        string uri = Nav.GetUriWithHash("#section1");
+        Nav.NavigateTo(uri);
+    }
+}
+```
+
+### NavigationOptions.RelativeToCurrentUri
+
+New `bool` init-only property. When `true`, the target URI resolves relative
+to the current URI rather than the base URI.
+
+```razor
+@inject NavigationManager Nav
+
+@code {
+    private void GoToSettings()
+    {
+        // From /app/dashboard → /app/settings
+        Nav.NavigateTo("../settings", new NavigationOptions
+        {
+            RelativeToCurrentUri = true
+        });
+    }
+}
+```
+
+### NavLink.RelativeToCurrentUri
+
+| Type | Default | Description |
+|------|---------|-------------|
+| `bool` | `false` | When `true`, matching is relative to current URI |
+
+```razor
+<NavLink href="settings/profile" RelativeToCurrentUri="true"
+         Match="NavLinkMatch.Prefix">
+    Profile Settings
+</NavLink>
+```
+
+---
+
+## Component Model
+Assembly: `Microsoft.AspNetCore.Components`
+
+### IComponentPropertyActivator
+
+Interface for custom component property activation.
+
+```csharp
+public interface IComponentPropertyActivator
+{
+    Action<IServiceProvider, IComponent> GetActivator(Type type);
+}
+```
+
+### Contravariant RenderFragment&lt;in TValue&gt;
+
+`RenderFragment<TValue>` now uses `in` variance, enabling assignment
+compatibility with more derived types.
+
+```csharp
+RenderFragment<Animal> animalFragment = (animal) => builder =>
+{
+    builder.AddContent(0, $"Animal: {animal.Name}");
+};
+
+// Valid due to contravariance
+RenderFragment<Dog> dogFragment = animalFragment;
+```
+
+---
+
+## Form Components
+Assembly: `Microsoft.AspNetCore.Components.Web`
+
+### Label&lt;TValue&gt;
+
+Renders `<label>` with `for` auto-bound to the target input's `id`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `For` | `Expression<Func<TValue>>` | Field expression |
+| `ChildContent` | `RenderFragment?` | Label text/markup |
+| `AdditionalAttributes` | `IDictionary<string, object>?` | Extra HTML attributes |
+
+### DisplayName&lt;TValue&gt;
+
+Renders the display name from `[Display]` or `[DisplayName]` annotations.
+
+### InputBase&lt;TValue&gt;.IdAttributeValue
+
+Protected property exposing the computed `id` attribute value.
+
+### Example
+
+```razor
+<EditForm Model="@person" OnValidSubmit="Save">
+    <Label For="@(() => person.Name)">Full Name:</Label>
+    <InputText @bind-Value="person.Name" />
+
+    <Label For="@(() => person.Email)">
+        <DisplayName For="@(() => person.Email)" />
+    </Label>
+    <InputText @bind-Value="person.Email" />
+</EditForm>
+
+@code {
+    private Person person = new();
+    private void Save() { }
+
+    public class Person
+    {
+        [Display(Name = "Email Address")]
+        public string Email { get; set; } = "";
+        public string Name { get; set; } = "";
+    }
+}
+```
+
+---
+
+## Media Components
+Assembly: `Microsoft.AspNetCore.Components.Web`
+Namespace: `Microsoft.AspNetCore.Components.Web.Media`
+
+### MediaSource
+
+Wraps binary data with a MIME type and cache key.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| Constructor | `(byte[], string, string)` | Data, MIME type, cache key |
+| Constructor | `(Stream, string, string)` | Stream, MIME type, cache key |
+| `Stream` | `Stream` | Underlying data stream |
+| `MimeType` | `string` | MIME type |
+| `CacheKey` | `string` | Client-side cache key |
+| `Length` | `long` | Data length in bytes |
+
+### Image, Video, FileDownload Components
+
+- **`Image`** — Renders `<img>` from a `MediaSource`
+- **`Video`** — Renders `<video>` from a `MediaSource`
+- **`FileDownload`** — Triggers browser file download
+
+| Parameter (FileDownload) | Type | Description |
+|--------------------------|------|-------------|
+| `Source` | `MediaSource` (required) | File data |
+| `FileName` | `string` (required) | Download file name |
+| `Text` | `string?` | Button/link text |
+
+### Example: Image from Byte Array
+
+```razor
+@using Microsoft.AspNetCore.Components.Web.Media
+
+<Image Source="@imageSource" alt="Profile photo" width="200" />
+
+@code {
+    private MediaSource? imageSource;
+
+    protected override async Task OnInitializedAsync()
+    {
+        byte[] bytes = await LoadImageBytesAsync();
+        imageSource = new MediaSource(bytes, "image/png", "profile-photo");
+    }
+}
+```
+
+### Example: FileDownload
+
+```razor
+<FileDownload Source="@reportSource" FileName="report.pdf"
+              Text="Download Report" />
+
+@code {
+    private MediaSource? reportSource;
+
+    protected override void OnInitialized()
+    {
+        byte[] data = GenerateReport();
+        reportSource = new MediaSource(data, "application/pdf", "monthly-report");
+    }
+}
+```
+
+---
+
+## EnvironmentBoundary Component
+Assembly: `Microsoft.AspNetCore.Components.Web`
+
+Conditionally renders content based on the hosting environment.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Include` | `string?` | Comma-separated environments to render in |
+| `Exclude` | `string?` | Comma-separated environments to hide in |
+| `ChildContent` | `RenderFragment?` | Content to conditionally render |
+
+```razor
+<EnvironmentBoundary Include="Development">
+    <div class="alert alert-info">Debug Mode: diagnostics enabled.</div>
+</EnvironmentBoundary>
+
+<EnvironmentBoundary Exclude="Production">
+    <p>This content is hidden in production.</p>
+</EnvironmentBoundary>
+```
+
+---
+
+## BasePath & TempData
+Assembly: `Microsoft.AspNetCore.Components.Endpoints`
+
+### BasePath Component
+A sealed component that sets the Blazor app base path in SSR.
+
+```razor
+<head>
+    <BasePath />
+    <HeadOutlet />
+</head>
+```
+
+### ITempData Interface
+Dictionary-based temporary data that survives a single subsequent request.
+
+| Member | Description |
+|--------|-------------|
+| `this[string key]` | Gets or sets a temp data value |
+| `Get(string key)` | Gets and marks for deletion |
+| `Peek(string key)` | Gets without marking for deletion |
+| `Keep(string key)` | Retains value for next request |
+
+### TempDataProviderType Enum
+```csharp
+public enum TempDataProviderType { Cookie, SessionStorage }
+```
+
+### RazorComponentsServiceOptions
+| Property | Type | Description |
+|----------|------|-------------|
+| `TempDataCookie` | `CookieBuilder` | Cookie configuration |
+| `TempDataProviderType` | `TempDataProviderType` | Storage mechanism |
+
+### Example: Configure TempData
+
+```csharp
+builder.Services.AddRazorComponents(options =>
+{
+    options.TempDataProviderType = TempDataProviderType.SessionStorage;
+}).AddInteractiveServerComponents();
+```
+
+### Example: Use ITempData in Components
+
+```razor
+@page "/checkout"
+@inject ITempData TempData
+
+@code {
+    private void SaveAndNavigate()
+    {
+        TempData["OrderId"] = "ORD-12345";
+        TempData["Message"] = "Order placed successfully!";
+        Nav.NavigateTo("/confirmation");
+    }
+}
+```

--- a/plugins/dotnet11/skills/aspnetcore-middleware-services-net11/SKILL.md
+++ b/plugins/dotnet11/skills/aspnetcore-middleware-services-net11/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: aspnetcore-middleware-services-net11
+description: >
+  Covers new .NET 11 APIs for ASP.NET Core middleware and services:
+  zero-allocation data protection (ISpanDataProtector, ISpanAuthenticatedEncryptor),
+  Zstandard response compression (ZstandardCompressionProvider), and passkey
+  AAGUID support in Identity (UserPasskeyInfo.Aaguid, IdentityPasskeyData.Aaguid).
+  Use when configuring high-performance data protection, enabling zstd HTTP
+  response compression, or working with passkey authenticator identification
+  in .NET 11 ASP.NET Core applications.
+license: MIT
+---
+
+# ASP.NET Core Middleware & Services — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## Zero-Allocation Data Protection
+Assembly: `Microsoft.AspNetCore.DataProtection.Abstractions`,
+`Microsoft.AspNetCore.DataProtection`
+
+### ISpanDataProtector
+
+Extends `IDataProtector` with span-based protect/unprotect using
+`IBufferWriter<byte>` to avoid heap allocations.
+
+```csharp
+public interface ISpanDataProtector : IDataProtector, IDataProtectionProvider
+{
+    void Protect<TWriter>(ReadOnlySpan<byte> plaintext, ref TWriter destination)
+        where TWriter : IBufferWriter<byte>;
+    void Unprotect<TWriter>(ReadOnlySpan<byte> protectedData, ref TWriter destination)
+        where TWriter : IBufferWriter<byte>;
+}
+```
+
+### ISpanAuthenticatedEncryptor
+
+Extends `IAuthenticatedEncryptor` with span-based encrypt/decrypt.
+
+```csharp
+public interface ISpanAuthenticatedEncryptor : IAuthenticatedEncryptor
+{
+    void Encrypt<TWriter>(ReadOnlySpan<byte> plaintext,
+        ReadOnlySpan<byte> aad, ref TWriter destination)
+        where TWriter : IBufferWriter<byte>;
+    void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext,
+        ReadOnlySpan<byte> aad, ref TWriter destination)
+        where TWriter : IBufferWriter<byte>;
+}
+```
+
+### Example: Zero-Allocation Protect/Unprotect
+
+```csharp
+using System.Buffers;
+using Microsoft.AspNetCore.DataProtection;
+
+IDataProtector protector = provider.CreateProtector("MyPurpose");
+
+if (protector is ISpanDataProtector spanProtector)
+{
+    ReadOnlySpan<byte> plaintext = "sensitive data"u8;
+
+    var protectWriter = new ArrayBufferWriter<byte>();
+    spanProtector.Protect(plaintext, ref protectWriter);
+
+    var unprotectWriter = new ArrayBufferWriter<byte>();
+    spanProtector.Unprotect(protectWriter.WrittenSpan, ref unprotectWriter);
+}
+```
+
+### Example: Minimal API with Fallback
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddDataProtection();
+var app = builder.Build();
+
+app.MapGet("/protect", (IDataProtectionProvider provider) =>
+{
+    var protector = provider.CreateProtector("Demo");
+    if (protector is ISpanDataProtector spanProtector)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        spanProtector.Protect("secret"u8, ref writer);
+        return Results.Ok(Convert.ToBase64String(writer.WrittenSpan));
+    }
+    return Results.Ok(protector.Protect("secret"));
+});
+
+app.Run();
+```
+
+---
+
+## Zstandard Response Compression
+Assembly: `Microsoft.AspNetCore.ResponseCompression`
+
+### ZstandardCompressionProvider
+
+Implements `ICompressionProvider` for Zstandard compression.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `EncodingName` | `string` | Returns `"zstd"` |
+| `SupportsFlush` | `bool` | Whether the provider supports flushing |
+| `CreateStream(Stream)` | `Stream` | Wraps output with zstd compression |
+
+### ZstandardCompressionProviderOptions
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `CompressionOptions` | `ZstandardCompressionOptions` | Quality and settings |
+
+### Example: Basic Zstd Compression
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddResponseCompression(options =>
+{
+    options.Providers.Add<ZstandardCompressionProvider>();
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes;
+});
+
+var app = builder.Build();
+app.UseResponseCompression();
+app.MapGet("/", () => "Hello, compressed with Zstandard!");
+app.Run();
+```
+
+### Example: Combine with Brotli and Gzip
+
+```csharp
+builder.Services.AddResponseCompression(options =>
+{
+    options.Providers.Add<ZstandardCompressionProvider>();
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+    options.EnableForHttps = true;
+});
+
+builder.Services.Configure<ZstandardCompressionProviderOptions>(opt =>
+    opt.CompressionOptions = new ZstandardCompressionOptions { Quality = 3 });
+```
+
+---
+
+## Passkey AAGUID Support
+Assembly: `Microsoft.Extensions.Identity.Core`, `Microsoft.Extensions.Identity.Stores`
+
+The **AAGUID** (Authenticator Attestation Globally Unique Identifier) is a
+16-byte value identifying the make and model of a passkey authenticator.
+
+### New APIs
+
+| Type | Property | Description |
+|------|----------|-------------|
+| `UserPasskeyInfo` | `byte[]? Aaguid` | AAGUID in Identity.Core |
+| `IdentityPasskeyData` | `virtual byte[]? Aaguid` | AAGUID in Identity.Stores (overridable) |
+
+### Example: Identify Authenticator
+
+```csharp
+using Microsoft.AspNetCore.Identity;
+
+var passkeyInfo = new UserPasskeyInfo
+{
+    Aaguid = new byte[]
+    {
+        0xCB, 0x69, 0x48, 0x1E, 0x8F, 0xF7, 0x40, 0x39,
+        0x93, 0xEC, 0x0A, 0x27, 0x29, 0xA1, 0x54, 0xA8
+    }
+};
+
+if (passkeyInfo.Aaguid is { Length: 16 } aaguid)
+{
+    var guid = new Guid(aaguid);
+    Console.WriteLine($"Authenticator AAGUID: {guid}");
+}
+```
+
+### Example: Filter Passkeys by Authenticator
+
+```csharp
+private static readonly Dictionary<Guid, string> KnownAuthenticators = new()
+{
+    [new Guid("cb69481e-8ff7-4039-93ec-0a2729a154a8")] = "YubiKey 5 Series",
+    [new Guid("08987058-cadc-4b81-b6e1-30de50dcbe96")] = "Windows Hello",
+};
+
+public static string GetAuthenticatorName(this UserPasskeyInfo passkey)
+{
+    if (passkey.Aaguid is not { Length: 16 } aaguid)
+        return "Unknown Authenticator";
+    var guid = new Guid(aaguid);
+    return KnownAuthenticators.GetValueOrDefault(guid, $"Unknown ({guid})");
+}
+```

--- a/plugins/dotnet11/skills/dotnet-networking-net11/SKILL.md
+++ b/plugins/dotnet11/skills/dotnet-networking-net11/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: dotnet-networking-net11
+description: >
+  Covers new .NET 11 APIs in System.Net.Sockets and System.Net.Primitives.
+  Includes the ConnectAlgorithm enum and Socket.ConnectAsync overload for Happy
+  Eyeballs (RFC 8305) parallel IPv4/IPv6 connections, IPEndPoint UTF-8
+  Parse/TryParse/TryFormat for zero-allocation endpoint handling, and the
+  DecompressionMethods.Zstandard enum value for HttpClient. Use when implementing
+  low-latency dual-stack connections, high-performance endpoint parsing, or
+  enabling Zstandard HTTP decompression in .NET 11.
+license: MIT
+---
+
+# Networking — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## Happy Eyeballs Parallel Connect
+Assembly: `System.Net.Sockets`
+
+A new `Socket.ConnectAsync` overload and `ConnectAlgorithm` enum enable the
+Happy Eyeballs algorithm (RFC 8305) for parallel IPv4/IPv6 connection attempts,
+reducing connection latency on dual-stack networks.
+
+### ConnectAlgorithm Enum
+
+```csharp
+namespace System.Net.Sockets;
+
+public enum ConnectAlgorithm
+{
+    Default = 0,   // Sequential (existing behavior)
+    Parallel = 1   // Happy Eyeballs: concurrent IPv4/IPv6 attempts
+}
+```
+
+### Socket.ConnectAsync
+
+```csharp
+public static bool ConnectAsync(
+    SocketType socketType, ProtocolType protocolType,
+    SocketAsyncEventArgs e, ConnectAlgorithm algorithm);
+```
+
+### Example: Parallel Connect
+
+```csharp
+using System.Net;
+using System.Net.Sockets;
+
+var args = new SocketAsyncEventArgs();
+args.RemoteEndPoint = new DnsEndPoint("example.com", 443);
+args.Completed += (sender, e) =>
+{
+    if (e.SocketError == SocketError.Success)
+    {
+        Socket connected = e.ConnectSocket!;
+        Console.WriteLine($"Connected to {connected.RemoteEndPoint}");
+    }
+    else
+    {
+        Console.WriteLine($"Connection failed: {e.SocketError}");
+    }
+};
+
+Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp,
+    args, ConnectAlgorithm.Parallel);
+```
+
+### When to Use
+
+- **Dual-stack hosts:** Hostname resolves to both IPv4 and IPv6 — parallel
+  attempts use whichever succeeds first.
+- **Latency-sensitive apps:** Reduces worst-case connection time when one
+  address family is slower or unreachable.
+- **Client applications:** HTTP clients, database connectors, and any scenario
+  where connection setup latency matters.
+
+---
+
+## IPEndPoint UTF-8 Support
+Assembly: `System.Net.Primitives`
+
+New methods on `IPEndPoint` for parsing and formatting with UTF-8 byte spans,
+avoiding string allocations in hot paths.
+
+### New APIs
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `IPEndPoint.Parse(ReadOnlySpan<byte> utf8Text)` | `IPEndPoint` | Parse from UTF-8 bytes |
+| `IPEndPoint.TryParse(ReadOnlySpan<byte> utf8Text, out IPEndPoint?)` | `bool` | Try-parse from UTF-8 bytes |
+| `IPEndPoint.TryFormat(Span<byte> utf8Destination, out int bytesWritten)` | `bool` | Format to UTF-8 bytes |
+| `IPEndPoint.TryFormat(Span<char> destination, out int charsWritten)` | `bool` | Format to char span |
+
+### Example
+
+```csharp
+using System.Net;
+
+// Parse from UTF-8 bytes
+ReadOnlySpan<byte> utf8 = "192.168.1.1:8080"u8;
+IPEndPoint endpoint = IPEndPoint.Parse(utf8);
+
+// TryParse
+if (IPEndPoint.TryParse("10.0.0.1:443"u8, out IPEndPoint? parsed))
+    Console.WriteLine($"Address: {parsed.Address}, Port: {parsed.Port}");
+
+// TryFormat to UTF-8
+Span<byte> buffer = stackalloc byte[64];
+if (endpoint.TryFormat(buffer, out int bytesWritten))
+    Console.WriteLine($"Wrote {bytesWritten} UTF-8 bytes");
+
+// TryFormat to char span
+Span<char> charBuffer = stackalloc char[64];
+if (endpoint.TryFormat(charBuffer, out int charsWritten))
+    Console.WriteLine(charBuffer[..charsWritten]);
+```
+
+---
+
+## DecompressionMethods.Zstandard
+Assembly: `System.Net.Primitives`
+
+A new enum value enables Zstandard (zstd) decompression in HTTP handlers.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `DecompressionMethods.Zstandard` | `8` | Enables Zstandard decompression |
+
+### Example
+
+```csharp
+using System.Net;
+using System.Net.Http;
+
+// Enable Zstandard decompression
+var handler = new HttpClientHandler
+{
+    AutomaticDecompression = DecompressionMethods.Zstandard
+};
+using var client = new HttpClient(handler);
+
+// Combine multiple methods
+var multiHandler = new HttpClientHandler
+{
+    AutomaticDecompression = DecompressionMethods.GZip
+                           | DecompressionMethods.Brotli
+                           | DecompressionMethods.Zstandard
+};
+```

--- a/plugins/dotnet11/skills/dotnet-numerics-memory-net11/SKILL.md
+++ b/plugins/dotnet11/skills/dotnet-numerics-memory-net11/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: dotnet-numerics-memory-net11
+description: >
+  Covers new .NET 11 APIs in System.Memory and System.Runtime.Numerics
+  for BFloat16 data pipelines. Includes BFloat16 BinaryPrimitives read/write
+  methods (big-endian, little-endian, Try variants), BigInteger to/from BFloat16
+  explicit conversions, BigInteger UTF-8 TryFormat/TryParse, and implicit
+  Complex from BFloat16 conversion. Use when serializing ML tensor data,
+  converting between arbitrary-precision integers and BFloat16, or performing
+  zero-allocation BigInteger formatting in .NET 11.
+license: MIT
+---
+
+# Numerics & Memory — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## BFloat16 BinaryPrimitives
+Assembly: `System.Memory`
+
+Eight new methods on `System.Buffers.Binary.BinaryPrimitives` for reading and
+writing `BFloat16` values in big-endian and little-endian byte order.
+
+### Read Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `ReadBFloat16BigEndian(ReadOnlySpan<byte>)` | `BFloat16` | Read big-endian |
+| `ReadBFloat16LittleEndian(ReadOnlySpan<byte>)` | `BFloat16` | Read little-endian |
+| `TryReadBFloat16BigEndian(ReadOnlySpan<byte>, out BFloat16)` | `bool` | Safe big-endian read |
+| `TryReadBFloat16LittleEndian(ReadOnlySpan<byte>, out BFloat16)` | `bool` | Safe little-endian read |
+
+### Write Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `WriteBFloat16BigEndian(Span<byte>, BFloat16)` | `void` | Write big-endian |
+| `WriteBFloat16LittleEndian(Span<byte>, BFloat16)` | `void` | Write little-endian |
+| `TryWriteBFloat16BigEndian(Span<byte>, BFloat16)` | `bool` | Safe big-endian write |
+| `TryWriteBFloat16LittleEndian(Span<byte>, BFloat16)` | `bool` | Safe little-endian write |
+
+### Example: Basic Read/Write
+
+```csharp
+using System.Buffers.Binary;
+using System.Numerics;
+
+BFloat16 value = (BFloat16)3.14f;
+
+Span<byte> buffer = stackalloc byte[2];
+BinaryPrimitives.WriteBFloat16LittleEndian(buffer, value);
+BFloat16 read = BinaryPrimitives.ReadBFloat16LittleEndian(buffer);
+```
+
+### Example: Batch Processing ML Tensor Data
+
+```csharp
+using System.Buffers.Binary;
+using System.Numerics;
+
+byte[] fileData = File.ReadAllBytes("weights.bin");
+int count = fileData.Length / 2;
+var weights = new BFloat16[count];
+
+for (int i = 0; i < count; i++)
+    weights[i] = BinaryPrimitives.ReadBFloat16LittleEndian(
+        fileData.AsSpan(i * 2, 2));
+```
+
+---
+
+## BigInteger ↔ BFloat16 Conversions
+Assembly: `System.Runtime.Numerics`
+
+Explicit conversion operators between `BigInteger` and `BFloat16`.
+
+| Operator | Description |
+|----------|-------------|
+| `explicit operator BigInteger(BFloat16)` | Truncates fractional part |
+| `explicit operator BFloat16(BigInteger)` | May lose precision |
+
+```csharp
+using System.Numerics;
+
+BFloat16 bf = (BFloat16)42.0f;
+BigInteger big = (BigInteger)bf;     // 42
+BFloat16 back = (BFloat16)(BigInteger)1000;  // 1000 (approx)
+```
+
+---
+
+## BigInteger UTF-8 TryFormat/TryParse
+Assembly: `System.Runtime.Numerics`
+
+Zero-allocation UTF-8 formatting and parsing for `BigInteger`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `TryFormat(Span<byte> utf8Destination, out int bytesWritten, ...)` | `bool` | Format to UTF-8 bytes |
+| `TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles, IFormatProvider?, out BigInteger)` | `bool` | Parse from UTF-8 with style |
+| `TryParse(ReadOnlySpan<byte> utf8Text, out BigInteger)` | `bool` | Parse from UTF-8 (defaults) |
+
+```csharp
+using System.Numerics;
+
+BigInteger value = BigInteger.Parse("123456789012345678901234567890");
+
+Span<byte> utf8Buffer = stackalloc byte[64];
+if (value.TryFormat(utf8Buffer, out int bytesWritten))
+    Console.WriteLine($"Formatted {bytesWritten} UTF-8 bytes");
+
+if (BigInteger.TryParse("99999999999999999999"u8, out BigInteger parsed))
+    Console.WriteLine(parsed);
+```
+
+---
+
+## Complex ← BFloat16 Implicit Conversion
+Assembly: `System.Runtime.Numerics`
+
+| Operator | Description |
+|----------|-------------|
+| `implicit operator Complex(BFloat16)` | Converts to Complex (imaginary = 0) |
+
+```csharp
+using System.Numerics;
+
+BFloat16 bf = (BFloat16)2.5f;
+Complex c = bf;  // (2.5, 0)
+```

--- a/plugins/dotnet11/skills/dotnet-runtime-core-net11/SKILL.md
+++ b/plugins/dotnet11/skills/dotnet-runtime-core-net11/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: dotnet-runtime-core-net11
+description: >
+  Covers new .NET 11 APIs in System.Runtime and
+  System.Runtime.InteropServices. Includes BFloat16 numeric type, DivisionRounding
+  enum, String/StringBuilder Rune methods, RunePosition, Char/Rune.Equals with
+  StringComparison, Base64 char-based encode/decode, BitConverter BFloat16 support,
+  File.CreateHardLink, File.OpenNullHandle, Uri.UriSchemeData, IdnMapping span
+  methods, AsyncHelpers, ExtendedLayoutAttribute with CStruct/CUnion layouts,
+  CurrencyWrapper un-deprecated, and PosixSignal.SIGKILL. Use when working with
+  brain floating-point arithmetic, Unicode Rune text processing, Base64, file
+  system hard links, or C-compatible interop layouts on net11.0.
+license: MIT
+---
+
+# Runtime Core & Interop — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## BFloat16 Type
+Assembly: `System.Runtime`
+
+`System.Numerics.BFloat16` is a 16-bit brain floating-point type for ML
+workloads. Implements `IFloatingPointIeee754<BFloat16>` and all standard
+numeric interfaces.
+
+**Key members:** Arithmetic operators (`+`, `-`, `*`, `/`, `%`), conversions
+to/from `float`, `double`, `Half`, `int`, `long`, etc., `Parse()`,
+`TryParse()`, `ToString()`, `TryFormat()`, static helpers (`IsZero`,
+`IsNaN`, `IsInfinity`, `IsNormal`, etc.), constants (`Epsilon`, `MaxValue`,
+`MinValue`, `NaN`, `PositiveInfinity`, `NegativeInfinity`).
+
+```csharp
+using System.Numerics;
+
+BFloat16 a = (BFloat16)1.5f;
+BFloat16 b = (BFloat16)2.5f;
+BFloat16 sum = a + b;
+Console.WriteLine((float)sum); // 4.0
+Console.WriteLine(BFloat16.IsNaN(a)); // false
+```
+
+---
+
+## DivisionRounding Enum
+Assembly: `System.Runtime`
+
+Controls rounding behavior for integer division via new
+`IBinaryInteger<TSelf>` methods: `Divide()`, `DivRem()`, `Remainder()`.
+
+| Value | Description |
+|-------|-------------|
+| `Truncate` | Round toward zero (C# default) |
+| `Floor` | Round toward negative infinity |
+| `Ceiling` | Round toward positive infinity |
+| `AwayFromZero` | Round away from zero |
+| `Euclidean` | Non-negative remainder |
+
+```csharp
+int floor = int.Divide(-7, 2, DivisionRounding.Floor); // -4
+var (q, r) = int.DivRem(-7, 2, DivisionRounding.Euclidean); // q=-4, r=1
+```
+
+---
+
+## String Rune Methods
+Assembly: `System.Runtime`
+
+New overloads on `String` for first-class `Rune` support.
+
+| Method | Overloads |
+|--------|-----------|
+| `Contains(Rune)`, `Contains(Rune, StringComparison)` | 2 |
+| `IndexOf(Rune, ...)` | 8 |
+| `LastIndexOf(Rune, ...)` | 8 |
+| `StartsWith(Rune)`, `StartsWith(Rune, StringComparison)` | 2 |
+| `EndsWith(Rune)`, `EndsWith(Rune, StringComparison)` | 2 |
+| `Replace(Rune, Rune)` | 1 |
+| `Split(Rune, ...)` | 2 |
+| `Trim(Rune)`, `TrimStart(Rune)`, `TrimEnd(Rune)` | 3 |
+
+```csharp
+string text = "Hello 🌍 World";
+Rune globe = new Rune(0x1F30D);
+
+bool has = text.Contains(globe);           // true
+int idx = text.IndexOf(globe);             // 6
+string replaced = text.Replace(globe, new Rune('X'));
+string[] parts = "a🌍b🌍c".Split(globe);
+string trimmed = "***data***".Trim(new Rune('*'));
+```
+
+## Char.Equals and Rune.Equals
+```csharp
+char ch = 'a';
+bool eq = ch.Equals('A', StringComparison.OrdinalIgnoreCase); // true
+
+Rune r = new Rune('ß');
+bool runeEq = r.Equals(new Rune('ß'), StringComparison.CurrentCulture);
+```
+
+---
+
+## StringBuilder Rune Methods
+| Method | Description |
+|--------|-------------|
+| `Append(Rune)` | Appends a Rune |
+| `GetRuneAt(int)` | Gets the Rune at a position |
+| `TryGetRuneAt(int, out Rune)` | Try-gets the Rune at a position |
+| `Insert(int, Rune)` | Inserts a Rune |
+| `Replace(Rune, Rune)` | Replaces all occurrences |
+| `EnumerateRunes()` | Enumerates all Runes |
+
+---
+
+## RunePosition Struct
+Enables enumerating Runes with position metadata.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `Rune` | `Rune` | The Rune value |
+| `StartIndex` | `int` | Start index in source |
+| `Length` | `int` | Length in code units |
+| `WasReplaced` | `bool` | Whether it was a replacement char |
+
+Static methods: `RunePosition.EnumerateUtf16(ReadOnlySpan<char>)`,
+`RunePosition.EnumerateUtf8(ReadOnlySpan<byte>)`.
+
+---
+
+## TextInfo and TextWriter Rune Support
+```csharp
+Rune lower = CultureInfo.InvariantCulture.TextInfo.ToLower(new Rune('A'));
+Rune upper = CultureInfo.InvariantCulture.TextInfo.ToUpper(new Rune('a'));
+
+using var writer = new StringWriter();
+writer.Write(new Rune(0x1F30D));
+await writer.WriteAsync(new Rune('X'));
+writer.WriteLine(new Rune('!'));
+```
+
+---
+
+## Base64 Improvements
+Assembly: `System.Runtime`
+
+`System.Buffers.Text.Base64` gains char-based and simplified overloads.
+
+| Method | Description |
+|--------|-------------|
+| `EncodeToString(ReadOnlySpan<byte>)` | Encode bytes to Base64 string |
+| `EncodeToChars(ReadOnlySpan<byte>, Span<char>, ...)` | Encode to char span |
+| `DecodeFromChars(ReadOnlySpan<char>, Span<byte>, ...)` | Decode from char span |
+| `EncodeToUtf8(ReadOnlySpan<byte>)` | Simplified UTF-8 encode |
+| `GetEncodedLength(int)` / `GetMaxDecodedLength(int)` | Length calculations |
+| `TryEncodeToChars` / `TryDecodeFromChars` / `TryEncodeToUtf8` / `TryDecodeFromUtf8` | Try variants |
+
+```csharp
+using System.Buffers.Text;
+
+byte[] data = { 1, 2, 3, 4, 5 };
+string b64 = Base64.EncodeToString(data); // AQIDBAU=
+
+int len = Base64.GetEncodedLength(data.Length);
+Span<char> buf = stackalloc char[len];
+Base64.TryEncodeToChars(data, buf, out int written);
+```
+
+---
+
+## BitConverter BFloat16 Support
+| Method | Description |
+|--------|-------------|
+| `BFloat16ToInt16Bits(BFloat16)` | BFloat16 → Int16 bits |
+| `Int16BitsToBFloat16(short)` | Int16 bits → BFloat16 |
+| `GetBytes(BFloat16)` | BFloat16 → byte[] |
+| `ToBFloat16(byte[], int)` | bytes → BFloat16 |
+
+---
+
+## File Operations
+### Hard Links
+| Method | Description |
+|--------|-------------|
+| `File.CreateHardLink(string path, string pathToTarget)` | Creates a hard link |
+| `FileInfo.CreateAsHardLink(string pathToTarget)` | Creates file as hard link |
+
+### Null Handle
+| Method | Description |
+|--------|-------------|
+| `File.OpenNullHandle()` | Opens `SafeFileHandle` to null device |
+
+```csharp
+File.CreateHardLink("link.txt", "original.txt");
+using var nullHandle = File.OpenNullHandle();
+```
+
+---
+
+## Uri.UriSchemeData
+```csharp
+string scheme = Uri.UriSchemeData; // "data"
+```
+
+---
+
+## IdnMapping Span Methods
+| Method | Returns |
+|--------|---------|
+| `TryGetAscii(ReadOnlySpan<char>, Span<char>, out int)` | `bool` |
+| `TryGetUnicode(ReadOnlySpan<char>, Span<char>, out int)` | `bool` |
+
+```csharp
+var idn = new IdnMapping();
+Span<char> output = stackalloc char[256];
+if (idn.TryGetAscii("münchen.de", output, out int written))
+    Console.WriteLine(output[..written]); // xn--mnchen-3ya.de
+```
+
+---
+
+## StringSyntaxAttribute Constants
+| Constant | Value |
+|----------|-------|
+| `StringSyntaxAttribute.CSharp` | `"csharp"` |
+| `StringSyntaxAttribute.FSharp` | `"fsharp"` |
+| `StringSyntaxAttribute.VisualBasic` | `"visualbasic"` |
+
+---
+
+## AsyncHelpers
+| Method | Description |
+|--------|-------------|
+| `AsyncHelpers.HandleAsyncEntryPoint(Task)` | Handles async Main returning Task |
+| `AsyncHelpers.HandleAsyncEntryPoint(Task<int>)` | Handles async Main returning Task&lt;int&gt; |
+
+---
+
+## ExtendedLayoutAttribute & C-Compatible Layouts
+Assembly: `System.Runtime`, `System.Runtime.InteropServices`
+
+New attribute and enum for C-compatible struct and union memory layouts.
+
+| Type | Description |
+|------|-------------|
+| `ExtendedLayoutAttribute` | Specifies extended layout kind |
+| `ExtendedLayoutKind.CStruct` | C-compatible sequential struct layout |
+| `ExtendedLayoutKind.CUnion` | C-compatible union (all fields at offset 0) |
+| `LayoutKind.Extended` | New LayoutKind enum value |
+| `TypeAttributes.ExtendedLayout` | New type attribute flag |
+
+```csharp
+using System.Runtime.InteropServices;
+
+// C-compatible union: all fields overlap at offset 0
+[ExtendedLayout(ExtendedLayoutKind.CUnion)]
+struct MyUnion
+{
+    public int IntValue;
+    public float FloatValue;
+    public byte ByteValue;
+}
+
+// C-compatible struct with platform-specific padding
+[ExtendedLayout(ExtendedLayoutKind.CStruct)]
+struct MyCStruct
+{
+    public byte Flags;
+    public int Value;    // padded per C ABI rules
+    public short Extra;
+}
+```
+
+---
+
+## CurrencyWrapper Un-deprecated
+Assembly: `System.Runtime.InteropServices`
+
+The `[Obsolete]` attribute has been removed from `CurrencyWrapper`. It is
+once again fully supported for COM interop currency values.
+
+```csharp
+var wrapper = new CurrencyWrapper(99.95m);
+Console.WriteLine(wrapper.WrappedObject); // 99.95
+```
+
+---
+
+## PosixSignal.SIGKILL
+Assembly: `System.Runtime.InteropServices`
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `PosixSignal.SIGKILL` | `-11` | Force-terminate a process |
+
+> SIGKILL cannot be caught or ignored. This value is for sending signals
+> to other processes.
+
+```csharp
+PosixSignal signal = PosixSignal.SIGKILL;
+Console.WriteLine($"Signal value: {(int)signal}"); // -11
+```

--- a/plugins/dotnet11/skills/dotnet-security-cryptography-net11/SKILL.md
+++ b/plugins/dotnet11/skills/dotnet-security-cryptography-net11/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: dotnet-security-cryptography-net11
+description: >
+  Covers new .NET 11 APIs in System.Security.Cryptography and
+  System.Security.Cryptography.Pkcs. Includes constant-time hash verification
+  methods (VerifyHmac, HMAC/KMAC/IncrementalHash Verify), and cross-platform
+  CMS/PKCS#7 signing (SignedCms), encryption (EnvelopedCms), PKCS#12 archive
+  building, PKCS#8 private key info, and RFC 3161 timestamps. Use when
+  implementing hash verification, digital signatures, certificate-based
+  encryption, or PFX/PKCS#12 operations in .NET 11 applications.
+license: MIT
+---
+
+# Security & Cryptography — .NET 11 APIs
+
+Target framework: `net11.0`
+
+---
+
+## Constant-Time Hash Verification
+All HMAC, KMAC, and incremental hash classes now include built-in `Verify()`
+methods with constant-time comparison, eliminating manual `FixedTimeEquals`.
+
+### Migration Pattern
+
+```csharp
+// ❌ Before .NET 11
+byte[] computed = HMACSHA256.HashData(key, data);
+bool valid = CryptographicOperations.FixedTimeEquals(computed, expected);
+
+// ✅ .NET 11
+bool valid = HMACSHA256.Verify(key, data, expected);
+```
+
+### CryptographicOperations.VerifyHmac
+
+Static one-shot HMAC verification with algorithm selection.
+
+| Method | Description |
+|--------|-------------|
+| `VerifyHmac(HashAlgorithmName, byte[] key, byte[] source, byte[] hash)` | Byte array overload |
+| `VerifyHmac(HashAlgorithmName, ReadOnlySpan<byte>, ReadOnlySpan<byte>, ReadOnlySpan<byte>)` | Span overload |
+| `VerifyHmac(HashAlgorithmName, byte[] key, Stream source, byte[] hash)` | Stream overload |
+| `VerifyHmacAsync(HashAlgorithmName, byte[] key, Stream, byte[], CancellationToken)` | Async stream |
+
+```csharp
+byte[] key = RandomNumberGenerator.GetBytes(32);
+byte[] data = "Hello, World!"u8.ToArray();
+byte[] hash = HMACSHA256.HashData(key, data);
+
+bool ok = CryptographicOperations.VerifyHmac(
+    HashAlgorithmName.SHA256, key, data, hash);
+```
+
+### HMAC Classes: Verify and VerifyAsync
+
+Added to: `HMACMD5`, `HMACSHA1`, `HMACSHA256`, `HMACSHA384`, `HMACSHA512`,
+`HMACSHA3_256`, `HMACSHA3_384`, `HMACSHA3_512`.
+
+Each class gains:
+
+| Method | Description |
+|--------|-------------|
+| `Verify(byte[] key, byte[] source, byte[] hash)` | Byte array verify |
+| `Verify(ReadOnlySpan<byte>, ReadOnlySpan<byte>, ReadOnlySpan<byte>)` | Span verify |
+| `VerifyAsync(byte[] key, Stream, byte[], CancellationToken)` | Async stream |
+| `VerifyAsync(ReadOnlyMemory<byte>, Stream, ReadOnlyMemory<byte>, CancellationToken)` | Async memory |
+
+```csharp
+byte[] key = RandomNumberGenerator.GetBytes(32);
+byte[] data = "Sensitive payload"u8.ToArray();
+byte[] expected = HMACSHA256.HashData(key, data);
+
+bool valid = HMACSHA256.Verify(key, data, expected);
+
+// Async stream verification
+await using var stream = File.OpenRead("data.bin");
+bool streamValid = await HMACSHA256.VerifyAsync(key, stream, expected);
+```
+
+### IncrementalHash: VerifyCurrentHash and VerifyHashAndReset
+
+| Method | Description |
+|--------|-------------|
+| `VerifyCurrentHash(ReadOnlySpan<byte>)` | Verifies without resetting state |
+| `VerifyHashAndReset(ReadOnlySpan<byte>)` | Verifies and resets for reuse |
+
+```csharp
+using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+hash.AppendData("Part 1"u8);
+hash.AppendData("Part 2"u8);
+bool match = hash.VerifyHashAndReset(expectedHash);
+```
+
+### KMAC Classes: Verify Methods
+
+`Kmac128`, `Kmac256`, `KmacXof128`, `KmacXof256` all gain `Verify()`,
+`VerifyAsync()`, `VerifyCurrentHash()`, and `VerifyHashAndReset()`.
+
+```csharp
+byte[] key = RandomNumberGenerator.GetBytes(32);
+byte[] data = "KMAC input"u8.ToArray();
+byte[] customization = "MyApp"u8.ToArray();
+byte[] kmacHash = Kmac128.HashData(key, data, 32, customization);
+
+bool valid = Kmac128.Verify(key, data, kmacHash, customization);
+```
+
+---
+
+## CMS/PKCS#7 — Cross-Platform
+Assembly `System.Security.Cryptography.Pkcs` is now available cross-platform
+for ASP.NET Core in .NET 11, removing the previous Windows-only limitation.
+
+### SignedCms (CMS/PKCS#7 Signing)
+
+| Member | Description |
+|---|---|
+| `SignedCms(ContentInfo)` | Constructs a signed CMS message |
+| `ComputeSignature(CmsSigner)` | Computes and adds a signature |
+| `CheckSignature(bool)` | Verifies all signatures |
+| `Decode(byte[])` / `Encode()` | Round-trip encoding |
+| `SignerInfos` | Collection of signer info objects |
+| `Certificates` | Embedded certificates |
+
+Supports RSA, ECDsa, and post-quantum algorithms (MLDsa, SlhDsa,
+CompositeMLDsa — experimental `SYSLIB5006`).
+
+```csharp
+byte[] data = Encoding.UTF8.GetBytes("Hello, cross-platform CMS!");
+var cms = new SignedCms(new ContentInfo(data));
+cms.ComputeSignature(new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber, cert));
+byte[] signed = cms.Encode();
+
+// Verify
+var verify = new SignedCms();
+verify.Decode(signed);
+verify.CheckSignature(verifySignatureOnly: true);
+```
+
+### EnvelopedCms (CMS Encryption)
+
+| Member | Description |
+|---|---|
+| `EnvelopedCms(ContentInfo)` | Constructs an enveloped message |
+| `Encrypt(CmsRecipient)` | Encrypts for a recipient |
+| `Decrypt()` | Decrypts using certs from the store |
+| `ContentEncryptionAlgorithm` | Algorithm used for encryption |
+
+```csharp
+var env = new EnvelopedCms(new ContentInfo(plaintext));
+env.Encrypt(new CmsRecipient(recipientCert));
+byte[] encrypted = env.Encode();
+
+var dec = new EnvelopedCms();
+dec.Decode(encrypted);
+dec.Decrypt();
+byte[] decrypted = dec.ContentInfo.Content;
+```
+
+### PKCS#12 (PFX) Archive Building
+
+| Type | Description |
+|---|---|
+| `Pkcs12Builder` | Builds a PKCS#12/PFX archive |
+| `Pkcs12Info` | Reads PKCS#12 data |
+| `Pkcs12SafeContents` | Container for safe bags |
+| `Pkcs12CertBag` / `Pkcs12KeyBag` / `Pkcs12ShroudedKeyBag` | Bag types |
+
+```csharp
+var builder = new Pkcs12Builder();
+var contents = new Pkcs12SafeContents();
+var pbeParams = new PbeParameters(
+    PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 100_000);
+
+contents.AddCertificate(cert);
+contents.AddShroudedKey(key, "password", pbeParams);
+builder.AddSafeContentsEncrypted(contents, "password", pbeParams);
+builder.SealWithMac("password", HashAlgorithmName.SHA256, 100_000);
+byte[] pfx = builder.Encode();
+```
+
+### Additional Types
+
+- **PKCS#8:** `Pkcs8PrivateKeyInfo` for private key information
+- **PKCS#9 Attributes:** `Pkcs9ContentType`, `Pkcs9SigningTime`, `Pkcs9MessageDigest`,
+  `Pkcs9DocumentName`, `Pkcs9DocumentDescription`, `Pkcs9LocalKeyId`
+- **RFC 3161:** `Rfc3161TimestampRequest`, `Rfc3161TimestampToken`,
+  `Rfc3161TimestampTokenInfo`
+- **Recipients:** `CmsRecipient`, `CmsRecipientCollection`,
+  `KeyTransRecipientInfo`, `KeyAgreeRecipientInfo`

--- a/plugins/dotnet11/skills/system-io-compression-net11/SKILL.md
+++ b/plugins/dotnet11/skills/system-io-compression-net11/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: system-io-compression-net11
+description: >
+  Provides guidance on new Zstandard (zstd) compression APIs and ZipArchiveEntry
+  improvements added to System.IO.Compression in .NET 11.
+  It covers ZstandardStream for stream-based compression and decompression,
+  ZstandardEncoder and ZstandardDecoder for low-level operations,
+  ZstandardCompressionOptions and ZstandardDictionary for configuration,
+  and new ZipArchiveEntry.Open overloads with FileAccess and async support.
+  Use when working with zstd-compressed data, configuring advanced compression
+  options, or leveraging the improved ZipArchiveEntry API in .NET 11.
+license: MIT
+---
+
+# System.IO.Compression — Zstandard Support & ZipArchiveEntry Improvements
+
+Target framework: `net11.0`
+
+## Overview
+
+.NET 11 introduces first-class Zstandard (zstd) compression support in
+`System.IO.Compression`. Additionally, `ZipArchiveEntry` gains new methods for
+opening entries with explicit file-access modes and async support.
+
+## New APIs
+
+### ZstandardStream
+
+Stream-based Zstandard compression and decompression. Extends `Stream`.
+
+**Constructors:**
+
+| Signature | Description |
+|-----------|-------------|
+| `ZstandardStream(Stream, CompressionLevel)` | Compress with a standard level |
+| `ZstandardStream(Stream, CompressionLevel, bool leaveOpen)` | Compress, optionally leave base stream open |
+| `ZstandardStream(Stream, CompressionMode)` | Decompress |
+| `ZstandardStream(Stream, CompressionMode, bool leaveOpen)` | Decompress, optionally leave base stream open |
+| `ZstandardStream(Stream, ZstandardCompressionOptions, bool leaveOpen)` | Compress with advanced options |
+| `ZstandardStream(Stream, ZstandardEncoder, bool leaveOpen)` | Compress with a pre-configured encoder |
+| `ZstandardStream(Stream, ZstandardDecoder, bool leaveOpen)` | Decompress with a pre-configured decoder |
+| `ZstandardStream(Stream, ZstandardDictionary, CompressionLevel)` | Compress using a pre-trained dictionary |
+
+**Properties:** `BaseStream`, `CanRead`, `CanWrite`, `CanSeek`
+
+**Methods:** `SetSourceLength(long)` — hint the uncompressed size for better compression.
+
+### ZstandardEncoder
+
+Low-level encoder. Implements `IDisposable`.
+
+**Constructors:**
+
+- `ZstandardEncoder()` — default quality
+- `ZstandardEncoder(int quality)`
+- `ZstandardEncoder(int quality, int windowLog)`
+- `ZstandardEncoder(ZstandardCompressionOptions options)`
+- `ZstandardEncoder(ZstandardDictionary dictionary)`
+
+**Instance methods:** `Compress()`, `Flush()`, `Reset()`, `SetPrefix()`,
+`SetSourceLength()`, `GetMaxCompressedLength()`
+
+**Static methods:** `TryCompress(ReadOnlySpan<byte>, Span<byte>, out int)`
+
+### ZstandardDecoder
+
+Low-level decoder. Implements `IDisposable`.
+
+**Constructors:**
+
+- `ZstandardDecoder()`
+- `ZstandardDecoder(int maxWindowLog)`
+- `ZstandardDecoder(ZstandardDictionary dictionary)`
+- `ZstandardDecoder(ZstandardDictionary dictionary, int maxWindowLog)`
+
+**Instance methods:** `Decompress()`, `Reset()`, `SetPrefix()`
+
+**Static methods:** `TryDecompress(ReadOnlySpan<byte>, Span<byte>, out int)`,
+`TryGetMaxDecompressedLength(ReadOnlySpan<byte>, out long)`
+
+### ZstandardCompressionOptions
+
+Configuration for Zstandard compression.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Quality` | `int` | Compression quality level |
+| `WindowLog` | `int` | Window log size |
+| `EnableLongDistanceMatching` | `bool` | Enable LDM for large inputs |
+| `AppendChecksum` | `bool` | Append integrity checksum |
+| `TargetBlockSize` | `int` | Target block size hint |
+| `Dictionary` | `ZstandardDictionary?` | Pre-trained dictionary |
+
+**Static fields:** `DefaultQuality`, `MinQuality`, `MaxQuality`,
+`DefaultWindowLog`, `MinWindowLog`, `MaxWindowLog`
+
+### ZstandardDictionary
+
+Pre-trained dictionary for improved compression of small, similar payloads.
+Implements `IDisposable`.
+
+| Member | Description |
+|--------|-------------|
+| `Create(ReadOnlySpan<byte>)` | Create from raw dictionary data (static) |
+| `Train(ReadOnlySpan<byte>[], int)` | Train a dictionary from sample data (static) |
+| `Data` | The raw dictionary bytes (property) |
+
+### ZipArchiveEntry Improvements
+
+| Member | Description |
+|--------|-------------|
+| `Open(FileAccess access)` | Open with explicit read or write access |
+| `OpenAsync(FileAccess, CancellationToken)` | Async open with access mode |
+| `CompressionMethod` | Get the `ZipCompressionMethod` used |
+
+### ZipCompressionMethod Enum
+
+| Value | Description |
+|-------|-------------|
+| `Stored` | No compression |
+| `Deflate` | Deflate algorithm |
+| `Deflate64` | Enhanced Deflate |
+
+## Examples
+
+### Basic ZstandardStream Compression and Decompression
+
+```csharp
+using System.IO;
+using System.IO.Compression;
+
+// Compress a file with ZstandardStream
+await using var sourceStream = File.OpenRead("data.bin");
+await using var output = File.Create("data.zst");
+await using (var zstStream = new ZstandardStream(output, CompressionLevel.Optimal))
+{
+    await sourceStream.CopyToAsync(zstStream);
+}
+
+// Decompress a file with ZstandardStream
+await using var input = File.OpenRead("data.zst");
+await using var zstDecompress = new ZstandardStream(input, CompressionMode.Decompress);
+await using var result = new MemoryStream();
+await zstDecompress.CopyToAsync(result);
+Console.WriteLine($"Decompressed {result.Length} bytes");
+```
+
+### Using ZstandardEncoder and ZstandardDecoder Directly
+
+```csharp
+using System.IO.Compression;
+
+byte[] sourceData = File.ReadAllBytes("data.bin");
+
+// Compress with the low-level encoder
+var encoder = new ZstandardEncoder(quality: 3);
+byte[] compressed = new byte[encoder.GetMaxCompressedLength(sourceData.Length)];
+bool ok = ZstandardEncoder.TryCompress(sourceData, compressed, out int written);
+Console.WriteLine($"Compressed {sourceData.Length} → {written} bytes");
+
+// Decompress with the low-level decoder
+byte[] decompressed = new byte[sourceData.Length];
+bool decoded = ZstandardDecoder.TryDecompress(
+    compressed.AsSpan(0, written), decompressed, out int decompressedSize);
+Console.WriteLine($"Decompressed {decompressedSize} bytes");
+```
+
+### Advanced Options and Dictionary Training
+
+```csharp
+using System.IO.Compression;
+
+// Configure advanced compression options
+var options = new ZstandardCompressionOptions
+{
+    Quality = 6,
+    WindowLog = 22,
+    EnableLongDistanceMatching = true,
+    AppendChecksum = true
+};
+
+await using var src = File.OpenRead("large-dataset.bin");
+await using var dst = File.Create("large-dataset.zst");
+await using var zst = new ZstandardStream(dst, options, leaveOpen: false);
+await src.CopyToAsync(zst);
+```
+
+### ZipArchiveEntry New Methods
+
+```csharp
+using System.IO.Compression;
+
+// Inspect and read zip entries with new APIs
+using var archive = ZipFile.OpenRead("archive.zip");
+foreach (var entry in archive.Entries)
+{
+    // Query the compression method
+    Console.WriteLine($"{entry.FullName}: {entry.CompressionMethod}");
+
+    // Open with explicit access mode
+    using var stream = entry.Open(FileAccess.Read);
+    using var reader = new StreamReader(stream);
+    string content = await reader.ReadToEndAsync();
+}
+
+// Async open
+using var archive2 = ZipFile.OpenRead("archive.zip");
+var first = archive2.Entries[0];
+await using var asyncStream = await first.OpenAsync(
+    FileAccess.Read, CancellationToken.None);
+```


### PR DESCRIPTION
## Summary

Building on top of #535 (which introduced the `dotnet11` plugin and the initial `system-text-json-net11` skill), this PR adds 7 additional .NET 11 skills covering new/updated APIs across the framework:

- **aspnetcore-blazor-components-net11** — New .NET 11 APIs across Microsoft.AspNetCore.Components, Components.Web, and Components.Endpoints
- **aspnetcore-middleware-services-net11** — New .NET 11 APIs for ASP.NET Core middleware and services (zero-allocation data protection, etc.)
- **dotnet-networking-net11** — New .NET 11 APIs in System.Net.Sockets and System.Net.Primitives
- **dotnet-numerics-memory-net11** — New .NET 11 APIs in System.Memory and System.Runtime.Numerics for BFloat16 data pipelines
- **dotnet-runtime-core-net11** — New .NET 11 APIs in System.Runtime and System.Runtime.InteropServices
- **dotnet-security-cryptography-net11** — New .NET 11 APIs in System.Security.Cryptography and System.Security.Cryptography.Pkcs
- **system-io-compression-net11** — New Zstandard (zstd) compression APIs and ZipArchiveEntry improvements

## Attribution

These skills were contributed by @ManishJayaswal.