### PR TITLE
skill-validator: bump per-plugin aggregate description cap from 15K to 20K (and document its informal origin)

### DIFF
--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -34,10 +34,12 @@ public static partial class SkillProfiler
 
     // Per-plugin aggregate description size cap. NOTE: this is a local repo
     // policy, NOT a documented Copilot/agentskills constraint. The agentskills.io
-    // spec defines per-skill description limits (1024 chars) but no aggregate
-    // limit. The original 15,000 was introduced in #238 / discussed in #222
-    // ("15K characters was mentioned, we could choose smaller") as an informal
-    // guardrail against bloated metadata costs at startup.
+    // specification (https://agentskills.io/specification) defines per-skill
+    // description (1024), compatibility (500), and name (64) limits, but does
+    // NOT define any aggregate per-plugin cap. The original 15,000 was
+    // introduced in #238 / discussed in #222 ("15K characters was mentioned,
+    // we could choose smaller") as an informal guardrail against bloated
+    // metadata costs at startup.
     //
     // TODO: validate this guardrail against literature (skill-routing studies)
     // and run experiments measuring whether large aggregate description footprints

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -42,8 +42,8 @@ public static partial class SkillProfiler
     // TODO: validate this guardrail against literature (skill-routing studies)
     // and run experiments measuring whether large aggregate description footprints
     // actually degrade selection accuracy or just cost more tokens up-front.
-    // Until then, keep the cap as a soft check and pick a value that doesn't
-    // block reasonable plugin growth (dotnet-test alone is now ~14K with 22 skills).
+    // Until then, keep the cap aligned with current enforcement as a hard
+    // validation failure, while leaving enough headroom for reasonable plugin growth.
     internal const int MaxAggregateDescriptionLength = 20_000;
     private const int MaxNameLength = 64;
     internal const int MinDescriptionLength = 10;

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -35,11 +35,12 @@ public static partial class SkillProfiler
     // Per-plugin aggregate description size cap. NOTE: this is a local repo
     // policy, NOT a documented Copilot/agentskills constraint. The agentskills.io
     // specification (https://agentskills.io/specification) defines per-skill
-    // description (1024), compatibility (500), and name (64) limits, but does
-    // NOT define any aggregate per-plugin cap. The original 15,000 was
-    // introduced in #238 / discussed in #222 ("15K characters was mentioned,
-    // we could choose smaller") as an informal guardrail against bloated
-    // metadata costs at startup.
+    // limits — description (1024 chars, #description-field), compatibility
+    // (500 chars, #compatibility-field), and name (64 chars, #name-field) —
+    // but does NOT define any aggregate per-plugin cap. The original 15,000
+    // was introduced in #238 / discussed in #222 ("15K characters was
+    // mentioned, we could choose smaller") as an informal guardrail against
+    // bloated metadata costs at startup.
     //
     // TODO: validate this guardrail against literature (skill-routing studies)
     // and run experiments measuring whether large aggregate description footprints

--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -31,7 +31,20 @@ public static partial class SkillProfiler
     // Not tied to the configured eval/judge model — TiktokenTokenizer only supports OpenAI
     // vocabularies, but BPE counts are close enough across models for complexity classification.
     private static readonly Lazy<TiktokenTokenizer> s_bpeTokenizer = new(() => TiktokenTokenizer.CreateForModel("gpt-4"));
-    internal const int MaxAggregateDescriptionLength = 15_000;
+
+    // Per-plugin aggregate description size cap. NOTE: this is a local repo
+    // policy, NOT a documented Copilot/agentskills constraint. The agentskills.io
+    // spec defines per-skill description limits (1024 chars) but no aggregate
+    // limit. The original 15,000 was introduced in #238 / discussed in #222
+    // ("15K characters was mentioned, we could choose smaller") as an informal
+    // guardrail against bloated metadata costs at startup.
+    //
+    // TODO: validate this guardrail against literature (skill-routing studies)
+    // and run experiments measuring whether large aggregate description footprints
+    // actually degrade selection accuracy or just cost more tokens up-front.
+    // Until then, keep the cap as a soft check and pick a value that doesn't
+    // block reasonable plugin growth (dotnet-test alone is now ~14K with 22 skills).
+    internal const int MaxAggregateDescriptionLength = 20_000;
     private const int MaxNameLength = 64;
     internal const int MinDescriptionLength = 10;
     private const int MaxCompatibilityLength = 500;

--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -42,6 +42,15 @@
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.2.2" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.3.0" />
+
+    <!--
+      Transitive pin: StreamJsonRpc 2.24.84 (brought in by GitHub.Copilot.SDK)
+      drags in Nerdbank.MessagePack 1.0.2, which has a known high-severity
+      stackalloc vulnerability in DateTime decoding (GHSA-2cwq-pwfr-wcw3,
+      https://github.com/advisories/GHSA-2cwq-pwfr-wcw3). Fixed in 1.1.62.
+      Drop this direct reference once the upstream chain bumps past 1.1.62.
+    -->
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.1.62" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What

Bumps `MaxAggregateDescriptionLength` in `eng/skill-validator/src/Check/SkillProfiler.cs` from **15,000 → 20,000** characters and adds a comment block documenting the origin of the cap and a follow-up TODO.

## Why now

The `dotnet-test` plugin (22 skills) is now at **~14K** aggregate description characters and bumping into the 15,000 ceiling on every meaningful description change. Recent PRs (#647, #652) had to micro-trim wording purely to stay under the limit. The next plugin growth will hit the cap regardless of authoring intent.

## The cap is not a Copilot constraint

This is a local repo guardrail, not a documented Copilot/agentskills constraint. Evidence:

1. **Spec status**: the [agentskills.io specification](https://agentskills.io/specification) defines per-skill `description` (1024), `compatibility` (500), and `name` (64) limits. **It does not define any aggregate per-plugin cap.** The `MaxDescriptionLength = 1024` constant in this same file already cites the spec; the aggregate constant carried no citation comment.

2. **Origin**: `git log -S MaxAggregateDescriptionLength` traces to PR #238, which references issue #222. Issue #222 verbatim:

   > "users **may** apply a limit to the total size of 'description' across all skills in a plugin (...). 15K characters **was mentioned, we could choose smaller**."

   Picked because it "was mentioned", with the issue itself acknowledging the value is approximate.

## What this PR does

- **Bumps to 20,000.** Round value, ~30 % headroom over the largest current plugin (`dotnet-test` ~14K) without making the cap meaningless.
- **Adds a TODO comment** that (a) cites the agentskills.io spec, (b) records the informal origin (issue #222), and (c) flags the need to validate the guardrail against literature on skill-routing degradation and to run actual experiments before keeping or removing the check.

## What we should investigate next (not this PR)

- **Literature**: are there published studies on how aggregate description footprint affects router/selection accuracy in tool/skill ecosystems? Anthropic's "skill" routing, OpenAI tool-calling at scale, MCP servers — each has constraints we can mine.
- **Experiments**: `skill-validator` already has the infrastructure to A/B measure activation accuracy with and without noise (see the `--noise-skills-dir` flag). We could deliberately inflate descriptions and measure the activation regression curve, then set the cap at an empirically-derived inflection point.

The cost concern in #222 is real (every description is loaded at startup for routing) — we just do not have evidence for the right ceiling. Until that evidence exists, the cap should be loose enough not to obstruct legitimate authoring.

## What this PR does NOT do

- Does not remove the cap.
- Does not change per-skill limits.
- Does not relax the per-skill 1024-char limit (which IS spec-mandated).

## Validation

- `dotnet build eng/skill-validator/src` passes.
- `dotnet test eng/skill-validator/tests` **545/545 pass**, including the four `CheckCommandAggregateDescriptionTests` cases (they reference the constant symbolically and continue to verify `Under`/`At`/`Over`/`MultiplePlugins` behaviour).
