### PR TITLE
Update .NET 10→11 migration skill for Preview 2 and 3

### DIFF
--- a/eng/known-domains.txt
+++ b/eng/known-domains.txt
@@ -30,6 +30,7 @@ developer.android.com
 developer.apple.com
 
 # Repos
+github.com/dotnet/aspnetcore
 github.com/dotnet/csharplang
 github.com/dotnet/diagnostics
 github.com/dotnet/dotnet

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/SKILL.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/SKILL.md
@@ -11,7 +11,7 @@ description: >
   Dockerfiles for .NET 11.
   DO NOT USE FOR: .NET Framework migrations, upgrading from .NET 9 or earlier,
   greenfield .NET 11 projects, or cosmetic modernization unrelated to the upgrade.
-  NOTE: .NET 11 is in preview. Covers breaking changes through Preview 1.
+  NOTE: .NET 11 is in preview. Covers breaking changes through Preview 3.
 license: MIT
 ---
 
@@ -19,7 +19,7 @@ license: MIT
 
 Migrate a .NET 10 project or solution to .NET 11, systematically resolving all breaking changes. The outcome is a project targeting `net11.0` that builds cleanly, passes tests, and accounts for every behavioral, source-incompatible, and binary-incompatible change introduced in .NET 11.
 
-> **Note:** .NET 11 is currently in preview. This skill covers breaking changes documented through Preview 1. It will be updated as additional previews ship.
+> **Note:** .NET 11 is currently in preview. This skill covers breaking changes documented through Preview 3.
 
 ## When to Use
 
@@ -59,10 +59,14 @@ Migrate a .NET 10 project or solution to .NET 11, systematically resolving all b
    - **SDK attribute**: `Microsoft.NET.Sdk.Web` → ASP.NET Core; `Microsoft.NET.Sdk.WindowsDesktop` with `<UseWPF>` or `<UseWindowsForms>` → WPF/WinForms
    - **PackageReferences**: `Microsoft.EntityFrameworkCore.*` → EF Core; `Microsoft.EntityFrameworkCore.Cosmos` → Cosmos DB provider
    - **Dockerfile presence** → Container changes relevant
-   - **Cryptography API usage** → DSA on macOS affected
+   - **Cryptography API usage** → DSA on macOS affected; AIA cert download changes relevant
    - **Compression API usage** → DeflateStream/GZipStream/ZipArchive changes relevant
-   - **TAR API usage** → Header checksum validation change relevant
+   - **TAR API usage** → Header checksum validation and HardLink entry changes relevant
    - **`NamedPipeClientStream` usage with `SafePipeHandle`** → SYSLIB0063 constructor obsoletion relevant
+   - **`BackgroundService` usage** → Unhandled exceptions now stop the host
+   - **`Microsoft.OpenApi` direct usage** → v3 API breaking changes in ASP.NET Core OpenAPI
+   - **EF Core SQL Server with Entra ID auth** → SqlClient 7.0 auth dependency changes
+   - **NativeAOT native libraries on Unix** → Output filename prefix changed
 4. Record which reference documents are relevant (see the reference loading table in Step 3).
 5. Do a **clean build** (`dotnet build --no-incremental` or delete `bin`/`obj`) on the current `net10.0` target to establish a clean baseline. Record any pre-existing warnings.
 
@@ -93,9 +97,10 @@ Load reference documents based on the project's technology areas:
 | `references/csharp-compiler-dotnet10to11.md` | Always (C# 15 compiler breaking changes) |
 | `references/core-libraries-dotnet10to11.md` | Always (applies to all .NET 11 projects) |
 | `references/sdk-msbuild-dotnet10to11.md` | Always (SDK and build tooling changes) |
-| `references/efcore-dotnet10to11.md` | Project uses Entity Framework Core (especially Cosmos DB provider) |
-| `references/cryptography-dotnet10to11.md` | Project uses cryptography APIs or targets macOS |
-| `references/runtime-jit-dotnet10to11.md` | Deploying to older hardware or embedded devices |
+| `references/aspnetcore-dotnet10to11.md` | Project uses ASP.NET Core (OpenAPI, Blazor) |
+| `references/efcore-dotnet10to11.md` | Project uses Entity Framework Core |
+| `references/cryptography-dotnet10to11.md` | Project uses cryptography APIs, mTLS, or targets macOS |
+| `references/runtime-jit-dotnet10to11.md` | Deploying to older hardware, embedded devices, or using NativeAOT |
 
 Work through each build error systematically. Common patterns:
 
@@ -114,6 +119,12 @@ Work through each build error systematically. Common patterns:
 7. **SYSLIB0063: `NamedPipeClientStream` `isConnected` parameter obsoleted** — The constructor overload taking `bool isConnected` is obsoleted. Remove the `isConnected` argument and use the new 3-parameter constructor. Projects with `TreatWarningsAsErrors` will fail to build.
 
 8. **`when` switch-expression-arm parsing** — `(X.Y) when` is now parsed as a constant pattern with a `when` clause instead of a cast expression, which can cause existing code to fail to compile or change meaning. Review switch expressions using `when` and adjust syntax as needed.
+
+9. **Microsoft.OpenApi v3 breaking changes** — `Microsoft.AspNetCore.OpenApi` now depends on `Microsoft.OpenApi` 3.x. Code using `Microsoft.OpenApi` types directly (`OpenApiDocument`, `OpenApiSchema`, etc.) will have compile errors. Follow the v3 upgrade guide.
+
+10. **EF Core Design package no longer transitive** — `Microsoft.EntityFrameworkCore.Tools` and `.Tasks` no longer depend on `.Design`. Add an explicit `PackageReference` if needed.
+
+11. **EFOptimizeContext MSBuild property removed** — Replace with `<EFScaffoldModelStage>` and `<EFPrecompileQueriesStage>`.
 
 ### Step 4: Address behavioral changes
 
@@ -137,6 +148,24 @@ These changes compile successfully but alter runtime behavior. Review each one a
 
 9. **Mono launch target for .NET Framework** — No longer set automatically. If using Mono for .NET Framework apps on Linux, specify explicitly.
 
+10. **Unhandled BackgroundService exceptions stop the host** — Exceptions from `ExecuteAsync()` now propagate and crash the host. Add try/catch in background services that should not bring down the application.
+
+11. **ZipArchive CRC32 validation** — ZIP reads now validate CRC32 checksums. Corrupt or truncated archives that previously succeeded will now throw `InvalidDataException`.
+
+12. **TarWriter emits HardLink entries** — Hard-linked files are now written as `HardLink` entries instead of duplicated data. Consumers of .NET-produced tar archives must handle `HardLink` entries.
+
+13. **AIA certificate downloads disabled** — Server-side client-certificate validation no longer downloads intermediate CAs via AIA by default. Pre-install the full chain or have clients send intermediates.
+
+14. **Blazor Virtualize OverscanCount default changed** — Default `OverscanCount` changed from 3 to 15. Set explicitly if performance-sensitive.
+
+15. **Microsoft.Data.SqlClient 7.0 — Entra ID auth separated** — Azure/Entra ID authentication dependencies removed from the core SqlClient package. Add `Microsoft.Data.SqlClient.Extensions.Azure` if using Entra ID auth.
+
+16. **SqlVector&lt;T&gt; excluded from SELECT** — Vector properties are no longer auto-loaded. Use explicit projections to include vector values.
+
+17. **SQLitePCLRaw encryption bundles removed** — `bundle_e_sqlcipher` and other encryption bundle packages removed in SQLitePCLRaw 3.0.
+
+18. **NativeAOT Unix native library `lib` prefix** — Output filenames now include `lib` prefix on Linux/macOS (e.g., `libMyLib.so`).
+
 ### Step 5: Update infrastructure
 
 1. **Dockerfiles**: Update base images from 10.0 to 11.0:
@@ -155,7 +184,7 @@ These changes compile successfully but alter runtime behavior. Review each one a
       "sdk": {
    -    "version": "10.0.100",
    -    "rollForward": "latestFeature"
-   +    "version": "11.0.100-preview.1",
+   +    "version": "11.0.100-preview.3",
    +    "rollForward": "latestFeature"
       },
       "otherSettings": {
@@ -173,11 +202,15 @@ These changes compile successfully but alter runtime behavior. Review each one a
 3. If the application is containerized, build and test the container image
 4. Smoke-test the application, paying special attention to:
    - Compression behavior with empty streams
-   - TAR file reading
+   - TAR file reading (checksum validation and HardLink entries)
    - EF Core Cosmos DB operations (must be async)
    - DSA usage on macOS
    - Memory-intensive MemoryStream usage
    - Span collection expression assignments
+   - BackgroundService exception handling
+   - mTLS / client certificate chain validation
+   - EF Core SQL Server with Entra ID authentication
+   - NativeAOT output filenames on Unix
 5. Review the diff and ensure no unintended behavioral changes were introduced
 
 ## Reference Documents
@@ -189,6 +222,7 @@ The `references/` folder contains detailed breaking change information organized
 | `references/csharp-compiler-dotnet10to11.md` | Always (C# 15 compiler breaking changes) |
 | `references/core-libraries-dotnet10to11.md` | Always (applies to all .NET 11 projects) |
 | `references/sdk-msbuild-dotnet10to11.md` | Always (SDK and build tooling changes) |
-| `references/efcore-dotnet10to11.md` | Project uses Entity Framework Core (especially Cosmos DB provider) |
-| `references/cryptography-dotnet10to11.md` | Project uses cryptography APIs or targets macOS |
-| `references/runtime-jit-dotnet10to11.md` | Deploying to older hardware or embedded devices |
+| `references/aspnetcore-dotnet10to11.md` | Project uses ASP.NET Core (OpenAPI, Blazor) |
+| `references/efcore-dotnet10to11.md` | Project uses Entity Framework Core |
+| `references/cryptography-dotnet10to11.md` | Project uses cryptography APIs, mTLS, or targets macOS |
+| `references/runtime-jit-dotnet10to11.md` | Deploying to older hardware, embedded devices, or using NativeAOT |

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/aspnetcore-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/aspnetcore-dotnet10to11.md
@@ -22,6 +22,6 @@ Source: https://github.com/dotnet/aspnetcore/pull/65415
 
 **Impact: Low.** The default `OverscanCount` on the `Virtualize<TItem>` component changed from `3` to `15` to support variable-height item measurement. `QuickGrid` retains its own default of `3`.
 
-**Fix:** If performance-sensitive, set `OverscanCount` explicitly: `<Virtualize OverscanCount="3" ...>`.
+**Fix:** If performance-sensitive, set `OverscanCount` explicitly: `<Virtualize OverscanCount="3" />`.
 
 Source: https://github.com/dotnet/aspnetcore/pull/64964

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/aspnetcore-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/aspnetcore-dotnet10to11.md
@@ -1,0 +1,27 @@
+# ASP.NET Core Breaking Changes (.NET 11)
+
+These breaking changes affect ASP.NET Core projects. Source: https://learn.microsoft.com/en-us/dotnet/core/compatibility/11
+
+> **Note:** .NET 11 is in preview. Additional ASP.NET Core breaking changes are expected in later previews.
+
+## Source-Incompatible Changes
+
+### Microsoft.OpenApi updated to v3 with OpenAPI 3.2.0 support (Preview 2)
+
+**Impact: Medium.** `Microsoft.AspNetCore.OpenApi` updated its dependency from `Microsoft.OpenApi` 2.x to 3.x, adding OpenAPI 3.2.0 document generation. The underlying `Microsoft.OpenApi` library has breaking API changes in the v2→v3 transition.
+
+Code that directly uses `Microsoft.OpenApi` types (`OpenApiDocument`, `OpenApiSchema`, `OpenApiOperation`, etc.) will have compile errors.
+
+**Fix:** Follow the [Microsoft.OpenApi v3 upgrade guide](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-3.md). If you only use the ASP.NET Core OpenAPI integration (`.WithOpenApi()`, `MapOpenApi()`) without touching the object model directly, no changes are needed.
+
+Source: https://github.com/dotnet/aspnetcore/pull/65415
+
+## Behavioral Changes
+
+### Blazor Virtualize&lt;T&gt; default OverscanCount changed from 3 to 15 (Preview 3)
+
+**Impact: Low.** The default `OverscanCount` on the `Virtualize<TItem>` component changed from `3` to `15` to support variable-height item measurement. `QuickGrid` retains its own default of `3`.
+
+**Fix:** If performance-sensitive, set `OverscanCount` explicitly: `<Virtualize OverscanCount="3" ...>`.
+
+Source: https://github.com/dotnet/aspnetcore/pull/64964

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/core-libraries-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/core-libraries-dotnet10to11.md
@@ -85,3 +85,55 @@ Source: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-librari
 **Impact: Low.** The minimum supported date for the Japanese Calendar has been corrected. Code using very early dates in the Japanese Calendar may be affected.
 
 Source: https://learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/11/japanese-calendar-min-date
+
+### ZipArchive now validates CRC32 when reading entries (Preview 3)
+
+**Impact: Low–Medium.** ZIP archive reads now validate the CRC32 checksum of each entry. Previously, corrupt or truncated archives were silently accepted; they now throw `InvalidDataException`.
+
+**Fix:** Ensure ZIP files are not corrupted. If processing partially-written or legacy archives, add error handling for `InvalidDataException`.
+
+Source: https://github.com/dotnet/runtime/pull/124766
+
+### Unhandled BackgroundService exceptions now stop the host (Preview 3)
+
+**Impact: Medium.** Unhandled exceptions thrown from `BackgroundService.ExecuteAsync()` now propagate and stop the host application. Previously they were silently swallowed.
+
+```csharp
+// .NET 10: exception silently swallowed, host continues
+// .NET 11: exception propagates, host stops
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    throw new InvalidOperationException("oops"); // now kills the host
+}
+
+// FIX: Add proper exception handling
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    try
+    {
+        // ... work ...
+    }
+    catch (Exception ex) when (ex is not OperationCanceledException)
+    {
+        _logger.LogError(ex, "Background service failed");
+    }
+}
+```
+
+**Fix:** Add try/catch in `ExecuteAsync()` for any `BackgroundService` that should not crash the host on failure.
+
+Source: https://github.com/dotnet/runtime/pull/124863
+
+### TarWriter emits HardLink entries for hard-linked files (Preview 3)
+
+**Impact: Low.** When `TarWriter` archives a directory containing hard links, the same inode encountered more than once is now written as a `HardLink` entry pointing back to the first occurrence, rather than duplicating the file data.
+
+**Fix:** If consuming tar archives produced by .NET code, ensure the reader handles `HardLink` entry types.
+
+Source: https://github.com/dotnet/runtime/pull/123874
+
+### Zstandard APIs moved from preview package to System.IO.Compression (Preview 3)
+
+**Impact: Low.** `ZstandardStream` and related APIs that were previously in the `System.IO.Compression.Zstandard` preview NuGet package are now in-box in `System.IO.Compression`.
+
+**Fix:** Remove the `<PackageReference Include="System.IO.Compression.Zstandard" />` preview package if present. The APIs are now available without any additional package reference.

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/core-libraries-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/core-libraries-dotnet10to11.md
@@ -137,3 +137,5 @@ Source: https://github.com/dotnet/runtime/pull/123874
 **Impact: Low.** `ZstandardStream` and related APIs that were previously in the `System.IO.Compression.Zstandard` preview NuGet package are now in-box in `System.IO.Compression`.
 
 **Fix:** Remove the `<PackageReference Include="System.IO.Compression.Zstandard" />` preview package if present. The APIs are now available without any additional package reference.
+
+Source: https://github.com/dotnet/runtime/pull/114545

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/cryptography-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/cryptography-dotnet10to11.md
@@ -26,3 +26,14 @@ var signature = ecdsa.SignData(data, HashAlgorithmName.SHA256);
 - **Ed25519** — if available in your scenario
 
 This change only affects macOS. DSA continues to work on Windows and Linux (though it is generally considered a legacy algorithm).
+
+### AIA certificate downloads disabled by default during client-certificate validation (Preview 3)
+
+**Impact: Medium.** AIA (Authority Information Access) certificate downloads are now disabled by default when performing server-side client-certificate chain validation. Previously the runtime would attempt to fetch intermediate CA certificates online.
+
+**Fix:** If using mTLS where client certificates rely on AIA URLs for intermediate CAs, either:
+- Pre-install the full certificate chain on the server
+- Have clients send the full chain including intermediates
+- Re-enable AIA downloads via `X509ChainPolicy.DisableCertificateDownloads = false`
+
+Source: https://github.com/dotnet/runtime/pull/125049

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/efcore-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/efcore-dotnet10to11.md
@@ -2,7 +2,7 @@
 
 These breaking changes affect projects using Entity Framework Core 11. Source: https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-11.0/breaking-changes
 
-> **Note:** .NET 11 is in preview. The changes below were introduced in **Preview 1**. Additional EF Core breaking changes are expected in later previews.
+> **Note:** .NET 11 is in preview. The changes below were introduced in **Preview 1 through Preview 3**. Additional EF Core breaking changes are expected in later previews.
 
 ## Medium-Impact Changes
 

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/efcore-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/efcore-dotnet10to11.md
@@ -36,3 +36,69 @@ await context.SaveChangesAsync();
 - `Any()` → `await AnyAsync()`
 
 Tracking issue: https://github.com/dotnet/efcore/issues/37059
+
+### Cosmos: empty owned collections return empty collection instead of null (Preview 1)
+
+**Impact: Low.** When a Cosmos-backed entity has an owned collection with no items, the property now returns an empty collection rather than `null`.
+
+**Fix:** Update null checks to empty-collection checks: `if (entity.Items is null)` → `if (entity.Items.Count == 0)`.
+
+Tracking issue: https://github.com/dotnet/efcore/issues/36577
+
+## Preview 3 Changes
+
+### RelationalEventId.MigrationsNotFound now throws by default (Preview 3)
+
+**Impact: Low.** Calling `Migrate()` or `MigrateAsync()` when no migrations exist in the assembly now throws an exception rather than silently logging.
+
+**Fix:** If intentional, suppress with: `options.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsNotFound))`.
+
+Source: https://github.com/dotnet/efcore/pull/37839
+
+### EF Core Tools and Tasks no longer transitively depend on Design (Preview 3)
+
+**Impact: Low.** The `Microsoft.EntityFrameworkCore.Tools` and `Microsoft.EntityFrameworkCore.Tasks` NuGet packages no longer have a transitive dependency on `Microsoft.EntityFrameworkCore.Design`.
+
+**Fix:** If your project relied on this transitive reference, add it explicitly:
+
+```xml
+<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="11.0.0" PrivateAssets="all" />
+```
+
+Source: https://github.com/dotnet/efcore/pull/37837
+
+### EFOptimizeContext MSBuild property removed (Preview 3)
+
+**Impact: Low.** The `<EFOptimizeContext>true</EFOptimizeContext>` MSBuild property no longer exists. Code generation is now controlled by `<EFScaffoldModelStage>` and `<EFPrecompileQueriesStage>`.
+
+**Fix:** Replace `<EFOptimizeContext>` with the two new properties. With `PublishAOT=true`, generation is automatic during publish.
+
+Source: https://github.com/dotnet/efcore/pull/37838
+
+### SqlVector&lt;T&gt; properties excluded from SELECT by default (Preview 3)
+
+**Impact: Low.** `SqlVector<T>` properties are now excluded from `SELECT` statements when materializing entities (they return `null`). They can still be used in `WHERE`/`ORDER BY` for vector search.
+
+**Fix:** Use explicit projections to include vector values: `.Select(b => new { b.Id, b.Embedding })`.
+
+Source: https://github.com/dotnet/efcore/pull/37829
+
+### Microsoft.Data.SqlClient updated to 7.0 (Preview 3)
+
+**Impact: Medium.** EF Core's SQL Server provider now depends on `Microsoft.Data.SqlClient` 7.0. In v7, Azure/Entra ID authentication dependencies (`Azure.Core`, `Azure.Identity`, `Microsoft.Identity.Client`) have been removed from the core package.
+
+**Fix:** If using Entra ID authentication (e.g., `ActiveDirectoryDefault`, `ActiveDirectoryManagedIdentity`), add:
+
+```xml
+<PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.0" />
+```
+
+Source: https://github.com/dotnet/efcore/pull/37949
+
+### Encryption-enabled SQLite packages removed (Preview 3)
+
+**Impact: Medium.** `SQLitePCLRaw 3.0` (used by `Microsoft.Data.Sqlite` 11) removed `bundle_e_sqlcipher` and several other bundle packages.
+
+**Fix:** Switch to SQLite Encryption Extension (SEE), SQLCipher from Zetetic, or `SQLite3MultipleCiphers-NuGet`.
+
+Source: https://github.com/dotnet/efcore/issues/37059

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/runtime-jit-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/runtime-jit-dotnet10to11.md
@@ -49,3 +49,11 @@ For ReadyToRun-capable assemblies, there may be additional startup overhead on s
 **Fix:** Verify all deployment targets meet the new minimum requirements. For x86/x64, any CPU from ~2013 or later should be fine. For Windows Arm64, ensure `LSE` support (all Windows 11 compatible Arm64 devices).
 
 Source: https://learn.microsoft.com/en-us/dotnet/core/compatibility/jit/11/minimum-hardware-requirements
+
+### NativeAOT native-library outputs use `lib` prefix on Unix (Preview 3)
+
+**Impact: Low.** NativeAOT shared/native library outputs on Linux and macOS now follow Unix conventions and include the `lib` prefix (e.g., `libMyLib.so` instead of `MyLib.so`).
+
+**Fix:** Update build scripts, deployment pipelines, or P/Invoke declarations that reference output filenames by the old name without the `lib` prefix.
+
+Source: https://github.com/dotnet/runtime/pull/124611

--- a/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/sdk-msbuild-dotnet10to11.md
+++ b/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/references/sdk-msbuild-dotnet10to11.md
@@ -11,3 +11,19 @@ These changes affect the .NET SDK, CLI tooling, NuGet, and MSBuild behavior. Sou
 **Impact: Low.** The mono launch target is no longer set automatically for .NET Framework apps. If you require Mono for execution on Linux, you need to specify it explicitly in the configuration.
 
 Source: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/11/mono-launch-target-removed
+
+### NETSDK1235 warning for PackAsTool with custom .nuspec (Preview 2)
+
+**Impact: Low.** A new build warning `NETSDK1235` is emitted when a project has both `PackAsTool=true` and a custom `NuspecFile` property, which violates .NET Tool packaging requirements. Projects with `TreatWarningsAsErrors=true` will fail.
+
+**Fix:** Remove the custom `NuspecFile` property when packaging as a .NET Tool, or suppress the warning if the .nuspec is compatible.
+
+Source: https://github.com/dotnet/sdk/pull/52810
+
+### `dotnet publish --self-contained` now parses the passed value (Preview 3)
+
+**Impact: Low.** `dotnet publish --self-contained` previously always interpreted the flag as `true` regardless of the passed value. It now correctly parses the value (e.g., `--self-contained false` actually produces a framework-dependent publish).
+
+**Fix:** Review build scripts that pass `--self-contained` to ensure the intended value is correct.
+
+Source: https://github.com/dotnet/sdk/pull/52333

--- a/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
+++ b/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
@@ -261,3 +261,93 @@ stimuli:
         time
       - Recommends casting to concrete type or to dynamic
       - Explains ref readonly delegate synthesis requires InAttribute; recommends ensuring proper assembly references
+  - name: BackgroundService exceptions and ZipArchive CRC32 validation
+    prompt: >
+      I'm migrating a .NET 10 worker service to .NET 11. The app has several
+      BackgroundService implementations. One of them occasionally throws exceptions
+      in ExecuteAsync() — we were relying on the host silently ignoring those
+      failures and continuing to run. It also reads ZIP archives uploaded by users,
+      and some of those archives are truncated or partially corrupt — that worked
+      fine before. What breaks in .NET 11?
+    graders:
+      - type: exit-success
+      - type: output-matches
+        config:
+          pattern: (BackgroundService|ExecuteAsync|exception|host|stop|crash)
+      - type: output-matches
+        config:
+          pattern: (ZipArchive|CRC32|corrupt|InvalidDataException)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Explains that unhandled BackgroundService exceptions now propagate and stop the host; recommends adding
+        try/catch in ExecuteAsync()
+      - Explains ZipArchive now validates CRC32 checksums; corrupt or truncated archives throw InvalidDataException
+  - name: EF Core SQL Server with Entra ID auth and Design package dependency
+    prompt: |
+      We're upgrading a .NET 10 web API to .NET 11. The project uses EF Core with SQL Server
+      and connects via Entra ID managed identity (ActiveDirectoryManagedIdentity in the
+      connection string). We also use `dotnet ef` CLI tooling — it was working before with
+      just the Microsoft.EntityFrameworkCore.Tools package reference.
+
+      After upgrading all packages to 11.0.x, `dotnet ef migrations add` fails saying it
+      can't find design-time services, and the app throws at runtime when trying to connect
+      to SQL Server. What changed?
+    graders:
+      - type: exit-success
+      - type: output-matches
+        config:
+          pattern: (SqlClient|7\.0|Entra|Azure|authentication)
+      - type: output-matches
+        config:
+          pattern: (Design|Tools|transitive|explicit)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Explains Microsoft.Data.SqlClient updated to 7.0 and Entra ID auth dependencies were removed from the core
+        package; recommends adding Microsoft.Data.SqlClient.Extensions.Azure
+      - Explains EF Core Tools no longer transitively depends on Design; recommends adding explicit PackageReference
+        for Microsoft.EntityFrameworkCore.Design
+  - name: ASP.NET Core app with OpenAPI customizations and Blazor Virtualize
+    prompt: |
+      I'm upgrading a .NET 10 ASP.NET Core app to .NET 11. The app:
+      - Uses Microsoft.AspNetCore.OpenApi with custom document transformers that directly
+        manipulate OpenApiDocument and OpenApiSchema objects from the Microsoft.OpenApi library
+      - Has a Blazor Server component using <Virtualize> for rendering a large product list
+        without explicitly setting OverscanCount
+
+      After upgrading to .NET 11, I'm getting compile errors in the OpenAPI transformer code.
+      Also wondering if the Blazor component behavior will change. What's going on?
+    graders:
+      - type: exit-success
+      - type: output-matches
+        config:
+          pattern: (OpenApi|Microsoft\.OpenApi|v3|3\.2|upgrade)
+      - type: output-matches
+        config:
+          pattern: (Virtualize|OverscanCount|3|15)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Explains Microsoft.OpenApi updated from v2 to v3 with breaking API changes; recommends following the v3
+        upgrade guide
+      - Notes the Virtualize default OverscanCount changed from 3 to 15; recommends setting OverscanCount explicitly
+        if performance matters
+  - name: mTLS and AIA certificate chain validation
+    prompt: >
+      We have a .NET 10 gRPC service that uses mutual TLS. The server validates client
+      certificates. The client certificates are signed by an intermediate CA that is not
+      installed on the server — instead, the certificates include an AIA extension that
+      points to the intermediate CA's URL. This worked in .NET 10 but after upgrading to
+      .NET 11, client certificate validation fails. What happened?
+    graders:
+      - type: exit-success
+      - type: output-matches
+        config:
+          pattern: (AIA|certificate|download|disabled|chain)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Explains AIA certificate downloads are now disabled by default during client-certificate validation
+      - Recommends pre-installing the full certificate chain, having clients send intermediates, or re-enabling
+        AIA downloads via X509ChainPolicy

--- a/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
+++ b/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
@@ -325,7 +325,7 @@ stimuli:
           pattern: (OpenApi|Microsoft\.OpenApi|v3|3\.2|upgrade)
       - type: output-matches
         config:
-          pattern: (Virtualize|OverscanCount|3|15)
+          pattern: OverscanCount.*(3|15)
       - type: prompt
       - type: pairwise
     rubric:

--- a/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
+++ b/tests/dotnet-upgrade/migrate-dotnet10-to-dotnet11/eval.vally.yaml
@@ -276,7 +276,7 @@ stimuli:
           pattern: (BackgroundService|ExecuteAsync|exception|host|stop|crash)
       - type: output-matches
         config:
-          pattern: (ZipArchive|CRC32|corrupt|InvalidDataException)
+          pattern: (ZipArchive|CRC32|InvalidDataException|checksum)
       - type: prompt
       - type: pairwise
     rubric:


### PR DESCRIPTION
## Summary

Updates the migrate-dotnet10-to-dotnet11 skill to cover breaking changes through .NET 11 Preview 3 (previously Preview 1 only).

## Changes

**Reference files** — 15 new breaking changes added:
- **core-libraries**: BackgroundService exceptions stop host, ZipArchive CRC32 validation, TarWriter HardLink, Zstandard APIs in-box
- **cryptography**: AIA certificate downloads disabled by default
- **efcore**: Cosmos empty collections, MigrationsNotFound throws, Tools/Design dependency removed, EFOptimizeContext removed, SqlVector excluded, SqlClient 7.0 Entra auth, SQLitePCLRaw encryption bundles removed
- **runtime-jit**: NativeAOT lib prefix on Unix
- **sdk-msbuild**: NETSDK1235 warning, --self-contained parsing fix
- **aspnetcore** (new file): OpenAPI v3/Microsoft.OpenApi breaking changes, Blazor Virtualize OverscanCount 3→15

**SKILL.md** — Updated frontmatter (P1→P3), Step 1 assessment checklist, Step 3 code patterns, Step 4 behavioral changes, Step 5 global.json version, Step 6 verification items, reference tables.

**Evals** — 4 new scenarios: BackgroundService+ZipCRC32, EF Core SqlClient+Design, ASP.NET Core OpenAPI+Blazor, mTLS AIA certificates.

**known-domains.txt** — Added \github.com/dotnet/aspnetcore\.

## Validation

- ✅ skill-validator check passes (0 errors, 3465 BPE tokens)
- ✅ markdownlint — no new regressions
- ✅ All referenced GitHub URLs return HTTP 200