### PR TITLE
Restore investigation prompt to PR comment

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -862,11 +862,14 @@ jobs:
                 "${PR_NUMBER}" "${{ github.repository }}" "${RUN_ID}" "${{ github.repository }}" "${{ github.repository }}" "${{ needs.gate.outputs.head_sha }}")
             fi
 
-            # PR comment: simplified table + "Full results" link
+            # PR comment: simplified table + "Full results" link + investigation prompt
             {
               cat simplified-body.md
               echo ""
               echo "[🔍 Full Results - additional metrics and failure investigation steps]($RUN_URL)"
+              if [ -n "$INVESTIGATE_PROMPT" ]; then
+                echo "$INVESTIGATE_PROMPT"
+              fi
             } > consolidated-comment.md
 
             # Append AGENTVIZ replay link if session data was published

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -4,7 +4,7 @@ This guide is intended primarily for AI agents investigating skill evaluation fa
 
 ## Using this guide with an AI agent
 
-This document is designed to be read by AI coding agents. When a skill evaluation has failures, the workflow summary includes a ready-to-use prompt — just copy and paste it to your AI agent. The agent will download the artifacts, read this guide, analyze the results, and suggest fixes.
+This document is designed to be read by AI coding agents. When a skill evaluation has failures, the PR comment includes a ready-to-use prompt — just copy and paste it to your AI agent. The agent will download the artifacts, read this guide, analyze the results, and suggest fixes.
 
 If you need to run the investigation manually, follow the [Quick start](#quick-start) below.
 


### PR DESCRIPTION
PR #473 moved the failure investigation prompt out of the PR comment and only into the workflow run summary. This made the copy-paste prompt less discoverable — users had to click through to the run details to find it.

This PR moves it back to the PR comment so it's explicit and immediately visible inline on the PR. It remains in the workflow step summary as well.

## Changes

- `.github/workflows/evaluation.yml`: Re-add `INVESTIGATE_PROMPT` to `consolidated-comment.md` (the PR comment body) when there are failing verdicts.
- `eng/skill-validator/src/docs/InvestigatingResults.md`: Update guidance to say the prompt appears in the PR comment (reverting the wording change from #473).

The "Full Results" link text introduced by #473 is kept as-is.

Will comment `/evaluate` on this draft to verify the rendered comment.
