### PR TITLE
Add test-tagging evals for uncovered skill aspects

### DIFF
--- a/tests/dotnet-test/test-tagging/eval.vally.yaml
+++ b/tests/dotnet-test/test-tagging/eval.vally.yaml
@@ -165,3 +165,123 @@ stimuli:
     constraints:
       reject_skills:
         - "*"
+  - name: Tag a partially-tagged MSTest suite without duplicating existing traits
+    prompt: My MSTest project at OrderService.Tests/ already has some tests tagged with [TestCategory] but most are still
+      untagged. Can you fill in the missing category attributes for the untagged tests? Make sure you don't duplicate
+      the tags that are already there. I'd like a summary at the end.
+    environment:
+      files:
+        - src: fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj
+          dest: OrderService.Tests/OrderService.Tests.csproj
+        - src: fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs
+          dest: OrderService.Tests/OrderProcessorTests.cs
+        - src: fixtures/mstest-partially-tagged/OrderService/OrderService.csproj
+          dest: OrderService/OrderService.csproj
+        - src: fixtures/mstest-partially-tagged/OrderService/Order.cs
+          dest: OrderService/Order.cs
+        - src: fixtures/mstest-partially-tagged/OrderService/OrderProcessor.cs
+          dest: OrderService/OrderProcessor.cs
+    graders:
+      - type: file-contains
+        config:
+          path: OrderService.Tests/OrderProcessorTests.cs
+          value: TestCategory
+      - type: file-contains
+        config:
+          path: OrderService.Tests/OrderProcessorTests.cs
+          value: critical-path
+      - type: output-matches
+        config:
+          pattern: (positive|negative)
+      - type: output-matches
+        config:
+          pattern: (distribution|summary|trait|count)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Preserved the existing [TestCategory("positive")] and [TestCategory("critical-path")] on
+        PlaceOrder_ValidInput_ReturnsConfirmedOrder without duplicating them
+      - Preserved the existing [TestCategory("negative")] on PlaceOrder_NullEmail_ThrowsArgumentException without adding
+        a second negative tag
+      - Preserved the existing [TestCategory("negative")] and [TestCategory("boundary")] pair on PlaceOrder_ZeroQuantity
+        without duplicating either
+      - Added trait attributes to the previously untagged test methods (e.g., CalculateDiscount_NegativeTotal,
+        CancelOrder_ExistingPendingOrder, etc.)
+      - Used only trait values from the standard taxonomy (positive, negative, boundary, critical-path, smoke,
+        regression, integration, end-to-end, performance, security, concurrency, resilience, destructive,
+        configuration, flaky)
+      - Produced a trait distribution summary covering all tests in the suite
+  - name: Accurately classify NUnit tests with misleading method names
+    prompt: I have an NUnit test project at TaskManager.Tests/ covering a TaskService class. The test method names aren't
+      always descriptive of what's actually being tested. Can you analyze the test bodies and add the right Category
+      attributes? Please provide a summary when done.
+    environment:
+      files:
+        - src: fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
+          dest: TaskManager.Tests/TaskManager.Tests.csproj
+        - src: fixtures/nunit-misleading-names/TaskManager.Tests/TaskServiceTests.cs
+          dest: TaskManager.Tests/TaskServiceTests.cs
+        - src: fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj
+          dest: TaskManager/TaskManager.csproj
+        - src: fixtures/nunit-misleading-names/TaskManager/TaskItem.cs
+          dest: TaskManager/TaskItem.cs
+        - src: fixtures/nunit-misleading-names/TaskManager/TaskService.cs
+          dest: TaskManager/TaskService.cs
+    graders:
+      - type: file-contains
+        config:
+          path: TaskManager.Tests/TaskServiceTests.cs
+          value: "[Category("
+      - type: output-matches
+        config:
+          pattern: (positive|negative)
+      - type: output-matches
+        config:
+          pattern: (distribution|summary|trait|count)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Classified DeleteTask_Success as negative (and/or security) because the body asserts UnauthorizedAccessException,
+        despite the name suggesting success
+      - Classified CreateTask_Fails_WhenFieldsPresent as positive because the body verifies successful creation, despite
+        the name containing 'Fails'
+      - Classified GetByAssignee_Error_NoTasks as positive (and/or boundary) because the body asserts an empty result for
+        a valid query, despite the name containing 'Error'
+      - Recognized BulkAssign_UpdatesAllTasks as a concurrency-related test because the implementation uses Task.WhenAll
+        for parallel execution
+      - Classified DeleteTask_Validation as positive and security because the body verifies admin authorization succeeds
+      - Used NUnit [Category("...")] attribute syntax, not MSTest or xUnit syntax
+      - Every test method received at least one trait attribute
+  - name: Tag MSTest tests and verify the project still builds
+    prompt: I need you to tag all the tests in my OrderService.Tests/ MSTest project with appropriate category attributes.
+      After adding the tags, please verify the project still compiles by running dotnet build.
+    environment:
+      files:
+        - src: fixtures/mstest-untagged/OrderService.Tests/OrderService.Tests.csproj
+          dest: OrderService.Tests/OrderService.Tests.csproj
+        - src: fixtures/mstest-untagged/OrderService.Tests/OrderProcessorTests.cs
+          dest: OrderService.Tests/OrderProcessorTests.cs
+        - src: fixtures/mstest-untagged/OrderService/OrderService.csproj
+          dest: OrderService/OrderService.csproj
+        - src: fixtures/mstest-untagged/OrderService/Order.cs
+          dest: OrderService/Order.cs
+        - src: fixtures/mstest-untagged/OrderService/OrderProcessor.cs
+          dest: OrderService/OrderProcessor.cs
+    graders:
+      - type: file-contains
+        config:
+          path: OrderService.Tests/OrderProcessorTests.cs
+          value: TestCategory
+      - type: run-command
+        config:
+          command: dotnet build OrderService.Tests/OrderService.Tests.csproj
+          expected_exit_code: 0
+          stdout_matches: (Build succeeded|build succeeded|0 Error|0 error)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Added [TestCategory] attributes to the test methods
+      - Ran dotnet build (or equivalent compilation check) and confirmed the project compiles without errors after the
+        changes
+      - Used only valid trait values from the taxonomy — no invented category names that would cause logical errors
+      - Every test method received at least one positive or negative tag

--- a/tests/dotnet-test/test-tagging/eval.vally.yaml
+++ b/tests/dotnet-test/test-tagging/eval.vally.yaml
@@ -2,7 +2,7 @@ name: test-tagging
 description: Evaluates the dotnet-test/test-tagging skill
 type: capability
 config:
-  timeout: 6m
+  timeout: 10m
 stimuli:
   - name: Tag an untagged MSTest test suite
     prompt: I have an MSTest test project at OrderService.Tests/ with about 20 tests covering an OrderProcessor class. None

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -36,7 +36,7 @@ scenarios:
       - "Used the correct MSTest attribute syntax [TestCategory(\"...\")]"
       - "Produced a summary showing the count or distribution of tags across the test suite"
       - "Every test method received at least one positive or negative tag"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 2: Tag the same tests using xUnit syntax
@@ -75,7 +75,7 @@ scenarios:
       - "Used the correct xUnit attribute syntax [Trait(\"Category\", \"...\")]"
       - "Produced a summary showing the count or distribution of tags across the test suite"
       - "Every test method received at least one positive or negative tag"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 3: Tag the same tests using NUnit syntax
@@ -114,7 +114,7 @@ scenarios:
       - "Used the correct NUnit attribute syntax [Category(\"...\")]"
       - "Produced a summary showing the count or distribution of tags across the test suite"
       - "Every test method received at least one positive or negative tag"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 4: Audit-only mode (report without modifying files)
@@ -149,7 +149,7 @@ scenarios:
       - "Identified tests that cover boundary conditions (zero quantity, negative price, empty list, zero total, exactly-500-points tier boundary)"
       - "Provided observations about the test distribution balance or coverage gaps"
       - "Did NOT modify OrderProcessorTests.cs — analysis only"
-    timeout: 180
+    timeout: 300
 
   # ==========================================================================
   # Scenario 5: Non-activation — writing new tests is out of scope
@@ -181,7 +181,7 @@ scenarios:
     rubric:
       - "Wrote test methods for the PaymentGateway class"
       - "Covered both success and failure scenarios"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 6: Partially-tagged MSTest suite — preserve existing traits
@@ -223,7 +223,7 @@ scenarios:
       - "Added trait attributes to the previously untagged test methods (e.g., CalculateDiscount_NegativeTotal, CancelOrder_ExistingPendingOrder, etc.)"
       - "Used only trait values from the standard taxonomy (positive, negative, boundary, critical-path, smoke, regression, integration, end-to-end, performance, security, concurrency, resilience, destructive, configuration, flaky)"
       - "Produced a trait distribution summary covering all tests in the suite"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 7: Misleading method names — must read test body to classify
@@ -263,7 +263,7 @@ scenarios:
       - "Classified DeleteTask_Validation as positive and security because the body verifies admin authorization succeeds"
       - "Used NUnit [Category(\"...\")] attribute syntax, not MSTest or xUnit syntax"
       - "Every test method received at least one trait attribute"
-    timeout: 360
+    timeout: 600
 
   # ==========================================================================
   # Scenario 8: Verify project builds after tagging changes
@@ -299,4 +299,4 @@ scenarios:
       - "Ran dotnet build (or equivalent compilation check) and confirmed the project compiles without errors after the changes"
       - "Used only valid trait values from the taxonomy — no invented category names that would cause logical errors"
       - "Every test method received at least one positive or negative tag"
-    timeout: 360
+    timeout: 600

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -290,8 +290,10 @@ scenarios:
       - type: file_contains
         path: "OrderService.Tests/OrderProcessorTests.cs"
         value: "TestCategory"
-      - type: output_matches
-        pattern: "(Build succeeded|build succeeded|0 Error|succeeded)"
+      - type: run_command_and_assert
+        command: "dotnet build OrderService.Tests/OrderService.Tests.csproj"
+        expected_exit_code: 0
+        stdout_matches: "(Build succeeded|build succeeded|0 Error|0 error)"
     rubric:
       - "Added [TestCategory] attributes to the test methods"
       - "Ran dotnet build (or equivalent compilation check) and confirmed the project compiles without errors after the changes"

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -291,9 +291,10 @@ scenarios:
         path: "OrderService.Tests/OrderProcessorTests.cs"
         value: "TestCategory"
       - type: run_command_and_assert
-        command: "dotnet build OrderService.Tests/OrderService.Tests.csproj"
+        command_to_run: "dotnet"
+        command_arguments: "build OrderService.Tests/OrderService.Tests.csproj"
         expected_exit_code: 0
-        stdout_matches: "(Build succeeded|build succeeded|0 Error|0 error)"
+        expected_std_output_matches: "(Build succeeded|build succeeded|0 Error|0 error)"
     rubric:
       - "Added [TestCategory] attributes to the test methods"
       - "Ran dotnet build (or equivalent compilation check) and confirmed the project compiles without errors after the changes"

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -182,3 +182,119 @@ scenarios:
       - "Wrote test methods for the PaymentGateway class"
       - "Covered both success and failure scenarios"
     timeout: 360
+
+  # ==========================================================================
+  # Scenario 6: Partially-tagged MSTest suite — preserve existing traits
+  # ==========================================================================
+
+  - name: "Tag a partially-tagged MSTest suite without duplicating existing traits"
+    prompt: >-
+      My MSTest project at OrderService.Tests/ already has some tests tagged
+      with [TestCategory] but most are still untagged. Can you fill in the
+      missing category attributes for the untagged tests? Make sure you don't
+      duplicate the tags that are already there. I'd like a summary at the end.
+    setup:
+      files:
+        - path: "OrderService.Tests/OrderService.Tests.csproj"
+          source: "fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj"
+        - path: "OrderService.Tests/OrderProcessorTests.cs"
+          source: "fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs"
+        - path: "OrderService/OrderService.csproj"
+          source: "fixtures/mstest-partially-tagged/OrderService/OrderService.csproj"
+        - path: "OrderService/Order.cs"
+          source: "fixtures/mstest-partially-tagged/OrderService/Order.cs"
+        - path: "OrderService/OrderProcessor.cs"
+          source: "fixtures/mstest-partially-tagged/OrderService/OrderProcessor.cs"
+    assertions:
+      - type: file_contains
+        path: "OrderService.Tests/OrderProcessorTests.cs"
+        value: "TestCategory"
+      - type: file_contains
+        path: "OrderService.Tests/OrderProcessorTests.cs"
+        value: "critical-path"
+      - type: output_matches
+        pattern: "(positive|negative)"
+      - type: output_matches
+        pattern: "(distribution|summary|trait|count)"
+    rubric:
+      - "Preserved the existing [TestCategory(\"positive\")] and [TestCategory(\"critical-path\")] on PlaceOrder_ValidInput_ReturnsConfirmedOrder without duplicating them"
+      - "Preserved the existing [TestCategory(\"negative\")] on PlaceOrder_NullEmail_ThrowsArgumentException without adding a second negative tag"
+      - "Preserved the existing [TestCategory(\"negative\")] and [TestCategory(\"boundary\")] pair on PlaceOrder_ZeroQuantity without duplicating either"
+      - "Added trait attributes to the previously untagged test methods (e.g., CalculateDiscount_NegativeTotal, CancelOrder_ExistingPendingOrder, etc.)"
+      - "Used only trait values from the standard taxonomy (positive, negative, boundary, critical-path, smoke, regression, integration, end-to-end, performance, security, concurrency, resilience, destructive, configuration, flaky)"
+      - "Produced a trait distribution summary covering all tests in the suite"
+    timeout: 360
+
+  # ==========================================================================
+  # Scenario 7: Misleading method names — must read test body to classify
+  # ==========================================================================
+
+  - name: "Accurately classify NUnit tests with misleading method names"
+    prompt: >-
+      I have an NUnit test project at TaskManager.Tests/ covering a TaskService
+      class. The test method names aren't always descriptive of what's actually
+      being tested. Can you analyze the test bodies and add the right Category
+      attributes? Please provide a summary when done.
+    setup:
+      files:
+        - path: "TaskManager.Tests/TaskManager.Tests.csproj"
+          source: "fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj"
+        - path: "TaskManager.Tests/TaskServiceTests.cs"
+          source: "fixtures/nunit-misleading-names/TaskManager.Tests/TaskServiceTests.cs"
+        - path: "TaskManager/TaskManager.csproj"
+          source: "fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj"
+        - path: "TaskManager/TaskItem.cs"
+          source: "fixtures/nunit-misleading-names/TaskManager/TaskItem.cs"
+        - path: "TaskManager/TaskService.cs"
+          source: "fixtures/nunit-misleading-names/TaskManager/TaskService.cs"
+    assertions:
+      - type: file_contains
+        path: "TaskManager.Tests/TaskServiceTests.cs"
+        value: "[Category("
+      - type: output_matches
+        pattern: "(positive|negative)"
+      - type: output_matches
+        pattern: "(distribution|summary|trait|count)"
+    rubric:
+      - "Classified DeleteTask_Success as negative (and/or security) because the body asserts UnauthorizedAccessException, despite the name suggesting success"
+      - "Classified CreateTask_Fails_WhenFieldsPresent as positive because the body verifies successful creation, despite the name containing 'Fails'"
+      - "Classified GetByAssignee_Error_NoTasks as positive (and/or boundary) because the body asserts an empty result for a valid query, despite the name containing 'Error'"
+      - "Recognized BulkAssign_UpdatesAllTasks as a concurrency-related test because the implementation uses Task.WhenAll for parallel execution"
+      - "Classified DeleteTask_Validation as positive and security because the body verifies admin authorization succeeds"
+      - "Used NUnit [Category(\"...\")] attribute syntax, not MSTest or xUnit syntax"
+      - "Every test method received at least one trait attribute"
+    timeout: 360
+
+  # ==========================================================================
+  # Scenario 8: Verify project builds after tagging changes
+  # ==========================================================================
+
+  - name: "Tag MSTest tests and verify the project still builds"
+    prompt: >-
+      I need you to tag all the tests in my OrderService.Tests/ MSTest project
+      with appropriate category attributes. After adding the tags, please
+      verify the project still compiles by running dotnet build.
+    setup:
+      files:
+        - path: "OrderService.Tests/OrderService.Tests.csproj"
+          source: "fixtures/mstest-untagged/OrderService.Tests/OrderService.Tests.csproj"
+        - path: "OrderService.Tests/OrderProcessorTests.cs"
+          source: "fixtures/mstest-untagged/OrderService.Tests/OrderProcessorTests.cs"
+        - path: "OrderService/OrderService.csproj"
+          source: "fixtures/mstest-untagged/OrderService/OrderService.csproj"
+        - path: "OrderService/Order.cs"
+          source: "fixtures/mstest-untagged/OrderService/Order.cs"
+        - path: "OrderService/OrderProcessor.cs"
+          source: "fixtures/mstest-untagged/OrderService/OrderProcessor.cs"
+    assertions:
+      - type: file_contains
+        path: "OrderService.Tests/OrderProcessorTests.cs"
+        value: "TestCategory"
+      - type: output_matches
+        pattern: "(Build succeeded|build succeeded|0 Error|succeeded)"
+    rubric:
+      - "Added [TestCategory] attributes to the test methods"
+      - "Ran dotnet build (or equivalent compilation check) and confirmed the project compiles without errors after the changes"
+      - "Used only valid trait values from the taxonomy — no invented category names that would cause logical errors"
+      - "Every test method received at least one positive or negative tag"
+    timeout: 360

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs
@@ -39,14 +39,14 @@ public sealed class OrderProcessorTests
     // Already tagged — agent must preserve
     [TestMethod]
     [TestCategory("negative")]
-    public void PlaceOrder_NullEmail_ThrowsArgumentException()
+    public async Task PlaceOrder_NullEmail_ThrowsArgumentException()
     {
         var items = new List<OrderItem>
         {
             new() { ProductName = "Widget", Price = 5.00m, Quantity = 1 }
         };
 
-        Assert.ThrowsExactly<ArgumentException>(
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
             () => _processor.PlaceOrderAsync(null!, items));
     }
 

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderProcessorTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OrderService;
+
+namespace OrderService.Tests;
+
+[TestClass]
+public sealed class OrderProcessorTests
+{
+    private OrderProcessor _processor = null!;
+    private FakeOrderRepository _repository = null!;
+    private FakeEmailService _emailService = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _repository = new FakeOrderRepository();
+        _emailService = new FakeEmailService();
+        _processor = new OrderProcessor(_repository, _emailService);
+    }
+
+    // Already tagged — agent must preserve these and not duplicate them
+    [TestMethod]
+    [TestCategory("positive")]
+    [TestCategory("critical-path")]
+    public async Task PlaceOrder_ValidInput_ReturnsConfirmedOrder()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 9.99m, Quantity = 2 }
+        };
+
+        var order = await _processor.PlaceOrderAsync("customer@example.com", items);
+
+        Assert.AreEqual(OrderStatus.Confirmed, order.Status);
+        Assert.AreEqual("customer@example.com", order.CustomerEmail);
+        Assert.AreEqual(1, order.Items.Count);
+    }
+
+    // Already tagged — agent must preserve
+    [TestMethod]
+    [TestCategory("negative")]
+    public void PlaceOrder_NullEmail_ThrowsArgumentException()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 5.00m, Quantity = 1 }
+        };
+
+        Assert.ThrowsExactly<ArgumentException>(
+            () => _processor.PlaceOrderAsync(null!, items));
+    }
+
+    // Already tagged — agent must preserve
+    [TestMethod]
+    [TestCategory("negative")]
+    [TestCategory("boundary")]
+    public async Task PlaceOrder_ZeroQuantity_ThrowsArgumentException()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 5.00m, Quantity = 0 }
+        };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => _processor.PlaceOrderAsync("user@test.com", items));
+    }
+
+    // --- Untagged tests below — agent should add traits ---
+
+    [TestMethod]
+    public void CalculateDiscount_NegativeTotal_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => _processor.CalculateDiscount(-1m, 100));
+    }
+
+    [TestMethod]
+    public async Task CancelOrder_ExistingPendingOrder_SetsCancelledStatus()
+    {
+        var order = new Order { Id = 1, Status = OrderStatus.Pending };
+        _repository.Orders[1] = order;
+
+        await _processor.CancelOrderAsync(1);
+
+        Assert.AreEqual(OrderStatus.Cancelled, order.Status);
+    }
+
+    [TestMethod]
+    public void CalculateDiscount_HighPoints_Returns15Percent()
+    {
+        var discount = _processor.CalculateDiscount(100.00m, 1000);
+        Assert.AreEqual(15.00m, discount);
+    }
+
+    [TestMethod]
+    public async Task PlaceOrder_MultipleItems_CalculatesTotalCorrectly()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 10.00m, Quantity = 2 },
+            new() { ProductName = "Gadget", Price = 25.00m, Quantity = 1 }
+        };
+
+        var order = await _processor.PlaceOrderAsync("buyer@test.com", items);
+
+        Assert.AreEqual(45.00m, order.Total);
+    }
+
+    [TestMethod]
+    public void Constructor_NullRepository_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(
+            () => new OrderProcessor(null!, _emailService));
+    }
+
+    [TestMethod]
+    public void CalculateDiscount_ZeroTotal_ReturnsZeroRegardlessOfPoints()
+    {
+        var discount = _processor.CalculateDiscount(0m, 1000);
+        Assert.AreEqual(0m, discount);
+    }
+
+    [TestMethod]
+    public async Task PlaceOrder_EmptyEmail_ThrowsArgumentException()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 5.00m, Quantity = 1 }
+        };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => _processor.PlaceOrderAsync("", items));
+    }
+
+    [TestMethod]
+    public async Task CancelOrder_ShippedOrder_ThrowsInvalidOperationException()
+    {
+        var order = new Order { Id = 1, Status = OrderStatus.Shipped };
+        _repository.Orders[1] = order;
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => _processor.CancelOrderAsync(1));
+    }
+
+    [TestMethod]
+    public void CalculateDiscount_Exactly500Points_Returns10Percent()
+    {
+        var discount = _processor.CalculateDiscount(200.00m, 500);
+        Assert.AreEqual(20.00m, discount);
+    }
+
+    [TestMethod]
+    public async Task PlaceOrder_SendsConfirmationEmail()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = 5.00m, Quantity = 1 }
+        };
+
+        await _processor.PlaceOrderAsync("user@test.com", items);
+
+        Assert.IsTrue(_emailService.SentEmails.Count > 0);
+        Assert.AreEqual("user@test.com", _emailService.SentEmails[0]);
+    }
+
+    [TestMethod]
+    public void CalculateDiscount_NegativePoints_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => _processor.CalculateDiscount(100m, -1));
+    }
+
+    [TestMethod]
+    public async Task PlaceOrder_NegativePrice_ThrowsArgumentException()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { ProductName = "Widget", Price = -1.00m, Quantity = 1 }
+        };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => _processor.PlaceOrderAsync("user@test.com", items));
+    }
+}
+
+// --- Test doubles ---
+
+internal sealed class FakeOrderRepository : IOrderRepository
+{
+    public Dictionary<int, Order> Orders { get; } = new();
+
+    public Task<Order?> GetByIdAsync(int id, CancellationToken ct = default)
+    {
+        Orders.TryGetValue(id, out var order);
+        return Task.FromResult(order);
+    }
+
+    public Task SaveAsync(Order order, CancellationToken ct = default)
+    {
+        Orders[order.Id] = order;
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeEmailService : IEmailService
+{
+    public List<string> SentEmails { get; } = [];
+
+    public Task SendConfirmationAsync(string email, int orderId, CancellationToken ct = default)
+    {
+        SentEmails.Add(email);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OrderService\OrderService.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/Order.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/Order.cs
@@ -1,0 +1,25 @@
+namespace OrderService;
+
+public sealed class Order
+{
+    public int Id { get; set; }
+    public string CustomerEmail { get; set; } = string.Empty;
+    public List<OrderItem> Items { get; set; } = [];
+    public decimal Total => Items.Sum(i => i.Price * i.Quantity);
+    public OrderStatus Status { get; set; } = OrderStatus.Pending;
+}
+
+public sealed class OrderItem
+{
+    public string ProductName { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int Quantity { get; set; }
+}
+
+public enum OrderStatus
+{
+    Pending,
+    Confirmed,
+    Shipped,
+    Cancelled
+}

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderProcessor.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderProcessor.cs
@@ -1,0 +1,85 @@
+using System.Text.RegularExpressions;
+
+namespace OrderService;
+
+public sealed partial class OrderProcessor
+{
+    private readonly IOrderRepository _repository;
+    private readonly IEmailService _emailService;
+
+    public OrderProcessor(IOrderRepository repository, IEmailService emailService)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+    }
+
+    public async Task<Order> PlaceOrderAsync(string customerEmail, List<OrderItem> items, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(customerEmail))
+            throw new ArgumentException("Email is required.", nameof(customerEmail));
+
+        if (!EmailRegex().IsMatch(customerEmail))
+            throw new ArgumentException("Invalid email format.", nameof(customerEmail));
+
+        if (items is null || items.Count == 0)
+            throw new ArgumentException("At least one item is required.", nameof(items));
+
+        if (items.Any(i => i.Quantity <= 0))
+            throw new ArgumentException("All item quantities must be positive.", nameof(items));
+
+        if (items.Any(i => i.Price < 0))
+            throw new ArgumentException("Item prices cannot be negative.", nameof(items));
+
+        var order = new Order
+        {
+            CustomerEmail = customerEmail,
+            Items = items,
+            Status = OrderStatus.Confirmed
+        };
+
+        await _repository.SaveAsync(order, ct);
+        await _emailService.SendConfirmationAsync(customerEmail, order.Id, ct);
+
+        return order;
+    }
+
+    public async Task CancelOrderAsync(int orderId, CancellationToken ct = default)
+    {
+        var order = await _repository.GetByIdAsync(orderId, ct)
+            ?? throw new InvalidOperationException($"Order {orderId} not found.");
+
+        if (order.Status == OrderStatus.Shipped)
+            throw new InvalidOperationException("Cannot cancel a shipped order.");
+
+        order.Status = OrderStatus.Cancelled;
+        await _repository.SaveAsync(order, ct);
+    }
+
+    public decimal CalculateDiscount(decimal total, int loyaltyPoints)
+    {
+        if (total < 0) throw new ArgumentOutOfRangeException(nameof(total));
+        if (loyaltyPoints < 0) throw new ArgumentOutOfRangeException(nameof(loyaltyPoints));
+
+        return loyaltyPoints switch
+        {
+            >= 1000 => total * 0.15m,
+            >= 500 => total * 0.10m,
+            >= 100 => total * 0.05m,
+            _ => 0m
+        };
+    }
+
+    [GeneratedRegex(@"^[^@\s]+@[^@\s]+\.[^@\s]+$")]
+    private static partial Regex EmailRegex();
+}
+
+public interface IOrderRepository
+{
+    Task<Order?> GetByIdAsync(int id, CancellationToken ct = default);
+    Task SaveAsync(Order order, CancellationToken ct = default);
+}
+
+public interface IEmailService
+{
+    Task SendConfirmationAsync(string email, int orderId, CancellationToken ct = default);
+}

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderService.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderService.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TaskManager\TaskManager.csproj" />

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TaskManager\TaskManager.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskServiceTests.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskServiceTests.cs
@@ -1,0 +1,150 @@
+using NUnit.Framework;
+using TaskManager;
+
+namespace TaskManager.Tests;
+
+[TestFixture]
+public sealed class TaskServiceTests
+{
+    private TaskService _service = null!;
+    private FakeTaskNotifier _notifier = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _notifier = new FakeTaskNotifier();
+        _service = new TaskService(_notifier);
+    }
+
+    // Name says "Success" but the body tests an authorization check —
+    // a naive name-based classifier would tag this as "positive" only,
+    // but reading the body reveals it's a security test (negative path).
+    [Test]
+    public void DeleteTask_Success()
+    {
+        var task = _service.CreateTask("Fix bug", "alice", TaskPriority.High);
+
+        Assert.Throws<UnauthorizedAccessException>(
+            () => _service.DeleteTask(task.Id, "bob"));
+    }
+
+    // Name says "Fails" suggesting negative, but the body verifies
+    // correct successful creation — it's actually a positive test.
+    [Test]
+    public void CreateTask_Fails_WhenFieldsPresent()
+    {
+        var task = _service.CreateTask("Write docs", "charlie", TaskPriority.Low);
+
+        Assert.That(task.Id, Is.GreaterThan(0));
+        Assert.That(task.Title, Is.EqualTo("Write docs"));
+        Assert.That(task.Status, Is.EqualTo(TaskItemStatus.Open));
+    }
+
+    // Name says "Error" suggesting negative, but the body actually
+    // tests a boundary condition with empty result — it's a positive
+    // boundary test (valid query that returns empty).
+    [Test]
+    public void GetByAssignee_Error_NoTasks()
+    {
+        _service.CreateTask("Task A", "alice", TaskPriority.High);
+
+        var result = _service.GetByAssignee("nobody");
+
+        Assert.That(result, Is.Empty);
+    }
+
+    // Name is generic but the body uses Task.WhenAll for concurrent
+    // assignment — this is a concurrency test.
+    [Test]
+    public async Task BulkAssign_UpdatesAllTasks()
+    {
+        var t1 = _service.CreateTask("A", "alice", TaskPriority.Low);
+        var t2 = _service.CreateTask("B", "alice", TaskPriority.Medium);
+        var t3 = _service.CreateTask("C", "alice", TaskPriority.High);
+
+        await _service.BulkAssignAsync(new[] { t1.Id, t2.Id, t3.Id }, "bob");
+
+        Assert.That(_service.GetById(t1.Id)!.AssignedTo, Is.EqualTo("bob"));
+        Assert.That(_service.GetById(t2.Id)!.AssignedTo, Is.EqualTo("bob"));
+        Assert.That(_service.GetById(t3.Id)!.AssignedTo, Is.EqualTo("bob"));
+    }
+
+    // Name is misleading — says "Returns" suggesting a simple positive test,
+    // but the body tests the boundary of priority range enum values.
+    [Test]
+    public void GetTasksByPriorityRange_Returns()
+    {
+        _service.CreateTask("Low task", "alice", TaskPriority.Low);
+        _service.CreateTask("Critical task", "alice", TaskPriority.Critical);
+
+        var result = _service.GetTasksByPriorityRange(TaskPriority.Low, TaskPriority.Low);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Priority, Is.EqualTo(TaskPriority.Low));
+    }
+
+    // Name says "Validation" suggesting a basic check, but the body
+    // tests that admin can delete another user's task — a security /
+    // authorization positive test.
+    [Test]
+    public void DeleteTask_Validation()
+    {
+        var task = _service.CreateTask("Fix bug", "alice", TaskPriority.High);
+
+        _service.DeleteTask(task.Id, "admin");
+
+        Assert.That(task.Status, Is.EqualTo(TaskItemStatus.Deleted));
+    }
+
+    // Name is vague but body tests inverted priority range —
+    // this is a negative boundary test.
+    [Test]
+    public void GetTasksByPriorityRange_InvalidRange()
+    {
+        Assert.Throws<ArgumentException>(
+            () => _service.GetTasksByPriorityRange(TaskPriority.Critical, TaskPriority.Low));
+    }
+
+    // Straightforward negative test — name matches body.
+    [Test]
+    public void CreateTask_NullTitle_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(
+            () => _service.CreateTask(null!, "alice", TaskPriority.High));
+    }
+
+    // Name says "Check" — vague. Body verifies the assignee owns
+    // the task and can delete it (authorization positive path).
+    [Test]
+    public void DeleteTask_Check_AssigneeCanDelete()
+    {
+        var task = _service.CreateTask("Clean up", "alice", TaskPriority.Medium);
+
+        _service.DeleteTask(task.Id, "alice");
+
+        Assert.That(task.Status, Is.EqualTo(TaskItemStatus.Deleted));
+    }
+
+    // Name says nothing about concurrency, but the body creates
+    // tasks in rapid succession checking thread-safe ID generation.
+    [Test]
+    public void CreateTask_MultipleRapidCreations_UniqueIds()
+    {
+        var tasks = Enumerable.Range(0, 50)
+            .Select(i => _service.CreateTask($"Task {i}", "alice", TaskPriority.Low))
+            .ToList();
+
+        var uniqueIds = tasks.Select(t => t.Id).Distinct().Count();
+        Assert.That(uniqueIds, Is.EqualTo(50));
+    }
+}
+
+internal sealed class FakeTaskNotifier : ITaskNotifier
+{
+    public List<TaskItem> Notifications { get; } = [];
+
+    public void NotifyCreated(TaskItem task)
+    {
+        Notifications.Add(task);
+    }
+}

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskItem.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskItem.cs
@@ -1,0 +1,27 @@
+namespace TaskManager;
+
+public sealed class TaskItem
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string AssignedTo { get; set; } = string.Empty;
+    public TaskPriority Priority { get; set; }
+    public TaskItemStatus Status { get; set; } = TaskItemStatus.Open;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public enum TaskPriority
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}
+
+public enum TaskItemStatus
+{
+    Open,
+    InProgress,
+    Completed,
+    Deleted
+}

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskService.cs
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskService.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+
+namespace TaskManager;
+
+public sealed class TaskService
+{
+    private readonly ConcurrentDictionary<int, TaskItem> _tasks = new();
+    private readonly ITaskNotifier _notifier;
+    private int _nextId;
+
+    public TaskService(ITaskNotifier notifier)
+    {
+        _notifier = notifier ?? throw new ArgumentNullException(nameof(notifier));
+    }
+
+    public TaskItem CreateTask(string title, string assignedTo, TaskPriority priority)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title is required.", nameof(title));
+
+        if (string.IsNullOrWhiteSpace(assignedTo))
+            throw new ArgumentException("AssignedTo is required.", nameof(assignedTo));
+
+        var id = Interlocked.Increment(ref _nextId);
+        var task = new TaskItem
+        {
+            Id = id,
+            Title = title,
+            AssignedTo = assignedTo,
+            Priority = priority,
+            Status = TaskItemStatus.Open
+        };
+
+        _tasks[id] = task;
+        _notifier.NotifyCreated(task);
+        return task;
+    }
+
+    public TaskItem? GetById(int id) => _tasks.GetValueOrDefault(id);
+
+    public IReadOnlyList<TaskItem> GetByAssignee(string assignedTo)
+    {
+        return _tasks.Values
+            .Where(t => t.AssignedTo.Equals(assignedTo, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    public void DeleteTask(int id, string requestedBy)
+    {
+        if (!_tasks.TryGetValue(id, out var task))
+            throw new InvalidOperationException($"Task {id} not found.");
+
+        // Only the assignee or an admin can delete
+        if (!task.AssignedTo.Equals(requestedBy, StringComparison.OrdinalIgnoreCase)
+            && !requestedBy.Equals("admin", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UnauthorizedAccessException("Only the assignee or admin can delete a task.");
+        }
+
+        task.Status = TaskItemStatus.Deleted;
+    }
+
+    public async Task BulkAssignAsync(IEnumerable<int> taskIds, string assignee, CancellationToken ct = default)
+    {
+        var tasks = new List<Task>();
+        foreach (var id in taskIds)
+        {
+            if (_tasks.TryGetValue(id, out var task))
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    task.AssignedTo = assignee;
+                    _notifier.NotifyCreated(task);
+                }, ct));
+            }
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    public IReadOnlyList<TaskItem> GetTasksByPriorityRange(TaskPriority minPriority, TaskPriority maxPriority)
+    {
+        if (minPriority > maxPriority)
+            throw new ArgumentException("minPriority cannot exceed maxPriority.");
+
+        return _tasks.Values
+            .Where(t => t.Priority >= minPriority && t.Priority <= maxPriority)
+            .ToList();
+    }
+}
+
+public interface ITaskNotifier
+{
+    void NotifyCreated(TaskItem task);
+}


### PR DESCRIPTION
- [x] Inspect current `test-tagging` eval files against new review comments
- [x] Run baseline validation/checks for the touched files
- [x] Determine whether further code changes are required
- [x] Reply to new actionable PR comments
- [x] Run final validation pass