### PR TITLE
dotnet-msbuild: move AITools.BinlogMcp source to dotnet-tools feed

### DIFF
--- a/plugins/dotnet-msbuild/plugin.json
+++ b/plugins/dotnet-msbuild/plugin.json
@@ -18,7 +18,7 @@
         "--yes",
         "--prerelease",
         "--add-source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
@@ -33,7 +33,7 @@ Use the available MCP server tools to query the binary log for:
 ## Fallback workflow — text-log replay (when MCP is unavailable)
 
 Use this only when the MCP server cannot be started (for example, on an older
-SDK or in an offline environment without access to the `dotnet-eng` NuGet feed).
+SDK or in an offline environment without access to the `dotnet-tools` NuGet feed).
 
 ### Replay the binlog to text logs
 


### PR DESCRIPTION
Follow-up to #673. The `AITools.BinlogMcp` package was relocated from the dnceng `dotnet-eng` public feed to the dnceng `dotnet-tools` public feed, so the plugin can no longer restore it.

## What changed

- **`plugins/dotnet-msbuild/plugin.json`** — `--add-source` URL updated to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json`.
- **`plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md`** — fallback note updated to reference the `dotnet-tools` feed.

Verified the package resolves on the new feed:

```
> dotnet package search AITools.BinlogMcp --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json --prerelease
| Package ID        | Latest Version        |
| AITools.BinlogMcp | 1.0.0-preview.26270.7 |
```
