### PR TITLE
dotnet-test: drop tools field from agents that declared it

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,7 +6,6 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
-tools: ['read', 'search', 'edit', 'task', 'skill', 'bash', 'powershell']
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/test-migration.agent.md
+++ b/plugins/dotnet-test/agents/test-migration.agent.md
@@ -6,7 +6,6 @@ description: >-
   and guides users through end-to-end upgrades. Use when asked to upgrade
   MSTest, migrate to xUnit v3, switch to Microsoft.Testing.Platform, modernize
   test infrastructure, or when the user says "migrate my tests".
-tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 user-invokable: true
 disable-model-invocation: false
 handoffs:

--- a/plugins/dotnet-test/agents/test-quality-auditor.agent.md
+++ b/plugins/dotnet-test/agents/test-quality-auditor.agent.md
@@ -9,7 +9,6 @@ description: >-
   running multiple analysis skills in sequence. Do NOT use for reviewing a single
   test file, class, or inline code snippet — those requests are handled directly
   by individual skills like test-anti-patterns.
-tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 user-invokable: true
 disable-model-invocation: false
 handoffs:

--- a/plugins/dotnet-test/agents/testability-migration.agent.md
+++ b/plugins/dotnet-test/agents/testability-migration.agent.md
@@ -6,7 +6,6 @@ description: >-
   Use when asked to make code testable, remove static coupling, migrate to
   TimeProvider, adopt IFileSystem, or improve testability of a legacy codebase.
 name: testability-migration
-tools: ['read', 'search', 'edit', 'bash', 'powershell', 'skill']
 handoffs:
   - label: Generate Tests for Migrated Code
     agent: code-testing-generator


### PR DESCRIPTION
Removes the `tools:` field from the four `dotnet-test` agents that previously declared it. Per Jan's suggestion on #660 (which I initially misread): rather than maintaining a curated tool list per agent, just drop the field so the agent inherits the runtime's default tool surface.

## Why

- The four agents (`code-testing-generator`, `test-migration`, `testability-migration`, `test-quality-auditor`) are the only `dotnet-test` agents that had `tools:` set, and the list was the cause of #660 in the first place (the validator flagged `terminal`, then #660 swapped it for `bash`/`powershell`).
- Most other agents in the repo don't declare a `tools:` field, so removing it brings these four in line with the rest.
- No need to babysit a tool allowlist per agent — the runtime already controls which tools are available.

## What changed

Deleted the `tools: [...]` line from:

- `plugins/dotnet-test/agents/code-testing-generator.agent.md`
- `plugins/dotnet-test/agents/test-migration.agent.md`
- `plugins/dotnet-test/agents/test-quality-auditor.agent.md`
- `plugins/dotnet-test/agents/testability-migration.agent.md`

## Verification

`dotnet run --project eng/skill-validator/src -- check --plugin plugins/dotnet-test --allowed-external-deps eng/allowed-external-deps.txt` → all checks pass, no `terminal`/tool warnings.

Follow-up to #660.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
