### PR TITLE
Add Go, Java, Rust, Ruby, Swift, and Kotlin extensions to code-testing-extensions

### DIFF
--- a/plugins/dotnet-test/skills/code-testing-extensions/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/SKILL.md
@@ -22,6 +22,12 @@ This skill provides access to language-specific guidance files used by the code-
 | [extensions/typescript.md](extensions/typescript.md) | TypeScript/JavaScript | Build/test commands (Jest/Vitest/Mocha), framework detection, mocking, TS-specific considerations |
 | [extensions/powershell.md](extensions/powershell.md) | PowerShell | Test commands (Pester v5), module import patterns, discovery/run pitfalls, mocking, common errors |
 | [extensions/cpp.md](extensions/cpp.md) | C++ | Testing internals with friend declarations |
+| [extensions/go.md](extensions/go.md) | Go | `go test` commands, table-driven tests, integration vs unit layout, mocking via interfaces, common errors |
+| [extensions/java.md](extensions/java.md) | Java | Maven/Gradle commands, JUnit 4/5 and TestNG detection, Mockito, Spring Boot slices, common errors |
+| [extensions/rust.md](extensions/rust.md) | Rust | `cargo test` commands, unit vs integration vs doc tests, features, async test harnesses, common errors |
+| [extensions/ruby.md](extensions/ruby.md) | Ruby | RSpec and Minitest commands, Bundler usage, Rails specifics, mocking patterns, common errors |
+| [extensions/swift.md](extensions/swift.md) | Swift | SPM and Xcode test commands, XCTest vs Swift Testing, `@testable import`, async/throws tests, common errors |
+| [extensions/kotlin.md](extensions/kotlin.md) | Kotlin | Gradle commands, JUnit/Kotest detection, MockK, coroutines test, KMP and Android specifics, common errors |
 | [extensions/dotnet-examples.md](extensions/dotnet-examples.md) | .NET (C#/F#/VB) | Concrete pipeline examples: sample research output, plan, generated tests, fix cycles, final report |
 
 ## Usage

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/go.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/go.md
@@ -1,0 +1,158 @@
+# Go Extension
+
+Language-specific guidance for Go test generation.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — find `*_test.go` files and copy their style (table-driven layout, helper usage, assertion library, build tags)
+2. **`go.mod` / `go.sum`** — module path, Go version, dependencies (e.g. `testify`, `gomock`, `mockery`)
+3. **Build/CI scripts** — `Makefile`, `magefile.go`, `Taskfile.yml`, `.github/workflows/*.yml`
+4. **`go.work`** — if present, you are in a workspace; tests for a module must run from that module's directory or use `-C` (Go 1.20+)
+
+Use whatever assertion style and test layout the repo already uses. Do not introduce `testify` if the repo uses the standard library only.
+
+## Toolchain Detection
+
+| Indicator | Meaning |
+|-----------|---------|
+| `go.mod` `go 1.x` directive | Minimum Go version — match it locally with `go version` |
+| `go.work` at the root | Multi-module workspace; commands resolve dependent modules from sibling directories |
+| `vendor/` directory | Vendored deps; many commands implicitly add `-mod=vendor` |
+| `tools.go` with `//go:build tools` | Tool versions pinned in `go.mod` (e.g. `mockgen`); install with `go install` from the listed paths |
+
+## Build Commands
+
+| Scope | Command |
+|-------|---------|
+| Compile a package | `go build ./path/to/pkg` |
+| Vet (static analysis) | `go vet ./...` |
+| Compile tests without running | `go test -count=1 -run=^$ ./path/to/pkg` |
+| Whole module | `go build ./...` |
+
+`go build ./...` is the closest thing to a "does it compile" gate. It does not exercise test files — use `go test -run=^$` to type-check tests as well.
+
+## Test Commands
+
+| Scope | Command |
+|-------|---------|
+| All tests in a package | `go test ./path/to/pkg` |
+| All tests in module | `go test ./...` |
+| Single test | `go test -run '^TestName$' ./path/to/pkg` |
+| Subtest | `go test -run '^TestName$/^subname$' ./path/to/pkg` |
+| Verbose | `go test -v ./path/to/pkg` |
+| Race detector | `go test -race ./...` |
+| Disable cache | `go test -count=1 ./...` |
+| Short mode | `go test -short ./...` |
+
+- `-run` arguments are **regular expressions anchored** with `^...$`; without anchors the pattern matches as a substring
+- `go test -count=1` is the canonical way to bypass the test result cache; never use a fake `-count=2` or environment hacks
+- `-race` significantly slows tests and requires CGO — only enable if the repo's CI does
+
+## Lint Command
+
+Use the repo's lint script first (`make lint`, `task lint`). Otherwise detect from `.golangci.yml`/`.golangci.yaml`:
+
+- `.golangci.yml` present → `golangci-lint run ./...`
+- No config → `gofmt -w .` and `go vet ./...`
+- `goimports` config / pre-commit hook → `goimports -w path/to/file.go`
+
+Never disable existing linters in the test files you generate.
+
+## Project Layout and Imports
+
+Go uses package paths derived from the module path in `go.mod`.
+
+| Scenario | Test placement | Package declaration |
+|----------|----------------|----------------------|
+| Internal-only test (white-box) | `foo_test.go` next to `foo.go` | `package foo` (same as production) |
+| External-only test (black-box) | `foo_test.go` next to `foo.go` | `package foo_test` (forces use of public API) |
+| Integration / build-tag gated | `foo_integration_test.go` | Add `//go:build integration` at top |
+
+- Test files **must** end with `_test.go` — the toolchain ignores other names
+- A package directory may contain both `package foo` and `package foo_test` test files simultaneously
+- Helpers shared across tests in one package go in `helpers_test.go` — do not export them; put them in the `_test` package only if integration tests in another package need them
+- Imports use the full module path: `import "github.com/org/module/pkg"` — copy the exact module path from `go.mod`
+
+## Test Function Signatures
+
+| Kind | Signature |
+|------|-----------|
+| Standard test | `func TestThing(t *testing.T)` |
+| Subtests | `t.Run("name", func(t *testing.T) { ... })` |
+| Benchmark | `func BenchmarkThing(b *testing.B)` |
+| Example (godoc) | `func ExampleThing()` with `// Output:` comment |
+| Fuzz (Go 1.18+) | `func FuzzThing(f *testing.F)` |
+| Per-package setup | `func TestMain(m *testing.M)` — call `m.Run()` and `os.Exit` with its code |
+
+Use **table-driven tests** when generating multiple cases for the same behavior — this is idiomatic Go and matches what most repos already use:
+
+```go
+func TestAdd(t *testing.T) {
+    tests := []struct {
+        name string
+        a, b int
+        want int
+    }{
+        {"positives", 2, 3, 5},
+        {"negatives", -1, -1, -2},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if got := Add(tt.a, tt.b); got != tt.want {
+                t.Errorf("Add(%d,%d) = %d, want %d", tt.a, tt.b, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+When iterating with `t.Run` over a loop variable on Go < 1.22, capture it with `tt := tt` to avoid closure-over-loop-variable bugs.
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `package X is not in std` / `cannot find module providing package X` | Add the import to `go.mod`: `go get path/to/module@version`, then `go mod tidy` |
+| `import cycle not allowed in test` | Move shared helpers to a separate package, or switch to a `_test` package for black-box tests |
+| `undefined: X` in `_test` package | The symbol is unexported; either use `package foo` (white-box) or export it intentionally |
+| `t.Parallel called multiple times` | Each subtest can call `t.Parallel()` once; do not call it twice in the same test |
+| `panic: test executed panic(nil) or runtime.Goexit` | A goroutine called `t.Fatal` outside the test goroutine; only the main test goroutine may call `Fatal`/`FailNow` |
+| `flag provided but not defined: -X` | Flags registered in `init()` of test files must use `flag.NewFlagSet` carefully; place test-only flags in `TestMain` |
+| `go: cannot find main module` | Run inside the module directory (where `go.mod` lives), or use `-C path` (Go 1.20+) |
+| `build constraints exclude all Go files in...` | Build tags filtered out every file — match the repo's tag with `-tags=integration` etc. |
+| `missing go.sum entry for module` | Run `go mod download` or `go mod tidy` |
+| Race detector reports data race | Fix the race; do not silence it. CGO must be enabled |
+
+## Mocking Rules
+
+Go has no reflection-based mocking framework that's universally adopted. Pick what the repo already uses:
+
+- **Interfaces + hand-written fakes** (most idiomatic) — define a small interface in the consumer package and pass a struct that implements it
+- **`gomock` / `mockgen`** — if the repo has `//go:generate mockgen ...` directives or `mocks/` directories, regenerate via `go generate ./...` rather than editing generated files
+- **`testify/mock`** — used in many repos; instantiate with `new(MockX)` and chain `.On("Method", ...).Return(...)`
+- **`httptest`** — for HTTP clients/servers; spin up `httptest.NewServer` instead of mocking `http.Client`
+
+Always prefer dependency injection over global function patching. If a test needs more than 3 mocks, flag it as a design smell.
+
+## Concurrency and Cleanup
+
+- Use `t.Cleanup(func() { ... })` instead of deferring in test bodies — runs even if `t.FailNow` fires
+- Use `t.TempDir()` for temp files — auto-cleaned at test end
+- Use `t.Context()` (Go 1.24+) or pass an explicit `context.Background()` — never call real network or filesystem APIs without one in long-running tests
+
+## Dependency Installation (Last Resort)
+
+Only install packages after investigation confirms they are missing:
+
+```
+go get github.com/stretchr/testify@latest
+go mod tidy
+```
+
+Run `go mod tidy` after any `go get` to keep `go.sum` consistent. Never edit `go.sum` by hand.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (`-cover`, `-coverprofile`, `go tool cover`). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/java.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/java.md
@@ -1,0 +1,198 @@
+# Java Extension
+
+Language-specific guidance for Java test generation.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — find `*Test.java` / `*Tests.java` / `*IT.java` (integration) files and copy their style (JUnit version, assertion library, mock library, lifecycle methods)
+2. **Build file** — `pom.xml` (Maven), `build.gradle` / `build.gradle.kts` (Gradle), `BUILD` / `BUILD.bazel` (Bazel)
+3. **Java version** — `<maven.compiler.release>`, `sourceCompatibility`, or `toolchains` block
+4. **Wrapper scripts** — always prefer `./mvnw` or `./gradlew` over a system-installed Maven/Gradle so you match the project's pinned version
+
+Use whatever framework the repo already uses (JUnit 4, JUnit 5/Jupiter, TestNG). Do not migrate to a different framework as a side effect of writing tests.
+
+## Build Tool Detection
+
+| Indicator | Build tool | Default test command |
+|-----------|------------|----------------------|
+| `pom.xml` | Maven | `./mvnw test` |
+| `build.gradle` / `build.gradle.kts` | Gradle | `./gradlew test` |
+| `settings.gradle*` with `include 'subproject'` | Gradle multi-project | `./gradlew :subproject:test` |
+| `BUILD` / `BUILD.bazel` | Bazel | `bazel test //path/to:test` |
+
+If both `pom.xml` and `build.gradle` exist, pick the one used by CI.
+
+## Build Commands
+
+| Scope | Maven | Gradle |
+|-------|-------|--------|
+| Compile main + test | `./mvnw test-compile` | `./gradlew testClasses` |
+| Compile only | `./mvnw compile` | `./gradlew classes` |
+| Full build | `./mvnw verify` | `./gradlew build` |
+| Skip tests during build | `./mvnw -DskipTests package` | `./gradlew assemble` |
+
+- Use `-q` (Maven) / `--console=plain` (Gradle) to reduce output noise
+- For Gradle, prefer `--no-daemon` only in CI; locally the daemon makes incremental builds far faster
+
+## Test Commands
+
+| Scope | Maven | Gradle |
+|-------|-------|--------|
+| All unit tests | `./mvnw test` | `./gradlew test` |
+| Single class | `./mvnw test -Dtest=MyClassTest` | `./gradlew test --tests MyClassTest` |
+| Single method | `./mvnw test -Dtest=MyClassTest#myMethod` | `./gradlew test --tests MyClassTest.myMethod` |
+| Tag filter (JUnit 5) | `./mvnw test -Dgroups=fast` | `./gradlew test -PincludeTags=fast` (if configured) or `--tests` |
+| Integration tests | `./mvnw verify -DskipUnitTests` (with failsafe-plugin) | `./gradlew integrationTest` (if registered) |
+
+- `Surefire` runs unit tests (`*Test.java`); `Failsafe` runs integration tests (`*IT.java`) — do not put long integration tests under Surefire
+- Gradle's `--tests` accepts wildcards: `--tests "*MyMethod*"`
+- Use `--rerun-tasks` (Gradle) or `-DforkCount=...` (Surefire) only when troubleshooting cache issues
+
+## Lint Command
+
+Use the repo's existing lint task first. Otherwise check for:
+
+- Checkstyle (`checkstyle.xml`, `<plugin>checkstyle</plugin>`) → `./mvnw checkstyle:check` or `./gradlew checkstyleMain`
+- Spotless (`spotless` block / plugin) → `./mvnw spotless:apply` or `./gradlew spotlessApply`
+- ErrorProne / NullAway → integrated into compilation; run a normal build
+- google-java-format / palantir-java-format → use the repo's configured formatter
+
+Never disable existing checks in the test files you generate.
+
+## Project Layout and Imports
+
+Maven/Gradle conventional layout:
+
+```
+src/
+├── main/java/com/example/foo/Bar.java
+├── main/resources/
+├── test/java/com/example/foo/BarTest.java
+└── test/resources/
+```
+
+| Layout | Test placement |
+|--------|----------------|
+| Standard | `src/test/java/<same package as production class>/<ClassName>Test.java` |
+| Integration tests separated | `src/integrationTest/java/...` (Gradle) or `src/it/java/...` (Maven w/ failsafe) |
+| Multi-module Maven | Tests live in the same module as the code under test |
+
+- Test classes must mirror the production class's **package** to access package-private members
+- Use **wildcard imports** only if the repo already does — most style guides discourage them
+- For JUnit 5: `import org.junit.jupiter.api.*;` and `import static org.junit.jupiter.api.Assertions.*;`
+- For JUnit 4: `import org.junit.*;` and `import static org.junit.Assert.*;`
+
+## Test Framework Detection
+
+| Indicator | Framework | Annotations | Assertion style |
+|-----------|-----------|-------------|------------------|
+| `junit-jupiter-*` deps | JUnit 5 | `@Test`, `@ParameterizedTest`, `@BeforeEach`, `@DisplayName` | `Assertions.assertEquals(expected, actual)` |
+| `junit:junit:4.x` | JUnit 4 | `@Test`, `@Before`, `@RunWith` | `Assert.assertEquals(expected, actual)` |
+| `org.testng:testng` | TestNG | `@Test(groups=...)`, `@BeforeMethod` | `Assert.assertEquals(actual, expected)` (note **reversed** order) |
+| `org.assertj:assertj-core` | AssertJ (assertions only) | n/a | `assertThat(actual).isEqualTo(expected)` |
+| `org.hamcrest:hamcrest` | Hamcrest matchers | n/a | `assertThat(actual, is(equalTo(expected)))` |
+
+**Argument order matters**: JUnit/AssertJ use `(expected, actual)`; TestNG uses `(actual, expected)`. Reversing them produces confusing failure messages.
+
+## JUnit 5 Template
+
+```java
+package com.example.foo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CalculatorTest {
+
+    @Test
+    @DisplayName("add returns sum of two positive numbers")
+    void add_positiveNumbers_returnsSum() {
+        Calculator sut = new Calculator();
+        assertEquals(5, sut.add(2, 3));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "2, 3, 5",
+        "-1, 1, 0"
+    })
+    void add_validInputs_returnsSum(int a, int b, int expected) {
+        assertEquals(expected, new Calculator().add(a, b));
+    }
+
+    @Test
+    void divide_byZero_throws() {
+        Calculator sut = new Calculator();
+        assertThrows(ArithmeticException.class, () -> sut.divide(1, 0));
+    }
+}
+```
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `package X does not exist` | Add the dependency to `pom.xml` / `build.gradle`; run `./mvnw dependency:resolve` or `./gradlew --refresh-dependencies` |
+| `cannot find symbol` | Verify class name and import path; check that the test source set sees the production source set |
+| `No tests found for given includes` (Gradle) | `--tests` pattern doesn't match; class must be public, methods annotated with `@Test`, and class name matches the test task's `include` pattern (default `**/*Test*.class`) |
+| `Test class should have exactly one public zero-argument constructor` (JUnit 4) | Remove constructors with parameters; use `@Before` for setup |
+| `org.junit.runners.model.InvalidTestClassError` (JUnit 4) | Class is missing `public`, has wrong constructor, or method signature is wrong |
+| Mixing `org.junit.Test` (4) and `org.junit.jupiter.api.Test` (5) | Pick one framework per test class — imports must match the framework annotation |
+| `java.lang.NoClassDefFoundError` at runtime | Test runtime classpath is missing a transitive dep; add it to `testRuntimeOnly` (Gradle) or `<scope>test</scope>` (Maven) |
+| `UnsupportedClassVersionError` | JDK used to run tests is older than the JDK used to compile; align toolchains |
+| `Mockito cannot mock final class` | Add `mockito-inline` dep (or `mockito-subclass` in Mockito 5+), or refactor the class to be non-final |
+| `WrongTypeOfReturnValue` (Mockito) | The stubbed method returns a different type than the mock was set up for — check return type signatures |
+
+## Mocking Rules
+
+- Use whatever the repo already uses: **Mockito** (most common), **EasyMock**, **JMockit**, or hand-written fakes
+- For JUnit 5 + Mockito, use `@ExtendWith(MockitoExtension.class)` with `@Mock` / `@InjectMocks` fields
+- For JUnit 4 + Mockito, use `@RunWith(MockitoJUnitRunner.class)` or `MockitoAnnotations.openMocks(this)` in `@Before`
+- Use `when(mock.method(...)).thenReturn(...)` for stubs and `verify(mock).method(...)` for interactions
+- Use `ArgumentCaptor` to assert on complex argument values rather than over-specifying matchers
+- Prefer constructor injection so production code stays testable without `@InjectMocks`
+- If a test needs more than 3 mocks, flag it as a design smell
+
+## Spring Boot
+
+If the repo uses Spring Boot:
+
+- `@SpringBootTest` loads the full context — slow; use only when needed
+- Slice tests are faster: `@WebMvcTest`, `@DataJpaTest`, `@JsonTest`
+- Use `@MockBean` (Spring) only inside Spring tests; in plain unit tests use `@Mock`
+- Use `@Testcontainers` for real-DB integration tests if the repo already has it on the classpath
+
+## Dependency Installation (Last Resort)
+
+Only add dependencies after investigation confirms they are missing.
+
+Maven (`pom.xml`):
+
+```xml
+<dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter</artifactId>
+    <version>5.10.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+Gradle (`build.gradle.kts`):
+
+```kotlin
+testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+```
+
+If the repo uses BOMs (`<dependencyManagement>` or Gradle platforms), reuse them — don't pin a different version than the BOM publishes.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (JaCoCo, Cobertura, OpenClover). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/java.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/java.md
@@ -80,9 +80,9 @@ src/
 | Multi-module Maven | Tests live in the same module as the code under test |
 
 - Test classes must mirror the production class's **package** to access package-private members
-- Use **wildcard imports** only if the repo already does — most style guides discourage them
-- For JUnit 5: `import org.junit.jupiter.api.*;` and `import static org.junit.jupiter.api.Assertions.*;`
-- For JUnit 4: `import org.junit.*;` and `import static org.junit.Assert.*;`
+- Avoid wildcard imports unless the repo already uses them — match the explicit imports shown in the templates below
+- For JUnit 5: import `org.junit.jupiter.api.Test` (and other annotations as needed) and `org.junit.jupiter.api.Assertions.assertEquals` etc. as static imports
+- For JUnit 4: import `org.junit.Test`, `org.junit.Before`, etc., and `org.junit.Assert.assertEquals` etc. as static imports
 
 ## Test Framework Detection
 
@@ -141,13 +141,13 @@ class CalculatorTest {
 |-------|-----|
 | `package X does not exist` | Add the dependency to `pom.xml` / `build.gradle`; run `./mvnw dependency:resolve` or `./gradlew --refresh-dependencies` |
 | `cannot find symbol` | Verify class name and import path; check that the test source set sees the production source set |
-| `No tests found for given includes` (Gradle) | `--tests` pattern doesn't match; class must be public, methods annotated with `@Test`, and class name matches the test task's `include` pattern (default `**/*Test*.class`) |
+| `No tests found for given includes` (Gradle) | `--tests` pattern doesn't match; verify the class/method names, that test methods are annotated with `@Test`, and that the class name matches the test task's `include` pattern (default `**/*Test*.class`). For JUnit 4 only, the class must also be `public` with a public no-arg constructor — JUnit 5 allows package-private classes and methods |
 | `Test class should have exactly one public zero-argument constructor` (JUnit 4) | Remove constructors with parameters; use `@Before` for setup |
 | `org.junit.runners.model.InvalidTestClassError` (JUnit 4) | Class is missing `public`, has wrong constructor, or method signature is wrong |
 | Mixing `org.junit.Test` (4) and `org.junit.jupiter.api.Test` (5) | Pick one framework per test class — imports must match the framework annotation |
 | `java.lang.NoClassDefFoundError` at runtime | Test runtime classpath is missing a transitive dep; add it to `testRuntimeOnly` (Gradle) or `<scope>test</scope>` (Maven) |
 | `UnsupportedClassVersionError` | JDK used to run tests is older than the JDK used to compile; align toolchains |
-| `Mockito cannot mock final class` | Add `mockito-inline` dep (or `mockito-subclass` in Mockito 5+), or refactor the class to be non-final |
+| `Mockito cannot mock final class` | Use Mockito's inline mock maker — Mockito 5+ uses it by default; for Mockito 3.x/4.x add the `mockito-inline` artifact (replaces `mockito-core`). Or switch to MockK for Kotlin. `mockito-subclass` does **not** mock final classes |
 | `WrongTypeOfReturnValue` (Mockito) | The stubbed method returns a different type than the mock was set up for — check return type signatures |
 
 ## Mocking Rules

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin.md
@@ -1,0 +1,226 @@
+# Kotlin Extension
+
+Language-specific guidance for Kotlin test generation. For pure-Java codebases, use `java.md` instead.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — find files in `src/test/kotlin/`, `src/commonTest/kotlin/`, `src/jvmTest/kotlin/`, etc., and copy their style (framework, assertion library, mock library, coroutine helpers)
+2. **Build file** — `build.gradle.kts` / `build.gradle` — note Kotlin version, plugins (`kotlin("jvm")`, `kotlin("multiplatform")`, `kotlin("android")`), and `dependencies { testImplementation(...) }`
+3. **`gradle/libs.versions.toml`** — the version catalog if the repo uses one; reference aliases instead of hard-coded versions
+4. **Wrapper script** — always invoke `./gradlew` (Unix) or `.\gradlew.bat` (Windows), never a system-installed Gradle
+5. **Multiplatform layout** — `src/<sourceSet>/kotlin/` indicates KMP; tests live in matching `*Test` source sets (`commonTest`, `jvmTest`, `nativeTest`)
+
+Use whatever framework the repo already uses (JUnit Jupiter, JUnit 4, Kotest, kotlin.test). Do not switch.
+
+## Project Type Detection
+
+| Indicator | Project type |
+|-----------|--------------|
+| `kotlin("jvm")` plugin | Plain JVM Kotlin |
+| `kotlin("multiplatform")` plugin with `kotlin { jvm(); js(); ... }` | Kotlin Multiplatform |
+| `com.android.application` / `com.android.library` plugin | Android |
+| `org.springframework.boot` plugin | Spring Boot Kotlin |
+| `kotlin("jvm")` + `application` plugin | Kotlin CLI / server |
+
+For **Android**, see also platform-specific test types: `src/test/` for unit tests on the JVM, `src/androidTest/` for instrumented tests on a device/emulator. They use different runners and gradle tasks.
+
+## Build Commands
+
+| Scope | Command |
+|-------|---------|
+| Compile main + test (JVM) | `./gradlew compileTestKotlin` |
+| Full build | `./gradlew build` |
+| Skip tests | `./gradlew assemble` |
+| Single module | `./gradlew :module-name:build` |
+| KMP target only | `./gradlew :module:jvmTest` (or `linuxX64Test`, etc.) |
+
+- Use `--console=plain` to suppress Gradle's animated output
+- Use `--build-cache` (often default in CI) to reuse outputs
+- For Android: `./gradlew assembleDebug` (build APK) and `./gradlew testDebugUnitTest` (run unit tests)
+
+## Test Commands
+
+| Scope | Command |
+|-------|---------|
+| All tests (JVM) | `./gradlew test` |
+| Single class | `./gradlew test --tests "com.example.WidgetTest"` |
+| Single method | `./gradlew test --tests "com.example.WidgetTest.add returns sum"` |
+| KMP all targets | `./gradlew allTests` |
+| KMP one target | `./gradlew jvmTest`, `./gradlew jsTest`, `./gradlew linuxX64Test` |
+| Android unit tests | `./gradlew testDebugUnitTest` |
+| Android instrumented | `./gradlew connectedDebugAndroidTest` (requires device/emulator) |
+
+- `--tests` accepts wildcards: `--tests "*Widget*"`. Method names with spaces or backticks must be quoted: `--tests "com.example.WidgetTest.creates a widget"`
+- Use `--rerun-tasks` only when troubleshooting cache issues
+- For Kotest, the runner is registered with JUnit Platform — the standard `./gradlew test` and `--tests` flags work the same way
+
+## Lint Command
+
+Use the repo's lint tooling first:
+
+- `./gradlew ktlintCheck` (autoformat: `./gradlew ktlintFormat`) when ktlint is configured
+- `./gradlew detekt` when detekt is configured
+- `./gradlew spotlessCheck` / `spotlessApply` for the Spotless plugin
+- Android Studio's IDE inspections; `./gradlew lint` (Android-only) for the Android Lint task
+
+## Project Layout
+
+```
+src/
+├── main/kotlin/com/example/foo/Bar.kt
+├── main/resources/
+├── test/kotlin/com/example/foo/BarTest.kt   # mirrors production package
+└── test/resources/
+```
+
+KMP layout:
+
+```
+src/
+├── commonMain/kotlin/...        # shared
+├── commonTest/kotlin/...        # shared tests using kotlin.test
+├── jvmMain/kotlin/...
+├── jvmTest/kotlin/...
+├── jsMain/kotlin/...
+└── jsTest/kotlin/...
+```
+
+- Test classes mirror the production class's package so they can access `internal` members (Kotlin's `internal` is module-scoped — within the same Gradle module, including the test source set)
+- For KMP common tests, you can only import from `kotlin.test` and other multiplatform-aware libraries (e.g. `kotlinx.coroutines.test`, Kotest multiplatform, MockK on JVM only)
+
+## Test Framework Detection
+
+| Dependency | Framework | Annotations / DSL |
+|------------|-----------|--------------------|
+| `org.jetbrains.kotlin:kotlin-test` | kotlin.test (multiplatform) | `@Test`, `@BeforeTest`, `assertEquals`, `assertFailsWith` |
+| `junit-jupiter-*` | JUnit 5 | `@Test`, `@ParameterizedTest`, `@BeforeEach`, `@DisplayName` |
+| `junit:junit:4.x` | JUnit 4 | `@Test`, `@Before`, `@RunWith(JUnitPlatform::class)` rare |
+| `io.kotest:kotest-runner-junit5` | Kotest | `class FooSpec : FunSpec({ test("...") { ... } })` (DSL — many styles: `StringSpec`, `BehaviorSpec`, etc.) |
+| `org.spekframework.spek2:spek-dsl-jvm` | Spek 2 | `object FooSpec : Spek({ describe(...) { it(...) {} } })` (legacy) |
+
+For Kotest, **stick to the spec style the repo already uses** — mixing styles is confusing.
+
+## Test Templates
+
+### JUnit 5
+
+```kotlin
+package com.example.foo
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class CalculatorTest {
+
+    @Test
+    @DisplayName("add returns sum of two positive numbers")
+    fun `add returns sum of two positives`() {
+        val sut = Calculator()
+        assertEquals(5, sut.add(2, 3))
+    }
+
+    @Test
+    fun `divide by zero throws`() {
+        val sut = Calculator()
+        assertThrows<ArithmeticException> { sut.divide(1, 0) }
+    }
+}
+```
+
+Backticked method names (`` `like this` ``) are idiomatic for Kotlin tests because they read better in failure messages.
+
+### Kotest (StringSpec)
+
+```kotlin
+package com.example.foo
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+
+class CalculatorSpec : StringSpec({
+    "add returns sum of two positive numbers" {
+        Calculator().add(2, 3) shouldBe 5
+    }
+
+    "divide by zero throws" {
+        shouldThrow<ArithmeticException> { Calculator().divide(1, 0) }
+    }
+})
+```
+
+## Coroutines
+
+- Add `org.jetbrains.kotlinx:kotlinx-coroutines-test` only if it's already on the classpath
+- Use `runTest { ... }` (replaces the older `runBlockingTest`) for `suspend` test bodies
+- For virtual time advance, get the dispatcher from `testScheduler` rather than calling `delay` and waiting in real time
+- Inject a `CoroutineDispatcher` into production code instead of using `Dispatchers.Main/IO` directly — then swap it in tests via `Dispatchers.setMain(testDispatcher)`
+
+```kotlin
+@Test
+fun `loads data eventually`() = runTest {
+    val repo = FakeRepo()
+    val sut = Loader(repo, testScheduler.testDispatcher())
+    sut.start()
+    advanceUntilIdle()
+    assertEquals(LoadState.Done, sut.state.value)
+}
+```
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `Unresolved reference: X` | Add the import; verify the test source set sees the production source set; for KMP, the dep may be declared only in `jvmTest` |
+| `Cannot access 'X': it is internal in module Y` | Either move the test into the same Gradle module, or mark the symbol `@VisibleForTesting internal` deliberately |
+| `Class 'XTest' is not abstract and does not implement abstract member` (Kotest spec) | The spec class needs a no-arg constructor and a primary-constructor block — match the existing spec style |
+| `No tests found for given includes` (Gradle) | `--tests` pattern doesn't match; verify class name and that the framework's runner is registered on the test task (`useJUnitPlatform()`) |
+| `kotlin.UninitializedPropertyAccessException: lateinit property X has not been initialized` | The `@BeforeEach` (or `BeforeTest`) didn't run, or the field was reset; use `lateinit` only after confirming the lifecycle hook fires |
+| `IllegalStateException: Module with the Main dispatcher had failed to initialize` | Coroutines test needs `Dispatchers.setMain(...)` before launching anything that touches `Dispatchers.Main`; reset with `Dispatchers.resetMain()` in teardown |
+| `Mockito cannot mock final class` | Kotlin classes are `final` by default — either use **MockK** (works with final classes) or apply the `kotlin-allopen` plugin scoped to a marker annotation |
+| `MissingMockKException` | The mock wasn't initialized; call `MockKAnnotations.init(this)` or use `@MockK` with `@MockKExtension` (JUnit 5) |
+| KMP common test references a JVM-only API | Move the test to `jvmTest`, or use `expect/actual` declarations |
+| Android: `Method ... not mocked` | The unit test runs on the JVM and the SDK class is just a stub — either use Robolectric, move the test to instrumented (`androidTest`), or refactor to inject the dependency |
+
+## Mocking Rules
+
+- **MockK** is the de-facto standard for Kotlin (final classes, coroutine support): `every { mock.foo() } returns 1`, `coEvery { mock.suspendFn() } returns 1`, `verify { mock.foo() }`, `coVerify { ... }`
+- Mockito works on Kotlin too with `mockito-kotlin` extensions, but you'll need `mockito-inline`/`mockito-subclass` for final classes
+- Avoid `mockkStatic`/`mockkObject` for production code you control — refactor to a wrapper instead
+- Prefer constructor injection so you don't need framework annotations (`@InjectMocks`) at all
+- If a test needs more than 3 mocks, flag it as a design smell
+
+## Android Specifics
+
+- Robolectric tests live under `src/test/` and emulate the Android framework on the JVM — fast but imperfect
+- Instrumented tests live under `src/androidTest/`, require a connected device/emulator, and are slow — use sparingly
+- Compose UI tests use `createComposeRule()` and `composeTestRule.onNodeWithText(...).performClick()` — match the existing test setup if Compose is in the project
+- Hilt: use `@HiltAndroidTest` and `HiltAndroidRule` for instrumented tests; for unit tests pass fakes directly to ViewModels
+
+## Dependency Installation (Last Resort)
+
+Only add dependencies after investigation confirms they are missing.
+
+`build.gradle.kts`:
+
+```kotlin
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+```
+
+If the repo uses a version catalog, add to `gradle/libs.versions.toml` and reference via `libs.junit.jupiter` etc. Match the major versions already in use.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (JaCoCo, Kover). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin.md
@@ -155,16 +155,17 @@ class CalculatorSpec : StringSpec({
 
 ## Coroutines
 
-- Add `org.jetbrains.kotlinx:kotlinx-coroutines-test` only if it's already on the classpath
+- Use `kotlinx-coroutines-test` when it's already on the classpath; otherwise add it as a `testImplementation` only after confirming it is missing (see Dependency Installation)
 - Use `runTest { ... }` (replaces the older `runBlockingTest`) for `suspend` test bodies
-- For virtual time advance, get the dispatcher from `testScheduler` rather than calling `delay` and waiting in real time
+- For virtual time advance, use a `TestDispatcher` built from `testScheduler` — e.g. `StandardTestDispatcher(testScheduler)` or `UnconfinedTestDispatcher(testScheduler)` — rather than calling `delay` and waiting in real time
 - Inject a `CoroutineDispatcher` into production code instead of using `Dispatchers.Main/IO` directly — then swap it in tests via `Dispatchers.setMain(testDispatcher)`
 
 ```kotlin
 @Test
 fun `loads data eventually`() = runTest {
     val repo = FakeRepo()
-    val sut = Loader(repo, testScheduler.testDispatcher())
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val sut = Loader(repo, dispatcher)
     sut.start()
     advanceUntilIdle()
     assertEquals(LoadState.Done, sut.state.value)
@@ -176,7 +177,7 @@ fun `loads data eventually`() = runTest {
 | Error | Fix |
 |-------|-----|
 | `Unresolved reference: X` | Add the import; verify the test source set sees the production source set; for KMP, the dep may be declared only in `jvmTest` |
-| `Cannot access 'X': it is internal in module Y` | Either move the test into the same Gradle module, or mark the symbol `@VisibleForTesting internal` deliberately |
+| `Cannot access 'X': it is internal in module Y` | `internal` is module-scoped, so a test in another Gradle module cannot see it. Move the test into the same module, expose a public seam (e.g. a `*-testing` artifact, or change visibility deliberately), or add the consuming module to the source module's `friend modules` via the Kotlin compiler `-Xfriend-paths` option. `@VisibleForTesting` does **not** widen Kotlin visibility |
 | `Class 'XTest' is not abstract and does not implement abstract member` (Kotest spec) | The spec class needs a no-arg constructor and a primary-constructor block — match the existing spec style |
 | `No tests found for given includes` (Gradle) | `--tests` pattern doesn't match; verify class name and that the framework's runner is registered on the test task (`useJUnitPlatform()`) |
 | `kotlin.UninitializedPropertyAccessException: lateinit property X has not been initialized` | The `@BeforeEach` (or `BeforeTest`) didn't run, or the field was reset; use `lateinit` only after confirming the lifecycle hook fires |
@@ -189,7 +190,7 @@ fun `loads data eventually`() = runTest {
 ## Mocking Rules
 
 - **MockK** is the de-facto standard for Kotlin (final classes, coroutine support): `every { mock.foo() } returns 1`, `coEvery { mock.suspendFn() } returns 1`, `verify { mock.foo() }`, `coVerify { ... }`
-- Mockito works on Kotlin too with `mockito-kotlin` extensions, but you'll need `mockito-inline`/`mockito-subclass` for final classes
+- Mockito works on Kotlin too with `mockito-kotlin` extensions, but Kotlin classes are `final` by default — use Mockito's inline mock maker (default in Mockito 5+; the `mockito-inline` artifact for Mockito 3.x/4.x). `mockito-subclass` cannot mock final classes
 - Avoid `mockkStatic`/`mockkObject` for production code you control — refactor to a wrapper instead
 - Prefer constructor injection so you don't need framework annotations (`@InjectMocks`) at all
 - If a test needs more than 3 mocks, flag it as a design smell

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
@@ -56,7 +56,7 @@ For Rails: load all classes once with `bundle exec rails zeitwerk:check` to catc
 
 | Scope | Command |
 |-------|---------|
-| All tests | `bundle exec rake test` (Rails) or `bundle exec ruby -Ilib -Itest -e 'Dir.glob("./test/**/*_test.rb").each { require _1 }'` |
+| All tests | `bundle exec rake test` (Rails) or `bundle exec ruby -Ilib -Itest -e 'Dir.glob("./test/**/*_test.rb").each { |f| require f }'` |
 | Single file | `bundle exec ruby -Itest test/models/widget_test.rb` |
 | Single test | `bundle exec ruby -Itest test/models/widget_test.rb -n test_creates_widget` |
 | By name pattern | `... -n /pattern/` |

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
@@ -1,0 +1,191 @@
+# Ruby Extension
+
+Language-specific guidance for Ruby test generation.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — find `spec/**/*_spec.rb` (RSpec) or `test/**/*_test.rb` (Minitest) and copy their style (matchers, helpers, factories, contexts)
+2. **`Gemfile` / `Gemfile.lock`** — Ruby version, test framework, supporting gems (`rspec`, `minitest`, `factory_bot`, `webmock`, `vcr`, `rails`)
+3. **`.ruby-version`** / `.tool-versions` — pinned Ruby version
+4. **Test helpers** — `spec/spec_helper.rb`, `spec/rails_helper.rb`, `test/test_helper.rb` — these dictate the load path, requires, and global config
+5. **Rake tasks** — `Rakefile` may define a `default` task that runs the full test suite
+
+Use the framework the repo already uses. Do not introduce RSpec into a Minitest project (or vice versa).
+
+## Toolchain Detection
+
+| Indicator | Manager | Run prefix |
+|-----------|---------|------------|
+| `Gemfile.lock` | Bundler | `bundle exec <cmd>` |
+| `.ruby-version` + `rbenv` | rbenv | combine with `bundle exec` |
+| `mise.toml` / `asdf` `.tool-versions` | mise/asdf | the wrapper handles version selection; still use `bundle exec` |
+| Plain Ruby, no Bundler | system Ruby | `ruby <file>` (rare in real projects) |
+
+Always run inside `bundle exec` if a `Gemfile.lock` is present — otherwise you may pick up a system gem version that disagrees with the lockfile.
+
+## Build Commands
+
+Ruby is interpreted — there is no compile step. The closest validations:
+
+| Scope | Command |
+|-------|---------|
+| Syntax check | `ruby -c path/to/file.rb` |
+| Lint (RuboCop) | `bundle exec rubocop path/to/file.rb` |
+| Type check (Sorbet) | `bundle exec srb tc` (only if `sorbet/` dir exists) |
+| Type check (RBS/Steep) | `bundle exec steep check` |
+
+For Rails: load all classes once with `bundle exec rails zeitwerk:check` to catch missing constants before running tests.
+
+## Test Commands
+
+### RSpec
+
+| Scope | Command |
+|-------|---------|
+| All specs | `bundle exec rspec` |
+| Single file | `bundle exec rspec spec/models/widget_spec.rb` |
+| Single line | `bundle exec rspec spec/models/widget_spec.rb:42` |
+| By name | `bundle exec rspec -e "creates a widget"` |
+| Tagged | `bundle exec rspec --tag focus` |
+| Fail fast | `bundle exec rspec --fail-fast` |
+| Documentation format | `bundle exec rspec --format documentation` |
+
+### Minitest
+
+| Scope | Command |
+|-------|---------|
+| All tests | `bundle exec rake test` (Rails) or `bundle exec ruby -Ilib -Itest -e 'Dir.glob("./test/**/*_test.rb").each { require _1 }'` |
+| Single file | `bundle exec ruby -Itest test/models/widget_test.rb` |
+| Single test | `bundle exec ruby -Itest test/models/widget_test.rb -n test_creates_widget` |
+| By name pattern | `... -n /pattern/` |
+
+### Rails (any framework)
+
+| Scope | Command |
+|-------|---------|
+| Default suite | `bin/rails test` (Minitest) or `bundle exec rspec` |
+| Single Rails test file | `bin/rails test test/models/widget_test.rb:42` |
+| System tests | `bin/rails test:system` |
+
+Always prefer the wrapper script (`bin/rails`, `bin/rspec`) when present — they enforce the project's loader/setup.
+
+## Lint Command
+
+- `bundle exec rubocop` — autocorrect with `bundle exec rubocop -A` (only if existing tests already conform; do not autocorrect unrelated files)
+- `bundle exec standardrb --fix` if `standard` is in the Gemfile
+- Some Rails projects add `rubocop-rails`, `rubocop-rspec`, `rubocop-performance` — they enforce extra rules
+
+## Project Layout and Loading
+
+| Layout | Test placement |
+|--------|----------------|
+| Plain gem (RSpec) | `spec/` mirrors `lib/` (e.g. `lib/foo/bar.rb` → `spec/foo/bar_spec.rb`) |
+| Plain gem (Minitest) | `test/` mirrors `lib/` (e.g. `test/foo/bar_test.rb`) |
+| Rails (RSpec) | `spec/models`, `spec/controllers`, `spec/requests`, `spec/system`, etc. |
+| Rails (Minitest) | `test/models`, `test/controllers`, `test/integration`, `test/system` |
+
+**Loading source code:**
+
+- RSpec: `spec/spec_helper.rb` typically does `require 'my_gem'` or sets `$LOAD_PATH`. Match its pattern in new specs by `require 'spec_helper'` (or `require 'rails_helper'` in Rails)
+- Minitest: each `_test.rb` typically `require 'test_helper'`
+- Rails uses Zeitwerk autoloading — do **not** add `require_relative '../../app/models/widget'`; just `require 'rails_helper'` and reference the constant
+
+## Test File Naming
+
+| Framework | File suffix | Class/example |
+|-----------|-------------|---------------|
+| RSpec | `_spec.rb` | `RSpec.describe Widget do ... end`, `it "..." do ... end` |
+| Minitest (classic) | `_test.rb` | `class WidgetTest < Minitest::Test`, methods `def test_...` |
+| Minitest (spec) | `_test.rb` | `describe Widget do ... it "..." do ... end end` |
+| Rails Minitest | `_test.rb` | `class WidgetTest < ActiveSupport::TestCase` |
+
+## RSpec Template
+
+```ruby
+require 'spec_helper'
+require 'calculator'
+
+RSpec.describe Calculator do
+  subject(:calculator) { described_class.new }
+
+  describe '#add' do
+    it 'returns the sum of two positive numbers' do
+      expect(calculator.add(2, 3)).to eq(5)
+    end
+
+    context 'with negative numbers' do
+      it 'returns the correct sum' do
+        expect(calculator.add(-1, 1)).to eq(0)
+      end
+    end
+
+    it 'raises when given non-numeric input' do
+      expect { calculator.add('a', 1) }.to raise_error(TypeError)
+    end
+  end
+end
+```
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `LoadError: cannot load such file -- foo` | Missing `require` or load path; check `spec_helper.rb` for the established pattern instead of patching `$LOAD_PATH` ad hoc |
+| `NameError: uninitialized constant X` | Constant isn't loaded — in Rails, ensure you require `rails_helper`; in plain Ruby, add the appropriate `require` |
+| `ArgumentError: wrong number of arguments (given X, expected Y)` | Read the method signature; pass keyword vs positional args correctly |
+| `NoMethodError: undefined method 'foo' for nil:NilClass` | Test setup left a value `nil`; check `let`/`before` ordering and factory data |
+| `Failure/Error: ... received :foo with unexpected arguments` (RSpec) | Tighten the matcher: `with(hash_including(...))` or relax to `with(any_args)` deliberately |
+| `expected #<...> to receive :foo (1 time) but received it 0 times` | Either the code path didn't call the stub, or you stubbed the wrong receiver |
+| `DEPRECATION WARNING` (Rails) | Address the deprecation rather than silencing it; tests that warn today break tomorrow |
+| `ActiveRecord::PendingMigrationError` | Run `bin/rails db:migrate RAILS_ENV=test` before tests |
+| `Mysql2::Error / PG::ConnectionBad` in CI | Tests need a database — check `config/database.yml` and CI service containers |
+| `Capybara::ElementNotFound` (system tests) | Use `find` with explicit waits; do not add `sleep` |
+
+## Mocking Rules (RSpec)
+
+- Use `instance_double(Klass)` and `class_double(Klass)` — they verify that the method actually exists, unlike `double`
+- `allow(obj).to receive(:method).and_return(value)` for stubs; `expect(obj).to receive(:method)` for interaction expectations
+- Prefer `instance_double` over plain `double`; prefer dependency injection over `allow_any_instance_of`
+- Use `let` for memoized helpers; use `let!` only when the side effect must run before each example
+- Avoid global state mutation in tests — wrap in `around` blocks or use `ClimateControl` for env vars
+- For HTTP, use `webmock` (`stub_request(:get, ...)`) or `vcr` cassettes if the project already uses them
+- If a test needs more than 3 mocks, flag it as a design smell
+
+## Mocking Rules (Minitest)
+
+- Use `Minitest::Mock` for simple cases: `mock = Minitest::Mock.new; mock.expect(:method, return_value, [arg])`
+- For richer mocking, projects commonly add `mocha`: `obj.expects(:method).returns(value)` (in `test_helper.rb`: `require 'mocha/minitest'`)
+- Always verify mocks at end of test (`mock.verify` for `Minitest::Mock`); Mocha verifies automatically
+
+## Rails Specifics
+
+- Use the **smallest** spec type that covers the behavior: model spec for pure logic, request spec for HTTP, system spec only when JS/UI matters
+- `rails-controller-testing` gem must be present for `assigns(:foo)` and `assert_template`
+- `ActiveJob::TestHelper` and `ActiveSupport::Testing::TimeHelpers` (`travel_to`) come with Rails — use them instead of `Timecop` if Rails ≥ 5
+- Use fixtures only if the project already uses them; `factory_bot` is more common in modern Rails apps
+- Database transactions wrap each test by default — for system tests with browser drivers, use `DatabaseCleaner` strategies the project already configures
+
+## Dependency Installation (Last Resort)
+
+Only add gems after investigation confirms they are missing. Edit `Gemfile`:
+
+```ruby
+group :test do
+  gem 'rspec'
+  gem 'webmock'
+end
+```
+
+Then run:
+
+```
+bundle install
+```
+
+Never `gem install` outside Bundler — it bypasses the lockfile and changes the global Ruby environment.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (SimpleCov). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust.md
@@ -1,0 +1,180 @@
+# Rust Extension
+
+Language-specific guidance for Rust test generation.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — look at `#[cfg(test)] mod tests` blocks inside `src/`, integration tests in `tests/`, doc tests in source comments, and any `examples/` that double as smoke tests
+2. **`Cargo.toml`** — workspace layout (`[workspace]`), edition, `dev-dependencies`, feature flags, `[[bench]]` / `[[test]]` declarations
+3. **`Cargo.lock`** — if checked in, you must not break it without intent
+4. **Toolchain** — `rust-toolchain.toml` pins the channel (stable / nightly / specific version)
+5. **`build.rs`** — custom build scripts may set `cfg` flags or generate code that tests rely on
+
+Match the repo's existing conventions — assertion macros, mock approach, feature-gating — exactly. Do not introduce `tokio::test` if the repo uses `async-std`, etc.
+
+## Toolchain Detection
+
+| Indicator | Meaning |
+|-----------|---------|
+| `rust-toolchain.toml` with `channel = "..."` | Use rustup to install/select that channel — `rustup show active-toolchain` |
+| `rust-version = "1.x"` in `Cargo.toml` | Minimum supported Rust version (MSRV); do not use newer language features |
+| `[workspace]` in root `Cargo.toml` | Multi-crate workspace; commands accept `-p <crate>` to target one member |
+| `nightly` channel | Tests may use `#![feature(...)]` flags; do not remove them |
+
+## Build Commands
+
+| Scope | Command |
+|-------|---------|
+| Type-check fast | `cargo check` |
+| Type-check whole workspace | `cargo check --workspace --all-targets` |
+| Build (debug) | `cargo build` |
+| Build with all features | `cargo build --all-features` |
+| Build a single crate | `cargo build -p crate-name` |
+| Build tests without running | `cargo test --no-run` |
+
+`cargo check` is far faster than `cargo build` and catches almost the same errors. Prefer it during the fix loop; use `cargo build --tests` (or `cargo test --no-run`) before declaring tests compilable.
+
+## Test Commands
+
+| Scope | Command |
+|-------|---------|
+| All tests | `cargo test` |
+| Workspace | `cargo test --workspace` |
+| Single crate | `cargo test -p crate-name` |
+| Filter by name | `cargo test substring_of_test_name` |
+| Exact name | `cargo test -- --exact path::to::test_fn` |
+| Single integration file | `cargo test --test file_stem` (no `.rs`) |
+| Doc tests only | `cargo test --doc` |
+| Show stdout | `cargo test -- --nocapture` |
+| Single-threaded | `cargo test -- --test-threads=1` |
+| Ignored tests | `cargo test -- --ignored` |
+| With features | `cargo test --features "feat1 feat2"` |
+| All features | `cargo test --all-features` |
+
+- Arguments before `--` are for cargo; arguments after `--` go to the test binary
+- `cargo test foo` runs every test with `foo` in its full path (`module::tests::foo_does_a_thing`) — to avoid surprise matches use `--exact`
+- `cargo nextest run` is significantly faster if the repo already uses it (`Cargo.toml` `[profile.nextest...]` or `.config/nextest.toml`) — match the repo's choice
+
+## Lint Command
+
+Use the repo's lint script first. Otherwise:
+
+- `cargo fmt --all -- --check` (CI), `cargo fmt` (apply)
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- If `clippy.toml` / `rustfmt.toml` exists, the project has opinions — never override them in your tests
+
+## Project Layout
+
+```
+my_crate/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs        # library crate root
+│   ├── main.rs       # binary crate root (mutually OK with lib.rs)
+│   └── module.rs     # private/public module
+├── tests/            # integration tests — each .rs is a separate crate
+│   └── widget.rs
+├── benches/          # cargo bench targets
+└── examples/         # cargo run --example name
+```
+
+| Test type | Where | Sees |
+|-----------|-------|------|
+| Unit test | `#[cfg(test)] mod tests` inside the source file | Private items in the surrounding module |
+| Integration test | `tests/<name>.rs` | Only the public API of the crate |
+| Doc test | `///` doctests in source comments | Only the public API; runs via `cargo test --doc` |
+
+- **Unit tests** at the bottom of `module.rs`:
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+
+      #[test]
+      fn name_scenario_expected() {
+          // ...
+      }
+  }
+  ```
+
+- **Integration tests** import the crate by name: `use my_crate::PublicType;`
+- Helpers shared between integration tests must live in `tests/common/mod.rs` (the `mod.rs` form prevents cargo from treating them as a top-level test crate)
+
+## Test Function Patterns
+
+| Kind | Attribute |
+|------|-----------|
+| Sync test | `#[test]` |
+| Should panic | `#[test] #[should_panic(expected = "message substring")]` |
+| Ignored (long/manual) | `#[test] #[ignore = "reason"]` |
+| Async test (Tokio) | `#[tokio::test]` (or `#[tokio::test(flavor = "multi_thread")]`) |
+| Async test (async-std) | `#[async_std::test]` |
+| Returning `Result` | `fn name() -> Result<(), Box<dyn Error>>` — use `?` instead of `.unwrap()` |
+
+Pick the async harness the repo already uses. Do not mix `tokio` and `async-std` in tests.
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `cannot find type X in this scope` | Add `use crate::module::X;` or `use super::*;` inside the test module |
+| `function or associated item not found in 'X'` | Verify the method exists on the exact type; check trait imports (e.g. `use std::io::Read`) |
+| `the trait bound 'X: Y' is not satisfied` | Either implement the trait, add a `where` bound, or change the test to use a type that already implements it |
+| `borrow of moved value` | Add `.clone()`, borrow with `&`, or restructure ownership — do not use `mem::transmute` to dodge it |
+| `cannot borrow as mutable` | Make the binding `let mut x` or restructure to avoid simultaneous mutable + immutable borrows |
+| `lifetime may not live long enough` | Add explicit lifetime annotations or use owned types (`String` instead of `&str`) in the test |
+| `mismatched types` between `i32` and `usize` | Use `as` casts deliberately or change the literal type with a suffix (`5usize`, `5u32`) |
+| `unresolved import 'crate::...'` in `tests/foo.rs` | Integration tests must import via the **crate name** (as listed in `Cargo.toml`), not `crate::` |
+| `error: no test target found` for `cargo test --test foo` | The file must live directly in `tests/`, not `tests/subdir/foo.rs` (subdirs are treated as helpers) |
+| `attempt to subtract with overflow` (debug) | Underflow on unsigned types; use `checked_sub`/`saturating_sub` or compare before subtracting |
+| Doctest fails to compile | Add `# ` to hide setup lines; mark code blocks `ignore`/`no_run`/`should_panic` if needed |
+| `the following imports are unused` (warning treated as error) | Remove unused `use` statements; do not silence with `#[allow(unused_imports)]` |
+
+## Mocking Rules
+
+Rust has no single dominant mocking framework. Match the repo:
+
+- **Trait + struct fakes** (most idiomatic): define a trait, pass `Arc<dyn Trait>` or generic `T: Trait`, implement a fake struct in tests
+- **`mockall`** crate: `#[automock]` on a trait generates `MockTrait` for use in tests
+- **`mockito`** / **`wiremock`**: HTTP server mocks for client tests
+- **`tempfile`**: scoped temp directories that auto-clean (`tempfile::tempdir()`)
+
+Avoid `unsafe` patches to "mock" free functions. Refactor to inject a trait instead. If a test needs more than 3 mocks, flag it as a design smell.
+
+## Features and `cfg`
+
+- Tests behind a feature flag run only when that feature is enabled — use `#[cfg(feature = "foo")]` on the `mod tests` or individual `#[test]` functions
+- `--all-features` exercises everything but may pull conflicting features in some workspaces; check `cargo test --all-features` is part of CI before relying on it
+- Use `#[cfg(test)]` to gate test-only helpers in production source files — not `#[cfg(feature = "test")]`
+
+## Concurrency, IO, and `unsafe`
+
+- Tests run in parallel by default. If your tests share global state (env vars, current dir, statics), serialize them with the `serial_test` crate (if present) or move state into the test
+- Never write to `/tmp` or the repo dir directly — use `tempfile::tempdir()` so cleanup is automatic
+- Tests in `unsafe` code should also run under Miri (`cargo +nightly miri test`) if the repo's CI does
+
+## Dependency Installation (Last Resort)
+
+Only add dependencies after investigation confirms they are missing:
+
+```toml
+[dev-dependencies]
+mockall = "0.12"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Or via cargo:
+
+```
+cargo add --dev mockall
+cargo add --dev tokio --features macros,rt-multi-thread
+```
+
+Match the major version of any tokio/serde/etc. already pinned by the workspace.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (`cargo tarpaulin`, `cargo llvm-cov`, `grcov`). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust.md
@@ -130,7 +130,7 @@ Pick the async harness the repo already uses. Do not mix `tokio` and `async-std`
 | `unresolved import 'crate::...'` in `tests/foo.rs` | Integration tests must import via the **crate name** (as listed in `Cargo.toml`), not `crate::` |
 | `error: no test target found` for `cargo test --test foo` | The file must live directly in `tests/`, not `tests/subdir/foo.rs` (subdirs are treated as helpers) |
 | `attempt to subtract with overflow` (debug) | Underflow on unsigned types; use `checked_sub`/`saturating_sub` or compare before subtracting |
-| Doctest fails to compile | Add `# ` to hide setup lines; mark code blocks `ignore`/`no_run`/`should_panic` if needed |
+| Doctest fails to compile | Use a leading "# " on hidden setup lines; mark code blocks `ignore`/`no_run`/`should_panic` if needed |
 | `the following imports are unused` (warning treated as error) | Remove unused `use` statements; do not silence with `#[allow(unused_imports)]` |
 
 ## Mocking Rules

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/swift.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/swift.md
@@ -1,0 +1,227 @@
+# Swift Extension
+
+Language-specific guidance for Swift test generation.
+
+## Rule #1: Investigate the Repo First
+
+Before writing any test or running any command, read:
+
+1. **Existing tests** — find files in `Tests/` (SPM) or `*Tests/` groups (Xcode) and copy their style. Distinguish **XCTest** (`import XCTest`, classes inheriting `XCTestCase`) from **Swift Testing** (`import Testing`, free functions tagged `@Test`)
+2. **Project file** — `Package.swift` (SPM), `*.xcodeproj`, `*.xcworkspace`, or `Project.swift` (Tuist)
+3. **Swift toolchain** — `.swift-version`, `swift-tools-version` line in `Package.swift`, `IPHONEOS_DEPLOYMENT_TARGET` and `SWIFT_VERSION` build settings in Xcode
+4. **CI scripts** — `.github/workflows/*.yml`, `Fastfile`, `Makefile` — these reveal the canonical build/test invocation
+
+Use the testing framework the repo already uses. Both XCTest and Swift Testing can coexist in one target — match what the file you're adding tests next to uses.
+
+## Project Type Detection
+
+| Indicator | Project type | Build tool |
+|-----------|--------------|------------|
+| `Package.swift` only | Swift Package Manager | `swift build` / `swift test` |
+| `*.xcodeproj` or `*.xcworkspace` | Xcode project (often app/iOS) | `xcodebuild` |
+| Both | SPM library + Xcode app shell | Use SPM for library targets, Xcode for app targets |
+| `Project.swift` (Tuist) | Tuist-generated Xcode project | Run `tuist generate` first, then xcodebuild |
+| `project.yml` (XcodeGen) | XcodeGen-generated project | Run `xcodegen generate` first |
+
+If both an `.xcodeproj` and `.xcworkspace` exist (e.g. CocoaPods), **always pass `-workspace` not `-project`** to xcodebuild.
+
+## Build Commands
+
+### Swift Package Manager
+
+| Scope | Command |
+|-------|---------|
+| Build all | `swift build` |
+| Build a target | `swift build --target MyLibrary` |
+| Build for release | `swift build -c release` |
+
+### Xcode (`xcodebuild`)
+
+```
+xcodebuild build \
+  -workspace MyApp.xcworkspace \
+  -scheme MyAppScheme \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -configuration Debug
+```
+
+- Always specify `-destination` for iOS/tvOS/watchOS — the default may not exist on the build machine
+- Use `-quiet` to suppress xcodebuild's chatty output, and pipe to `xcbeautify`/`xcpretty` if installed
+- For deterministic CI builds add `-derivedDataPath ./DerivedData`
+
+## Test Commands
+
+### Swift Package Manager
+
+| Scope | Command |
+|-------|---------|
+| All tests | `swift test` |
+| Filter by test name (XCTest) | `swift test --filter MyClassTests/testFooBar` |
+| Filter by test name (Swift Testing) | `swift test --filter MyTestSuite.fooBar` |
+| Parallel | `swift test --parallel` |
+| Single platform | `swift test --triple x86_64-apple-macosx` (rare; usually skip) |
+
+### Xcode
+
+```
+xcodebuild test \
+  -workspace MyApp.xcworkspace \
+  -scheme MyAppScheme \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:MyAppTests/MyClassTests/testFooBar
+```
+
+- `-only-testing:` and `-skip-testing:` accept `Bundle/Class/Method` paths and may be repeated
+- `xcodebuild test-without-building` skips compilation if you've already built
+- For Swift Testing in Xcode 16+, use the same `-only-testing:` syntax — the runner handles both frameworks
+
+## Lint Command
+
+Use the repo's lint tooling first:
+
+- `swiftlint lint --quiet` (autocorrect: `swiftlint --fix`) when `.swiftlint.yml` is present
+- `swiftformat .` when `.swiftformat` is present
+- Some projects gate format on a build phase — running `xcodebuild` may already invoke it
+
+## Project Layout
+
+### SPM
+
+```
+Package.swift
+Sources/
+└── MyLibrary/
+    ├── Foo.swift
+    └── Bar.swift
+Tests/
+└── MyLibraryTests/
+    └── FooTests.swift
+```
+
+- Test target name conventionally is `<TargetName>Tests` and lives in `Tests/<TargetName>Tests/`
+- Test target must list its production target as a dependency in `Package.swift`:
+
+  ```swift
+  .testTarget(
+      name: "MyLibraryTests",
+      dependencies: ["MyLibrary"]),
+  ```
+
+### Xcode
+
+- Tests live in a separate target (e.g. `MyAppTests`) added to the scheme's "Test" action
+- The test target's "Host Application" determines whether tests run on the simulator with the app loaded (unit tests) or as a UI test runner
+
+## Imports
+
+- XCTest: `import XCTest` plus `@testable import MyLibrary` to access `internal` symbols
+- Swift Testing: `import Testing` plus `@testable import MyLibrary`
+- `@testable` works only when the production target is built with `-enable-testing` (the SPM test target and Xcode "Debug" config do this by default)
+- Never mark production code `public` solely to make it visible to tests — use `@testable import` instead
+
+## Test File Templates
+
+### Swift Testing (Xcode 16 / Swift 6)
+
+```swift
+import Testing
+@testable import MyLibrary
+
+@Suite("Calculator")
+struct CalculatorTests {
+    @Test("add returns the sum of two integers")
+    func addReturnsSum() {
+        let calc = Calculator()
+        #expect(calc.add(2, 3) == 5)
+    }
+
+    @Test("add throws on overflow", arguments: [
+        (Int.max, 1),
+        (Int.min, -1),
+    ])
+    func addThrowsOnOverflow(a: Int, b: Int) {
+        #expect(throws: ArithmeticError.self) {
+            try Calculator().add(a, b)
+        }
+    }
+}
+```
+
+### XCTest
+
+```swift
+import XCTest
+@testable import MyLibrary
+
+final class CalculatorTests: XCTestCase {
+    func testAddReturnsSum() {
+        let calc = Calculator()
+        XCTAssertEqual(calc.add(2, 3), 5)
+    }
+
+    func testAddThrowsOnOverflow() {
+        XCTAssertThrowsError(try Calculator().add(.max, 1)) { error in
+            XCTAssertEqual(error as? ArithmeticError, .overflow)
+        }
+    }
+}
+```
+
+- XCTest requires test methods to start with `test` and take no arguments
+- Mark XCTest classes `final` to silence warnings and prevent unintended subclassing
+- Use `XCTUnwrap` instead of force-unwrapping (`!`) inside tests so the failure is reported rather than crashing the runner
+
+## Async, Throws, and Concurrency
+
+- Test methods may be `async` and/or `throws` in both frameworks
+- For asynchronous expectations under XCTest, use `XCTestExpectation` + `wait(for:timeout:)` only when you cannot refactor to `async`
+- For Swift Testing, use `await confirmation { ... }` to assert that a callback fires
+- Cancel tasks deliberately with `Task.cancel()` instead of relying on test timeout
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| `cannot find 'X' in scope` from a test | Add `@testable import MyLibrary` (and ensure the test target depends on it) |
+| `module 'MyLibrary' was not compiled for testing` | Build the production target with `-enable-testing`; SPM test targets do this automatically — Xcode Debug configs need "Enable Testability" = YES |
+| `failed to launch test runner` (Xcode) | Simulator destination may be invalid; list with `xcrun simctl list devices` and pick an existing one |
+| `No such module 'XCTest'` outside a test target | XCTest is only available in test targets — do not import it from production code |
+| `Static method 'expect(_:_:sourceLocation:)' is unavailable` | Swift Testing requires Xcode 16 / Swift 5.10+; either upgrade or use XCTest |
+| `Symbol not found: _OBJC_CLASS_$_...` | Linker missing a framework; add it to the test target's "Link Binary With Libraries" |
+| `signal SIGABRT` in tests | Often a force-unwrap on `nil`; replace `!` with `XCTUnwrap` to localize the failure |
+| `MainActor-isolated property cannot be referenced from a non-isolated context` | Mark the test method `@MainActor` or move setup into a `MainActor` task |
+| `Sandbox: ... deny file-write-create` | Use `FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)` instead of writing to fixed paths |
+| Test discovery shows zero tests on Linux | XCTest on Linux needs `XCTMain([testCase(MyTests.allTests), ...])` in `Tests/LinuxMain.swift` (legacy SwiftPM only); for Swift 5.4+ this is auto-generated |
+
+## Mocking Rules
+
+Swift has no Mockito-equivalent — favor protocol-oriented design:
+
+- Define a **protocol** for the dependency, pass it via initializer, and implement a fake/stub struct in the test target
+- For URL/HTTP, use `URLProtocol` subclasses to intercept `URLSession` requests, or use `MockingbirdSwift` / `Cuckoo` if the repo already adopts them
+- For dates/clocks, inject a `Clock` (`ContinuousClock`, `SuspendingClock`, or a custom `Clock`-conforming type) — do not call `Date()` directly in business logic
+- Avoid `swizzling` and runtime hacks — they break under Swift's optimizer
+
+If a test needs more than 3 mocks, flag it as a design smell.
+
+## Cross-Platform Considerations
+
+- Swift on Linux supports XCTest but **not** all of Foundation — guard with `#if canImport(Darwin)` or `#if os(macOS)` only when necessary
+- Use `String(decoding:as:)` rather than `String(contentsOf:encoding:)` for cross-platform reads
+- Be careful with `Bundle.main` in tests — on macOS unit tests it points to `xctest`, not your bundle; use `Bundle(for: type(of: self))` (XCTest) or a resource-bundle helper
+
+## Dependency Installation (Last Resort)
+
+Only add dependencies after investigation confirms they are missing.
+
+`Package.swift`:
+
+```swift
+.package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+```
+
+Then add to the test target's `dependencies:`. For CocoaPods/Carthage, edit `Podfile`/`Cartfile` and run `pod install` / `carthage update --use-xcframeworks`.
+
+## Skip Coverage Tools
+
+Do not configure or run coverage tools (`-enableCodeCoverage YES`, `xccov`, `slather`). Coverage is measured separately by the evaluation harness.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/swift.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/swift.md
@@ -186,7 +186,7 @@ final class CalculatorTests: XCTestCase {
 | `module 'MyLibrary' was not compiled for testing` | Build the production target with `-enable-testing`; SPM test targets do this automatically — Xcode Debug configs need "Enable Testability" = YES |
 | `failed to launch test runner` (Xcode) | Simulator destination may be invalid; list with `xcrun simctl list devices` and pick an existing one |
 | `No such module 'XCTest'` outside a test target | XCTest is only available in test targets — do not import it from production code |
-| `Static method 'expect(_:_:sourceLocation:)' is unavailable` | Swift Testing requires Xcode 16 / Swift 5.10+; either upgrade or use XCTest |
+| `Static method 'expect(_:_:sourceLocation:)' is unavailable` / `No such module 'Testing'` | Swift Testing requires Swift 6 / Xcode 16+. On older toolchains, fall back to XCTest |
 | `Symbol not found: _OBJC_CLASS_$_...` | Linker missing a framework; add it to the test target's "Link Binary With Libraries" |
 | `signal SIGABRT` in tests | Often a force-unwrap on `nil`; replace `!` with `XCTUnwrap` to localize the failure |
 | `MainActor-isolated property cannot be referenced from a non-isolated context` | Mark the test method `@MainActor` or move setup into a `MainActor` task |


### PR DESCRIPTION
Adds six new language-specific guidance files to the `code-testing-extensions` skill so the code-testing pipeline has curated guidance for more ecosystems.

## What changed

New extension files under `plugins/dotnet-test/skills/code-testing-extensions/extensions/`:

| File | Coverage |
|---|---|
| `go.md` | `go test`, table-driven tests, package layout (`package foo` vs `foo_test`), build tags, mocking via interfaces |
| `java.md` | Maven & Gradle (with wrappers), JUnit 4/5 + TestNG detection, Mockito (incl. final-class gotchas), Spring Boot slices |
| `rust.md` | `cargo test`/`cargo check`, unit/integration/doc tests, features, async harnesses, workspace targeting |
| `ruby.md` | RSpec & Minitest, Bundler, Rails specifics (Zeitwerk, slice tests), MockK/Mocha, factories |
| `swift.md` | SPM and Xcode (`swift test`, `xcodebuild test`), XCTest vs Swift Testing, `@testable import`, async/throws tests |
| `kotlin.md` | Gradle (incl. KMP source sets), JUnit/Kotest detection, MockK + coroutines test, Android (Robolectric vs instrumented) |

Each follows the same template as the existing `python.md` / `typescript.md` files:

- "Investigate the Repo First" rule
- Toolchain / build-tool detection
- Build, test, and lint commands
- Project layout & imports
- Test file naming and templates
- Common errors with fixes
- Mocking rules
- Dependency installation as last resort
- "Skip Coverage Tools" footer

`SKILL.md` is updated to advertise the new files in the discovery table.

## Out of scope

Per request, the existing `cpp.md` stub is left as-is rather than expanded.

## Validation

`skill-validator check --plugin plugins/dotnet-test` passes:

> All checks passed (22 skill(s), 11 agent(s), 1 plugin(s))

The two warnings on the `code-testing-extensions` discovery `SKILL.md` ("no code blocks", "no numbered workflow steps") are pre-existing and by design - the file is just a routing index of paths.
