### PR TITLE
Aggregate sharded plugin results in publish-eval-data

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1265,17 +1265,59 @@ jobs:
 
           $plugins = '${{ needs.discover.outputs.plugins }}' | ConvertFrom-Json
           foreach ($plugin in $plugins) {
-            $artifactDir = "all-results/skill-validator-results-$plugin"
-            $runDir = Get-ChildItem -Path $artifactDir -Directory -ErrorAction SilentlyContinue |
-              Where-Object { $_.Name -match '^\d{8}-\d{6}$' } |
-              Sort-Object Name -Descending |
-              Select-Object -First 1
-            if (-not $runDir) {
+            # A plugin may have been fanned out into multiple shards by the
+            # discover job (artifact names "skill-validator-results-<plugin>--shard-<tag>"),
+            # or it may be a single artifact ("skill-validator-results-<plugin>").
+            # Collect the latest run dir from every matching artifact and
+            # merge their verdicts into a single results.json so the dashboard
+            # records ONE datapoint per plugin per scheduled run.
+            $artifactDirs = @(Get-ChildItem -Path "all-results" -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -eq "skill-validator-results-$plugin" -or $_.Name -like "skill-validator-results-$plugin--shard-*" })
+
+            if ($artifactDirs.Count -eq 0) {
               Write-Warning "No run results found for $plugin, skipping"
               continue
             }
 
-            $resultsFile = Join-Path $runDir.FullName "results.json"
+            $resultsFiles = @()
+            foreach ($ad in $artifactDirs) {
+              $runDir = Get-ChildItem -Path $ad.FullName -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match '^\d{8}-\d{6}$' } |
+                Sort-Object Name -Descending |
+                Select-Object -First 1
+              if ($runDir) {
+                $rf = Join-Path $runDir.FullName "results.json"
+                if (Test-Path $rf) { $resultsFiles += $rf }
+              }
+            }
+
+            if ($resultsFiles.Count -eq 0) {
+              Write-Warning "No results.json found in any artifact for $plugin, skipping"
+              continue
+            }
+
+            if ($resultsFiles.Count -eq 1) {
+              $resultsFile = $resultsFiles[0]
+            } else {
+              # Merge shard verdicts into a single synthetic results.json.
+              # Schema: { model, verdicts[], ... }. We concat verdicts arrays
+              # and keep top-level scalars from the first shard.
+              Write-Host "Merging $($resultsFiles.Count) shard results.json files for $plugin"
+              $merged = $null
+              $allVerdicts = [System.Collections.Generic.List[object]]::new()
+              foreach ($rf in ($resultsFiles | Sort-Object)) {
+                $r = Get-Content $rf -Raw | ConvertFrom-Json
+                if ($null -eq $merged) { $merged = $r }
+                if ($r.verdicts) { foreach ($v in $r.verdicts) { $allVerdicts.Add($v) } }
+              }
+              $merged.verdicts = $allVerdicts.ToArray()
+              $mergedDir = "all-results/_merged"
+              New-Item -ItemType Directory -Force -Path $mergedDir | Out-Null
+              $resultsFile = Join-Path $mergedDir "$plugin.results.json"
+              $merged | ConvertTo-Json -Depth 100 | Out-File -FilePath $resultsFile -Encoding utf8
+              Write-Host "  Merged verdict count: $($allVerdicts.Count) -> $resultsFile"
+            }
+
             Write-Host "`n=== Generating benchmark data for: $plugin ==="
             $existingFile = "/tmp/eval-data/data/$plugin.json"
             $params = @{


### PR DESCRIPTION
## Problem

`dotnet-msbuild` data has been missing from the dashboard since #692 landed (the sharding PR). The latest scheduled run [26484154365](https://github.com/dotnet/skills/actions/runs/26484154365) ran all three msbuild shards green, uploaded artifacts, but the `publish-eval-data` step then logged:

```
WARNING: No run results found for dotnet-msbuild, skipping
```

## Root cause

`publish-eval-data` walks `discover.outputs.plugins` (`["dotnet-msbuild", ...]`) and does an exact-name lookup against `all-results/skill-validator-results-<plugin>`. When the discover job fans a plugin into shards, the artifact names become `skill-validator-results-<plugin>--shard-<tag>`, which the exact-match misses. `publish-token-data` and `publish-session-data` were already shard-tolerant (wildcard match / source-agnostic scan).

## Fix

For each plugin, collect the latest `results.json` from every matching artifact dir (exact name OR `--shard-*` suffix) and:
- single match → use directly (unchanged behavior)
- multiple matches → concat the `verdicts` arrays into one synthetic `results.json` before calling `generate-benchmark-data.ps1`

Calling the script per-shard would have emitted N separate datapoints with the same commit/timestamp and skewed the dashboard.