### PR TITLE
Bump GitHub.Copilot.SDK to 0.3.0 and address breaking changes

### DIFF
--- a/eng/skill-validator/src/Evaluate/AgentRunner.cs
+++ b/eng/skill-validator/src/Evaluate/AgentRunner.cs
@@ -74,8 +74,8 @@ public static class AgentRunner
                     InitialCwd = Environment.CurrentDirectory,
                     SessionStatePath = "session-state",
                     Conventions = OperatingSystem.IsWindows()
-                        ? GitHub.Copilot.SDK.Rpc.SessionFsSetProviderRequestConventions.Windows
-                        : GitHub.Copilot.SDK.Rpc.SessionFsSetProviderRequestConventions.Posix,
+                        ? GitHub.Copilot.SDK.Rpc.SessionFsSetProviderConventions.Windows
+                        : GitHub.Copilot.SDK.Rpc.SessionFsSetProviderConventions.Posix,
                 },
             };
 
@@ -284,12 +284,12 @@ public static class AgentRunner
             noiseDirs.Add(stageDir);
         }
 
-        // Convert MCPServerDef records to the SDK's Dictionary<string, object> shape
+        // Convert MCPServerDef records to the SDK's McpServerConfig shape
         // Security hardening: validate commands, sanitize args/env, drop custom cwd.
-        Dictionary<string, object>? sdkMcp = null;
+        IDictionary<string, McpServerConfig>? sdkMcp = null;
         if (mcpServers is { Count: > 0 })
         {
-            sdkMcp = new Dictionary<string, object>();
+            sdkMcp = new Dictionary<string, McpServerConfig>();
             foreach (var (name, def) in mcpServers)
             {
                 if (!IsAllowedMcpCommand(def.Command))
@@ -307,17 +307,16 @@ public static class AgentRunner
                     continue;
                 }
 
-                var entry = new Dictionary<string, object>
+                var entry = new McpStdioServerConfig
                 {
-                    ["type"] = def.Type ?? "stdio",
-                    ["command"] = def.Command,
-                    ["args"] = sanitizedArgs,
-                    ["tools"] = def.Tools ?? ["*"],
+                    Command = def.Command,
+                    Args = sanitizedArgs,
+                    Tools = def.Tools ?? ["*"],
                 };
 
                 // Sanitize env: strip dangerous keys that could hijack the process.
                 var sanitizedEnv = SanitizeMcpEnv(def.Env);
-                if (sanitizedEnv is not null) entry["env"] = sanitizedEnv;
+                if (sanitizedEnv is not null) entry.Env = sanitizedEnv;
 
                 // Drop custom cwd — MCP servers run in workDir, not attacker-chosen dirs.
                 sdkMcp[name] = entry;
@@ -440,8 +439,8 @@ public static class AgentRunner
             McpServers = sdkMcp,
             CustomAgents = customAgents,
             InfiniteSessions = new InfiniteSessionConfig { Enabled = false },
-            // SDK 0.2.x removed the built-in local-filesystem session-state
-            // handler.  Without this, events.jsonl files are never written and
+            // SDK 0.3.0 requires a SessionFsProvider (abstract base class).
+            // Without this, events.jsonl files are never written and
             // session replay data is lost.
             CreateSessionFsHandler = _ => new LocalSessionFsHandler(configDir),
             OnPermissionRequest = (request, _) =>

--- a/eng/skill-validator/src/Evaluate/AgentRunner.cs
+++ b/eng/skill-validator/src/Evaluate/AgentRunner.cs
@@ -299,6 +299,14 @@ public static class AgentRunner
                     continue;
                 }
 
+                // Only stdio servers are supported; reject unknown types early.
+                if (def.Type is not null and not "stdio")
+                {
+                    Console.Error.WriteLine(
+                        $"Skipping MCP server '{name}': unsupported type '{def.Type}' (only 'stdio' is supported)");
+                    continue;
+                }
+
                 var sanitizedArgs = SanitizeMcpArgs(def.Command, def.Args);
                 if (sanitizedArgs is null)
                 {

--- a/eng/skill-validator/src/Evaluate/Judge.cs
+++ b/eng/skill-validator/src/Evaluate/Judge.cs
@@ -49,7 +49,7 @@ public static class Judge
                 // pure LLM task — no file access or tool execution needed.
                 return Task.FromResult(new PermissionRequestResult
                 {
-                    Kind = PermissionRequestResultKind.DeniedByRules,
+                    Kind = PermissionRequestResultKind.UserNotAvailable,
                 });
             },
             cancellationToken: cancellationToken);

--- a/eng/skill-validator/src/Evaluate/LlmSession.cs
+++ b/eng/skill-validator/src/Evaluate/LlmSession.cs
@@ -55,7 +55,7 @@ internal static class LlmSession
             CreateSessionFsHandler = _ => new LocalSessionFsHandler(tempConfigDir),
             OnPermissionRequest = onPermissionRequest ?? ((_, _) => Task.FromResult(new PermissionRequestResult
             {
-                Kind = PermissionRequestResultKind.DeniedByRules,
+                Kind = PermissionRequestResultKind.UserNotAvailable,
             })),
         });
 

--- a/eng/skill-validator/src/Evaluate/LocalSessionFsHandler.cs
+++ b/eng/skill-validator/src/Evaluate/LocalSessionFsHandler.cs
@@ -1,14 +1,15 @@
+using GitHub.Copilot.SDK;
 using GitHub.Copilot.SDK.Rpc;
 
 namespace SkillValidator.Evaluate;
 
 /// <summary>
-/// A local-filesystem implementation of <see cref="ISessionFsHandler"/> that
+/// A local-filesystem implementation of <see cref="SessionFsProvider"/> that
 /// maps SDK session-state I/O requests to physical files under a given root
-/// directory.  Required since Copilot SDK 0.2.x no longer ships a built-in
+/// directory.  Required since Copilot SDK no longer ships a built-in
 /// default; without this handler, <c>events.jsonl</c> files are never written.
 /// </summary>
-internal sealed class LocalSessionFsHandler : ISessionFsHandler
+internal sealed class LocalSessionFsHandler : SessionFsProvider
 {
     private readonly string _rootDir;
 
@@ -29,130 +30,129 @@ internal sealed class LocalSessionFsHandler : ISessionFsHandler
         return full;
     }
 
-    public async Task<SessionFsReadFileResult> ReadFileAsync(SessionFsReadFileParams request, CancellationToken cancellationToken)
+    protected override async Task<string> ReadFileAsync(string path, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        var content = await File.ReadAllTextAsync(path, cancellationToken);
-        return new SessionFsReadFileResult { Content = content };
+        var resolved = ResolvePath(path);
+        return await File.ReadAllTextAsync(resolved, cancellationToken);
     }
 
-    public async Task WriteFileAsync(SessionFsWriteFileParams request, CancellationToken cancellationToken)
+    protected override async Task WriteFileAsync(string path, string content, int? mode, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        var dir = Path.GetDirectoryName(path);
+        var resolved = ResolvePath(path);
+        var dir = Path.GetDirectoryName(resolved);
         if (dir is not null) Directory.CreateDirectory(dir);
-        await File.WriteAllTextAsync(path, request.Content, cancellationToken);
+        await File.WriteAllTextAsync(resolved, content, cancellationToken);
     }
 
-    public async Task AppendFileAsync(SessionFsAppendFileParams request, CancellationToken cancellationToken)
+    protected override async Task AppendFileAsync(string path, string content, int? mode, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        var dir = Path.GetDirectoryName(path);
+        var resolved = ResolvePath(path);
+        var dir = Path.GetDirectoryName(resolved);
         if (dir is not null) Directory.CreateDirectory(dir);
-        await File.AppendAllTextAsync(path, request.Content, cancellationToken);
+        await File.AppendAllTextAsync(resolved, content, cancellationToken);
     }
 
-    public Task<SessionFsExistsResult> ExistsAsync(SessionFsExistsParams request, CancellationToken cancellationToken)
+    protected override Task<bool> ExistsAsync(string path, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        var exists = File.Exists(path) || Directory.Exists(path);
-        return Task.FromResult(new SessionFsExistsResult { Exists = exists });
+        var resolved = ResolvePath(path);
+        var exists = File.Exists(resolved) || Directory.Exists(resolved);
+        return Task.FromResult(exists);
     }
 
-    public Task<SessionFsStatResult> StatAsync(SessionFsStatParams request, CancellationToken cancellationToken)
+    protected override Task<SessionFsStatResult> StatAsync(string path, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        if (File.Exists(path))
+        var resolved = ResolvePath(path);
+        if (File.Exists(resolved))
         {
-            var info = new FileInfo(path);
+            var info = new FileInfo(resolved);
             return Task.FromResult(new SessionFsStatResult
             {
                 IsFile = true,
                 IsDirectory = false,
                 Size = info.Length,
-                Mtime = info.LastWriteTimeUtc.ToString("O"),
-                Birthtime = info.CreationTimeUtc.ToString("O"),
+                Mtime = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero),
+                Birthtime = new DateTimeOffset(info.CreationTimeUtc, TimeSpan.Zero),
             });
         }
 
-        if (Directory.Exists(path))
+        if (Directory.Exists(resolved))
         {
-            var info = new DirectoryInfo(path);
+            var info = new DirectoryInfo(resolved);
             return Task.FromResult(new SessionFsStatResult
             {
                 IsFile = false,
                 IsDirectory = true,
                 Size = 0,
-                Mtime = info.LastWriteTimeUtc.ToString("O"),
-                Birthtime = info.CreationTimeUtc.ToString("O"),
+                Mtime = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero),
+                Birthtime = new DateTimeOffset(info.CreationTimeUtc, TimeSpan.Zero),
             });
         }
 
-        throw new FileNotFoundException($"Not found: {request.Path}");
+        throw new FileNotFoundException($"Not found: {path}");
     }
 
-    public Task MkdirAsync(SessionFsMkdirParams request, CancellationToken cancellationToken)
+    protected override Task MkdirAsync(string path, bool recursive, int? mode, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        Directory.CreateDirectory(path);
+        var resolved = ResolvePath(path);
+        Directory.CreateDirectory(resolved);
         return Task.CompletedTask;
     }
 
-    public Task<SessionFsReaddirResult> ReaddirAsync(SessionFsReaddirParams request, CancellationToken cancellationToken)
+    protected override Task<IList<string>> ReaddirAsync(string path, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
+        var resolved = ResolvePath(path);
         var entries = new List<string>();
-        if (Directory.Exists(path))
+        if (Directory.Exists(resolved))
         {
-            foreach (var entry in Directory.EnumerateFileSystemEntries(path))
+            foreach (var entry in Directory.EnumerateFileSystemEntries(resolved))
                 entries.Add(Path.GetFileName(entry));
         }
-        return Task.FromResult(new SessionFsReaddirResult { Entries = entries });
+        return Task.FromResult<IList<string>>(entries);
     }
 
-    public Task<SessionFsReaddirWithTypesResult> ReaddirWithTypesAsync(SessionFsReaddirWithTypesParams request, CancellationToken cancellationToken)
+    protected override Task<IList<SessionFsReaddirWithTypesEntry>> ReaddirWithTypesAsync(string path, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        var entries = new List<Entry>();
-        if (Directory.Exists(path))
+        var resolved = ResolvePath(path);
+        var entries = new List<SessionFsReaddirWithTypesEntry>();
+        if (Directory.Exists(resolved))
         {
-            foreach (var entry in new DirectoryInfo(path).EnumerateFileSystemInfos())
+            foreach (var entry in new DirectoryInfo(resolved).EnumerateFileSystemInfos())
             {
-                entries.Add(new Entry
+                entries.Add(new SessionFsReaddirWithTypesEntry
                 {
                     Name = entry.Name,
-                    Type = entry is DirectoryInfo ? EntryType.Directory : EntryType.File,
+                    Type = entry is DirectoryInfo ? SessionFsReaddirWithTypesEntryType.Directory : SessionFsReaddirWithTypesEntryType.File,
                 });
             }
         }
-        return Task.FromResult(new SessionFsReaddirWithTypesResult { Entries = entries });
+        return Task.FromResult<IList<SessionFsReaddirWithTypesEntry>>(entries);
     }
 
-    public Task RmAsync(SessionFsRmParams request, CancellationToken cancellationToken)
+    protected override Task RmAsync(string path, bool recursive, bool force, CancellationToken cancellationToken)
     {
-        var path = ResolvePath(request.Path);
-        if (File.Exists(path))
+        var resolved = ResolvePath(path);
+        if (File.Exists(resolved))
         {
-            File.Delete(path);
+            File.Delete(resolved);
         }
-        else if (Directory.Exists(path))
+        else if (Directory.Exists(resolved))
         {
-            Directory.Delete(path, recursive: request.Recursive ?? false);
+            Directory.Delete(resolved, recursive: recursive);
         }
         return Task.CompletedTask;
     }
 
-    public Task RenameAsync(SessionFsRenameParams request, CancellationToken cancellationToken)
+    protected override Task RenameAsync(string src, string dest, CancellationToken cancellationToken)
     {
-        var src = ResolvePath(request.Src);
-        var dest = ResolvePath(request.Dest);
-        var destDir = Path.GetDirectoryName(dest);
+        var resolvedSrc = ResolvePath(src);
+        var resolvedDest = ResolvePath(dest);
+        var destDir = Path.GetDirectoryName(resolvedDest);
         if (destDir is not null) Directory.CreateDirectory(destDir);
 
-        if (File.Exists(src))
-            File.Move(src, dest, overwrite: true);
-        else if (Directory.Exists(src))
-            Directory.Move(src, dest);
+        if (File.Exists(resolvedSrc))
+            File.Move(resolvedSrc, resolvedDest, overwrite: true);
+        else if (Directory.Exists(resolvedSrc))
+            Directory.Move(resolvedSrc, resolvedDest);
         return Task.CompletedTask;
     }
 }

--- a/eng/skill-validator/src/Evaluate/PairwiseJudge.cs
+++ b/eng/skill-validator/src/Evaluate/PairwiseJudge.cs
@@ -89,7 +89,7 @@ public static class PairwiseJudge
                 // should operate purely on the provided text — no tool execution.
                 return Task.FromResult(new PermissionRequestResult
                 {
-                    Kind = PermissionRequestResultKind.DeniedByRules,
+                    Kind = PermissionRequestResultKind.UserNotAvailable,
                 });
             },
             cancellationToken: cancellationToken);

--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -39,16 +39,14 @@
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
     <!-- external -->
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.2.2" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.3.0" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="0.3.0" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
+    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="17.0.0" />
 
     <!--
-      Transitive pin: StreamJsonRpc 2.24.84 (brought in by GitHub.Copilot.SDK)
-      drags in Nerdbank.MessagePack 1.0.2, which has a known high-severity
-      stackalloc vulnerability in DateTime decoding (GHSA-2cwq-pwfr-wcw3,
-      https://github.com/advisories/GHSA-2cwq-pwfr-wcw3). Fixed in 1.1.62.
-      Drop this direct reference once the upstream chain bumps past 1.1.62.
+      Transitive pin: GitHub.Copilot.SDK still drags in Nerdbank.MessagePack
+      1.0.2 which has a known high-severity vulnerability (GHSA-2cwq-pwfr-wcw3).
+      Fixed in 1.1.62.  Drop this once the upstream chain bumps past 1.1.62.
     -->
     <PackageReference Include="Nerdbank.MessagePack" Version="1.1.62" />
   </ItemGroup>

--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -6,6 +6,9 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- YamlDotNet 17.x is not fully trim/AOT-compatible; suppress the
+         assembly-level trim analysis warning so native publish succeeds. -->
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
 
     <!-- Packaging -->
     <PackageId>Microsoft.DotNet.SkillValidator</PackageId>

--- a/eng/skill-validator/tests/Evaluate/RunnerTests.cs
+++ b/eng/skill-validator/tests/Evaluate/RunnerTests.cs
@@ -335,11 +335,11 @@ public class BuildSessionConfigTests
         Assert.NotNull(config.McpServers);
         Assert.True(config.McpServers.ContainsKey("ok"));
         // Dangerous keys are stripped; safe keys remain
-        var entry = (Dictionary<string, object>)config.McpServers["ok"];
-        var env = (Dictionary<string, string>)entry["env"];
-        Assert.False(env.ContainsKey("NODE_OPTIONS"));
-        Assert.False(env.ContainsKey("PATH"));
-        Assert.True(env.ContainsKey("MY_SETTING"));
+        var entry = (McpStdioServerConfig)config.McpServers["ok"];
+        Assert.NotNull(entry.Env);
+        Assert.False(entry.Env.ContainsKey("NODE_OPTIONS"));
+        Assert.False(entry.Env.ContainsKey("PATH"));
+        Assert.True(entry.Env.ContainsKey("MY_SETTING"));
     }
 
     [Fact]
@@ -355,8 +355,8 @@ public class BuildSessionConfigTests
         };
         var config = await AgentRunner.BuildSessionConfig(MockSkill, null, "gpt-4.1", "C:\\tmp\\work", mcpServers);
         Assert.NotNull(config.McpServers);
-        var entry = (Dictionary<string, object>)config.McpServers["ok"];
-        Assert.False(entry.ContainsKey("cwd"));
+        var entry = (McpStdioServerConfig)config.McpServers["ok"];
+        Assert.Null(entry.Cwd);
     }
 
     [Fact]


### PR DESCRIPTION
Upgrades GitHub.Copilot.SDK from 0.2.2 to 0.3.0 and addresses all breaking API changes.

Supersedes #596 (Dependabot PR that bumps the same packages but doesn't address breaking changes).

## Package updates
- **GitHub.Copilot.SDK** 0.2.2 → 0.3.0
- **YamlDotNet** 16.3.0 → 17.1.0
- **Vecc.YamlDotNet.Analyzers.StaticGenerator** 16.3.0 → 17.0.0
- **Nerdbank.MessagePack** pinned to 1.1.62 (fixes GHSA-2cwq-pwfr-wcw3)

## Breaking changes addressed
- `LocalSessionFsHandler` now extends the new abstract `SessionFsProvider` class (simplified method signatures taking raw parameters instead of Request objects)
- MCP server config uses typed `McpStdioServerConfig` instead of `Dictionary<string, object>`
- `SessionFsSetProviderRequestConventions` → `SessionFsSetProviderConventions`
- `PermissionRequestResultKind.DeniedByRules` → `.UserNotAvailable` (marked obsolete)
- `Mtime`/`Birthtime` properties now `DateTimeOffset` instead of `string`
- `Entry`/`EntryType` → `SessionFsReaddirWithTypesEntry`/`SessionFsReaddirWithTypesEntryType`

All 545 tests pass.