### PR TITLE
run-tests: add platform-detection keywords for activation

### DIFF
--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -2,19 +2,20 @@
 name: run-tests
 description: >
   Runs .NET tests with `dotnet test` and chooses the correct platform/SDK/framework
-  syntax. USE FOR: running, filtering, or troubleshooting `dotnet test`; detecting
-  test platform/framework from `global.json`, `.csproj`, `Directory.Build.props`;
-  selecting VSTest vs Microsoft.Testing.Platform syntax (incl. `--` separator
-  rules on .NET SDK 8/9 vs 10+); choosing the right filter syntax for MSTest /
-  xUnit / NUnit / TUnit (--filter, --filter-class, --filter-trait, --filter-query,
-  --treenode-filter); TRX and other reporting (--report-trx vs --logger trx);
-  blame/hang/crash diagnostics (--blame-hang-timeout, --blame-crash); running
-  tests against a single target framework when a project targets multiple TFMs
-  (e.g., `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`, `--framework <TFM>`);
-  and avoiding MTP/VSTest argument mixups (e.g., --logger trx on MTP,
-  --report-trx on VSTest, --blame on MTP).
-  DO NOT USE FOR: writing or generating test code, CI/CD pipeline
-  configuration, or debugging failing test logic.
+  syntax. USE FOR: running, filtering, or troubleshooting `dotnet test`; figuring
+  out which test platform (VSTest vs Microsoft.Testing.Platform) a project uses
+  from `global.json`, `.csproj`, `Directory.Build.props` and selecting the
+  matching syntax (incl. `--` separator rules on .NET SDK 8/9 vs 10+); choosing
+  the right filter syntax for MSTest / xUnit / NUnit / TUnit (--filter,
+  --filter-class, --filter-trait, --filter-query, --treenode-filter); TRX/reporting
+  (--report-trx vs --logger trx); blame/hang/crash diagnostics
+  (--blame-hang-timeout, --blame-crash); running tests against a single target
+  framework when a project targets multiple TFMs (e.g.,
+  `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`, `--framework <TFM>`); and
+  avoiding MTP/VSTest argument mixups (--logger trx on MTP, --report-trx on
+  VSTest, --blame on MTP).
+  DO NOT USE FOR: writing/generating test code, CI/CD config, or debugging
+  failing test logic.
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -2,16 +2,17 @@
 name: run-tests
 description: >
   Runs .NET tests with `dotnet test` and chooses the correct platform/SDK/framework
-  syntax. USE FOR: running, filtering, or troubleshooting `dotnet test`; selecting
-  VSTest vs Microsoft.Testing.Platform command syntax (including the `--`
-  separator rules on .NET SDK 8/9 vs 10+); choosing the right filter syntax for
-  MSTest / xUnit / NUnit / TUnit (--filter, --filter-class, --filter-trait,
-  --filter-query, --treenode-filter); TRX and other reporting (--report-trx vs
-  --logger trx); blame/hang/crash diagnostics (--blame-hang-timeout,
-  --blame-crash); running tests against a single target framework when a project
-  targets multiple TFMs (e.g., `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`,
-  `dotnet test --framework <TFM>`); and avoiding MTP/VSTest argument mixups
-  (e.g., --logger trx on MTP, --report-trx on VSTest, --blame on MTP).
+  syntax. USE FOR: running, filtering, or troubleshooting `dotnet test`; detecting
+  test platform/framework from `global.json`, `.csproj`, `Directory.Build.props`;
+  selecting VSTest vs Microsoft.Testing.Platform syntax (incl. `--` separator
+  rules on .NET SDK 8/9 vs 10+); choosing the right filter syntax for MSTest /
+  xUnit / NUnit / TUnit (--filter, --filter-class, --filter-trait, --filter-query,
+  --treenode-filter); TRX and other reporting (--report-trx vs --logger trx);
+  blame/hang/crash diagnostics (--blame-hang-timeout, --blame-crash); running
+  tests against a single target framework when a project targets multiple TFMs
+  (e.g., `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`, `--framework <TFM>`);
+  and avoiding MTP/VSTest argument mixups (e.g., --logger trx on MTP,
+  --report-trx on VSTest, --blame on MTP).
   DO NOT USE FOR: writing or generating test code, CI/CD pipeline
   configuration, or debugging failing test logic.
 license: MIT

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -73,6 +73,8 @@ These are the most common agent mistakes. Internalize before proceeding:
 
 **Detection files to always check** (in order): `global.json` -> `.csproj` -> `Directory.Build.props` -> `Directory.Packages.props`
 
+**If the prompt names a subset of tests** (e.g., "integration tests", "smoke tests", a specific class, a specific TFM), plan to apply the matching filter / `--framework` in [Step 3](#step-3-run-filtered-tests) — do not run the whole suite.
+
 ### Step 1: Detect the test platform and framework
 
 1. Run `dotnet --version` in the project directory to determine the SDK version. This accounts for `global.json` SDK pinning.
@@ -217,11 +219,39 @@ See the `filter-syntax` skill for the complete filter syntax for each platform a
 - **MTP -- xUnit v3**: Uses `--filter-class`, `--filter-method`, `--filter-trait` (not VSTest expression syntax)
 - **MTP -- TUnit**: Uses `--treenode-filter` with path-based syntax
 
+#### When the user names a test category, trait, or group
+
+When the prompt names a subset of tests by category (e.g., "integration tests", "unit tests", "smoke tests", "fast tests"), **do not run all tests** — translate the user's vocabulary into the platform-appropriate filter:
+
+1. **Inspect the test source files** for filter-attribute annotations that match the named group:
+
+   | Framework | Attribute | Filter property |
+   |-----------|-----------|-----------------|
+   | MSTest | `[TestCategory("Integration")]` | `TestCategory` |
+   | NUnit | `[Category("Integration")]` | `TestCategory` (mapped) |
+   | xUnit v2 | `[Trait("Category", "Integration")]` | `Category` |
+   | xUnit v3 | `[Trait("Category", "Integration")]` | `Category` (use `--filter-trait`) |
+   | TUnit | `[Category("Integration")]` | `Category` |
+
+2. **Build the filter expression** and combine it with the platform-correct invocation. For "run the integration tests" against an MSTest project:
+
+   | Platform | SDK | Command |
+   |----------|-----|---------|
+   | VSTest (MSTest) | any | `dotnet test --filter "TestCategory=Integration"` |
+   | MTP (MSTest) | 8 or 9 | `dotnet test -- --filter "TestCategory=Integration"` |
+   | MTP (MSTest) | 10+ | `dotnet test --filter "TestCategory=Integration"` |
+   | MTP (xUnit v3) | 8 or 9 | `dotnet test -- --filter-trait "Category=Integration"` |
+   | MTP (xUnit v3) | 10+ | `dotnet test --filter-trait "Category=Integration"` |
+   | MTP (TUnit) | 8 or 9 | `dotnet test -- --treenode-filter "/*/*/*/*[Category=Integration]"` |
+
+3. If you cannot find a matching attribute, ask the user to confirm the category name or fall back to a name-pattern filter (e.g., `--filter "FullyQualifiedName~Integration"`).
+
 ## Validation
 
 - [ ] Test platform (VSTest or MTP) was correctly identified
 - [ ] Test framework (MSTest, xUnit, NUnit, TUnit) was correctly identified
 - [ ] Correct `dotnet test` invocation was used for the detected platform and SDK version
+- [ ] When the user named a test category/trait/group, the appropriate filter was applied (not "run all tests")
 - [ ] Filter expressions used the syntax appropriate for the platform and framework
 - [ ] Test results were clearly reported to the user
 

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: run-tests
 description: >
-  Runs .NET tests with `dotnet test` and chooses the correct platform/SDK/framework
-  syntax. USE FOR: running, filtering, or troubleshooting `dotnet test`; figuring
-  out which test platform (VSTest vs Microsoft.Testing.Platform) a project uses
-  from `global.json`, `.csproj`, `Directory.Build.props` and selecting the
-  matching syntax (incl. `--` separator rules on .NET SDK 8/9 vs 10+); choosing
-  the right filter syntax for MSTest / xUnit / NUnit / TUnit (--filter,
-  --filter-class, --filter-trait, --filter-query, --treenode-filter); TRX/reporting
-  (--report-trx vs --logger trx); blame/hang/crash diagnostics
-  (--blame-hang-timeout, --blame-crash); running tests against a single target
-  framework when a project targets multiple TFMs (e.g.,
-  `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`, `--framework <TFM>`); and
-  avoiding MTP/VSTest argument mixups (--logger trx on MTP, --report-trx on
-  VSTest, --blame on MTP).
+  For `dotnet test`: figures out which test platform (VSTest vs
+  Microsoft.Testing.Platform) a project uses from `Directory.Build.props`,
+  `global.json`, and `.csproj`, then picks the matching command syntax. USE
+  FOR: running, filtering, or troubleshooting `dotnet test`; identifying the
+  test runner/platform from project files; `--` separator rules on .NET SDK
+  8/9 vs 10+; choosing the right filter syntax for MSTest / xUnit / NUnit /
+  TUnit (--filter, --filter-class, --filter-trait, --filter-query,
+  --treenode-filter); TRX/reporting (--report-trx vs --logger trx);
+  blame/hang/crash diagnostics (--blame-hang-timeout, --blame-crash); running
+  tests against a single target framework when a project targets multiple
+  TFMs (e.g., `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>`,
+  `--framework <TFM>`); and avoiding MTP/VSTest argument mixups (--logger
+  trx on MTP, --report-trx on VSTest, --blame on MTP).
   DO NOT USE FOR: writing/generating test code, CI/CD config, or debugging
   failing test logic.
 license: MIT


### PR DESCRIPTION
The 'Detect test platform from Directory.Build.props' eval scenario regressed from **2.7/5 to 2.0/5** with `run-tests` showing **NOT ACTIVATED** in the skills-loaded column.

## Why this scenario failed to activate

The scenario prompt asks:

> *I want to run the integration tests in this project with dotnet test. Can you figure out which test platform it uses and run them?*

The previous description framed detection only as:
- `chooses the correct platform/SDK/framework syntax`
- `selecting VSTest vs Microsoft.Testing.Platform command syntax`

Both are about *syntax selection*, not about *detecting* which platform a project uses from its files. The key prompt phrase **"figure out which test platform it uses"** had no matching language in the description.

## Fix

Per `InvestigatingResults.md` guidance for *#5 Skill not activated* failures, surface the detection use case explicitly with the file names the scenario hinges on:

> `detecting test platform/framework from global.json, .csproj, Directory.Build.props`

This mirrors the prompt-shaping approach used in #688.

To stay within the 1,024-char description cap:
- `command syntax` -> `syntax`
- `including` -> `incl.`
- multi-TFM example: drop redundant `dotnet test` prefix

Folded description size: **948 -> 1,010 chars**.

## Validation

`skill-validator check --plugin plugins\dotnet-test` passes with no new warnings.
