### PR TITLE
fix(groom): prune resolved rows, add First Seen column, handle duplicate sections

### DIFF
--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -357,11 +357,11 @@ Replace the entire issue body with the following structure:
 > Deep investigations are dispatched for new critical/warning findings.
 > The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
 
-| Finding | Severity | Status | Result |
-|---------|----------|--------|--------|
+| Finding | Severity | Investigation | First Seen | Result |
+|---------|----------|---------------|------------|--------|
 {For each finding dispatched in the current run:}
-| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | [Workflow Run]({workflow_actions_url}) |
-{Preserve any rows from the previous issue body that already show ✅ Done or ✅ Resolved — do not remove them}
+| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date, e.g. 2026-05-09} | ⏳ Investigation dispatched — results arriving shortly... |
+{Preserve any rows from the previous issue body that show ✅ Done and whose finding is still in the active set (New Findings or Existing Findings sections). Drop rows for resolved findings.}
 {If no findings were dispatched AND no previous rows exist, render the table header with zero rows — the section MUST still appear in the output}
 
 ---
@@ -475,7 +475,7 @@ Before finishing, verify:
 - [ ] At least one `dispatch-workflow` call was made (if any 🔴 critical or qualifying 🟡 warning findings exist)
 - [ ] All 🔴 critical NEW findings have been dispatched (up to budget cap)
 - [ ] The "🔍 Investigation Results" section in the issue body shows newly dispatched findings as "🔄 Dispatched"
-- [ ] Any existing "✅ Done" or "✅ Resolved" rows from the previous issue body are preserved
+- [ ] Any existing "✅ Done" rows from the previous issue body are preserved only if the finding is still active (in New/Existing Findings sections). Resolved rows are dropped.
 - [ ] The noop summary message mentions how many investigations were dispatched
 
 ---

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -352,6 +352,19 @@ Replace the entire issue body with the following structure:
 
 ---
 
+## 🔍 Investigation Results
+
+> Deep investigations are dispatched for new critical/warning findings.
+> The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
+
+| Finding | Severity | Investigation | First Seen | Result |
+|---------|----------|---------------|------------|--------|
+{Preserve rows from the previous issue body’s Investigation Results table (look inside the `<!-- gh-aw-island-start:devops-health-groom -->` block if present). Copy all rows as-is — do not modify them. Then append new rows for findings dispatched in the current run:}
+| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date} | ⏳ Investigation dispatched — results arriving shortly... |
+{If no dispatched findings AND no previous rows exist, render the table header with zero data rows.}
+
+---
+
 ## ✅ Resolved Since Yesterday ({resolved_count})
 
 > These were in yesterday's report but are no longer detected.
@@ -460,6 +473,7 @@ dispatch-workflow:
 Before finishing, verify:
 - [ ] At least one `dispatch-workflow` call was made (if any 🔴 critical or qualifying 🟡 warning findings exist)
 - [ ] All 🔴 critical NEW findings have been dispatched (up to budget cap)
+- [ ] The "🔍 Investigation Results" section in the issue body includes newly dispatched findings as "🔄 Dispatched" and preserves existing rows from the previous body
 - [ ] The noop summary message mentions how many investigations were dispatched
 
 ---
@@ -469,7 +483,7 @@ Before finishing, verify:
 - **Time budget**: You have a 60-minute timeout. Prioritize reaching Steps 4 and 5 (issue update + dispatch). Do NOT write intermediate scripts or analysis files. Work through each check, collect findings in memory, and proceed directly to output. Aim to complete data collection (Step 1) within 30 minutes.
 - **Efficiency**: Process API responses in memory. Do NOT create Python/bash scripts to analyze data — parse JSON directly using `jq` or inline analysis. Do NOT write intermediate files unless explicitly required by the output format.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **complete, literal issue body text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. Pass the body directly as the string value.
-- **Do NOT create an Investigation Results section**: The `## 🔍 Investigation Results` section is owned by the downstream [grooming workflow](../workflows/devops-health-groom.md), which runs ~3 hours later and manages it via its own `replace-island` block. If the health-check also creates this section, the issue body ends up with two duplicate `## 🔍 Investigation Results` headings. The health-check must NOT emit this section.
+- **CRITICAL — Investigation Results section**: The `## 🔍 Investigation Results` section MUST always appear in the issue body template. The downstream [grooming workflow](../workflows/devops-health-groom.md) manages this section via a `replace-island` block — so the health-check must **preserve existing rows** from the previous issue body (look inside `<!-- gh-aw-island-start:devops-health-groom -->` markers if present, and copy those table rows into the new section). Do NOT wrap the section in island markers yourself — the groom adds those. Only append new "🔄 Dispatched" rows for findings dispatched in the current run.
 - **Be data-driven**: Include specific numbers, durations, percentages, and links.
 - **Be precise with fingerprints**: Use the exact fingerprint formulas from the knowledge file. Consistency is critical — the same finding MUST produce the same fingerprint across runs.
 - **First run handling**: If `cache-memory` has no previous state, note: "⚠️ This is the first health check run. All findings appear as new. Diff will resume from next run."

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -352,20 +352,6 @@ Replace the entire issue body with the following structure:
 
 ---
 
-## 🔍 Investigation Results
-
-> Deep investigations are dispatched for new critical/warning findings.
-> The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
-
-| Finding | Severity | Investigation | First Seen | Result |
-|---------|----------|---------------|------------|--------|
-{For each finding dispatched in the current run:}
-| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date, e.g. 2026-05-09} | ⏳ Investigation dispatched — results arriving shortly... |
-{Preserve any rows from the previous issue body that show ✅ Done and whose finding is still in the active set (New Findings or Existing Findings sections). Drop rows for resolved findings.}
-{If no findings were dispatched AND no previous rows exist, render the table header with zero rows — the section MUST still appear in the output}
-
----
-
 ## ✅ Resolved Since Yesterday ({resolved_count})
 
 > These were in yesterday's report but are no longer detected.
@@ -474,8 +460,6 @@ dispatch-workflow:
 Before finishing, verify:
 - [ ] At least one `dispatch-workflow` call was made (if any 🔴 critical or qualifying 🟡 warning findings exist)
 - [ ] All 🔴 critical NEW findings have been dispatched (up to budget cap)
-- [ ] The "🔍 Investigation Results" section in the issue body shows newly dispatched findings as "🔄 Dispatched"
-- [ ] Any existing "✅ Done" rows from the previous issue body are preserved only if the finding is still active (in New/Existing Findings sections). Resolved rows are dropped.
 - [ ] The noop summary message mentions how many investigations were dispatched
 
 ---
@@ -485,7 +469,7 @@ Before finishing, verify:
 - **Time budget**: You have a 60-minute timeout. Prioritize reaching Steps 4 and 5 (issue update + dispatch). Do NOT write intermediate scripts or analysis files. Work through each check, collect findings in memory, and proceed directly to output. Aim to complete data collection (Step 1) within 30 minutes.
 - **Efficiency**: Process API responses in memory. Do NOT create Python/bash scripts to analyze data — parse JSON directly using `jq` or inline analysis. Do NOT write intermediate files unless explicitly required by the output format.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **complete, literal issue body text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. Pass the body directly as the string value.
-- **CRITICAL — Investigation Results section is MANDATORY**: The `## 🔍 Investigation Results` section MUST always appear in the issue body, even if no investigations were dispatched (in that case, render the section with the table header and zero data rows). The downstream grooming workflow depends on this section to link investigation results. Never omit it. Never inline investigation status elsewhere (e.g., inside the New Findings section). The section must appear **exactly** between the `## 🆕 New Findings` section and the `## ✅ Resolved` section.
+- **Do NOT create an Investigation Results section**: The `## 🔍 Investigation Results` section is owned by the downstream [grooming workflow](../workflows/devops-health-groom.md), which runs ~3 hours later and manages it via its own `replace-island` block. If the health-check also creates this section, the issue body ends up with two duplicate `## 🔍 Investigation Results` headings. The health-check must NOT emit this section.
 - **Be data-driven**: Include specific numbers, durations, percentages, and links.
 - **Be precise with fingerprints**: Use the exact fingerprint formulas from the knowledge file. Consistency is critical — the same finding MUST produce the same fingerprint across runs.
 - **First run handling**: If `cache-memory` has no previous state, note: "⚠️ This is the first health check run. All findings appear as new. Diff will resume from next run."

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -359,8 +359,8 @@ Replace the entire issue body with the following structure:
 
 | Finding | Severity | Investigation | First Seen | Result |
 |---------|----------|---------------|------------|--------|
-{Preserve rows from the previous issue body’s Investigation Results table (look inside the `<!-- gh-aw-island-start:devops-health-groom -->` block if present). Copy all rows as-is — do not modify them. Then append new rows for findings dispatched in the current run:}
-| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date} | ⏳ Investigation dispatched — results arriving shortly... |
+{Preserve rows from the previous issue body's Investigation Results table (look inside the `<!-- gh-aw-island-start:devops-health-groom -->` block if present). Copy all rows as-is for findings that are still active (appear in New Findings or Existing Findings). Drop rows whose finding is no longer active (resolved). If the previous table uses the old 4-column schema (`| Finding | Severity | Status | Result |`), migrate each row to the new 5-column schema: rename Status to Investigation, and populate First Seen from the finding's `<summary>` line (`first seen YYYY-MM-DD`) or use today's date as fallback. Then append new rows for findings dispatched in the current run:}
+| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date} | [⏳ Investigation dispatched — results arriving shortly...]({link_to_dispatched_investigate_run_or_this_health_check_run}) |
 {If no dispatched findings AND no previous rows exist, render the table header with zero data rows.}
 
 ---

--- a/.github/workflows/devops-health-groom.md
+++ b/.github/workflows/devops-health-groom.md
@@ -167,11 +167,19 @@ For each **Daily overview** comment, extract:
 
 ### 3.1 Parse the Current Issue Body
 
-Look for the `## 🔍 Investigation Results` section in the issue body. This section, when present, contains a markdown table with rows like:
+Look for the `## 🔍 Investigation Results` section in the issue body. This section, when present, contains a markdown table with the header:
 
 ```
-| {finding_title} | {severity} | 🔄 Dispatched | [Workflow Run]({url}) |
+| Finding | Severity | Investigation | First Seen | Result |
 ```
+
+and rows like:
+
+```
+| {finding_title} | {severity} | 🔄 Dispatched | {date} | ⏳ Investigation dispatched… |
+```
+
+**Duplicate section handling:** If the issue body contains **multiple** `## 🔍 Investigation Results` sections, merge all rows from every occurrence into a single table (de-duplicate by finding title). The `replace-island` operation will replace the **first** occurrence and remove the others.
 
 **If the section is missing** (the health check agent sometimes omits it), you MUST
 create it. Do NOT skip this step — creating the section is the primary purpose of
@@ -185,8 +193,9 @@ For each row in the existing Investigation Results table:
 1. Determine the `finding_id` for this row. Match by comparing the finding title in the table row against the `finding_id` or heading title in each investigation comment.
 2. Look up the `finding_id` in the investigation comments collected in Step 2.
 3. If a matching investigation comment exists:
-   - Change the status from `🔄 Dispatched` to `✅ Done`
+   - Change the Investigation column from `🔄 Dispatched` to `✅ Done`
    - Replace the Result cell with `[{executive_summary}]({comment_url})`
+   - Preserve the First Seen date from the existing row
 4. If no matching investigation comment exists yet, leave the row unchanged.
 
 **If the Investigation Results section does NOT exist** in the issue body:
@@ -196,7 +205,7 @@ comments collected in Step 2:
 
 1. For each investigation comment, create a table row:
    ```
-   | {finding_title from comment heading} | {severity from comment} | ✅ Done | [{executive_summary}]({comment_url}) |
+   | {finding_title from comment heading} | {severity from comment} | ✅ Done | {first_seen date from Existing/New Findings section, or comment created_at date} | [{executive_summary}]({comment_url}) |
    ```
 2. Wrap the rows in the standard section structure:
    ```markdown
@@ -205,8 +214,8 @@ comments collected in Step 2:
    > Deep investigations are dispatched for new critical/warning findings.
    > The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
 
-   | Finding | Severity | Status | Result |
-   |---------|----------|--------|--------|
+   | Finding | Severity | Investigation | First Seen | Result |
+   |---------|----------|---------------|------------|--------|
    {rows}
    ```
 3. Insert this section into the issue body **immediately before** the first of
@@ -243,11 +252,12 @@ For each investigation comment found in Step 2:
 2. If the `finding_id` is **NOT** in the current fingerprints → the finding has been resolved since the investigation was posted.
 3. For these resolved findings, check if they are already marked in the "✅ Resolved Since Yesterday" section or if the investigation table already shows them as resolved.
 
-### 4.3 Mark Resolved Investigations in the Issue Body
+### 4.3 Remove Resolved Investigations from the Table
 
-In the Investigation Results table, for findings whose investigation is complete AND the finding is now resolved:
-- Change status from `✅ Done` to `✅ Resolved`
-- Keep the link to the investigation comment (still useful for historical context until pruned)
+For findings whose investigation is complete AND the finding is now resolved:
+- **Remove the entire row** from the Investigation Results table
+- The investigation comment is still accessible via the issue's comment history — no need to keep resolved rows in the table
+- This keeps the table focused on active/in-progress investigations only
 
 ### 4.4 Write the Updated Issue Body
 
@@ -263,9 +273,9 @@ The `body` field must contain **only** the Investigation Results island — star
 > Deep investigations are dispatched for new critical/warning findings.
 > The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
 
-| Finding | Severity | Status | Result |
-|---------|----------|--------|--------|
-| ... | ... | ✅ Done | [summary](url) |
+| Finding | Severity | Investigation | First Seen | Result |
+|---------|----------|---------------|------------|--------|
+| ... | ... | ✅ Done | 2026-05-09 | [summary](url) |
 ```
 
 Only call `update-issue` if at least one change was made across Steps 3 and 4. If nothing changed, skip the call.
@@ -349,7 +359,7 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 
 ## Guidelines
 
-- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically.
+- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically. If multiple `## 🔍 Investigation Results` sections exist in the body, `replace-island` targets the first one — the groomer must merge all rows into that single section.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **literal section text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. The body must be passed directly as the string value.
 - **Minimal edits only**: You are a groomer, not a rewriter. Only change: (a) investigation table rows (status + link), (b) resolved-finding annotations. Copy all other sections **byte-for-byte** from the original body. Do not reformat, re-wrap, or reorganize sections you are not changing.
 - **Be precise with comment parsing**: The comment format is well-defined (see the investigation worker template). Match the exact patterns — don't be fuzzy.
@@ -357,6 +367,8 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 - **Don't hide human comments**: Never hide comments authored by humans. For bot comments (`github-actions[bot]`), P1–P3 only target Investigation and Daily overview patterns. P4 (hard age cutoff > 28 days) may hide any bot comment regardless of pattern. Never hide human comments, bot reactions from humans, etc.
 - **Idempotent**: Running this workflow twice should produce the same result. If investigation results are already linked, don't re-link them. If comments are already hidden, they won't appear in the API results (collapsed).
 - **Create missing sections**: If the issue body doesn't contain a `## 🔍 Investigation Results` section, **create it** from investigation comments (see Step 3). Do NOT silently skip linking — this is the groomer's primary job. Only skip Step 3 if there are zero investigation comments to link. When creating a missing section, use `operation: "replace-island"` — this will insert the section at the appropriate location.
+- **Prune resolved rows**: Rows for findings that are no longer in the active fingerprint set (i.e. resolved) must be **removed** from the Investigation Results table entirely. The table should only show active investigations (🔄 Dispatched, ⏳ Skipped, ✅ Done for still-active findings). Historical investigation results remain accessible via the issue's comment history.
+- **Column schema**: The Investigation Results table MUST use the header `| Finding | Severity | Investigation | First Seen | Result |`. If the existing table uses a different schema (e.g. `| Finding | Severity | Status | Result |`), migrate it to the new schema during this grooming run. Map the old `Status` column to `Investigation`, and populate `First Seen` from the finding's `**First seen:**` line in the Existing/New Findings sections (or use the investigation comment's `created_at` date as fallback).
 - **No intermediate files**: Do all work in memory. Do NOT write intermediate scripts, JSON files, or body text files. Hold parsed data and the issue body as in-memory variables.
 - **Use MCP `issue_read` for fetching comments**: Use the GitHub MCP `issue_read` tool with `method: get_comments` for fetching issue comments. If the response includes a `[Filtered]` notice, continue working with the comments that were returned — filtered items are from non-bot authors and are irrelevant to grooming. Do NOT call `report_incomplete` or `missing_tool` because of filtered items.
 - **`gh` CLI is NOT authenticated in the sandbox**: Never use `gh api` or other `gh` commands for GitHub API calls — the sandbox strips credentials by design. Use MCP tools for all GitHub reads.

--- a/.github/workflows/devops-health-groom.md
+++ b/.github/workflows/devops-health-groom.md
@@ -176,10 +176,10 @@ Look for the `## 🔍 Investigation Results` section in the issue body. This sec
 and rows like:
 
 ```
-| {finding_title} | {severity} | 🔄 Dispatched | {date} | ⏳ Investigation dispatched… |
+| {finding_title} | {severity} | 🔄 Dispatched | {date} | ⏳ Investigation dispatched — results arriving shortly... |
 ```
 
-**Duplicate section handling:** If the issue body contains **multiple** `## 🔍 Investigation Results` sections, merge all rows from every occurrence into a single table (de-duplicate by finding title). The `replace-island` operation will replace the **first** occurrence and remove the others.
+**Duplicate section handling:** If the issue body contains **multiple** `## 🔍 Investigation Results` sections, merge all rows from every occurrence into a single table (de-duplicate by finding title). The `replace-island` operation only replaces the **first** occurrence — it does NOT automatically remove later duplicates. If duplicates exist, extract all rows first, then the single `replace-island` call will place them in the first section. Any remaining duplicate sections will be overwritten by the next health-check run (which replaces the entire issue body).
 
 **If the section is missing** (the health check agent sometimes omits it), you MUST
 create it. Do NOT skip this step — creating the section is the primary purpose of
@@ -250,7 +250,7 @@ The union of new + existing fingerprints forms the current active set. Findings 
 For each investigation comment found in Step 2:
 1. Check if the `finding_id` is still present in the current fingerprint set.
 2. If the `finding_id` is **NOT** in the current fingerprints → the finding has been resolved since the investigation was posted.
-3. For these resolved findings, check if they are already marked in the "✅ Resolved Since Yesterday" section or if the investigation table already shows them as resolved.
+3. For these resolved findings, they will be removed from the Investigation Results table in the next step.
 
 ### 4.3 Remove Resolved Investigations from the Table
 
@@ -359,7 +359,7 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 
 ## Guidelines
 
-- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically. If multiple `## 🔍 Investigation Results` sections exist in the body, `replace-island` targets the first one — the groomer must merge all rows into that single section.
+- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically. If multiple `## 🔍 Investigation Results` sections exist in the body, `replace-island` targets the first one — the groomer must merge all rows from every occurrence into that single section before calling `replace-island`. Later duplicate sections are not automatically removed; the next health-check run (which replaces the full body) will clean them up.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **literal section text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. The body must be passed directly as the string value.
 - **Minimal edits only**: You are a groomer, not a rewriter. Only change: (a) investigation table rows (status + link), (b) resolved-finding annotations. Copy all other sections **byte-for-byte** from the original body. Do not reformat, re-wrap, or reorganize sections you are not changing.
 - **Be precise with comment parsing**: The comment format is well-defined (see the investigation worker template). Match the exact patterns — don't be fuzzy.
@@ -368,7 +368,7 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 - **Idempotent**: Running this workflow twice should produce the same result. If investigation results are already linked, don't re-link them. If comments are already hidden, they won't appear in the API results (collapsed).
 - **Create missing sections**: If the issue body doesn't contain a `## 🔍 Investigation Results` section, **create it** from investigation comments (see Step 3). Do NOT silently skip linking — this is the groomer's primary job. Only skip Step 3 if there are zero investigation comments to link. When creating a missing section, use `operation: "replace-island"` — this will insert the section at the appropriate location.
 - **Prune resolved rows**: Rows for findings that are no longer in the active fingerprint set (i.e. resolved) must be **removed** from the Investigation Results table entirely. The table should only show active investigations (🔄 Dispatched, ⏳ Skipped, ✅ Done for still-active findings). Historical investigation results remain accessible via the issue's comment history.
-- **Column schema**: The Investigation Results table MUST use the header `| Finding | Severity | Investigation | First Seen | Result |`. If the existing table uses a different schema (e.g. `| Finding | Severity | Status | Result |`), migrate it to the new schema during this grooming run. Map the old `Status` column to `Investigation`, and populate `First Seen` from the finding's `**First seen:**` line in the Existing/New Findings sections (or use the investigation comment's `created_at` date as fallback).
+- **Column schema**: The Investigation Results table MUST use the header `| Finding | Severity | Investigation | First Seen | Result |`. If the existing table uses a different schema (e.g. `| Finding | Severity | Status | Result |`), migrate it to the new schema during this grooming run. Map the old `Status` column to `Investigation`, and populate `First Seen` from the `<summary>` line in the Existing/New Findings sections (format: `first seen YYYY-MM-DD`), or use the investigation comment's `created_at` date as fallback.
 - **No intermediate files**: Do all work in memory. Do NOT write intermediate scripts, JSON files, or body text files. Hold parsed data and the issue body as in-memory variables.
 - **Use MCP `issue_read` for fetching comments**: Use the GitHub MCP `issue_read` tool with `method: get_comments` for fetching issue comments. If the response includes a `[Filtered]` notice, continue working with the comments that were returned — filtered items are from non-bot authors and are irrelevant to grooming. Do NOT call `report_incomplete` or `missing_tool` because of filtered items.
 - **`gh` CLI is NOT authenticated in the sandbox**: Never use `gh api` or other `gh` commands for GitHub API calls — the sandbox strips credentials by design. Use MCP tools for all GitHub reads.


### PR DESCRIPTION
## Changes

Improves the Investigation Results table in the health dashboard issue (#288).

### Problems
1. **Duplicate section**: The issue body contains two \## 🔍 Investigation Results\ sections — one from health-check, one appended by the groomer
2. **Resolved rows accumulate forever**: 13+ resolved investigation rows clutter the table with historical data that's no longer relevant
3. **Ambiguous Status column**: The column name \Status\ is confusing alongside other status-like columns

### Fixes

**Groom workflow:**
- Rename \Status\ column to \Investigation\ for clarity
- Add \First Seen\ column showing when the finding was first detected
- **Remove** resolved investigation rows entirely (instead of marking them \✅ Resolved\ and keeping them)
- Handle duplicate \## 🔍 Investigation Results\ sections by merging rows and producing a single section
- Add column schema migration guidance for transitioning from old to new format

**Health-check workflow:**
- Update table template to use matching \| Finding | Severity | Investigation | First Seen | Result |\ schema
- Drop resolved rows from table preservation logic (only keep \✅ Done\ rows for still-active findings)