### PR TITLE
Add LSP support for .razor and .cshtml file extensions

### DIFF
--- a/plugins/dotnet/lsp.json
+++ b/plugins/dotnet/lsp.json
@@ -12,7 +12,9 @@
         "--autoLoadProjects"
       ],
       "fileExtensions": {
-        ".cs": "csharp"
+        ".cs": "csharp",
+        ".razor": "aspnetcorerazor",
+        ".cshtml": "aspnetcorerazor"
       }
     }
   }


### PR DESCRIPTION
The roslyn-language-server package includes the Razor LSP bits now.

Fixes https://github.com/dotnet/razor/issues/13140

Package that adds this support is: https://www.nuget.org/packages/roslyn-language-server/5.8.0-1.26262.10