### PR TITLE
Fix vally eval isolation: pin baseline to 0 skills, skilled to 1

### DIFF
--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -112,8 +112,22 @@ jobs:
 
       - name: Find eval specs
         id: find-evals
+        env:
+          DISPATCH_SKILL: ${{ inputs.skill }}
         run: |
-          EVALS=$(find tests/${{ matrix.entry.plugin }} -name "eval.vally.yaml" -type f | sort)
+          # For workflow_dispatch targeting a specific skill, only run that one
+          # eval. Otherwise run every eval discovered under the plugin's tests
+          # directory.
+          if [ -n "$DISPATCH_SKILL" ]; then
+            CANDIDATE="tests/${{ matrix.entry.plugin }}/${DISPATCH_SKILL}/eval.vally.yaml"
+            if [ -f "$CANDIDATE" ]; then
+              EVALS="$CANDIDATE"
+            else
+              EVALS=""
+            fi
+          else
+            EVALS=$(find tests/${{ matrix.entry.plugin }} -name "eval.vally.yaml" -type f | sort)
+          fi
           if [ -z "$EVALS" ]; then
             echo "No eval.vally.yaml files found for ${{ matrix.entry.plugin }}"
             echo "has_evals=false" >> $GITHUB_OUTPUT
@@ -129,7 +143,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}
           RESULTS_DIR: artifacts/TestResults/vally/${{ matrix.entry.name }}
         run: |
-          SKILL_DIR="./${{ matrix.entry.skills_path }}"
+          PLUGIN="${{ matrix.entry.plugin }}"
 
           while IFS= read -r EVAL_SPEC; do
             EVAL_NAME=$(basename $(dirname "$EVAL_SPEC"))
@@ -139,10 +153,29 @@ jobs:
             SKILLED_DIR="$RESULTS_DIR/$EVAL_NAME/skilled"
             mkdir -p "$BASELINE_DIR" "$SKILLED_DIR"
 
-            # Baseline run (no skill)
+            # Each eval targets a single skill named after the eval folder.
+            # Evals that do not map 1:1 to a skill (e.g. `agent.*` evals that
+            # exercise multi-skill orchestrator agents and declare their own
+            # `environment.skills`) are skipped — they are out of scope for
+            # the skill-vs-baseline pipeline.
+            PER_SKILL_DIR="./plugins/$PLUGIN/skills/$EVAL_NAME"
+            if [ ! -f "$PER_SKILL_DIR/SKILL.md" ]; then
+              echo "::warning::Skipping $EVAL_NAME — no SKILL.md at $PER_SKILL_DIR (likely an agent eval; not supported by the skill-isolation pipeline)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Empty dir used as `--skill-dir` for the baseline so vally
+            # discovers zero skills. Without this, vally walks up to the repo's
+            # .vally.yaml and loads every skill under plugins/, contaminating
+            # the baseline.
+            EMPTY_SKILL_DIR=$(mktemp -d -t vally-empty-skills-XXXXXX)
+
+            # Baseline run (no skills)
             echo "--- Baseline run ---"
             vally eval \
               --eval-spec "$EVAL_SPEC" \
+              --skill-dir "$EMPTY_SKILL_DIR" \
               --model ${{ env.MODEL }} \
               --runs 1 --workers 3 \
               --skip-validate \
@@ -150,17 +183,19 @@ jobs:
               --output-dir "$BASELINE_DIR" \
               2>&1 || echo "::warning::Baseline eval failed for $EVAL_NAME"
 
-            # Skilled run
+            # Skilled run (exactly the one skill under evaluation)
             echo "--- Skilled run ---"
             vally eval \
               --eval-spec "$EVAL_SPEC" \
-              --skill-dir "$SKILL_DIR" \
+              --skill-dir "$PER_SKILL_DIR" \
               --model ${{ env.MODEL }} \
               --runs 1 --workers 3 \
               --skip-validate \
               --judge-model ${{ env.JUDGE_MODEL }} \
               --output-dir "$SKILLED_DIR" \
               2>&1 || echo "::warning::Skilled eval failed for $EVAL_NAME"
+
+            rm -rf "$EMPTY_SKILL_DIR"
 
             # Adapt results — find JSONL in timestamped subdirs
             BASELINE_JSONL=$(find "$BASELINE_DIR" -name "*.jsonl" -type f 2>/dev/null | head -1)
@@ -172,7 +207,7 @@ jobs:
                 --baseline "$(dirname "$BASELINE_JSONL")" \
                 --skilled "$(dirname "$SKILLED_JSONL")" \
                 --skill-name "$EVAL_NAME" \
-                --skill-path "${{ matrix.entry.skills_path }}" \
+                --skill-path "plugins/$PLUGIN/skills/$EVAL_NAME" \
                 --model "${{ env.MODEL }}" \
                 --judge-model "${{ env.JUDGE_MODEL }}" \
                 --output "$RESULTS_DIR/$EVAL_NAME/results.json"

--- a/eng/vally-adapter/run-vally-evals.sh
+++ b/eng/vally-adapter/run-vally-evals.sh
@@ -108,21 +108,34 @@ run_one_eval() {
   mkdir -p "$BASELINE_DIR" "$SKILLED_DIR"
 
   if [ ! -d "$SKILL_DIR" ]; then
+    # Skipped: this eval (commonly `agent.*`) targets an orchestrator agent or
+    # otherwise does not map to a single skill directory under
+    # plugins/<plugin>/skills/<eval-name>. Such evals are out of scope for the
+    # skill-vs-baseline pipeline (e.g. they declare `environment.skills`
+    # explicitly and would not produce a meaningful 0-skill baseline).
     echo "SKIP: skill dir not found: $SKILL_DIR" > "$LOG"
     echo -e "  ${YELLOW}⚠${NC} $EVAL_PLUGIN/$EVAL_NAME (skipped — no skill dir)"
     echo "skip" > "$STATUS_DIR/$EVAL_PLUGIN--$EVAL_NAME"
     return
   fi
 
+  # Empty dir used as `--skill-dir` for the baseline so vally discovers zero
+  # skills (without it, vally walks up to the repo's .vally.yaml and loads
+  # every skill under plugins/, contaminating the baseline). One dir per eval
+  # to avoid any cross-run contention when running in parallel.
+  local EMPTY_SKILL_DIR
+  EMPTY_SKILL_DIR=$(mktemp -d -t vally-empty-skills-XXXXXX)
+
   echo -e "  ${BOLD}▶${NC} $EVAL_PLUGIN/$EVAL_NAME — baseline..." >&2
 
   {
     echo "=== $EVAL_PLUGIN/$EVAL_NAME ==="
 
-    # Baseline
+    # Baseline: no skills available to the agent.
     echo "--- Baseline run ---"
     $VALLY eval \
       --eval-spec "$EVAL_SPEC" \
+      --skill-dir "$EMPTY_SKILL_DIR" \
       --model "$MODEL" \
       --runs "$RUNS" --workers "$WORKERS" \
       --skip-validate \
@@ -132,7 +145,7 @@ run_one_eval() {
 
     echo -e "  ${BOLD}▶${NC} $EVAL_PLUGIN/$EVAL_NAME — skilled..." >&2
 
-    # Skilled
+    # Skilled: exactly the one skill under evaluation.
     echo "--- Skilled run ---"
     $VALLY eval \
       --eval-spec "$EVAL_SPEC" \
@@ -177,6 +190,8 @@ run_one_eval() {
     echo "error" > "$STATUS_DIR/$EVAL_PLUGIN--$EVAL_NAME"
     echo -e "  ${RED}✘${NC} $EVAL_PLUGIN/$EVAL_NAME (see $LOG)"
   fi
+
+  rm -rf "$EMPTY_SKILL_DIR"
 }
 
 export -f run_one_eval


### PR DESCRIPTION
## Problem

vally evaluations were not isolating skills properly. In the failing run https://github.com/dotnet/skills/actions/runs/26021981688, the `dotnet-test` job's eval for `code-testing-agent` reported **`Found 77 skill(s)`** in the baseline run and **`Found 22 skill(s)`** in the skilled run — instead of the expected 0 and 1.

## Root cause

`vally eval` derives its skill set via `discoverSkills(skillRoot, ...)` where `skillRoot = opts.skillDir ?? cwd`:

- The **baseline** call omitted `--skill-dir`, so vally fell back to the repo root, walked up to `.vally.yaml`, and loaded every skill under `plugins/` (77 total).
- The CI workflow's **skilled** call passed `--skill-dir ./plugins/<plugin>/skills` (from `matrix.entry.skills_path`, which for scheduled/infra runs is plugin-level). That directory has no `SKILL.md` at its root, so vally's Step-4 child scan picked up every sibling skill in the plugin (22 for `dotnet-test`).

## Fix

Applied to both `eng/vally-adapter/run-vally-evals.sh` and `.github/workflows/vally-evaluation.yml`:

- **Baseline** now passes `--skill-dir <empty mktemp dir>` so vally discovers 0 skills.
- **Skilled** now uses `plugins/<plugin>/skills/<eval-name>` (the specific skill dir, not the plugin-level one) so vally matches Step-1 (`SKILL.md` at root) and discovers exactly 1 skill.
- Evals with no matching `SKILL.md` — i.e. the `agent.*` orchestrator evals that declare their own `environment.skills` — are explicitly **skipped** with a warning. Baseline-vs-skilled isolation is not meaningful for them since they require multi-skill setup by design.
- The CI workflow's `Find eval specs` step now narrows to a single eval when `workflow_dispatch` is invoked with a specific `skill` input, so single-skill dispatches don't accidentally run every eval in the plugin.
- Empty temp dirs are created per-eval and cleaned up after each run to avoid any cross-run contention under parallel execution.

## Expected outcome

After this PR, CI logs should show:

- `--- Baseline run ---` → `Found 0 skill(s)`
- `--- Skilled run ---` → `Found 1 skill(s): <skill-name>`
