### PR TITLE
Fix markdownlint workflow: recursive pathspec and npx --yes

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -37,7 +37,7 @@ jobs:
           if [ -n "$CONFIG_CHANGED" ]; then
             echo "mode=all" >> "$GITHUB_OUTPUT"
           else
-            FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '*.md' | tr '\n' ' ')
+            FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '**/*.md' | tr '\n' ' ')
             echo "files=$FILES" >> "$GITHUB_OUTPUT"
             if [ -n "$FILES" ]; then
               echo "mode=changed" >> "$GITHUB_OUTPUT"
@@ -50,7 +50,7 @@ jobs:
         if: steps.scope.outputs.mode != 'none'
         run: |
           if [ "${{ steps.scope.outputs.mode }}" = "all" ]; then
-            npx markdownlint-cli2 "**/*.md"
+            npx --yes markdownlint-cli2 "**/*.md"
           else
-            npx markdownlint-cli2 ${{ steps.scope.outputs.files }}
+            npx --yes markdownlint-cli2 ${{ steps.scope.outputs.files }}
           fi


### PR DESCRIPTION
Follow-up to #629. Addresses two review feedback items:

1. **Recursive pathspec**: Changed \-- '*.md'\ to \-- '**/*.md'\ in \git diff\ so markdown files in subdirectories are detected (not just root-level files).

2. **npx --yes flag**: Added \--yes\ to \
px markdownlint-cli2\ calls to avoid interactive install prompts in CI.