### PR TITLE
skill-validator: serialize concurrent writes per path in LocalSessionFsHandler

### DIFF
--- a/eng/skill-validator/src/Evaluate/LocalSessionFsHandler.cs
+++ b/eng/skill-validator/src/Evaluate/LocalSessionFsHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using GitHub.Copilot.SDK.Rpc;
 
 namespace SkillValidator.Evaluate;
@@ -11,6 +12,11 @@ namespace SkillValidator.Evaluate;
 internal sealed class LocalSessionFsHandler : ISessionFsHandler
 {
     private readonly string _rootDir;
+    // The SDK can report "timeout while waiting for mutex to become available"
+    // when multiple session-state writes race on the same JSONL file, so serialize
+    // writes per resolved path inside the handler as well.
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _pathLocks =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public LocalSessionFsHandler(string rootDir)
     {
@@ -29,6 +35,20 @@ internal sealed class LocalSessionFsHandler : ISessionFsHandler
         return full;
     }
 
+    private async Task ExecuteWithPathLockAsync(string path, Func<Task> action, CancellationToken cancellationToken)
+    {
+        var pathLock = _pathLocks.GetOrAdd(path, static _ => new SemaphoreSlim(1, 1));
+        await pathLock.WaitAsync(cancellationToken);
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            pathLock.Release();
+        }
+    }
+
     public async Task<SessionFsReadFileResult> ReadFileAsync(SessionFsReadFileParams request, CancellationToken cancellationToken)
     {
         var path = ResolvePath(request.Path);
@@ -36,20 +56,26 @@ internal sealed class LocalSessionFsHandler : ISessionFsHandler
         return new SessionFsReadFileResult { Content = content };
     }
 
-    public async Task WriteFileAsync(SessionFsWriteFileParams request, CancellationToken cancellationToken)
+    public Task WriteFileAsync(SessionFsWriteFileParams request, CancellationToken cancellationToken)
     {
         var path = ResolvePath(request.Path);
-        var dir = Path.GetDirectoryName(path);
-        if (dir is not null) Directory.CreateDirectory(dir);
-        await File.WriteAllTextAsync(path, request.Content, cancellationToken);
+        return ExecuteWithPathLockAsync(path, async () =>
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (dir is not null) Directory.CreateDirectory(dir);
+            await File.WriteAllTextAsync(path, request.Content, cancellationToken);
+        }, cancellationToken);
     }
 
-    public async Task AppendFileAsync(SessionFsAppendFileParams request, CancellationToken cancellationToken)
+    public Task AppendFileAsync(SessionFsAppendFileParams request, CancellationToken cancellationToken)
     {
         var path = ResolvePath(request.Path);
-        var dir = Path.GetDirectoryName(path);
-        if (dir is not null) Directory.CreateDirectory(dir);
-        await File.AppendAllTextAsync(path, request.Content, cancellationToken);
+        return ExecuteWithPathLockAsync(path, async () =>
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (dir is not null) Directory.CreateDirectory(dir);
+            await File.AppendAllTextAsync(path, request.Content, cancellationToken);
+        }, cancellationToken);
     }
 
     public Task<SessionFsExistsResult> ExistsAsync(SessionFsExistsParams request, CancellationToken cancellationToken)


### PR DESCRIPTION
## What

Serialize concurrent writes per resolved path inside `LocalSessionFsHandler`. Both `WriteFileAsync` and `AppendFileAsync` now route through a per-path `SemaphoreSlim` keyed by the absolute path via `ConcurrentDictionary<string, SemaphoreSlim>`. Reads remain unlocked.

## Why

During multi-model skill-validator evals (`claude-haiku-4.5`, `claude-opus-4.6`, `gpt-5.3-codex`, `gpt-5.4-mini`), judge calls intermittently fail with:

> `Failed to persist session events: Error: Failed to append to JSONL file session-state\events.jsonl: Error: timeout while waiting for mutex to become available`

Hit `claude-opus-4.6` (~14 errors) and `gpt-5.4-mini` (~12 errors) hardest under 4-way parallel runs.

The error wording (the literal word `mutex`) does not originate in our C# code — it is reported by the GitHub Copilot SDK over RPC, so the underlying contention lives **inside** the SDK's session event-persistence layer. `AgentRunner` already gives each session its own `configDir` and `LlmSession` (judge) gives each call a unique temp root, so paths cannot collide *across* sessions — this points to intra-session contention on a single `events.jsonl` path.

Even though the conflict surfaces inside the SDK, removing one variable (our handler issuing concurrent writes to the same file) is good defense and makes the `ISessionFsHandler` thread-safe in its own right. The dictionary is bounded by the number of unique files written within one session (typically <10), so leak risk is negligible for the per-session object lifetime.

## Validation

- `dotnet build eng/skill-validator/src` passes.
- `dotnet test eng/skill-validator/tests` 545/545 pass.
- A follow-up multi-model eval is recommended to confirm the rate of judge mutex errors drops.
