### PR TITLE
[dotnet-msbuild] Fix AP-13/AP-14 false positives and add source-vs-packed layout guidance

### DIFF
--- a/plugins/dotnet-msbuild/agents/msbuild-code-review.agent.md
+++ b/plugins/dotnet-msbuild/agents/msbuild-code-review.agent.md
@@ -19,6 +19,7 @@ Before starting any review, verify the context is MSBuild-related. If the worksp
 1. **Discovery**: Scan the workspace for MSBuild files:
    - Glob for `**/*.csproj`, `**/*.vbproj`, `**/*.fsproj`, `**/*.props`, `**/*.targets`, `**/*.proj`
    - Check for `Directory.Build.props`, `Directory.Build.targets`, `Directory.Packages.props`
+   - **Record packaging mappings**: glob for `**/*.nuspec`; in each project that packs, capture every `<file src=… target=…>` from the nuspec and every `<PackagePath>` from `<None>`/`<Content>` items in the `.csproj`. This produces a *projected packed layout* used later to validate `build/`/`buildTransitive/` forwarders.
    - Note the project structure (solution file, project count, nesting)
 
 2. **Analysis**: For each file, check against these categories:
@@ -50,14 +51,22 @@ Before starting any review, verify the context is MSBuild-related. If the worksp
 - Are there condition evaluation issues (wrong syntax, always true/false)?
 - Missing `PrivateAssets="all"` on analyzer packages?
 - Are there **property** conditions on `$(TargetFramework)` in `.props` files? (AP-21 — silently fails for single-targeting projects; move to `.targets`). See the AP-21 section in the [msbuild-antipatterns skill](../skills/msbuild-antipatterns/SKILL.md) for the full explanation. **Item and target conditions are NOT affected** and must not be flagged.
+- For any unguarded `<Import>` inside `build/<tfm>/` or `buildTransitive/<tfm>/`: resolve it against the **projected packed layout** recorded in Discovery. Do **not** flag as "missing Exists() guard" or "broken path" unless the target is missing from *both* the source tree and the packed layout. See `msbuild-antipatterns` AP-13 ("NuGet package forwarders" exception) and the `extension-points` skill ("Source Tree vs Packed Layout") for the rationale.
+- For backslash path separators (`\`) in `<Import Project=…>` or other path-typed evaluator inputs: do **not** report as a cross-platform 🔴 error. MSBuild normalizes them on Unix (`FileUtilities.MaybeAdjustFilePath`). Backslashes are only a real correctness defect in `<Exec Command=…>` raw shell strings, CDATA blocks, or paths handed verbatim to non-MSBuild consumers. See `msbuild-antipatterns` AP-14.
 
-3. **Report**: Produce a structured review organized by severity:
+3. **Veracity gate** (run before producing the report): for each candidate 🔴 finding, ask:
+   - *"If this were true, would this package's CI on Linux/macOS, or its install on the claimed TFM, be broken today?"*
+   - *"Has this code been shipping unchanged for multiple releases with no reported failures matching this symptom?"*
+   - If the answers contradict the finding, **downgrade to 🔵 (style)** or **drop it**. Cite the contradicting evidence in your reasoning.
+   - This step exists to prevent confidently-stated false positives — especially around NuGet packaging layouts and cross-platform path handling, which the static skill rules cannot fully model.
+
+4. **Report**: Produce a structured review organized by severity:
    - 🔴 **Errors**: Things that are likely broken or will cause build failures
    - 🟡 **Warnings**: Anti-patterns that should be fixed but aren't breaking
    - 🔵 **Suggestions**: Improvements for readability, maintainability, or performance
    - 🟢 **Positive**: Things done well (acknowledge good practices)
 
-4. **Fix**: If asked, apply the suggested fixes directly to the project files. Always verify with a build after making changes.
+5. **Fix**: If asked, apply the suggested fixes directly to the project files. Always verify with a build after making changes.
 
 ## Specialized Skills Reference
 This agent draws knowledge from these companion skills — load them for detailed guidance:

--- a/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
@@ -104,6 +104,55 @@ MyPackage/
 - `build/` affects direct consumers only. `buildTransitive/` affects the entire dependency chain.
 - Props are imported early (before the project), targets are imported late (after the project).
 
+## Source Tree vs Packed Layout
+
+When reviewing a NuGet build-extension package, the **source layout** in the repository can legitimately differ from the **packed layout** inside the produced `.nupkg`. This is a common source of false-positive "import points at a missing file" findings.
+
+Three packaging mechanisms reshape the layout at pack time:
+
+1. **`.nuspec` `<file src=… target=…>` mappings** — copy a single source file into multiple per-TFM targets:
+
+   ```xml
+   <!-- Source: src\MyAdapter\buildTransitive\common\MyAdapter.props
+        Packed: buildTransitive\net462\MyAdapter.props
+                buildTransitive\net8.0\MyAdapter.props
+                buildTransitive\net9.0\MyAdapter.props -->
+   <files>
+     <file src="net462\buildTransitive\common\MyAdapter.props" target="buildTransitive\net462\" />
+     <file src="net8.0\buildTransitive\common\MyAdapter.props" target="buildTransitive\net8.0\MyAdapter.props" />
+     <file src="net9.0\buildTransitive\common\MyAdapter.props" target="buildTransitive\net9.0\MyAdapter.props" />
+   </files>
+   ```
+
+2. **`.csproj` `<PackagePath>` metadata** on `<None Update=…>` or `<Content Include=…>` items — same effect via SDK pack:
+
+   ```xml
+   <ItemGroup>
+     <None Include="buildTransitive\common\MyAdapter.props" Pack="true" PackagePath="buildTransitive\net8.0\;buildTransitive\net9.0\" />
+   </ItemGroup>
+   ```
+
+3. **SDK conventions** — `IncludeBuildOutput`, `BuildOutputTargetFolder`, `IncludeContentInPack` automatically place built outputs under `lib/<tfm>/` or `build/<tfm>/`.
+
+### Implication for reviewers
+
+A forwarder like the following inside a packed `build/net462/` folder is **not** a "missing-file" bug, even if the source tree has no `buildTransitive/net462/` directory:
+
+```xml
+<!-- In packed build/net462/MyAdapter.props -->
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net462\MyAdapter.props" />
+</Project>
+```
+
+Before flagging an unguarded `<Import>` inside a `build/<tfm>/` or `buildTransitive/<tfm>/` folder:
+
+1. Look for `*.nuspec` in the project directory and its parent. Read every `<file target=…>` whose `target` matches the imported path.
+2. Read the `.csproj` for `<PackagePath>` metadata on `<None>`/`<Content>` items.
+3. Only flag the import if the target path is missing from **both** the source tree *and* the projected package layout.
+
+See also `msbuild-antipatterns` AP-13 ("NuGet package forwarders" exception).
+
 ## Import Guard Pattern
 
 The `.targets` file ensures `.props` was imported using a guard property:
@@ -171,7 +220,7 @@ Only the **nearest** file is discovered. Nested hierarchies must explicitly impo
 
 ## Common Pitfalls
 
-- **Missing `Exists()` on optional imports** causes build failures when files are absent.
+- **Missing `Exists()` on optional imports** causes build failures when files are absent. **Exception**: imports inside published `build/<tfm>/` and `buildTransitive/<tfm>/` folders of a NuGet package are a package contract — the target is guaranteed by the packed layout (see "Source Tree vs Packed Layout" above). Don't guard them and don't flag them.
 - **Overwriting Custom* properties** drops prior hooks. Append with `;` separator.
 - **NuGet package file names not matching package ID** silently skips the import.
 - **Nested Directory.Build.props** without parent import loses repo-root settings.

--- a/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
@@ -154,7 +154,7 @@ A forwarder like the following inside a packed `build/net462/` folder is **not**
 
 Before flagging an unguarded `<Import>` inside a `build/<tfm>/` or `buildTransitive/<tfm>/` folder:
 
-1. Look for `*.nuspec` in the project directory and its parent. Read every `<file target=…>` whose `target` matches the imported path.
+1. Look for `*.nuspec` in the project directory and its immediate parent directory (do not walk further up). Read every `<file target=…>` whose `target` matches the imported path.
 2. Read the `.csproj` for `<PackagePath>` metadata on `<None>`/`<Content>` items.
 3. Only flag the import if the target path is missing from **both** the source tree *and* the projected package layout.
 

--- a/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/extension-points/SKILL.md
@@ -113,24 +113,31 @@ Three packaging mechanisms reshape the layout at pack time:
 1. **`.nuspec` `<file src=… target=…>` mappings** — copy a single source file into multiple per-TFM targets:
 
    ```xml
-   <!-- Source: src\MyAdapter\buildTransitive\common\MyAdapter.props
-        Packed: buildTransitive\net462\MyAdapter.props
-                buildTransitive\net8.0\MyAdapter.props
-                buildTransitive\net9.0\MyAdapter.props -->
+   <!-- Source tree has ONE shared file:
+          buildTransitive\common\MyAdapter.props
+        Pack rewrites it to per-TFM targets inside the .nupkg:
+          buildTransitive\net462\MyAdapter.props
+          buildTransitive\net8.0\MyAdapter.props
+          buildTransitive\net9.0\MyAdapter.props -->
    <files>
-     <file src="net462\buildTransitive\common\MyAdapter.props" target="buildTransitive\net462\" />
-     <file src="net8.0\buildTransitive\common\MyAdapter.props" target="buildTransitive\net8.0\MyAdapter.props" />
-     <file src="net9.0\buildTransitive\common\MyAdapter.props" target="buildTransitive\net9.0\MyAdapter.props" />
+     <file src="buildTransitive\common\MyAdapter.props" target="buildTransitive\net462\MyAdapter.props" />
+     <file src="buildTransitive\common\MyAdapter.props" target="buildTransitive\net8.0\MyAdapter.props" />
+     <file src="buildTransitive\common\MyAdapter.props" target="buildTransitive\net9.0\MyAdapter.props" />
    </files>
    ```
 
-2. **`.csproj` `<PackagePath>` metadata** on `<None Update=…>` or `<Content Include=…>` items — same effect via SDK pack:
+   In the `<file>` element, a `target` ending in `\` is treated as a folder (filename preserved from `src`); a `target` ending in a filename renames the file.
+
+2. **`.csproj` `<PackagePath>` metadata** on `<None Update=…>` or `<Content Include=…>` items — same effect via SDK pack. Use one item per destination to keep the mapping unambiguous:
 
    ```xml
    <ItemGroup>
-     <None Include="buildTransitive\common\MyAdapter.props" Pack="true" PackagePath="buildTransitive\net8.0\;buildTransitive\net9.0\" />
+     <None Include="buildTransitive\common\MyAdapter.props" Pack="true" PackagePath="buildTransitive\net8.0\MyAdapter.props" />
+     <None Include="buildTransitive\common\MyAdapter.props" Pack="true" PackagePath="buildTransitive\net9.0\MyAdapter.props" />
    </ItemGroup>
    ```
+
+   NuGet/SDK pack also accepts a semicolon-separated list (`PackagePath="buildTransitive\net8.0\;buildTransitive\net9.0\"`) to fan one source out to multiple destinations, but the multi-item form above is harder to misread.
 
 3. **SDK conventions** — `IncludeBuildOutput`, `BuildOutputTargetFolder`, `IncludeContentInPack` automatically place built outputs under `lib/<tfm>/` or `build/<tfm>/`.
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -336,13 +336,13 @@ See `incremental-build` skill for deep guidance on Inputs/Outputs, FileWrites, a
 
 **Exception — required imports**: Imports that are *required* for the build to work correctly should fail fast — don't guard those. Guard imports that are optional or environment-specific (e.g., local developer overrides, CI-specific settings).
 
-**Exception — NuGet package forwarders**: `.props`/`.targets` files inside a NuGet package's `build/<tfm>/` or `buildTransitive/<tfm>/` folder routinely import a sibling file under `buildTransitive/<tfm>/…` without an `Exists()` guard. These are a **package contract**: the target file is guaranteed to be present in the restored package, even if it doesn't appear in the source tree at that relative path. The package layout is typically produced by:
+**Exception — NuGet package forwarders**: `.props`/`.targets` files inside a NuGet package's per-TFM `build/` or `buildTransitive/` folder routinely import a sibling file under `buildTransitive/<tfm>/…` without an `Exists()` guard. These are a **package contract**: the target file is guaranteed to be present in the restored package, even if it doesn't appear in the source tree at that relative path. The package layout is typically produced by:
 
-- A custom `.nuspec` with `<file src="..." target="buildTransitive\<tfm>\..." />` entries that copy files from a single source folder (e.g. `buildTransitive/common/`) into per-TFM subfolders at pack time, or
-- `<None Update="..."><PackagePath>buildTransitive/<tfm>/</PackagePath></None>` / `<Content Include="..."><PackagePath>...</PackagePath></Content>` in the `.csproj`, or
+- A custom `.nuspec` with per-TFM `<file>` entries — e.g. `<file src="buildTransitive\common\MyAdapter.props" target="buildTransitive\net8.0\MyAdapter.props" />` — that copy files from a single source folder (such as `buildTransitive/common/`) into per-TFM subfolders at pack time, or
+- `<None Update="...">` / `<Content Include="...">` items in the `.csproj` with a per-TFM `<PackagePath>` (e.g. `<PackagePath>buildTransitive/net8.0/</PackagePath>`), declared once per target TFM, or
 - SDK conventions (e.g. `IncludeBuildOutput`, `BuildOutputTargetFolder`) that place built outputs under `build/<tfm>/`.
 
-Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `*.nuspec` in the project directory **and any parent directory** (shared nuspecs are common in mono-repos), and any `<PackagePath>` metadata on `<None>`/`<Content>` items in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. The `dotnet-msbuild/extension-points` skill — *Source tree vs packed layout* — documents the full cross-check procedure.
+Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `*.nuspec` in the project directory **and its immediate parent directory** (shared nuspecs are common in mono-repos; do not walk further up), and any `<PackagePath>` metadata on `<None>`/`<Content>` items in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. The `dotnet-msbuild/extension-points` skill — *Source tree vs packed layout* — documents the full cross-check procedure.
 
 ---
 
@@ -350,28 +350,28 @@ Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` 
 
 **Smell**: Backslash path separators in `.props`/`.targets` files meant to run cross-platform.
 
-**Where this is a real bug (🔴)** — paths that MSBuild does **not** route through its path normalizer:
+**Where this is a real bug (🔴 Error)** — paths that MSBuild does **not** route through its path normalizer:
 
 - Raw shell strings inside `<Exec Command="...\tools\foo.exe ..." />` — passed verbatim to `bash`/`sh` on Unix, which treats `\` as an escape.
 - Backslash-delimited paths inside CDATA blocks, embedded in source files written by `<WriteLinesToFile>`, or constructed for non-MSBuild consumers (custom scripts, response files, environment variables).
 - Paths handed to custom tasks that call OS file APIs directly without going through MSBuild path utilities.
 
-**Where this is only a style preference (🔵)** — paths that go through MSBuild's evaluator (`<Import Project="...">`, file-path properties consumed by built-in tasks like `<Copy>`/`<MakeDir>`/`<Delete>`, item `Include=`/`Exclude=` globs):
+**Where this is only a style preference (🔵 Style)** — paths that go through MSBuild's evaluator (`<Import Project="...">`, file-path properties consumed by built-in tasks like `<Copy>`/`<MakeDir>`/`<Delete>`, item `Include=`/`Exclude=` globs):
 
-MSBuild's evaluator normalizes `\` → `/` on Unix-like systems before resolving the path. See `FileUtilities.MaybeAdjustFilePath` and `ConvertToUnixSlashes` in [`microsoft/msbuild` `src/Framework/FileUtilities.cs`](https://github.com/dotnet/msbuild/blob/main/src/Framework/FileUtilities.cs). So `<Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />` resolves correctly on Linux/macOS today. Forward slashes are still **preferred for consistency**, but the import will not break and existing backslash-style imports should not be flagged as 🔴 errors.
+MSBuild's evaluator normalizes `\` → `/` on Unix-like systems before resolving the path. See `FileUtilities.MaybeAdjustFilePath` and `ConvertToUnixSlashes` in [`microsoft/msbuild` `src/Framework/FileUtilities.cs`](https://github.com/dotnet/msbuild/blob/main/src/Framework/FileUtilities.cs). So `<Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />` resolves correctly on Linux/macOS today. Forward slashes are still **preferred for consistency**, but the import will not break and existing backslash-style imports should not be flagged as 🔴 **Error**.
 
 ```xml
-<!-- 🔴 Real bug: \ in raw shell string breaks on Linux/macOS -->
+<!-- 🔴 Error: \ in raw shell string breaks on Linux/macOS -->
 <Exec Command="$(MSBuildThisFileDirectory)tools\release\sign.exe $(OutputPath)" />
 
-<!-- 🔵 Style preference: \ in Import is normalized on Unix, but / is nicer -->
+<!-- 🔵 Style: \ in Import is normalized on Unix, but / is nicer -->
 <Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />
 
 <!-- ✅ Recommended in new code -->
 <Import Project="$(MSBuildThisFileDirectory)../../build/common.props" />
 ```
 
-**Verification rule**: Before flagging a backslash path as 🔴, ask *"does this string flow through MSBuild's evaluator, or is it handed verbatim to a non-MSBuild consumer?"* Only the second case is a correctness defect.
+**Verification rule**: Before flagging a backslash path as 🔴 **Error**, ask *"does this string flow through MSBuild's evaluator, or is it handed verbatim to a non-MSBuild consumer?"* Only the second case is a correctness defect.
 
 **Note**: `$(MSBuildThisFileDirectory)` already ends with a platform-appropriate separator, so `$(MSBuildThisFileDirectory)tools/mytool` works on both platforms.
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -342,7 +342,7 @@ See `incremental-build` skill for deep guidance on Inputs/Outputs, FileWrites, a
 - `<None Update="..."><PackagePath>buildTransitive/<tfm>/</PackagePath></None>` / `<Content Include="..."><PackagePath>...</PackagePath></Content>` in the `.csproj`, or
 - SDK conventions (e.g. `IncludeBuildOutput`, `BuildOutputTargetFolder`) that place built outputs under `build/<tfm>/`.
 
-Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `*.nuspec` in the project directory **and any parent directory** (shared nuspecs are common in mono-repos), and any `<PackagePath>` metadata on `<None>`/`<Content>` items in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. See [`extension-points` skill — Source tree vs packed layout](../extension-points/SKILL.md) for the full cross-check procedure.
+Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `*.nuspec` in the project directory **and any parent directory** (shared nuspecs are common in mono-repos), and any `<PackagePath>` metadata on `<None>`/`<Content>` items in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. The `dotnet-msbuild/extension-points` skill — *Source tree vs packed layout* — documents the full cross-check procedure.
 
 ---
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -342,7 +342,7 @@ See `incremental-build` skill for deep guidance on Inputs/Outputs, FileWrites, a
 - `<None Update="..."><PackagePath>buildTransitive/<tfm>/</PackagePath></None>` / `<Content Include="..."><PackagePath>...</PackagePath></Content>` in the `.csproj`, or
 - SDK conventions (e.g. `IncludeBuildOutput`, `BuildOutputTargetFolder`) that place built outputs under `build/<tfm>/`.
 
-Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `.nuspec` in the project directory and any `<PackagePath>` metadata in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. See [`extension-points` skill — Source tree vs packed layout](../extension-points/SKILL.md) for the cross-check procedure.
+Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `*.nuspec` in the project directory **and any parent directory** (shared nuspecs are common in mono-repos), and any `<PackagePath>` metadata on `<None>`/`<Content>` items in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. See [`extension-points` skill — Source tree vs packed layout](../extension-points/SKILL.md) for the full cross-check procedure.
 
 ---
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -334,25 +334,44 @@ See `incremental-build` skill for deep guidance on Inputs/Outputs, FileWrites, a
 <Project Sdk="Microsoft.NET.Sdk">
 ```
 
-**Exception**: Imports that are *required* for the build to work correctly should fail fast — don't guard those. Guard imports that are optional or environment-specific (e.g., local developer overrides, CI-specific settings).
+**Exception — required imports**: Imports that are *required* for the build to work correctly should fail fast — don't guard those. Guard imports that are optional or environment-specific (e.g., local developer overrides, CI-specific settings).
+
+**Exception — NuGet package forwarders**: `.props`/`.targets` files inside a NuGet package's `build/<tfm>/` or `buildTransitive/<tfm>/` folder routinely import a sibling file under `buildTransitive/<tfm>/…` without an `Exists()` guard. These are a **package contract**: the target file is guaranteed to be present in the restored package, even if it doesn't appear in the source tree at that relative path. The package layout is typically produced by:
+
+- A custom `.nuspec` with `<file src="..." target="buildTransitive\<tfm>\..." />` entries that copy files from a single source folder (e.g. `buildTransitive/common/`) into per-TFM subfolders at pack time, or
+- `<None Update="..."><PackagePath>buildTransitive/<tfm>/</PackagePath></None>` / `<Content Include="..."><PackagePath>...</PackagePath></Content>` in the `.csproj`, or
+- SDK conventions (e.g. `IncludeBuildOutput`, `BuildOutputTargetFolder`) that place built outputs under `build/<tfm>/`.
+
+Before flagging an unguarded `<Import>` inside a `build/` or `buildTransitive/` folder, **resolve it against the packed layout** — read every `.nuspec` in the project directory and any `<PackagePath>` metadata in the `.csproj`. Only flag if the target path is missing from **both** the source tree *and* the projected package layout. See [`extension-points` skill — Source tree vs packed layout](../extension-points/SKILL.md) for the cross-check procedure.
 
 ---
 
-## AP-14: Using Backslashes in Paths (Cross-Platform Issue)
+## AP-14: Backslashes in Paths — Where It Matters
 
-**Smell**: `<Import Project="$(RepoRoot)\eng\common.props" />` with backslash separators in `.props`/`.targets` files meant to be cross-platform.
+**Smell**: Backslash path separators in `.props`/`.targets` files meant to run cross-platform.
 
-**Why it's bad**: Backslashes work on Windows but fail on Linux/macOS. MSBuild normalizes forward slashes on all platforms.
+**Where this is a real bug (🔴)** — paths that MSBuild does **not** route through its path normalizer:
+
+- Raw shell strings inside `<Exec Command="...\tools\foo.exe ..." />` — passed verbatim to `bash`/`sh` on Unix, which treats `\` as an escape.
+- Backslash-delimited paths inside CDATA blocks, embedded in source files written by `<WriteLinesToFile>`, or constructed for non-MSBuild consumers (custom scripts, response files, environment variables).
+- Paths handed to custom tasks that call OS file APIs directly without going through MSBuild path utilities.
+
+**Where this is only a style preference (🔵)** — paths that go through MSBuild's evaluator (`<Import Project="...">`, file-path properties consumed by built-in tasks like `<Copy>`/`<MakeDir>`/`<Delete>`, item `Include=`/`Exclude=` globs):
+
+MSBuild's evaluator normalizes `\` → `/` on Unix-like systems before resolving the path. See `FileUtilities.MaybeAdjustFilePath` and `ConvertToUnixSlashes` in [`microsoft/msbuild` `src/Framework/FileUtilities.cs`](https://github.com/dotnet/msbuild/blob/main/src/Framework/FileUtilities.cs). So `<Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />` resolves correctly on Linux/macOS today. Forward slashes are still **preferred for consistency**, but the import will not break and existing backslash-style imports should not be flagged as 🔴 errors.
 
 ```xml
-<!-- BAD: Breaks on Linux/macOS -->
-<Import Project="$(RepoRoot)\eng\common.props" />
-<Content Include="assets\images\**" />
+<!-- 🔴 Real bug: \ in raw shell string breaks on Linux/macOS -->
+<Exec Command="$(MSBuildThisFileDirectory)tools\release\sign.exe $(OutputPath)" />
 
-<!-- GOOD: Forward slashes work everywhere -->
-<Import Project="$(RepoRoot)/eng/common.props" />
-<Content Include="assets/images/**" />
+<!-- 🔵 Style preference: \ in Import is normalized on Unix, but / is nicer -->
+<Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />
+
+<!-- ✅ Recommended in new code -->
+<Import Project="$(MSBuildThisFileDirectory)../../build/common.props" />
 ```
+
+**Verification rule**: Before flagging a backslash path as 🔴, ask *"does this string flow through MSBuild's evaluator, or is it handed verbatim to a non-MSBuild consumer?"* Only the second case is a correctness defect.
 
 **Note**: `$(MSBuildThisFileDirectory)` already ends with a platform-appropriate separator, so `$(MSBuildThisFileDirectory)tools/mytool` works on both platforms.
 


### PR DESCRIPTION
Fixes two confidently-stated false positives that the `msbuild-quality-review` workflow produced on `microsoft/testfx` (see [run #26403247485](https://github.com/microsoft/testfx/actions/runs/26403247485)), plus the underlying gaps in the rubric that caused them. After this change every consumer of the `dotnet-msbuild` plugin will reason about NuGet packaging layouts and cross-platform path handling correctly.

## Motivation — what the agent got wrong

### Claim 1: `build/<tfm>/` forwarders import non-existent paths under `buildTransitive/<tfm>/`

The reviewer flagged this as a 🔴 build-breaking error for `MSTest.TestAdapter` and `MSTest.TestFramework.Extensions`, citing that the source tree only has `buildTransitive/common/` and `buildTransitive/uwp/` (or `buildTransitive/others/` and `buildTransitive/net8.0AndLater/`).

In reality, these packages use a custom `.nuspec` that re-targets files at pack time. From `MSTest.TestAdapter.nuspec`:

``xml
<file src="net462\buildTransitive\common\MSTest.TestAdapter.props"  target="buildTransitive\net462\" />
<file src="net8.0\buildTransitive\common\MSTest.TestAdapter.props"  target="buildTransitive\net8.0\MSTest.TestAdapter.props" />
<file src="net9.0\buildTransitive\common\MSTest.TestAdapter.props"  target="buildTransitive\net9.0\MSTest.TestAdapter.props" />
<file src="uap10.0.16299\buildTransitive\uwp\MSTest.TestAdapter.props" target="buildTransitive\uap10.0\MSTest.TestAdapter.props" />
``

The forwarders in `build/<tfm>/` resolve against the packed layout, not the source tree. There is no bug.

### Claim 2: backslashes in `<Import Project="...\...\...">` break Linux/macOS

The reviewer flagged this as a 🔴 cross-platform error. But MSBuild's evaluator normalizes path separators on Unix before resolving imports, via `FileUtilities.MaybeAdjustFilePath` / `ConvertToUnixSlashes` in [`dotnet/msbuild` `src/Framework/FileUtilities.cs`](https://github.com/dotnet/msbuild/blob/main/src/Framework/FileUtilities.cs):

``csharp
// If on Unix, convert backslashes to slashes for strings that resemble paths.
internal static string MaybeAdjustFilePath(string value, string baseDirectory = "")
{
    if (NativeMethods.IsWindows || …) return value;
    Span<char> newValue = ConvertToUnixSlashes(value.ToCharArray()); // [\\/]+ -> /
    …
}
``

MSTest has shipped to Linux/macOS users for years with backslash-using imports; if this were broken, it would have been a P0 issue long ago.

## Changes

| File | Change |
|---|---|
| `plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md` (AP-13) | Adds an explicit **"NuGet package forwarders" exception** — imports inside published `build/<tfm>/` and `buildTransitive/<tfm>/` folders are a package contract; reviewers must consult `.nuspec` `<file target=>` and `.csproj` `<PackagePath>` before flagging. |
| `plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md` (AP-14) | Rewritten to distinguish where backslashes are a real correctness defect (🔴 — raw `<Exec>` shell strings, CDATA, paths handed to non-MSBuild consumers) from where they're only a style preference (🔵 — `<Import>` and other evaluator-routed paths). Cites the MSBuild source so future readers can verify the normalization. |
| `plugins/dotnet-msbuild/skills/extension-points/SKILL.md` | New **"Source Tree vs Packed Layout"** section documenting the three packaging mechanisms (`.nuspec` `<file>` mappings, csproj `<PackagePath>` metadata, SDK pack conventions) that legitimately reshape the layout, with the cross-check procedure reviewers must run before flagging "missing-file" imports. Updates the "Common Pitfalls" entry on `Exists()` to note the NuGet-forwarder exception. |
| `plugins/dotnet-msbuild/agents/msbuild-code-review.agent.md` | Discovery now records the projected packed layout. Category 4 references the AP-13/AP-14 nuances explicitly so the agent doesn't repeat the same false positives. Adds a new **Veracity gate** step before the Report phase that downgrades or drops 🔴 findings whose claims would imply currently-shipping CI is broken — a backstop for cases the static rubric cannot fully model. |

## Validation

- ``markdownlint-cli2`` clean on all three edited files.
- `tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml` rubric does not enumerate AP-13/AP-14 by id (only the F#-specific scenarios are itemized), so no fixture changes are required and the existing scenarios remain valid.
- No skill-validator code, `evaluation.yml`, or `Models.cs` is touched — `InvestigatingResults.md` does not need updating.
- Description fields are unchanged (already within the 1024-char SDK limit).

## Risk

Low. The rule softening is targeted and explicit:
- AP-13 stays a 🟡 finding for genuinely unguarded optional imports outside packaged `build/`/`buildTransitive/`.
- AP-14 stays a 🔴 finding for `<Exec Command=>` and the other non-evaluator cases listed in the catalog.
- No existing rule is silently weakened; the changes are additions of explicit exceptions and verification procedures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
