### PR TITLE
Bump our warmup timeout to something higher

### DIFF
--- a/plugins/dotnet/lsp.json
+++ b/plugins/dotnet/lsp.json
@@ -15,7 +15,8 @@
         ".cs": "csharp",
         ".razor": "aspnetcorerazor",
         ".cshtml": "aspnetcorerazor"
-      }
+      },
+      "warmupTimeoutMs": 120000
     }
   }
 }


### PR DESCRIPTION
30 seconds is the default, but a bit higher has a chance of completing for more users successfully.