### PR TITLE
Fix non-built-in 'terminal' tool warnings in dotnet-test agents

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,7 +6,7 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
-tools: ['read', 'search', 'edit', 'task', 'skill', 'terminal']
+tools: ['read', 'search', 'edit', 'task', 'skill', 'bash', 'powershell']
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/test-migration.agent.md
+++ b/plugins/dotnet-test/agents/test-migration.agent.md
@@ -6,7 +6,7 @@ description: >-
   and guides users through end-to-end upgrades. Use when asked to upgrade
   MSTest, migrate to xUnit v3, switch to Microsoft.Testing.Platform, modernize
   test infrastructure, or when the user says "migrate my tests".
-tools: ['read', 'search', 'edit', 'terminal', 'skill']
+tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 user-invokable: true
 disable-model-invocation: false
 handoffs:

--- a/plugins/dotnet-test/agents/test-quality-auditor.agent.md
+++ b/plugins/dotnet-test/agents/test-quality-auditor.agent.md
@@ -9,7 +9,7 @@ description: >-
   running multiple analysis skills in sequence. Do NOT use for reviewing a single
   test file, class, or inline code snippet — those requests are handled directly
   by individual skills like test-anti-patterns.
-tools: ['read', 'search', 'edit', 'terminal', 'skill']
+tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 user-invokable: true
 disable-model-invocation: false
 handoffs:

--- a/plugins/dotnet-test/agents/testability-migration.agent.md
+++ b/plugins/dotnet-test/agents/testability-migration.agent.md
@@ -6,7 +6,7 @@ description: >-
   Use when asked to make code testable, remove static coupling, migrate to
   TimeProvider, adopt IFileSystem, or improve testability of a legacy codebase.
 name: testability-migration
-tools: ['read', 'search', 'edit', 'terminal', 'skill']
+tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 handoffs:
   - label: Generate Tests for Migrated Code
     agent: code-testing-generator


### PR DESCRIPTION
The skill-validator's built-in tool list recognizes `bash` and `powershell` as shell tools, but not `terminal`. This caused four warnings:

```n[agent:testability-migration]   Non-built-in tool 'terminal' in tools list
[agent:code-testing-generator]  Non-built-in tool 'terminal' in tools list
[agent:test-quality-auditor]    Non-built-in tool 'terminal' in tools list
[agent:test-migration]          Non-built-in tool 'terminal' in tools list
```

Replaces `terminal` with both `bash` and `powershell` in the four affected agent frontmatters to keep cross-platform shell support for the `dotnet` commands these agents invoke.

Verified by running `dotnet run --project eng/skill-validator/src -- check --plugin plugins/dotnet-test` — all checks pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>