### PR TITLE
Fix triage workflow: separate label and assignee operations

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"34f923b1251dd1f8ecdc6859d8e23b716ffce2b9c0192de82e4193807110ee75","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9d84acbe670b15f0fad28982b52f35846f4011624de9f33d043a8e7876122da7","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -204,16 +204,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9059e2e0bc40a859_EOF'
+          cat << 'GH_AW_PROMPT_3b73926d56558ce4_EOF'
           <system>
-          GH_AW_PROMPT_9059e2e0bc40a859_EOF
+          GH_AW_PROMPT_3b73926d56558ce4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9059e2e0bc40a859_EOF'
+          cat << 'GH_AW_PROMPT_3b73926d56558ce4_EOF'
           <safe-output-tools>
-          Tools: add_comment, update_issue, add_labels(max:5), missing_tool, missing_data, noop
+          Tools: add_comment, update_issue(max:2), add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -243,12 +243,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9059e2e0bc40a859_EOF
+          GH_AW_PROMPT_3b73926d56558ce4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9059e2e0bc40a859_EOF'
+          cat << 'GH_AW_PROMPT_3b73926d56558ce4_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_9059e2e0bc40a859_EOF
+          GH_AW_PROMPT_3b73926d56558ce4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -416,9 +416,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7d3605807752c6a3_EOF'
-          {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7d3605807752c6a3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3b39a0ac5851b90_EOF'
+          {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":2,"target":"*"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_a3b39a0ac5851b90_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -426,7 +426,7 @@ jobs:
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
                 "add_labels": " CONSTRAINTS: Maximum 5 label(s) can be added.",
-                "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *."
+                "update_issue": " CONSTRAINTS: Maximum 2 issue(s) can be updated. Target: *."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -673,7 +673,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_b0feae974faa66ab_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_679f0355f30b09bf_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -714,7 +714,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b0feae974faa66ab_EOF
+          GH_AW_MCP_CONFIG_679f0355f30b09bf_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1317,7 +1317,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"max\":5},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"max\":5},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":2,\"target\":\"*\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -75,7 +75,7 @@ safe-outputs:
     max: 5
   update-issue:
     target: "*"
-    max: 1
+    max: 2
   add-comment:
     max: 1
 
@@ -93,6 +93,8 @@ You are a triage assistant for the dotnet/skills GitHub repository. Your task is
 ## Target Issue
 
 Triage issue number: `${{ github.event.issue.number || inputs.issue_number }}`
+
+**Important — workflow_dispatch context:** When this workflow is triggered via `workflow_dispatch`, there is no triggering issue context. You MUST pass `issue_number` (for `update_issue`) or `item_number` (for `add_labels` and `add_comment`) explicitly in every safe-output tool call. Use the issue number from the Target Issue above.
 
 ## Step 1: Retrieve Issue Content
 
@@ -153,7 +155,9 @@ Using the CODEOWNERS file, determine the most appropriate owners for the issue b
 4. If the issue is general or cross-cutting, use the default owners from the `*` rule
 5. If you cannot confidently determine owners, add the `needs-manual-assignment` label instead of assigning
 
-Use the `update_issue` tool to **directly assign** the determined owners to the issue. If a user cannot be assigned (e.g., teams cannot be set as assignees), mention them in the triage comment instead.
+Use the `update_issue` tool to **directly assign** the determined owners to the issue by setting the `assignees` field. **Only set assignees in this call — do NOT set labels here.** Labels are handled separately in Step 6 using the `add_labels` tool.
+
+If a user cannot be assigned (e.g., teams cannot be set as assignees), mention them in the triage comment instead.
 
 ## Step 5: Determine Issue Type
 
@@ -167,7 +171,9 @@ If the type is ambiguous, make your best judgment. You must always assign exactl
 
 ## Step 6: Apply Labels
 
-Use the `update_issue` tool to apply labels to the issue:
+Use the `add_labels` tool (NOT `update_issue`) to apply labels to the issue. The `add_labels` tool is additive — it does not remove existing labels.
+
+Add the following labels:
 - The determined `area-*` label (if one was determined)
 - The issue type label (`bug`, `enhancement`, `task`, or `question`)
 - The `Triaged` label

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -155,7 +155,7 @@ Using the CODEOWNERS file, determine the most appropriate owners for the issue b
 4. If the issue is general or cross-cutting, use the default owners from the `*` rule
 5. If you cannot confidently determine owners, add the `needs-manual-assignment` label instead of assigning
 
-Use the `update_issue` tool to **directly assign** the determined owners to the issue by setting the `assignees` field. **Only set assignees in this call — do NOT set labels here.** Labels are handled separately in Step 6 using the `add_labels` tool.
+Use the `update_issue` tool to **directly assign** the determined owners to the issue by setting the `assignees` field. To satisfy tool validation, include a no-op `title` field set to the issue's current title fetched in Step 1, unchanged. **Do NOT set labels in this call.** Labels are handled separately in Step 6 using the `add_labels` tool.
 
 If a user cannot be assigned (e.g., teams cannot be set as assignees), mention them in the triage comment instead.
 


### PR DESCRIPTION
## Problem

The triage workflow has two issues observed from production runs:

### 1. Assignees not being set
The prompt instructs the agent to use update_issue for both assignees (Step 4) and labels (Step 6), but update_issue max 1 only allows one call. The agent uses its single call for labels and just mentions owners in the triage comment text without actually assigning them.

Evidence: Issue 562 triage comment says Assigned owners but the issue has no assignees.

### 2. workflow_dispatch runs failing
Run 25439049715 emitted report_incomplete because the agent got confused when triaging via workflow_dispatch (no triggering issue context).

## Fix

1. Separate label and assignee operations: Step 4 uses update_issue with assignees only. Step 6 uses add_labels tool.
2. Increase update_issue max to 2 for flexibility.
3. Add explicit workflow_dispatch guidance at the top: agent MUST pass issue_number/item_number on all safe-output calls.

## aw Issues
- 616: Caused by the report_incomplete from the workflow_dispatch run. This fix addresses the root cause.
- 620: Normal gh-aw framework behavior (no-op tracking issue). Not a bug.
- 625: Unrelated (different workflow - DevOps Health).
