### PR TITLE
Isolate failures during eval and judging

### DIFF
--- a/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
@@ -453,7 +453,19 @@ public static class EvaluateCommand
         using var scenarioLimit = new ConcurrencyLimiter(effectiveParallelScenarios);
 
         var scenarioTasks = target.EvalConfig.Scenarios.Select(scenario =>
-            scenarioLimit.RunAsync(() => ExecuteAgentScenario(scenario, target, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, targetSha, cancellationToken), cancellationToken));
+            scenarioLimit.RunAsync(async () =>
+            {
+                try
+                {
+                    return await ExecuteAgentScenario(scenario, target, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, targetSha, cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    var tag = singleScenario ? $"[{agent.Name}]" : $"[{agent.Name}/{scenario.Name}]";
+                    spinner.Log($"{tag} {Ansi.Yellow}⚠️  Scenario failed: {SanitizeErrorMessage(ex.Message)}{Ansi.Reset}");
+                    return CreateFailedScenarioComparison(scenario.Name, SanitizeErrorMessage(ex.Message));
+                }
+            }, cancellationToken));
         var comparisons = (await Task.WhenAll(scenarioTasks)).ToList();
 
         var verdict = Comparator.ComputeVerdict(
@@ -519,10 +531,27 @@ public static class EvaluateCommand
             scenarioLog("📋 Starting scenario");
 
         var runTasks = Enumerable.Range(0, config.Runs).Select(i =>
-            runLimit.RunAsync(() => ExecuteAgentRun(i, scenario, target, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, targetSha, cancellationToken), cancellationToken));
-        var runResults = await Task.WhenAll(runTasks);
+            runLimit.RunAsync(async () =>
+            {
+                try
+                {
+                    return (Result: await ExecuteAgentRun(i, scenario, target, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, targetSha, cancellationToken), Error: (Exception?)null);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    scenarioLog($"{Ansi.Yellow}⚠️  Run {i + 1} failed: {SanitizeErrorMessage(ex.Message)}{Ansi.Reset}");
+                    return (Result: (RunExecutionResult?)null, Error: ex);
+                }
+            }, cancellationToken));
+        var settledRuns = await Task.WhenAll(runTasks);
+        var runResults = settledRuns.Where(s => s.Result is not null).Select(s => s.Result!).ToArray();
+        var failedRunCount = settledRuns.Count(s => s.Error is not null);
+        if (failedRunCount > 0)
+            scenarioLog($"{Ansi.Yellow}⚠️  {failedRunCount}/{config.Runs} run(s) failed{Ansi.Reset}");
+        if (runResults.Length == 0)
+            throw new InvalidOperationException($"All {config.Runs} run(s) failed for scenario '{scenario.Name}'");
 
-        scenarioLog($"✓ All {config.Runs} run(s) complete");
+        scenarioLog($"✓ {runResults.Length}/{config.Runs} run(s) complete");
 
         var baselineRuns = runResults.Select(r => r.Baseline).ToList();
         var isolatedRuns = runResults.Select(r => r.SkilledIsolated).ToList();
@@ -862,7 +891,19 @@ public static class EvaluateCommand
         using var scenarioLimit = new ConcurrencyLimiter(effectiveParallelScenarios);
 
         var scenarioTasks = evalSkill.EvalConfig.Scenarios.Select(scenario =>
-            scenarioLimit.RunAsync(() => ExecuteScenario(scenario, evalSkill, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, skillSha, cancellationToken), cancellationToken));
+            scenarioLimit.RunAsync(async () =>
+            {
+                try
+                {
+                    return await ExecuteScenario(scenario, evalSkill, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, skillSha, cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    var tag = singleScenario ? $"[{skill.Name}]" : $"[{skill.Name}/{scenario.Name}]";
+                    spinner.Log($"{tag} {Ansi.Yellow}⚠️  Scenario failed: {SanitizeErrorMessage(ex.Message)}{Ansi.Reset}");
+                    return CreateFailedScenarioComparison(scenario.Name, SanitizeErrorMessage(ex.Message));
+                }
+            }, cancellationToken));
         var comparisons = (await Task.WhenAll(scenarioTasks)).ToList();
 
         // Await overfitting result (non-fatal — never blocks an otherwise-successful evaluation)
@@ -962,10 +1003,27 @@ public static class EvaluateCommand
             scenarioLog("📋 Starting scenario");
 
         var runTasks = Enumerable.Range(0, config.Runs).Select(i =>
-            runLimit.RunAsync(() => ExecuteRun(i, scenario, evalSkill, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, skillSha, cancellationToken), cancellationToken));
-        var runResults = await Task.WhenAll(runTasks);
+            runLimit.RunAsync(async () =>
+            {
+                try
+                {
+                    return (Result: await ExecuteRun(i, scenario, evalSkill, config, usePairwise, singleScenario, spinner, sessionsDir, sessionDb, skillSha, cancellationToken), Error: (Exception?)null);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    scenarioLog($"{Ansi.Yellow}⚠️  Run {i + 1} failed: {SanitizeErrorMessage(ex.Message)}{Ansi.Reset}");
+                    return (Result: (RunExecutionResult?)null, Error: ex);
+                }
+            }, cancellationToken));
+        var settledRuns = await Task.WhenAll(runTasks);
+        var runResults = settledRuns.Where(s => s.Result is not null).Select(s => s.Result!).ToArray();
+        var failedRunCount = settledRuns.Count(s => s.Error is not null);
+        if (failedRunCount > 0)
+            scenarioLog($"{Ansi.Yellow}⚠️  {failedRunCount}/{config.Runs} run(s) failed{Ansi.Reset}");
+        if (runResults.Length == 0)
+            throw new InvalidOperationException($"All {config.Runs} run(s) failed for scenario '{scenario.Name}'");
 
-        scenarioLog($"✓ All {config.Runs} run(s) complete");
+        scenarioLog($"✓ {runResults.Length}/{config.Runs} run(s) complete");
 
         var baselineRuns = runResults.Select(r => r.Baseline).ToList();
         var isolatedRuns = runResults.Select(r => r.SkilledIsolated).ToList();
@@ -1592,6 +1650,28 @@ public static class EvaluateCommand
         var raw = message ?? "unknown error";
         var singleLine = raw.ReplaceLineEndings(" ");
         return singleLine.Length > 150 ? singleLine[..150] + "…" : singleLine;
+    }
+
+    /// <summary>
+    /// Creates a degraded ScenarioComparison for a scenario that failed with an exception.
+    /// This allows the evaluation to continue with other scenarios instead of aborting.
+    /// </summary>
+    private static ScenarioComparison CreateFailedScenarioComparison(string scenarioName, string errorMessage)
+    {
+        var emptyMetrics = new RunMetrics { ErrorCount = 1 };
+        var emptyJudge = new JudgeResult([], 0, $"Scenario failed: {errorMessage}");
+        var emptyResult = new RunResult(emptyMetrics, emptyJudge);
+        var emptyBreakdown = new MetricBreakdown(0, 0, 0, 0, 0, 0, 0);
+        return new ScenarioComparison
+        {
+            ScenarioName = scenarioName,
+            Baseline = emptyResult,
+            SkilledIsolated = emptyResult,
+            SkilledPlugin = emptyResult,
+            ImprovementScore = 0,
+            Breakdown = emptyBreakdown,
+            TimedOut = true,
+        };
     }
 
     /// <summary>

--- a/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
@@ -650,6 +650,7 @@ public static class EvaluateCommand
         comparison.TimedOut = runResults.Any(r =>
             r.Baseline.Metrics.TimedOut || r.SkilledIsolated.Metrics.TimedOut || r.SkilledPlugin.Metrics.TimedOut);
         comparison.ExpectActivation = scenario.ExpectActivation;
+        comparison.FailedRunCount = failedRunCount;
 
         return comparison;
     }
@@ -1135,6 +1136,7 @@ public static class EvaluateCommand
         // Propagate timeout and expect_activation from scenario config
         comparison.TimeoutSeconds = scenario.Timeout;
         comparison.ExpectActivation = scenario.ExpectActivation;
+        comparison.FailedRunCount = failedRunCount;
 
         return comparison;
     }
@@ -1656,7 +1658,7 @@ public static class EvaluateCommand
     /// Creates a degraded ScenarioComparison for a scenario that failed with an exception.
     /// This allows the evaluation to continue with other scenarios instead of aborting.
     /// </summary>
-    private static ScenarioComparison CreateFailedScenarioComparison(string scenarioName, string errorMessage)
+    internal static ScenarioComparison CreateFailedScenarioComparison(string scenarioName, string errorMessage)
     {
         var emptyMetrics = new RunMetrics { ErrorCount = 1 };
         var emptyJudge = new JudgeResult([], 0, $"Scenario failed: {errorMessage}");
@@ -1670,7 +1672,7 @@ public static class EvaluateCommand
             SkilledPlugin = emptyResult,
             ImprovementScore = 0,
             Breakdown = emptyBreakdown,
-            TimedOut = true,
+            ExecutionError = errorMessage,
         };
     }
 

--- a/eng/skill-validator/src/Evaluate/Models.cs
+++ b/eng/skill-validator/src/Evaluate/Models.cs
@@ -293,6 +293,10 @@ public sealed class ScenarioComparison
     public int? TimeoutSeconds { get; set; }
     /// <summary>When false, non-activation is expected (negative test) and should not flag the verdict.</summary>
     public bool ExpectActivation { get; set; } = true;
+    /// <summary>Number of individual runs that failed with exceptions and were excluded from aggregation.</summary>
+    public int FailedRunCount { get; set; }
+    /// <summary>Non-null when the entire scenario failed with an execution error (not a timeout).</summary>
+    public string? ExecutionError { get; set; }
 
     // Backward-compatible aliases for JSON deserialization of older results files.
     [JsonPropertyName("withSkill")]

--- a/eng/skill-validator/tests/Evaluate/FailureIsolationTests.cs
+++ b/eng/skill-validator/tests/Evaluate/FailureIsolationTests.cs
@@ -1,0 +1,130 @@
+using SkillValidator.Evaluate;
+using SkillValidator.Shared;
+
+namespace SkillValidator.Tests;
+
+public class FailureIsolationTests
+{
+    private static readonly SkillInfo MockSkill = new(
+        Name: "test-skill",
+        Description: "A test skill",
+        Path: "/test",
+        SkillMdPath: "/test/SKILL.md",
+        SkillMdContent: "# Test");
+
+    [Fact]
+    public void CreateFailedScenarioComparison_SetsExecutionError()
+    {
+        var result = EvaluateCommand.CreateFailedScenarioComparison("test-scenario", "Something went wrong");
+
+        Assert.Equal("test-scenario", result.ScenarioName);
+        Assert.Equal("Something went wrong", result.ExecutionError);
+    }
+
+    [Fact]
+    public void CreateFailedScenarioComparison_DoesNotSetTimedOut()
+    {
+        var result = EvaluateCommand.CreateFailedScenarioComparison("test-scenario", "OOM killed");
+
+        Assert.False(result.TimedOut);
+    }
+
+    [Fact]
+    public void CreateFailedScenarioComparison_SetsZeroImprovementScore()
+    {
+        var result = EvaluateCommand.CreateFailedScenarioComparison("test-scenario", "error");
+
+        Assert.Equal(0, result.ImprovementScore);
+        Assert.Equal(0, result.Breakdown.QualityImprovement);
+        Assert.Equal(0, result.Breakdown.TokenReduction);
+    }
+
+    [Fact]
+    public void CreateFailedScenarioComparison_HasNonNullRunResults()
+    {
+        var result = EvaluateCommand.CreateFailedScenarioComparison("test-scenario", "error");
+
+        Assert.NotNull(result.Baseline);
+        Assert.NotNull(result.SkilledIsolated);
+        Assert.NotNull(result.SkilledPlugin);
+        Assert.Equal(1, result.Baseline.Metrics.ErrorCount);
+    }
+
+    [Fact]
+    public void FailedScenario_ProducesFailedVerdict()
+    {
+        var failed = EvaluateCommand.CreateFailedScenarioComparison("scenario-1", "Runner OOM killed");
+
+        var verdict = Comparator.ComputeVerdict(MockSkill, [failed], 0.1, true);
+
+        Assert.False(verdict.Passed);
+    }
+
+    [Fact]
+    public void FailedScenario_MixedWithSuccessful_StillProducesVerdict()
+    {
+        var baseline = new RunResult(
+            new RunMetrics
+            {
+                TokenEstimate = 1000,
+                ToolCallCount = 10,
+                ToolCallBreakdown = new Dictionary<string, int> { ["bash"] = 5 },
+                TurnCount = 5,
+                WallTimeMs = 10000,
+                AgentOutput = "output",
+                Events = [],
+            },
+            new JudgeResult([new RubricScore("Q", 3, "")], 3, "OK"));
+
+        var withSkill = new RunResult(
+            new RunMetrics
+            {
+                TokenEstimate = 500,
+                ToolCallCount = 5,
+                ToolCallBreakdown = new Dictionary<string, int> { ["bash"] = 3 },
+                TurnCount = 3,
+                WallTimeMs = 5000,
+                TaskCompleted = true,
+                AgentOutput = "better output",
+                Events = [],
+            },
+            new JudgeResult([new RubricScore("Q", 5, "")], 5, "Great"));
+
+        var successScenario = Comparator.CompareScenario("good-scenario", baseline, withSkill);
+        var failedScenario = EvaluateCommand.CreateFailedScenarioComparison("bad-scenario", "Exception thrown");
+
+        // Verdict should still be computed (not throw) when mixing failed + successful scenarios
+        var verdict = Comparator.ComputeVerdict(MockSkill, [successScenario, failedScenario], 0.1, true);
+
+        Assert.NotNull(verdict);
+        Assert.Equal(2, verdict.Scenarios.Count);
+    }
+
+    [Fact]
+    public void FailedRunCount_DefaultsToZero()
+    {
+        var baseline = new RunResult(
+            new RunMetrics
+            {
+                TokenEstimate = 1000,
+                ToolCallCount = 10,
+                ToolCallBreakdown = new Dictionary<string, int> { ["bash"] = 5 },
+                TurnCount = 5,
+                WallTimeMs = 10000,
+                AgentOutput = "output",
+                Events = [],
+            },
+            new JudgeResult([new RubricScore("Q", 3, "")], 3, "OK"));
+
+        var comparison = Comparator.CompareScenario("test", baseline, baseline);
+        Assert.Equal(0, comparison.FailedRunCount);
+    }
+
+    [Fact]
+    public void FailedScenarioComparison_HasZeroFailedRunCount()
+    {
+        // A scenario-level failure is different from run-level failures
+        var result = EvaluateCommand.CreateFailedScenarioComparison("test", "error");
+        Assert.Equal(0, result.FailedRunCount);
+    }
+}


### PR DESCRIPTION
### Context

We missed daily evaluation on May/1 - May/4
The rootcause analysis: https://github.com/dotnet/skills/issues/288#issuecomment-4357877597

### Fix

Isolating failures during eval and judging - to impact only the evaluated scenario