### PR TITLE
dotnet-test: add cross-language edit-boundary rules to code-testing-implementer

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -51,6 +51,15 @@ For each test file in your phase:
 - Include tests for: happy path, edge cases (empty, null, boundary), error conditions
 - Mock all external dependencies — never call external URLs, bind ports, or depend on timing
 
+#### Edit boundaries (cross-language invariants)
+
+These rules apply to every language and override any pattern an existing test file may suggest. They keep generated changes additive so reviewers, CI gates, and test-quality benchmarks treat your output as a clean test addition rather than a refactor:
+
+- **Existing test files are append-only.** When growing an existing test file, insert new test methods/cases at the end of the relevant class/describe-block/module. Do not reformat, reorder, rename, or remove any existing line — even whitespace-only churn counts as a destructive edit.
+- **Do not modify non-test source files.** If a class, method, or symbol is hard to test (sealed, internal, no seam, tightly coupled), record the gap in `.testagent/plan.md` as a follow-up. Do not edit production code to make it testable as part of test generation — that is the scope of the `testability-migration` agent, not this one.
+- **Prefer new test files over edits to existing ones** when both options are equally valid (e.g., a new feature, a separate concern, or any case where the existing file isn't strictly required). A new file is always purely additive.
+- **One exception**: build-system manifests (`.csproj`/`.sln`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited when registering a new test project or adding a missing test dependency. Keep these edits minimal and limited to the registration/dependency change.
+
 ### 5. Verify with Build
 
 Call the `code-testing-builder` sub-agent to compile. Build only the specific test project, not the full solution.
@@ -99,3 +108,4 @@ ISSUES:
 3. **Match patterns** — follow existing test style
 4. **Be thorough** — cover edge cases
 5. **Report clearly** — state what was done and any issues
+6. **Stay within edit boundaries** — existing test files are append-only; never modify non-test source files (see Step 4 for details)


### PR DESCRIPTION
## Why

The code-testing-* agent family in the `dotnet-test` plugin generates tests for **12 languages** (not just .NET — see `code-testing-extensions/extensions/{dotnet,python,typescript,powershell,cpp,go,java,rust,ruby,swift,kotlin}.md` + `dotnet-examples.md`). However, nothing in the implementer prompt tells it to keep changes additive. In practice it routinely:

- modifies existing test files non-additively (deletes/reformats lines), and
- edits non-test production code to make something easier to test.

Both behaviors are rejected by:

- the msbench `simple` test verifier (any `dels > 0` on a test file, or any change to a non-test file, sets `reward=0`);
- most real-world test-quality gates and code-review policies (this is what the `testability-migration` agent exists for).

In a recent msbench comparison (vanilla `github-copilot-cli` vs. `cta-dotnet-all` with all `dotnet/skills` plugins enabled), the skill-enabled run regressed on 26 tasks where vanilla passed. After excluding tasks where a separate runner bug hid the agent's commits, ~8 of the remaining regressions trace directly back to destructive edits on test files or to edits of non-test source files — exactly what these rules forbid.

## What

Add a short `Edit boundaries (cross-language invariants)` subsection to Step 4 of `code-testing-implementer.agent.md`, plus a single corresponding entry in the `Rules` section:

1. **Existing test files are append-only.** No reformat/reorder/rename/remove. Even whitespace-only churn counts as destructive.
2. **Do not modify non-test source files.** Surface untestable seams as follow-ups for the `testability-migration` agent.
3. **Prefer new test files over edits to existing ones** when both options are valid.
4. **One exception**: build-system manifests (`.csproj`/`.sln`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited only for project/dependency registration.

Total change: `+10 / -0` in a single file. No behavioral change to skills or other agents.

## Why the implementer agent specifically

The implementer is the only agent in the pipeline that writes test files. The orchestrator (`code-testing-generator`) and the upstream agents (`researcher`, `planner`) don't author code. Putting the invariants where the file edits actually happen keeps the rule close to the action.