### PR TITLE
skill-validator: remove the tools check

### DIFF
--- a/eng/allowed-external-deps.txt
+++ b/eng/allowed-external-deps.txt
@@ -5,8 +5,6 @@
 # Types:
 #   script:SKILL-NAME:relative/path    - Script file in a skill's scripts/ directory
 #   invokes:SKILL-NAME                 - INVOKES pattern in a skill description
-#   tool-ref:NAME:#tool:reference      - Non-built-in #tool: reference in skill/agent content
-#   agent-tool:AGENT-NAME:tool-name    - Non-built-in tool in agent frontmatter tools array
 #   mcp-server:PLUGIN-NAME:server-name - MCP server declaration in plugin.json
 #
 # To get clean, remove entries as the underlying dependency is resolved.
@@ -18,7 +16,3 @@ invokes:android-tombstone-symbolication
 
 # dotnet-upgrade plugin: migrate-nullable-references skill
 script:migrate-nullable-references:scripts/Get-NullableReadiness.ps1
-
-# dotnet-msbuild plugin: msbuild agent
-tool-ref:msbuild:#tool:web/fetch
-tool-ref:msbuild:#tool:agent/runSubagent

--- a/eng/allowed-external-deps.txt
+++ b/eng/allowed-external-deps.txt
@@ -1,10 +1,10 @@
 # Allowed external dependencies for the skill-validator.
 # One entry per line. Lines starting with # are comments.
-# Format: type:name:detail
+# Format: type:name[:detail]   (detail is required for some types — see below)
 #
 # Types:
 #   script:SKILL-NAME:relative/path    - Script file in a skill's scripts/ directory
-#   invokes:SKILL-NAME                 - INVOKES pattern in a skill description
+#   invokes:SKILL-NAME                 - INVOKES pattern in a skill description (no detail)
 #   mcp-server:PLUGIN-NAME:server-name - MCP server declaration in plugin.json
 #
 # To get clean, remove entries as the underlying dependency is resolved.

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -211,7 +211,7 @@ public static class CheckCommand
             }
         }
 
-        // Check for external dependencies (plugin-level check includes all three)
+        // Check for external dependencies (skill scripts/INVOKES and plugin MCP servers)
         CheckExternalDeps(config.AllowedExternalDepsFile, allSkillsList, allPlugins);
 
         // Run reference scanner if known-domains file is provided

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -212,7 +212,7 @@ public static class CheckCommand
         }
 
         // Check for external dependencies (plugin-level check includes all three)
-        CheckExternalDeps(config.AllowedExternalDepsFile, allSkillsList, allAgents, allPlugins);
+        CheckExternalDeps(config.AllowedExternalDepsFile, allSkillsList, allPlugins);
 
         // Run reference scanner if known-domains file is provided
         if (RunReferenceScanner(config.KnownDomainsFile, config.PluginPaths))
@@ -400,7 +400,7 @@ public static class CheckCommand
         return hasErrors;
     }
 
-    private static void CheckExternalDeps(string? allowedExternalDepsFile, IReadOnlyList<SkillInfo> skills, IReadOnlyList<AgentInfo> agents, IReadOnlyList<PluginInfo> plugins)
+    private static void CheckExternalDeps(string? allowedExternalDepsFile, IReadOnlyList<SkillInfo> skills, IReadOnlyList<PluginInfo> plugins)
     {
         if (allowedExternalDepsFile is null)
             return;
@@ -412,14 +412,6 @@ public static class CheckCommand
             foreach (var warning in ExternalDependencyChecker.CheckSkill(skill, allowed))
             {
                 Console.WriteLine($"{Ansi.Yellow}⚠  [skill:{skill.Name}] {warning}{Ansi.Reset}");
-                hasExternalDeps = true;
-            }
-        }
-        foreach (var agent in agents)
-        {
-            foreach (var warning in ExternalDependencyChecker.CheckAgent(agent, allowed))
-            {
-                Console.WriteLine($"{Ansi.Yellow}⚠  [agent:{agent.Name}] {warning}{Ansi.Reset}");
                 hasExternalDeps = true;
             }
         }

--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -4,22 +4,14 @@ using SkillValidator.Shared;
 namespace SkillValidator.Check;
 
 /// <summary>
-/// Detects structural external dependencies in skills, agents, and plugins.
-/// Flags scripts, non-built-in tool references, and MCP servers for human
-/// review. URL scanning is handled separately by the reference scanner
-/// (the ReferenceScanner service). Findings are advisory —
-/// authors should make an intentional decision to keep or remove each flagged
-/// dependency.
+/// Detects structural external dependencies in skills and plugins.
+/// Flags scripts (in skills) and MCP servers (in plugin.json) for human review.
+/// URL scanning is handled separately by the reference scanner
+/// (the ReferenceScanner service). Findings are advisory — authors should
+/// make an intentional decision to keep or remove each flagged dependency.
 /// </summary>
 public static partial class ExternalDependencyChecker
 {
-    private static readonly HashSet<string> BuiltInTools = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "read", "search", "edit", "create", "task", "skill", "web_search", "web_fetch",
-        "ask_user", "bash", "powershell", "grep", "glob", "view", "sql",
-        "report_intent", "store_memory", "fetch_copilot_cli_documentation",
-    };
-
     private static readonly HashSet<string> ScriptExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".ps1", ".sh", ".py", ".bat", ".cmd", ".bash",
@@ -46,7 +38,7 @@ public static partial class ExternalDependencyChecker
     }
 
     /// <summary>
-    /// Check a skill for structural external dependencies: scripts, tool references.
+    /// Check a skill for structural external dependencies: scripts.
     /// Returns advisory messages for human review. Entries matching the allowlist are skipped.
     /// </summary>
     public static IReadOnlyList<string> CheckSkill(SkillInfo skill, IReadOnlySet<string>? allowed = null)
@@ -76,57 +68,6 @@ public static partial class ExternalDependencyChecker
             var key = $"invokes:{skill.Name}";
             if (allowed?.Contains(key) != true)
                 findings.Add($"Description references an invoked script — review needed: skills should generally not depend on external scripts. Verify this is intentional. (allow: {key})");
-        }
-
-        // 3. Non-built-in tool references (#tool:...) in content (including frontmatter) — deduplicate by key
-        var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (Match match in ToolReferenceRegex().Matches(skill.SkillMdContent))
-        {
-            var toolName = match.Value[6..]; // strip "#tool:" prefix
-            if (!BuiltInTools.Contains(toolName))
-            {
-                var key = $"tool-ref:{skill.Name}:{match.Value}";
-                if (seenKeys.Add(key) && allowed?.Contains(key) != true)
-                    findings.Add($"Tool reference '{match.Value}' — review needed: verify this non-built-in tool reference is intentional. (allow: {key})");
-            }
-        }
-
-        return findings;
-    }
-
-    /// <summary>
-    /// Check an agent for structural external dependencies: tool references, non-built-in tools.
-    /// Returns advisory messages for human review. Entries matching the allowlist are skipped.
-    /// </summary>
-    public static IReadOnlyList<string> CheckAgent(AgentInfo agent, IReadOnlySet<string>? allowed = null)
-    {
-        var findings = new List<string>();
-
-        // 1. Non-built-in tool references (#tool:...) in content (including frontmatter) — deduplicate by key
-        var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (Match match in ToolReferenceRegex().Matches(agent.AgentMdContent))
-        {
-            var toolName = match.Value[6..]; // strip "#tool:" prefix
-            if (!BuiltInTools.Contains(toolName))
-            {
-                var key = $"tool-ref:{agent.Name}:{match.Value}";
-                if (seenKeys.Add(key) && allowed?.Contains(key) != true)
-                    findings.Add($"Tool reference '{match.Value}' — review needed: verify this non-built-in tool reference is intentional. (allow: {key})");
-            }
-        }
-
-        // 2. Non-built-in tools in frontmatter tools array
-        if (agent.Tools is not null)
-        {
-            foreach (var tool in agent.Tools)
-            {
-                if (!BuiltInTools.Contains(tool))
-                {
-                    var key = $"agent-tool:{agent.Name}:{tool}";
-                    if (allowed?.Contains(key) != true)
-                        findings.Add($"Non-built-in tool '{tool}' in tools list — review needed: verify this tool is intentional and available in the target environment. (allow: {key})");
-                }
-            }
         }
 
         return findings;
@@ -181,8 +122,4 @@ public static partial class ExternalDependencyChecker
     // Matches "INVOKES" followed by a script-like filename (word.ext)
     [GeneratedRegex(@"INVOKES\s+[\w./-]*\.\w+", RegexOptions.IgnoreCase)]
     private static partial Regex InvokesScriptRegex();
-
-    // Matches #tool:some/reference patterns used in VS Code Copilot
-    [GeneratedRegex(@"#tool:[\w/]+")]
-    private static partial Regex ToolReferenceRegex();
 }

--- a/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
+++ b/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
@@ -21,15 +21,6 @@ public class ExternalDependencyCheckerTests
         return new SkillInfo(name, description, path, skillMdPath, content);
     }
 
-    private static AgentInfo MakeAgent(
-        string content = "---\nname: test-agent\ndescription: A test agent.\n---\n# Test Agent\n",
-        string name = "test-agent",
-        string description = "A test agent.",
-        IReadOnlyList<string>? tools = null)
-    {
-        return new AgentInfo(name, description, "/tmp/agents/test-agent.agent.md", content, "test-agent.agent.md", tools);
-    }
-
     private static (PluginInfo Plugin, string Dir) MakePlugin(string name = "test-plugin", string? extraJson = null)
     {
         var dir = Path.Combine(Path.GetTempPath(), "dep-plugin-" + Guid.NewGuid().ToString("N"));
@@ -133,125 +124,6 @@ public class ExternalDependencyCheckerTests
     }
 
     // ========================================
-    // Skill: Tool reference detection
-    // ========================================
-
-    [Fact]
-    public void Skill_WithToolReference_FlagsWarning()
-    {
-        var content = "---\nname: test-skill\ndescription: A test skill.\n---\n# Test\nUse `#tool:web/fetch` to retrieve docs.\n";
-        var skill = MakeSkill(content: content);
-        try
-        {
-            var findings = ExternalDependencyChecker.CheckSkill(skill);
-            Assert.Contains(findings, e => e.Contains("#tool:web/fetch"));
-        }
-        finally { Cleanup(Directory.GetParent(skill.Path)!.FullName); }
-    }
-
-    [Fact]
-    public void Skill_WithBuiltInToolReference_NoWarning()
-    {
-        var content = "---\nname: test-skill\ndescription: A test skill.\n---\n# Test\nUse `#tool:edit` to modify files and `#tool:bash` to run commands.\n";
-        var skill = MakeSkill(content: content);
-        try
-        {
-            var findings = ExternalDependencyChecker.CheckSkill(skill);
-            Assert.Empty(findings);
-        }
-        finally { Cleanup(Directory.GetParent(skill.Path)!.FullName); }
-    }
-
-    [Fact]
-    public void Skill_WithNoToolReference_NoWarning()
-    {
-        var content = "---\nname: test-skill\ndescription: A test skill.\n---\n# Test\nNo tool references here.\n";
-        var skill = MakeSkill(content: content);
-        try
-        {
-            var findings = ExternalDependencyChecker.CheckSkill(skill);
-            Assert.Empty(findings);
-        }
-        finally { Cleanup(Directory.GetParent(skill.Path)!.FullName); }
-    }
-
-    [Fact]
-    public void Skill_WithDuplicateToolReferences_DeduplicatesWarnings()
-    {
-        var content = "---\nname: test-skill\ndescription: A test skill.\n---\n# Test\nUse `#tool:web/fetch` here and `#tool:web/fetch` again.\n";
-        var skill = MakeSkill(content: content);
-        try
-        {
-            var findings = ExternalDependencyChecker.CheckSkill(skill);
-            Assert.Single(findings);
-            Assert.Contains("#tool:web/fetch", findings[0]);
-        }
-        finally { Cleanup(Directory.GetParent(skill.Path)!.FullName); }
-    }
-
-    // ========================================
-    // Agent: Tool detection
-    // ========================================
-
-    [Fact]
-    public void Agent_WithAllBuiltInTools_NoWarning()
-    {
-        var agent = MakeAgent(tools: new[] { "read", "search", "edit" });
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Empty(findings);
-    }
-
-    [Fact]
-    public void Agent_WithNonBuiltInTool_FlagsWarning()
-    {
-        var agent = MakeAgent(tools: new[] { "read", "custom-tool" });
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Single(findings);
-        Assert.Contains("custom-tool", findings[0]);
-    }
-
-    [Fact]
-    public void Agent_WithToolReferenceInProse_FlagsWarning()
-    {
-        var content = "---\nname: test-agent\ndescription: A test agent.\n---\n# Test\nUse `#tool:agent/runSubagent` to delegate.\n";
-        var agent = MakeAgent(content: content);
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Contains(findings, e => e.Contains("#tool:agent/runSubagent"));
-    }
-
-    [Fact]
-    public void Agent_WithNoToolsArray_NoWarning()
-    {
-        var agent = MakeAgent(tools: null);
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Empty(findings);
-    }
-
-    [Fact]
-    public void Agent_BuiltInToolsCaseInsensitive()
-    {
-        var agent = MakeAgent(tools: new[] { "READ", "Search", "EDIT" });
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Empty(findings);
-    }
-
-    [Fact]
-    public void Agent_WithDuplicateToolReferences_DeduplicatesWarnings()
-    {
-        var content = "---\nname: test-agent\ndescription: A test agent.\n---\n# Test\nUse `#tool:agent/runSubagent` here and `#tool:agent/runSubagent` again.\n";
-        var agent = MakeAgent(content: content);
-
-        var findings = ExternalDependencyChecker.CheckAgent(agent);
-        Assert.Single(findings);
-        Assert.Contains("#tool:agent/runSubagent", findings[0]);
-    }
-
-    // ========================================
     // Plugin: MCP server detection
     // ========================================
 
@@ -316,11 +188,11 @@ public class ExternalDependencyCheckerTests
         var path = Path.Combine(Path.GetTempPath(), "allowlist-" + Guid.NewGuid().ToString("N") + ".txt");
         try
         {
-            File.WriteAllText(path, "# comment\n\nscript:my-skill:scripts/foo.ps1\ntool-ref:my-agent:#tool:web/fetch\n");
+            File.WriteAllText(path, "# comment\n\nscript:my-skill:scripts/foo.ps1\nmcp-server:my-plugin:my-server\n");
             var allowed = ExternalDependencyChecker.LoadAllowList(path);
             Assert.Equal(2, allowed.Count);
             Assert.Contains("script:my-skill:scripts/foo.ps1", allowed);
-            Assert.Contains("tool-ref:my-agent:#tool:web/fetch", allowed);
+            Assert.Contains("mcp-server:my-plugin:my-server", allowed);
         }
         finally { File.Delete(path); }
     }
@@ -360,32 +232,6 @@ public class ExternalDependencyCheckerTests
             Assert.Empty(findings);
         }
         finally { Cleanup(Directory.GetParent(skill.Path)!.FullName); }
-    }
-
-    [Fact]
-    public void Agent_WithAllowedToolRef_NoError()
-    {
-        var content = "---\nname: test-agent\ndescription: A test agent.\n---\n# Test\nUse `#tool:web/fetch` here.\n";
-        var agent = MakeAgent(content: content);
-        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "tool-ref:test-agent:#tool:web/fetch"
-        };
-        var findings = ExternalDependencyChecker.CheckAgent(agent, allowed);
-        Assert.Empty(findings);
-    }
-
-    [Fact]
-    public void Agent_WithPartiallyAllowedTools_FlagsUnallowed()
-    {
-        var agent = MakeAgent(tools: new[] { "custom_a", "custom_b" });
-        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "agent-tool:test-agent:custom_a"
-        };
-        var findings = ExternalDependencyChecker.CheckAgent(agent, allowed);
-        Assert.Single(findings);
-        Assert.Contains("custom_b", findings[0]);
     }
 
     [Fact]


### PR DESCRIPTION
Per Jan's suggestion on #660, this PR removes the tools check entirely instead of working around its brittle hardcoded `BuiltInTools` list.

## Why

The `ExternalDependencyChecker` carried a hand-maintained `BuiltInTools` set used to flag:

1. Non-built-in tool names in an agent's frontmatter `tools:` array (e.g. `terminal` → warning).
2. `#tool:foo/bar` references in skill / agent prose.

Both are brittle and low-value:

- The list goes stale the moment the agent runtime adds a tool (`terminal` was the trigger for #660 — four agents got warned for a tool that is perfectly valid).
- The runtime itself enforces which tools an agent can use; the validator does not need to second-guess it.
- Authors had to babysit `tool-ref:` / `agent-tool:` entries in `allowed-external-deps.txt` for legitimate uses, which is pure busywork.

## What changed

- Removed `BuiltInTools`, `ToolReferenceRegex`, and `ExternalDependencyChecker.CheckAgent`.
- Removed the agent loop in `CheckCommand.CheckExternalDeps`.
- Removed obsolete tests; `LoadAllowList_ParsesEntriesAndSkipsComments` now uses an `mcp-server:` example.
- Removed the `tool-ref:` / `agent-tool:` documentation and the two `tool-ref:msbuild:#tool:...` allowlist entries from `eng/allowed-external-deps.txt`.

The `script:` / `invokes:` / `mcp-server:` checks all stay — they don't depend on a hardcoded tool list and still catch real external dependencies.

## Verification

- `dotnet build` clean.
- `dotnet test` — all 533 tests pass.
- `check --plugin plugins/dotnet-test` and `check --plugin plugins/dotnet-msbuild` both pass cleanly with the existing allowlist; no more `terminal` warnings (making #660 unnecessary).

Supersedes #663 (which was opened from a fork and triggered the infra-from-fork bot).

Also addresses the two Copilot review comments from #663:

- Updated the `ExternalDependencyChecker` class-level XML doc to no longer claim it covers agents.
- Removed the now-unused `agents` parameter from `CheckCommand.CheckExternalDeps` (and updated the single call site).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
