### PR TITLE
Fix code-testing-agent baseline eval: search coverage XML recursively

### DIFF
--- a/tests/dotnet-test/code-testing-agent/eval.vally.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.vally.yaml
@@ -30,7 +30,10 @@ stimuli:
           timeout: 5m
       - type: run-command
         config:
-          command: sh -c 'find TestResults -type f -name coverage.cobertura.xml -print -quit | grep -q coverage.cobertura.xml'
+          # dotnet test --collect:"XPlat Code Coverage" writes the report under
+          # <TestProject>/TestResults/<guid>/coverage.cobertura.xml — not at a
+          # workspace-root TestResults/ — so search recursively from cwd.
+          command: sh -c 'find . -type f -name coverage.cobertura.xml -print -quit | grep -q coverage.cobertura.xml'
           expected_exit_code: 0
           timeout: 1m
       - type: prompt

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -32,7 +32,7 @@ scenarios:
         expected_std_output_contains: "Passed!"
         command_timeout: 300
       - type: file_exists
-        path: "TestResults/**/coverage.cobertura.xml"
+        path: "**/TestResults/**/coverage.cobertura.xml"
     rubric:
       - "Achieved high line coverage (>70%) across the ContosoUniversity source files as reported by the Cobertura XML in TestResults/"
       - "Tests are organized logically with clear naming that describes test scenarios"


### PR DESCRIPTION
## What

Fixes the `code-testing-agent` baseline eval failure where the coverage-XML-existence assertions never matched even when the agent produced a Cobertura report (observed e.g. with 120 passing tests / 77.4% line coverage in baseline runs).

## Why it was failing

`dotnet test ContosoUniversity.Tests/… --collect:"XPlat Code Coverage"` invoked from the workspace root writes the report under:

```
ContosoUniversity.Tests/TestResults/<guid>/coverage.cobertura.xml
```

…not under a workspace-root `TestResults/` directory.

- `eval.vally.yaml` had `find TestResults -type f -name coverage.cobertura.xml …`, which exits 1 with "No such file or directory" before searching, because `TestResults/` does not exist at cwd.
- `eval.yaml` had `path: "TestResults/**/coverage.cobertura.xml"`, a cwd-rooted glob that also cannot reach `<TestProject>/TestResults/…`.

## Fix

Search recursively from the workspace root in both files:

- `eval.vally.yaml` → `find . -type f -name coverage.cobertura.xml -print -quit | grep -q …` (with a comment documenting where XPlat Code Coverage actually writes the file).
- `eval.yaml` → `path: "**/TestResults/**/coverage.cobertura.xml"`.

This keeps the user-visible contract in the stimulus ("produces a Cobertura XML report under TestResults/") — `<TestProject>/TestResults/` still satisfies that wording — and only corrects the assertion to look in the right place, regardless of the test project layout the agent picks.

## Validation

No skill content / SKILL.md / source changes. The fix is grader-only and will be exercised by the existing baseline eval workflow on this PR.
