### PR TITLE
fix(health): remove Investigation Results section from health-check to eliminate duplicate

### DIFF
--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -352,19 +352,6 @@ Replace the entire issue body with the following structure:
 
 ---
 
-## 🔍 Investigation Results
-
-> Deep investigations are dispatched for new critical/warning findings.
-> The [grooming workflow](../workflows/devops-health-groom.md) links results ~3 hours after this run.
-
-| Finding | Severity | Investigation | First Seen | Result |
-|---------|----------|---------------|------------|--------|
-{Preserve rows from the previous issue body's Investigation Results table (look inside the `<!-- gh-aw-island-start:devops-health-groom -->` block if present). Copy all rows as-is for findings that are still active (appear in New Findings or Existing Findings). Drop rows whose finding is no longer active (resolved). If the previous table uses the old 4-column schema (`| Finding | Severity | Status | Result |`), migrate each row to the new 5-column schema: rename Status to Investigation, and populate First Seen from the finding's `<summary>` line (`first seen YYYY-MM-DD`) or use today's date as fallback. Then append new rows for findings dispatched in the current run:}
-| {finding_title} | {severity_emoji} {severity} | 🔄 Dispatched | {first_seen date} | [⏳ Investigation dispatched — results arriving shortly...]({link_to_dispatched_investigate_run_or_this_health_check_run}) |
-{If no dispatched findings AND no previous rows exist, render the table header with zero data rows.}
-
----
-
 ## ✅ Resolved Since Yesterday ({resolved_count})
 
 > These were in yesterday's report but are no longer detected.
@@ -473,7 +460,6 @@ dispatch-workflow:
 Before finishing, verify:
 - [ ] At least one `dispatch-workflow` call was made (if any 🔴 critical or qualifying 🟡 warning findings exist)
 - [ ] All 🔴 critical NEW findings have been dispatched (up to budget cap)
-- [ ] The "🔍 Investigation Results" section in the issue body includes newly dispatched findings as "🔄 Dispatched" and preserves existing rows from the previous body
 - [ ] The noop summary message mentions how many investigations were dispatched
 
 ---
@@ -483,7 +469,7 @@ Before finishing, verify:
 - **Time budget**: You have a 60-minute timeout. Prioritize reaching Steps 4 and 5 (issue update + dispatch). Do NOT write intermediate scripts or analysis files. Work through each check, collect findings in memory, and proceed directly to output. Aim to complete data collection (Step 1) within 30 minutes.
 - **Efficiency**: Process API responses in memory. Do NOT create Python/bash scripts to analyze data — parse JSON directly using `jq` or inline analysis. Do NOT write intermediate files unless explicitly required by the output format.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **complete, literal issue body text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. Pass the body directly as the string value.
-- **CRITICAL — Investigation Results section**: The `## 🔍 Investigation Results` section MUST always appear in the issue body template. The downstream [grooming workflow](../workflows/devops-health-groom.md) manages this section via a `replace-island` block — so the health-check must **preserve existing rows** from the previous issue body (look inside `<!-- gh-aw-island-start:devops-health-groom -->` markers if present, and copy those table rows into the new section). Do NOT wrap the section in island markers yourself — the groom adds those. Only append new "🔄 Dispatched" rows for findings dispatched in the current run.
+- **Do NOT emit an Investigation Results section**: The `## 🔍 Investigation Results` section is owned exclusively by the downstream [grooming workflow](../workflows/devops-health-groom.md) via its `replace-island` block. The gh-aw framework automatically preserves islands from other workflows when `update-issue` replaces the body. If the health-check emits its own `## 🔍 Investigation Results` section, the issue ends up with TWO such sections (one stale, one correct inside the groom’s island). Never create this section — the groom will create and maintain it.
 - **Be data-driven**: Include specific numbers, durations, percentages, and links.
 - **Be precise with fingerprints**: Use the exact fingerprint formulas from the knowledge file. Consistency is critical — the same finding MUST produce the same fingerprint across runs.
 - **First run handling**: If `cache-memory` has no previous state, note: "⚠️ This is the first health check run. All findings appear as new. Diff will resume from next run."

--- a/.github/workflows/devops-health-groom.md
+++ b/.github/workflows/devops-health-groom.md
@@ -179,9 +179,9 @@ and rows like:
 | {finding_title} | {severity} | 🔄 Dispatched | {date} | ⏳ Investigation dispatched — results arriving shortly... |
 ```
 
-**Duplicate section handling:** If the issue body contains **multiple** `## 🔍 Investigation Results` sections, merge all rows from every occurrence into a single table (de-duplicate by finding title). The `replace-island` operation only replaces the **first** occurrence — it does NOT automatically remove later duplicates. If duplicates exist, extract all rows first, then the single `replace-island` call will place them in the first section. Any remaining duplicate sections will be overwritten by the next health-check run (which replaces the entire issue body).
+**Duplicate section handling:** If the issue body contains **multiple** `## 🔍 Investigation Results` sections (legacy from before this fix), merge all rows from every occurrence into a single table (de-duplicate by finding title). The `replace-island` operation only replaces the content inside this workflow's island markers — it does NOT automatically remove sections outside the island. If duplicates exist, extract all rows first, then the single `replace-island` call will consolidate them into the island.
 
-**If the section is missing** (the health check agent sometimes omits it), you MUST
+**If the section is missing** (first run, or after a reset), you MUST
 create it. Do NOT skip this step — creating the section is the primary purpose of
 this workflow. Proceed to Step 3.2 with an empty table.
 
@@ -359,7 +359,7 @@ If changes were made, the summary is implicit in the safe-output calls. Do NOT c
 
 ## Guidelines
 
-- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically. If multiple `## 🔍 Investigation Results` sections exist in the body, `replace-island` targets the first one — the groomer must merge all rows from every occurrence into that single section before calling `replace-island`. Later duplicate sections are not automatically removed; the next health-check run (which replaces the full body) will clean them up.
+- **CRITICAL — Use `operation: "replace-island"`**: When calling `update-issue`, you **MUST** set `operation: "replace-island"`. This replaces only the `## 🔍 Investigation Results` section in the issue body, leaving all other sections untouched. The `body` field must contain only the Investigation Results section content (from the `## 🔍 Investigation Results` heading up to but not including the next `##`-level heading). Do NOT pass the full issue body — `replace-island` handles scoping automatically. The health-check workflow does NOT create this section — the groom is the sole owner. If the section doesn't exist yet, `replace-island` will create the island. If legacy duplicate sections exist in the body, merge all rows into your single `replace-island` call.
 - **CRITICAL — Safe output body must be inline**: When calling `update-issue`, the `body` field must contain the **literal section text**. NEVER write the body to a file and use a shell reference like `$(cat file.txt)` — safe outputs are literal JSON strings, not shell-evaluated. The body must be passed directly as the string value.
 - **Minimal edits only**: You are a groomer, not a rewriter. Only change: (a) investigation table rows (status + link), (b) resolved-finding annotations. Copy all other sections **byte-for-byte** from the original body. Do not reformat, re-wrap, or reorganize sections you are not changing.
 - **Be precise with comment parsing**: The comment format is well-defined (see the investigation worker template). Match the exact patterns — don't be fuzzy.


### PR DESCRIPTION
## Problem

Issue #288 has **two** `## Investigation Results` sections:
1. One created by the **health-check** (stale - rows stuck at 'Dispatched')
2. One inside the **groom's island** (correct - rows properly updated to 'Done')

Users see the stale first section and think investigations aren't being linked.

### Root Cause

The health-check replaces the **entire** issue body each run. It copies rows from its own previous section (which still says 'Dispatched'). The groom correctly updates rows in its island, but this island is appended at the bottom - creating a visible duplicate.

The gh-aw framework **automatically preserves islands from other workflows** when update-issue replaces the body. So the health-check doesn't need to manage this section at all.

## Fix

1. **Remove** the Investigation Results section from the health-check template entirely
2. **Update guideline** to explain that the groom owns this section via its island
3. **Update groom guidance** to reflect it's the sole owner (no more duplicate handling needed)
4. **Manually removed** the stale duplicate section from issue #288

## Verification

The groom already works correctly (today's run 25784070819 updated all rows to Done in its island). After this fix, the next health-check run will no longer recreate the stale section.
