### PR TITLE
Tighten crap-score boundary to fix coverage-analysis plateau activation

### DIFF
--- a/plugins/dotnet-test/skills/crap-score/SKILL.md
+++ b/plugins/dotnet-test/skills/crap-score/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: crap-score
 description: >
-  Calculates CRAP (Change Risk Anti-Patterns) score for .NET methods, classes,
-  or files. Use when the user asks to assess test quality, identify risky
-  untested code, compute CRAP scores, or evaluate whether complex methods have
-  sufficient test coverage. Requires code coverage data (Cobertura XML) and
-  cyclomatic complexity analysis.
-  DO NOT USE FOR: writing tests, general test execution unrelated to coverage/CRAP
-  analysis, or general code coverage reporting without CRAP context.
+  Calculates targeted CRAP (Change Risk Anti-Patterns) scores for a named .NET
+  method, class, or single source file. Use when the user explicitly asks to
+  compute CRAP scores or assess risky untested code for a specific target,
+  combining Cobertura coverage data with cyclomatic complexity analysis.
+  DO NOT USE FOR: project-wide coverage analysis, coverage plateau or "stuck
+  coverage" diagnosis, what's blocking coverage, or where to add tests across
+  a project (use coverage-analysis); writing tests; running tests without
+  CRAP context.
 license: MIT
 ---
 


### PR DESCRIPTION
Tighten the `crap-score` skill description so it stops competing with `coverage-analysis` for the "Coverage plateau diagnosis" eval scenario in plugin mode.

## Why

The `coverage-analysis` skill activates reliably in **isolated** mode (10/10 recent scheduled runs) but fails to activate in **plugin** mode for the *Coverage plateau diagnosis* scenario (8/10 recent scheduled runs returned `notActivated: true` per the [public dashboard](https://dotnet.github.io/skills/data/dotnet-test.json)). Investigating session events shows the failure mode is "no skill fires at all" — the model bypasses the skill system and answers from the file directly.

PR #647 strengthened `coverage-analysis`'s positive triggers, but did not address sibling attention competition. The most overlapping sibling is `crap-score`, whose previous description advertised:

> *"evaluate whether complex methods have sufficient test coverage. Requires code coverage data (Cobertura XML)"*

— a near-perfect match for the plateau prompt:

> *"My coverage is stuck at 75% and I can't get it higher. What's blocking me? Coverage data is in TestResults/coverage.cobertura.xml."*

With 22 sibling skills competing for attention budget, the ambiguity is enough to suppress activation altogether.

## What changed

`plugins/dotnet-test/skills/crap-score/SKILL.md` frontmatter only:

- Scoped positive triggers to **a named .NET method, class, or single source file** (the actual eval surface — all 3 scenarios in `tests/dotnet-test/crap-score/eval.yaml` target `OrderService.cs`).
- Added explicit `DO NOT USE FOR` redirects to `coverage-analysis` for: project-wide coverage analysis, coverage plateau / "stuck coverage" diagnosis, "what's blocking coverage", and "where to add tests across a project".
- Phrased the redirect as "where to add tests **across a project**" so the existing `Identify riskiest methods across a file` crap-score eval (which targets a single file) remains in scope.

No changes to `coverage-analysis`, `code-testing-agent`, or any other skill — those boundaries were already addressed in PR #647.

## Verification

- `skill-validator check --plugin plugins/dotnet-test` → ✅ All checks passed (22 skills, 11 agents, 1 plugin)
- Aggregate dotnet-test plugin description: **14,932 / 15,000** chars (68 chars headroom)
- markdownlint passes for the modified file
- All 3 `crap-score` eval scenarios still match the new positive triggers (each targets a specific file/method/class)

## Risk

Low. Single-file frontmatter change, no code or workflow changes. The risk is that the `crap-score` evals stop activating because the description got narrower; this was specifically guarded against by keeping "method, class, or single source file" and qualifying the redirect with "across a project".
