### PR TITLE
Make dotnet-test analysis skills and auditor agent polyglot

### DIFF
--- a/plugins/dotnet-test/README.md
+++ b/plugins/dotnet-test/README.md
@@ -1,15 +1,15 @@
 # dotnet-test
 
-Skills and agents for running, generating, analyzing, migrating, and improving .NET tests across all major frameworks (MSTest, xUnit, NUnit, TUnit) and platforms (VSTest, Microsoft.Testing.Platform).
+Skills and agents for running, generating, analyzing, migrating, and improving tests. Originally built for .NET (MSTest, xUnit, NUnit, TUnit) and platforms (VSTest, Microsoft.Testing.Platform); the test-generation pipeline and the five test-analysis skills (anti-patterns, smells, assertion quality, gap analysis, tagging) plus the `test-quality-auditor` agent are **polyglot** and also work with Python (pytest/unittest), TypeScript/JavaScript (Jest/Vitest/Mocha/Jasmine/node:test), Java (JUnit 4/5/TestNG), Go (testing/testify), Ruby (RSpec/Minitest), Rust (built-in/proptest), Swift (XCTest/Swift Testing), Kotlin (JUnit/Kotest), PowerShell (Pester), and C++ (GoogleTest/Catch2/doctest/Boost.Test).
 
 ## When to use this plugin
 
-- **Run tests** — execute `dotnet test` with automatic platform/framework detection and filter syntax
-- **Generate tests** — scaffold comprehensive unit tests for any language via a multi-agent pipeline
-- **Migrate tests** — upgrade MSTest v1/v2 → v3 → v4, xUnit v2 → v3, or VSTest → Microsoft.Testing.Platform
-- **Audit test quality** — detect anti-patterns, test smells, assertion gaps, and coverage risks
-- **Improve testability** — find static dependencies, generate wrappers, and migrate call sites to injectable abstractions
-- **Measure coverage** — collect code coverage, compute CRAP scores, and surface risk hotspots
+- **Run tests** *(.NET only)* — execute `dotnet test` with automatic platform/framework detection and filter syntax
+- **Generate tests** *(polyglot)* — scaffold comprehensive unit tests for any language via a multi-agent pipeline
+- **Migrate tests** *(.NET only)* — upgrade MSTest v1/v2 → v3 → v4, xUnit v2 → v3, or VSTest → Microsoft.Testing.Platform
+- **Audit test quality** *(polyglot)* — detect anti-patterns, test smells, assertion gaps, and (for .NET) coverage risks
+- **Improve testability** *(.NET only)* — find static dependencies, generate wrappers, and migrate call sites to injectable abstractions
+- **Measure coverage** *(.NET only)* — collect code coverage, compute CRAP scores, and surface risk hotspots
 
 ## Skills
 
@@ -36,24 +36,28 @@ Skills and agents for running, generating, analyzing, migrating, and improving .
 | **migrate-xunit-to-xunit-v3** | Upgrade xUnit.net v2 to v3 |
 | **migrate-vstest-to-mtp** | Migrate from VSTest runner to Microsoft.Testing.Platform |
 
-### Test quality & analysis
+### Test quality & analysis *(polyglot)*
+
+These five skills work across all supported languages by loading a per-language reference file from `test-analysis-extensions`.
 
 | Skill | Description |
 |---|---|
-| **test-anti-patterns** | Quick pragmatic scan for ~15 common test quality issues with severity ranking |
-| **test-smell-detection** | Deep formal audit using academic test smell taxonomy (19 smell types) |
-| **assertion-quality** | Measure assertion variety and depth — find shallow tests that barely verify anything |
-| **test-gap-analysis** | Pseudo-mutation analysis to find test blind spots that coverage numbers miss |
-| **test-tagging** | Tag tests with standardized traits (smoke, regression, boundary, critical-path, etc.) |
+| **test-anti-patterns** | Quick pragmatic scan for common test quality issues with severity ranking (any language) |
+| **test-smell-detection** | Deep formal audit using academic test smell taxonomy (19 smell types, any language) |
+| **assertion-quality** | Measure assertion variety and depth — find shallow tests that barely verify anything (any language) |
+| **test-gap-analysis** | Pseudo-mutation analysis to find test blind spots that coverage numbers miss (any language) |
+| **test-tagging** | Tag tests with standardized traits (smoke, regression, boundary, critical-path, etc.); auto-edits where the framework has canonical syntax, report-only otherwise |
 
-### Coverage & risk
+### Coverage & risk *(.NET only)*
 
 | Skill | Description |
 |---|---|
 | **coverage-analysis** | Project-wide code coverage collection with CRAP score computation and risk hotspot reporting |
 | **crap-score** | Calculate CRAP (Change Risk Anti-Patterns) scores for individual methods, classes, or files |
 
-### Testability improvement
+For non-.NET languages, use the native coverage tool: `coverage.py`/`pytest-cov` (Python), `jest --coverage`/`c8`/`nyc`/`vitest --coverage` (JS/TS), JaCoCo (Java), `go test -coverprofile` (Go), SimpleCov (Ruby), `cargo-tarpaulin`/`cargo-llvm-cov` (Rust), `xcrun llvm-cov` (Swift), Kover (Kotlin), Pester's built-in code coverage (PowerShell), `gcov`/`llvm-cov` (C++).
+
+### Testability improvement *(.NET only)*
 
 | Skill | Description |
 |---|---|
@@ -65,10 +69,11 @@ Skills and agents for running, generating, analyzing, migrating, and improving .
 
 | Skill | Description |
 |---|---|
-| **code-testing-extensions** | Language-specific guidance files loaded by the code-testing pipeline |
-| **platform-detection** | Detect VSTest vs MTP and identify the test framework from project files |
-| **filter-syntax** | Test filter syntax reference for VSTest and MTP across all frameworks |
-| **dotnet-test-frameworks** | Framework detection patterns, assertion APIs, skip annotations, and lifecycle methods |
+| **code-testing-extensions** | Language-specific guidance loaded by the code-testing pipeline (test generation) |
+| **test-analysis-extensions** | Language-specific guidance loaded by the polyglot analysis skills (test markers, assertion APIs, sleeps, skips, mystery-guest indicators, integration markers, tag-support capability) |
+| **platform-detection** *(.NET)* | Detect VSTest vs MTP and identify the test framework from project files |
+| **filter-syntax** *(.NET)* | Test filter syntax reference for VSTest and MTP across all frameworks |
+| **dotnet-test-frameworks** *(.NET)* | Framework detection patterns, assertion APIs, skip annotations, and lifecycle methods (kept for backward compatibility with .NET-only skills like `writing-mstest-tests`) |
 
 ## Agents
 
@@ -99,5 +104,11 @@ These are pipeline stages invoked automatically by the agents above (`user-invoc
 
 ## Prerequisites
 
+### For polyglot skills and agents
+
+The test-generation pipeline (`code-testing-generator` and friends) and the five test-analysis skills (`test-anti-patterns`, `test-smell-detection`, `assertion-quality`, `test-gap-analysis`, `test-tagging`) plus the `test-quality-auditor` agent work with any of the supported languages above. You just need a working test runtime for the language you're targeting (e.g., `python` + `pytest`, `node` + `npm test`, `mvn` / `gradle`, `go`, `bundle exec rspec`, `cargo test`, `swift test`, `pwsh` + Pester, `cmake` + your C++ test runner). The skills will detect the framework automatically.
+
+### For .NET-only skills and agents
+
 - .NET SDK installed (`dotnet` on PATH)
-- A project with an existing test framework (MSTest, xUnit, NUnit, or TUnit) for execution and analysis skills
+- A project with an existing test framework (MSTest, xUnit, NUnit, or TUnit) for execution, migration, coverage, CRAP, testability, and the experimental `dotnet-experimental` skills.

--- a/plugins/dotnet-test/agents/test-quality-auditor.agent.md
+++ b/plugins/dotnet-test/agents/test-quality-auditor.agent.md
@@ -1,14 +1,21 @@
 ---
 name: test-quality-auditor
 description: >-
-  Runs multi-skill audit pipelines for comprehensive .NET test suite assessment
-  across an entire workspace or project, combining assertion quality, test smell
-  detection, mock usage analysis, test gap analysis, coverage risk, and test tagging
-  into unified reports. Use when asked for a broad test suite health check, full
-  multi-dimensional quality audit, or comprehensive assessment that requires
-  running multiple analysis skills in sequence. Do NOT use for reviewing a single
-  test file, class, or inline code snippet — those requests are handled directly
-  by individual skills like test-anti-patterns.
+  Runs multi-skill audit pipelines for comprehensive test suite assessment
+  across a workspace or project, combining assertion quality, test smell
+  detection, mock usage analysis, test gap analysis, coverage risk, and
+  test tagging into unified reports. Polyglot: .NET (MSTest/xUnit/NUnit/
+  TUnit), Python (pytest/unittest), TS/JS (Jest/Vitest/Mocha/node:test),
+  Java (JUnit/TestNG), Go, Ruby (RSpec/Minitest), Rust, Swift, Kotlin
+  (JUnit/Kotest), PowerShell (Pester), C++ (GoogleTest/Catch2). A subset
+  of pipeline steps (coverage-analysis, CRAP score,
+  detect-static-dependencies, testability migration, experimental
+  dotnet-experimental skills) is .NET-only; for non-.NET audits those
+  steps are skipped with an explanation. Use when asked for a broad test
+  suite health check, full multi-dimensional quality audit, or
+  comprehensive assessment requiring multiple analysis skills in
+  sequence. Do NOT use for reviewing a single test file, class, or inline
+  snippet — those are handled directly by skills like test-anti-patterns.
 user-invokable: true
 disable-model-invocation: false
 handoffs:
@@ -22,21 +29,24 @@ handoffs:
     agent: testability-migration
     prompt: >-
       The audit found untestable code with static dependencies. Please run
-      the detect-generate-migrate pipeline on the flagged areas.
+      the detect-generate-migrate pipeline on the flagged areas. NOTE: this
+      handoff is .NET-only — only offer it when the audited project is .NET.
     send: false
 license: MIT
 ---
 
 # Test Quality Auditor Agent
 
-You are a .NET test quality auditor. You help developers understand and improve the quality of their test suites by routing to specialized analysis skills. Your role is primarily diagnostic: you mainly produce reports and recommendations, and you should only use file-modifying workflows (such as test tagging) when the user explicitly requests them or confirms that scope.
+You are a polyglot test quality auditor. You help developers understand and improve the quality of their test suites by routing to specialized analysis skills. Your role is primarily diagnostic: you mainly produce reports and recommendations, and you should only use file-modifying workflows (such as test tagging on auto-edit frameworks) when the user explicitly requests them or confirms that scope.
 
 ## Core Competencies
 
+- Detecting the language and test framework(s) present in the workspace
 - Triaging test quality concerns to the right analysis skill
 - Running multi-skill audit pipelines for comprehensive health checks
 - Synthesizing findings from multiple skills into a unified report
 - Identifying which quality dimensions matter most for a given codebase
+- Skipping skills that don't apply to the detected language and explaining why
 
 ## When Not to Invoke This Agent
 
@@ -44,83 +54,119 @@ You are a .NET test quality auditor. You help developers understand and improve 
 - Direct anti-pattern checks where the user is not asking for a broad multi-dimensional audit
 - Focused requests that clearly map to one skill (invoke that skill directly)
 
-## Domain Relevance Check
+## Language Detection
 
-Before proceeding, verify the workspace contains .NET test projects:
+Before proceeding, identify the language(s) and test framework(s) in the workspace. This drives which pipeline steps apply.
 
-1. **Quick check**: Are there `.csproj` files referencing test framework packages (`MSTest`, `xunit`, `NUnit`, `TUnit`)? Are there test files with `[TestMethod]`, `[Fact]`, `[Test]`, or similar attributes?
-2. **If yes**: Proceed with the audit
-3. **If unclear**: Scan the workspace (`glob **/*Test*.csproj`, `glob **/*Tests*.csproj`) to locate test projects
-4. **If no test projects found**: Explain that this agent specializes in .NET test quality auditing and suggest general-purpose assistance instead
+1. **Marker scan** (parallel `glob` calls):
+   - **.NET**: `**/*.csproj`, `**/*.fsproj`, `**/*.vbproj` containing `<PackageReference Include="MSTest..."`, `xunit`, `NUnit`, `TUnit`; test files with `[TestMethod]`, `[Fact]`, `[Test]`
+   - **Python**: `pyproject.toml`, `setup.py`, `setup.cfg`, `pytest.ini`, `tox.ini`, `conftest.py`, `test_*.py`, `*_test.py`
+   - **JS/TS**: `package.json` containing `jest`, `vitest`, `mocha`, `jasmine`, `@playwright/test`; `*.test.ts`, `*.spec.ts`, `*.test.js`, `*.spec.js`
+   - **Java**: `pom.xml`, `build.gradle`, `build.gradle.kts` containing `junit-jupiter`, `junit`, `testng`; `**/test/**/*Test.java`, `**/test/**/*Tests.java`
+   - **Go**: `go.mod`, `*_test.go`
+   - **Ruby**: `Gemfile` containing `rspec`, `minitest`; `*_spec.rb`, `test_*.rb`, `*_test.rb`
+   - **Rust**: `Cargo.toml`, `tests/*.rs`, inline `#[cfg(test)] mod tests` in `src/**/*.rs`
+   - **Swift**: `Package.swift`, `*.xcodeproj`, `*Tests.swift`
+   - **Kotlin**: `build.gradle.kts`, `*Test.kt`, `*Spec.kt`
+   - **PowerShell**: `*.Tests.ps1`
+   - **C++**: `CMakeLists.txt` referencing `gtest`/`Catch2`/`doctest`; `test_*.cpp`, `*_test.cpp`
+
+2. **Multi-language**: If multiple languages are detected, ask the user which to audit, or default to auditing each in turn.
+
+3. **No test projects found**: Explain that this agent specializes in test quality auditing and suggest general-purpose assistance instead.
+
+4. **Load the matching language extension**: Once the language is known, the routed analysis skills will read `test-analysis-extensions/extensions/<language>.md` for framework-specific patterns. You don't need to read it yourself, but you should confirm the file exists before routing.
+
+## Capability Matrix
+
+The following matrix shows which skills apply to each language. Use it to gate the pipeline.
+
+| Skill | .NET | Python | JS/TS | Java | Go | Ruby | Rust | Swift | Kotlin | PowerShell | C++ |
+|-------|:----:|:------:|:-----:|:----:|:--:|:----:|:----:|:-----:|:------:|:----------:|:---:|
+| `test-anti-patterns` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `assertion-quality` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `test-gap-analysis` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `test-smell-detection` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `test-tagging` | ✅ auto-edit | ✅ auto-edit | ⚠️ report-only | ✅ auto-edit | ⚠️ convention | ✅ auto-edit | ⚠️ report-only | ✅ auto-edit | ✅ auto-edit | ✅ auto-edit | ⚠️ Catch2/doctest auto-edit; GoogleTest report-only |
+| `coverage-analysis` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `crap-score` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `detect-static-dependencies` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `testability-migration` (agent handoff) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `exp-test-maintainability` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `exp-mock-usage-analysis` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+For non-.NET audits, the .NET-only rows are **skipped**. Always explain *why* in the report (e.g., "Coverage and CRAP-score steps were skipped because the project is Python; consider `pytest-cov` for Python coverage, `coverage.py` for line/branch metrics, or `mutmut`/`cosmic-ray` for mutation testing equivalents to `test-gap-analysis`.").
 
 ## Triage and Routing
 
-Classify the user's request and route to the appropriate skill:
+Classify the user's request and route to the appropriate skill. Skills marked .NET-only in the capability matrix only apply to .NET workspaces.
 
-| User Intent | Route To | Plugin |
-|---|---|---|
-| "Are my assertions good enough?" / shallow testing / assertion diversity | `assertion-quality` skill | dotnet-test |
-| "Find test smells" / comprehensive formal audit | `test-smell-detection` skill | dotnet-test |
-| "Pragmatic anti-pattern check" within a broader audit context | `test-anti-patterns` skill | dotnet-test |
-| "Find test duplication" / boilerplate / DRY up tests | `exp-test-maintainability` skill | dotnet-experimental |
-| "Are my mocks needed?" / over-mocking / mock audit | `exp-mock-usage-analysis` skill | dotnet-experimental |
-| "Would my tests catch bugs?" / mutation analysis / test gaps | `test-gap-analysis` skill | dotnet-test |
-| "Categorize my tests" / tag tests / trait distribution | `test-tagging` skill | dotnet-test |
-| "Coverage report" / risk hotspots / CRAP score | `coverage-analysis` skill (use `crap-score` only for explicitly targeted method/class CRAP analysis or narrow-scope Cobertura data) | dotnet-test |
-| "Find untestable code" / static dependencies | `detect-static-dependencies` skill → hand off to `testability-migration` agent for fixes | dotnet-test |
-| "Full health check" / "audit my tests" / broad quality request | Run the **Comprehensive Audit Pipeline** below | multiple |
+| User Intent | Route To | Plugin | Language scope |
+|---|---|---|---|
+| "Are my assertions good enough?" / shallow testing / assertion diversity | `assertion-quality` skill | dotnet-test | All languages |
+| "Find test smells" / comprehensive formal audit | `test-smell-detection` skill | dotnet-test | All languages |
+| "Pragmatic anti-pattern check" within a broader audit context | `test-anti-patterns` skill | dotnet-test | All languages |
+| "Find test duplication" / boilerplate / DRY up tests | `exp-test-maintainability` skill | dotnet-experimental | **.NET only** |
+| "Are my mocks needed?" / over-mocking / mock audit | `exp-mock-usage-analysis` skill | dotnet-experimental | **.NET only** |
+| "Would my tests catch bugs?" / mutation analysis / test gaps | `test-gap-analysis` skill | dotnet-test | All languages |
+| "Categorize my tests" / tag tests / trait distribution | `test-tagging` skill | dotnet-test | All languages (auto-edit / report-only per matrix) |
+| "Coverage report" / risk hotspots / CRAP score | `coverage-analysis` skill (use `crap-score` only for explicitly targeted method/class CRAP analysis or narrow-scope Cobertura data) | dotnet-test | **.NET only** — for other languages, recommend the native tool (Python: `coverage.py`/`pytest-cov`; JS/TS: `jest --coverage`/`c8`/`nyc`/`vitest --coverage`; Java: JaCoCo; Go: `go test -coverprofile`; Ruby: SimpleCov; Rust: `cargo-tarpaulin`/`cargo-llvm-cov`; Swift: `xcrun llvm-cov`; Kotlin: Kover/JaCoCo; PowerShell: Pester's built-in code coverage; C++: gcov/llvm-cov) |
+| "Find untestable code" / static dependencies | `detect-static-dependencies` skill → hand off to `testability-migration` agent for fixes | dotnet-test | **.NET only** |
+| "Full health check" / "audit my tests" / broad quality request | Run the **Comprehensive Audit Pipeline** below (capability-gated) | multiple | All languages, with .NET-only steps gated |
 
 ## Comprehensive Audit Pipeline
 
-When the user asks for a broad quality assessment (e.g., "audit my test suite", "how good are my tests?", "test health check"), run multiple skills in sequence and synthesize the results.
+When the user asks for a broad quality assessment (e.g., "audit my test suite", "how good are my tests?", "test health check"), run multiple skills in sequence and synthesize the results. **Gate each step against the Capability Matrix** — skip steps that don't apply to the detected language and explicitly note the skip and the recommended native tool.
 
 ### Recommended sequence
 
 Run these in order. Each step builds context for the next. Stop early if the user's scope is narrow or the codebase is small.
 
-1. **Anti-patterns** — `test-anti-patterns` skill
+1. **Anti-patterns** — `test-anti-patterns` skill *(all languages)*
    - Quick pragmatic scan for the most impactful issues
    - Produces severity-ranked findings (Critical → Low)
 
-2. **Assertion quality** — `assertion-quality` skill
+2. **Assertion quality** — `assertion-quality` skill *(all languages)*
    - Measures assertion variety and depth
    - Reveals whether tests actually verify meaningful behavior
 
-3. **Test gaps** — `test-gap-analysis` skill
+3. **Test gaps** — `test-gap-analysis` skill *(all languages)*
    - Pseudo-mutation analysis to find blind spots
    - Answers "would tests catch a bug here?"
 
-4. **Coverage and risk** — `coverage-analysis` skill
+4. **Coverage and risk** — `coverage-analysis` skill *(.NET only)*
    - Quantitative coverage data with CRAP score risk hotspots
    - Requires running `dotnet test` with coverage collection
+   - **For non-.NET projects**: Skip and explicitly recommend the native coverage tool from the Capability Matrix.
 
 ### Optional follow-ups (offer but don't run automatically)
 
-5. **Test smells** — `test-smell-detection` skill (if step 1 found many issues and the user wants a deeper formal audit)
-6. **Maintainability** — `exp-test-maintainability` skill (if the test suite is large and duplication is suspected)
-7. **Mock audit** — `exp-mock-usage-analysis` skill (if over-mocking was flagged in step 1)
-8. **Test tagging** — `test-tagging` skill (if the user wants to understand test type distribution)
+5. **Test smells** — `test-smell-detection` skill *(all languages)* — if step 1 found many issues and the user wants a deeper formal audit
+6. **Maintainability** — `exp-test-maintainability` skill *(.NET only)* — if the test suite is large and duplication is suspected. **For non-.NET**: skip and note alternatives (e.g., generic duplication detectors like `jscpd`, `pmd-cpd`, `dupl` for Go, `similarity-rs`, `clone-detective`).
+7. **Mock audit** — `exp-mock-usage-analysis` skill *(.NET only)* — if over-mocking was flagged in step 1. **For non-.NET**: note that `test-anti-patterns` already flagged the most egregious cases; deeper audits require language-specific tooling.
+8. **Test tagging** — `test-tagging` skill *(all languages)* — if the user wants to understand test type distribution. Will auto-edit for frameworks with canonical syntax and produce a report-only output for the rest (per Capability Matrix).
 
 ### Synthesizing results
 
-After running the pipeline, produce a unified summary:
+After running the pipeline, produce a unified summary. Indicate clearly when steps were skipped due to language scope.
 
 ```
-## Test Quality Summary
+## Test Quality Summary (Python / pytest)
 
 | Dimension | Status | Key Findings |
 |-----------|--------|-------------|
-| Anti-patterns | ⚠️ 3 critical, 5 warnings | Assertion-free tests, flaky Thread.Sleep |
+| Anti-patterns | ⚠️ 3 critical, 5 warnings | Assertion-free tests, time.sleep in unit tests |
 | Assertion depth | ❌ Low diversity | 80% equality-only, no state/structural checks |
-| Test gaps | ⚠️ 4 blind spots | Boundary conditions in PaymentCalculator uncovered |
-| Coverage risk | ✅ 78% coverage | 2 high-CRAP methods in OrderService |
+| Test gaps | ⚠️ 4 blind spots | Boundary conditions in payment_calculator uncovered |
+| Coverage risk | ⏭️ Skipped | .NET-only step; for Python use `coverage.py` or `pytest-cov` |
+| Mock audit | ⏭️ Skipped | .NET-only step; relevant mock-related issues already in anti-patterns above |
 ```
 
 Prioritize findings by impact:
 1. **Critical anti-patterns** (tests that give false confidence)
 2. **Test gaps** (bugs that would slip through)
 3. **Assertion quality** (shallow tests that pass but verify nothing)
-4. **Coverage risk** (complex untested code)
+4. **Coverage risk** (complex untested code) — when applicable to the detected language
 
 ## Decision Rules
 
@@ -136,19 +182,23 @@ Prioritize findings by impact:
 
 ### When to recommend instead of run
 
-- **Test tagging**: Only run if user explicitly asks — it modifies files (adds trait attributes)
-- **Mock audit**: Only run if the codebase uses mocking frameworks — check for Moq, NSubstitute, or FakeItEasy references first
-- **Maintainability**: Most useful for large test suites (50+ test files) — for small suites, mention it as available but skip
+- **Test tagging**: Only run if user explicitly asks — for `auto-edit` frameworks it modifies files (adds trait attributes); for `report-only` frameworks it produces a Markdown report only.
+- **Mock audit (`exp-mock-usage-analysis`)**: .NET only — first verify the codebase uses Moq, NSubstitute, or FakeItEasy. For non-.NET, decline and route to `test-anti-patterns` for over-mocking detection.
+- **Maintainability (`exp-test-maintainability`)**: .NET only and most useful for large test suites (50+ test files). For non-.NET, mention generic duplication detectors and skip.
+- **Coverage / CRAP / static-dependency detection / testability migration**: .NET only. For other languages, explicitly state the limitation and recommend the native tool from the Capability Matrix.
 
 ### Scope control
 
 - Default to the test project(s) the user points to
 - If no scope specified, scan for all test projects and ask the user to confirm scope
-- For comprehensive audits on large solutions, offer to audit one project at a time
+- For comprehensive audits on large solutions or monorepos, offer to audit one project (or one language) at a time
+- For polyglot monorepos, audit each language separately and produce one summary per language
 
 ## Response Guidelines
 
-- **Always start with detection**: Identify test framework, test project paths, and approximate test count before diving into analysis
+- **Always start with language detection**: Identify language(s), test framework(s), test paths, and approximate test count before diving into analysis. Then confirm which subset of the Capability Matrix applies.
 - **Lead with actionable findings**: Put the most impactful issues first
-- **Distinguish analysis from action**: This agent produces reports. If the user wants to fix issues, point them to the appropriate skill or agent (e.g., `testability-migration` for static dependencies, `code-testing-generator` for writing new tests)
-- **Be honest about experimental skills**: Skills from `dotnet-experimental` (`exp-test-maintainability`, `exp-mock-usage-analysis`) are being refined — mention this context when presenting their results
+- **Distinguish analysis from action**: This agent produces reports. If the user wants to fix issues, point them to the appropriate skill or agent — `code-testing-generator` (any language) for writing new tests; `testability-migration` (.NET only) for static dependencies.
+- **Be explicit about skipped steps**: Whenever a Capability Matrix gate causes a step to be skipped, note it in the synthesized report along with the recommended native tool. Never silently drop a step.
+- **Be honest about experimental skills**: Skills from `dotnet-experimental` (`exp-test-maintainability`, `exp-mock-usage-analysis`) are being refined and are .NET-only — mention this context when presenting their results.
+- **Don't offer the testability-migration handoff for non-.NET**: When responding for a non-.NET workspace, omit the "Fix Testability Issues" handoff or note that it's .NET-only.

--- a/plugins/dotnet-test/skills/assertion-quality/SKILL.md
+++ b/plugins/dotnet-test/skills/assertion-quality/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: assertion-quality
-description: "Analyzes the variety and depth of assertions across .NET test suites. Use when the user asks to evaluate assertion quality, find shallow testing, identify assertion-free tests (no assertions or only trivial ones like Assert.IsNotNull), flag self-referential or tautological assertions (output equals input on identity/round-trip operations), measure assertion coverage diversity, or audit whether tests verify different facets of correctness. Produces metrics and actionable recommendations. Works with MSTest, xUnit, NUnit, TUnit. DO NOT USE FOR: writing new tests (use writing-mstest-tests), other anti-patterns like flakiness or duplication (use test-anti-patterns), or fixing assertions."
+description: "Analyzes the variety and depth of assertions across test suites in any language. Use when the user asks to evaluate assertion quality, find shallow testing, identify assertion-free tests (no assertions or only trivial ones like Assert.IsNotNull / expect(x).toBeTruthy() / assert x is not None), flag self-referential or tautological assertions (output equals input on identity/round-trip operations), measure assertion coverage diversity, or audit whether tests verify different facets of correctness. Produces metrics and actionable recommendations. Polyglot: .NET (MSTest/xUnit/NUnit/TUnit), Python (pytest/unittest), TS/JS (Jest/Vitest/Mocha/Jasmine/node:test), Java (JUnit/TestNG), Go, Ruby (RSpec/Minitest), Rust, Swift (XCTest/Swift Testing), Kotlin (JUnit/Kotest), PowerShell (Pester), C++ (GoogleTest/Catch2/doctest). DO NOT USE FOR: writing new tests (use code-testing-agent, or writing-mstest-tests for MSTest), anti-patterns like flakiness or duplication (use test-anti-patterns), fixing assertions."
 license: MIT
 ---
 
 # Assertion Diversity Analysis
 
-Analyze .NET test code to measure how varied and meaningful the assertions are. Produce a metrics report that reveals whether tests verify different facets of correctness — not just "output equals X" but also structure, exceptions, state transitions, side effects, and invariants.
+Analyze test code in any supported language to measure how varied and meaningful the assertions are. Produce a metrics report that reveals whether tests verify different facets of correctness — not just "output equals X" but also structure, exceptions, state transitions, side effects, and invariants.
+
+> **Language-specific guidance**: Call the `test-analysis-extensions` skill to discover available extension files, then read the file matching the target codebase's language and framework (e.g., `dotnet.md` for .NET, `python.md` for pytest, `typescript.md` for Jest, `go.md` for the standard `testing` package). You MUST read the relevant extension file before classifying assertions, because assertion APIs differ significantly across frameworks.
 
 ## Why Assertion Diversity Matters
 
@@ -14,7 +16,7 @@ Low assertion diversity signals shallow testing. Tests may pass while bugs hide 
 
 | Problem | Symptom | Consequence |
 |---------|---------|-------------|
-| Trivial assertions | `Assert.IsNotNull(result)` only | Test passes but doesn't verify correctness |
+| Trivial assertions | Test contains only `Assert.IsNotNull(result)` / `assert result is not None` / `expect(x).toBeDefined()` | Test passes but doesn't verify correctness |
 | Single-value obsession | Always check one field or return value | Bugs in unasserted logic slip through |
 | No negative assertions | Never check what shouldn't happen | Regressions sneak in through false positives |
 | No state checks | Don't verify object state changes | Missed side-effects or lifecycle issues |
@@ -31,7 +33,7 @@ Low assertion diversity signals shallow testing. Tests may pass while bugs hide 
 
 ## When Not to Use
 
-- User wants to write new tests (use `writing-mstest-tests`)
+- User wants to write new tests (use `code-testing-agent` for any language, or `writing-mstest-tests` for MSTest specifically)
 - User wants to detect anti-patterns beyond assertions (use `test-anti-patterns`)
 - User wants to fix or rewrite assertions (help them directly)
 - User asks about code coverage percentages (out of scope — this analyzes assertion quality, not line coverage)
@@ -45,32 +47,38 @@ Low assertion diversity signals shallow testing. Tests may pass while bugs hide 
 
 ## Workflow
 
-### Step 1: Gather the test code
+### Step 1: Detect language and load extension
 
-Read all test files the user provides. If the user points to a directory or project, scan for all test files — see the `dotnet-test-frameworks` skill for framework-specific markers.
+Identify the target codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file (e.g., `extensions/dotnet.md` for .NET, `extensions/python.md` for pytest, `extensions/typescript.md` for Jest/Vitest, `extensions/go.md` for Go). The extension file lists the framework-specific assertion APIs you will classify in Step 3.
 
-### Step 2: Classify every assertion
+### Step 2: Gather the test code
 
-For each test method, identify all assertions and classify them into these categories:
+Read all test files the user provides. If the user points to a directory or project, scan for all test files using the markers in the language extension file (e.g., `[TestMethod]` for MSTest, `def test_*` for pytest, `it()` / `test()` for Jest, `func TestXxx` for Go).
 
-| Category | Examples | What it verifies |
-|----------|---------|-----------------|
-| **Equality** | `Assert.AreEqual`, `Assert.Equal`, `Is.EqualTo` | Return value matches expected |
-| **Boolean** | `Assert.IsTrue`, `Assert.IsFalse`, `Assert.True` | Condition holds |
-| **Null checks** | `Assert.IsNull`, `Assert.IsNotNull`, `Assert.NotNull` | Presence/absence of value |
-| **Exception** | `Assert.ThrowsException`, `Assert.Throws`, `Assert.ThrowsAsync` | Error handling behavior |
-| **Type checks** | `Assert.IsInstanceOfType`, `Assert.IsAssignableFrom` | Runtime type correctness |
-| **String** | `StringAssert.Contains`, `StringAssert.StartsWith`, `Assert.Matches` | Text content and format |
-| **Collection** | `CollectionAssert.Contains`, `Assert.Contains`, `Assert.All`, `Has.Member` | Collection contents and structure |
-| **Comparison** | `Assert.IsTrue(x > y)`, `Assert.InRange`, `Is.GreaterThan` | Ordering and magnitude |
-| **Approximate** | `Assert.AreEqual(expected, actual, delta)`, `Is.EqualTo().Within()` | Floating-point or tolerance-based |
-| **Negative** | `Assert.AreNotEqual`, `Assert.DoesNotContain`, `Assert.DoesNotThrow` | What should NOT happen |
-| **State/Side-effect** | Assertions on object properties after mutation, verifying mock calls | State transitions and side effects |
-| **Structural/Deep** | Assertions on nested properties, serialized forms, complex objects | Deep object correctness |
+### Step 3: Classify every assertion
 
-A single assertion can belong to multiple categories (e.g., `Assert.AreNotEqual` is both Equality and Negative).
+For each test method, identify all assertions and classify them into these language-neutral categories:
 
-### Step 3: Compute metrics
+| Category | What it verifies | Examples across languages |
+|----------|------------------|----------------------------|
+| **Equality** | Return value matches expected | `Assert.AreEqual` (MSTest), `Assert.Equal` (xUnit), `assert x == y` (pytest), `expect(x).toBe(y)` (Jest), `assertEquals` (JUnit), `if got != want { t.Error... }` / `assert.Equal(t, want, got)` (Go), `x shouldBe y` (Kotest), `Should -Be` (Pester), `EXPECT_EQ` (GoogleTest) |
+| **Boolean** | Condition holds | `Assert.IsTrue`, `assert flag` (Python), `expect(x).toBeTruthy()` (Jest), `assertTrue` (JUnit), `assert.True(t, ok)` (testify), `x.shouldBeTrue()` (Kotest), `Should -BeTrue` (Pester), `EXPECT_TRUE` |
+| **Null / None / Nil** | Presence/absence of value | `Assert.IsNull` (.NET), `assert x is None` (pytest), `expect(x).toBeNull()` (Jest), `assertNull` (JUnit), `assert.Nil(t, v)` (testify), `XCTAssertNil` (XCTest), `Should -BeNullOrEmpty` (Pester) |
+| **Exception / Error** | Error handling behavior | `Assert.Throws<T>()`, `pytest.raises(E)`, `expect(fn).toThrow(E)`, `assertThrows<E>`, `assert.Error(t, err)` / `assert.ErrorIs`, `#[should_panic]` (Rust), `XCTAssertThrowsError`, `Should -Throw`, `EXPECT_THROW` |
+| **Type checks** | Runtime type correctness | `Assert.IsInstanceOfType`, `assert isinstance(x, T)`, `expect(x).toBeInstanceOf(T)`, `assertInstanceOf`, `assert.IsType(t, T{}, v)`, `assert!(matches!(value, Pattern))` (Rust), `Should -BeOfType` |
+| **String** | Text content and format | `StringAssert.Contains`, `assert sub in s`, `expect(s).toMatch(/x/)`, `assertTrue(s.contains(...))`, `assert.Contains(t, s, sub)`, `s shouldContain sub`, `Should -Match`, `EXPECT_THAT(s, HasSubstr(...))` |
+| **Collection** | Collection contents and structure | `CollectionAssert.Contains`, `assert item in collection`, `expect(arr).toContain(x)`, `assertIterableEquals`, `assert.Contains(t, slice, item)`, `col shouldContainExactly listOf(...)`, `Should -Contain`, `EXPECT_THAT(c, ElementsAre(...))` |
+| **Comparison** | Ordering and magnitude | `Assert.IsTrue(x > y)`, `Is.GreaterThan`, `assert x > y`, `expect(x).toBeGreaterThan(y)`, `assertTrue(x > y)`, `assert.Greater(t, x, y)` (testify) |
+| **Approximate** | Floating-point or tolerance-based | `Assert.AreEqual(expected, actual, delta)`, `pytest.approx(y)`, `expect(x).toBeCloseTo(y)`, `assertEquals(x, y, delta)`, `assert.InDelta(t, x, y, delta)`, `EXPECT_NEAR`, `EXPECT_DOUBLE_EQ` |
+| **Negative** | What should NOT happen | `Assert.AreNotEqual`, `assert x != y`, `expect(x).not.toBe(y)`, `assertNotEquals`, `assert.NotEqual(t, x, y)`, `refute` (Minitest / Ruby), `Should -Not -Be` |
+| **State / Side-effect** | State transitions and side effects | Assertions on object properties after mutation; mock-call verifications: `mock.Verify(...)` (Moq), `mock_method.assert_called_with(...)` (Python `unittest.mock`), `expect(mock).toHaveBeenCalledWith(...)` (Jest), `verify(mock).method(...)` (Mockito), `Should -Invoke` (Pester), `expect { code }.to change(obj, :attr)` (RSpec) |
+| **Structural / Deep** | Deep object correctness | `Assert.AreEqual` with rich-equality types, `assertThat(obj).usingRecursiveComparison()` (AssertJ), `.toEqual({...})` (Jest deep equality), `cmp.Diff` (Go go-cmp), snapshot tests (`.toMatchSnapshot()`, `syrupy`, `SnapshotTesting`), `assertThat(col).extracting(...)` (AssertJ chains) |
+
+A single assertion can belong to multiple categories (e.g., `Assert.AreNotEqual` is both Equality and Negative; `expect(mock).toHaveBeenCalledWith(...)` is both State/Side-effect and a specific-call assertion).
+
+Read the loaded language extension file for the exact framework-specific list of assertion APIs.
+
+### Step 4: Compute metrics
 
 Calculate these metrics for the test suite:
 
@@ -90,19 +98,22 @@ Calculate these metrics for the test suite:
 - **Tests with structural/deep assertions**: Count and percentage
 - **Single-category tests**: Count and percentage of tests that use only one assertion category
 
-### Step 4: Apply calibration rules
+### Step 5: Apply calibration rules
 
 Before reporting, calibrate findings:
 
-- **Trivial means truly trivial.** `Assert.IsNotNull(result)` alone is trivial. But `Assert.IsNotNull(result)` followed by `Assert.AreEqual(expected, result.Value)` is not — the null check is a guard before the real assertion. Only flag a test as "trivial" if it has no meaningful value assertions.
-- **Boolean assertions checking meaningful conditions are not trivial.** `Assert.IsTrue(result.IsValid)` checks a specific property — it's a Boolean assertion, not a trivial one. `Assert.IsTrue(true)` is trivial.
-- **Consider the test's intent.** A test for a void method that verifies state change on a dependency is legitimate even if it only uses `Assert.IsTrue`.
-- **Exception tests are inherently low-assertion-count.** `Assert.ThrowsException<T>(() => ...)` may be the only assertion — that's fine for exception-focused tests. Don't penalize them for low assertion count.
-- **Don't conflate diversity with volume.** A test with 20 `Assert.AreEqual` calls has high volume but low diversity. A test with one equality, one null check, and one exception assertion has low volume but good diversity.
-- **Self-referential assertions are not meaningful equality checks.** `Assert.AreEqual(input, roundTrip(input))` looks like a real equality assertion but is tautological when the operation under test is expected to be identity. Flag these separately from normal equality assertions. If the test's *purpose* is to verify a round-trip (serialize/deserialize, encode/decode), the assertion is valid — but it should be accompanied by assertions on non-trivial inputs that exercise the transformation.
+- **Trivial means truly trivial.** A null/None/nil check alone is trivial (`Assert.IsNotNull(result)`, `assert result is not None`, `expect(x).toBeDefined()`). But a null check followed by a meaningful value assertion is not trivial — the null check is a guard before the real assertion. Only flag a test as "trivial" if it has no meaningful value assertions.
+- **Boolean assertions checking meaningful conditions are not trivial.** `Assert.IsTrue(result.IsValid)` / `assert result.is_valid` / `expect(result.isValid).toBe(true)` check a specific property — these are Boolean assertions, not trivial ones. Always-true assertions (`Assert.IsTrue(true)`, `assert True`, `expect(true).toBe(true)`) are trivial.
+- **Consider the test's intent.** A test for a void method that verifies state change on a dependency is legitimate even if it only uses one Boolean assertion.
+- **Exception tests are inherently low-assertion-count.** `Assert.ThrowsException<T>(() => ...)` / `with pytest.raises(E): ...` / `expect(fn).toThrow(E)` / `#[should_panic]` may be the only assertion — that's fine for exception-focused tests. Don't penalize them for low assertion count.
+- **Mock-call verifications and bare assertion forms count.** Treat `verify(mock).method(...)` (Mockito), `expect(mock).toHaveBeenCalledWith(...)` (Jest), `Should -Invoke` (Pester), `bare assert` (pytest), `if got != want { t.Errorf(...) }` (Go) all as real assertions of the appropriate category. Do not treat them as missing-framework-API smells.
+- **Snapshot assertions** (`.toMatchSnapshot()`, `syrupy`, `SnapshotTesting`) count as Structural/Deep assertions. Flag stale or never-updated snapshots separately.
+- **Property-based tests** (`@given` Hypothesis, `proptest!`, `forAll` Kotest) generate assertions implicitly through generated cases — count the inner assertion logic, not the outer scaffold.
+- **Don't conflate diversity with volume.** A test with 20 equality assertions has high volume but low diversity. A test with one equality, one null check, and one exception assertion has low volume but good diversity.
+- **Self-referential assertions are not meaningful equality checks.** Asserting that an output equals an input round-trip looks like a real equality assertion but is tautological when the operation under test is expected to be identity. Flag these separately from normal equality assertions. If the test's *purpose* is to verify a round-trip (serialize/deserialize, encode/decode), the assertion is valid — but it should be accompanied by assertions on non-trivial inputs that exercise the transformation.
 - **If assertions are well-diversified, say so.** A report concluding the suite has good diversity is perfectly valid.
 
-### Step 5: Report findings
+### Step 6: Report findings
 
 Present the analysis in this structure:
 
@@ -152,8 +163,11 @@ Present the analysis in this structure:
 | Pitfall | Solution |
 |---------|----------|
 | Penalizing exception tests for low assertion count | Exception assertions are complete on their own — skip count warnings for these |
-| Flagging null checks before value checks as trivial | Only flag tests where the null check is the ONLY assertion |
-| Counting `Assert.IsTrue(condition)` as trivial | Only `Assert.IsTrue(true)` or always-true conditions are trivial |
-| Ignoring framework differences | MSTest uses `Assert.AreEqual`, xUnit uses `Assert.Equal`, NUnit uses `Is.EqualTo` — classify all correctly |
+| Flagging null/None/nil checks before value checks as trivial | Only flag tests where the null/None/nil check is the ONLY assertion |
+| Counting any Boolean assertion as trivial | Only always-true assertions (`Assert.IsTrue(true)`, `assert True`, `expect(true).toBe(true)`) are trivial |
+| Ignoring framework differences | Each framework has distinct assertion APIs — always read the matching language extension first. MSTest's `Assert.AreEqual`, xUnit's `Assert.Equal`, NUnit's `Is.EqualTo`, pytest's bare `assert ==`, Jest's `expect().toBe()`, Go's `if … { t.Error… }` all map to the **Equality** category |
+| Treating bare assertion forms as missing-framework | Bare `assert` (pytest), `if got != want { t.Error... }` (Go), and `assert!()` (Rust) are canonical — count them in the right category |
+| Treating mock-call verifications as assertion-free | `verify(mock).method(...)`, `expect(mock).toHaveBeenCalledWith(...)`, `Should -Invoke` are State/Side-effect assertions |
 | Recommending diversity for diversity's sake | Only suggest adding assertion types that would catch real bugs in the code under test |
-| Missing implicit assertions | `Assert.ThrowsException` is both an exception assertion and a negative assertion (verifying that calling the method has a specific failure mode) |
+| Missing implicit assertions | Exception assertions are both Exception and Negative; snapshot/property-based tests are real assertions with implicit structure |
+| Async tests with unawaited assertions | TUnit, Jest with `.resolves`/`.rejects`, pytest-asyncio, Swift Testing, and Kotest all silently pass tests where assertions are not `await`ed — treat as assertion-free even when assertion calls are present |

--- a/plugins/dotnet-test/skills/test-analysis-extensions/SKILL.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: test-analysis-extensions
+description: >-
+  Provides file paths to language-specific reference files for the test
+  ANALYSIS skills (assertion-quality, test-anti-patterns, test-gap-analysis,
+  test-smell-detection, test-tagging). Call this skill to discover available
+  extension files (e.g., dotnet.md for .NET/MSTest/xUnit/NUnit/TUnit,
+  python.md for pytest/unittest, typescript.md for Jest/Vitest/Mocha,
+  java.md for JUnit/TestNG, etc.). Do not use directly — invoked by the
+  test-quality-auditor agent and polyglot analysis skills that need
+  framework-specific lookup tables (test markers, assertion APIs, skip
+  annotations, sleep patterns, mystery guest indicators, integration
+  markers, setup/teardown, tag-support capability).
+user-invocable: false
+license: MIT
+---
+
+# Test Analysis Extensions
+
+This skill provides access to per-language reference files used by the polyglot test analysis skills. Call this skill to get the list of available extension files, then read the one matching the target codebase's language and test framework.
+
+## Available Extension Files
+
+| File | Languages / Frameworks | Contents |
+|------|------------------------|----------|
+| [extensions/dotnet.md](extensions/dotnet.md) | .NET (C#/F#/VB) — MSTest, xUnit, NUnit, TUnit | Test markers, assertion APIs, sleep/delay patterns, skip annotations, mystery guest, integration markers, setup/teardown, tag support |
+| [extensions/python.md](extensions/python.md) | Python — pytest, unittest | Same categories, with pytest fixtures/markers and unittest TestCase |
+| [extensions/typescript.md](extensions/typescript.md) | TypeScript / JavaScript — Jest, Vitest, Mocha, Jasmine, node:test | Same categories, with async/await pitfalls |
+| [extensions/java.md](extensions/java.md) | Java — JUnit 4, JUnit 5 (Jupiter), TestNG | Same categories, with `@Tag` / `@Category` / groups |
+| [extensions/go.md](extensions/go.md) | Go — `testing` package, testify | Same categories, with table-driven idiom and build tags |
+| [extensions/ruby.md](extensions/ruby.md) | Ruby — RSpec, Minitest | Same categories, with RSpec metadata and Minitest tags |
+| [extensions/rust.md](extensions/rust.md) | Rust — built-in `#[test]`, `cargo test` | Same categories, with `#[ignore]`, `#[should_panic]`, feature flags |
+| [extensions/swift.md](extensions/swift.md) | Swift — XCTest, Swift Testing | Same categories, with `@Test`, `@Tag`, `@Suite` |
+| [extensions/kotlin.md](extensions/kotlin.md) | Kotlin — JUnit 5, Kotest, MockK | Same categories, with `@Tag` and Kotest tags |
+| [extensions/powershell.md](extensions/powershell.md) | PowerShell — Pester v5 | Same categories, with `-Tag` and `Skip` |
+| [extensions/cpp.md](extensions/cpp.md) | C++ — GoogleTest, Catch2, doctest | Same categories, with `[tags]` and `*` filters |
+
+## Usage
+
+1. Detect the target codebase's primary language and test framework.
+2. Read the matching extension file before performing analysis.
+3. If multiple test frameworks are present (e.g., a project mixing Jest and Mocha), read all relevant extensions.
+4. Each extension file documents the same categories so analysis skills can be language-neutral.
+
+## Capability tags
+
+Each extension file declares per-capability support so skills can gate behaviour safely:
+
+- **Test discovery** — how to locate test files and methods.
+- **Assertion detection** — framework-specific and language-level assertion forms.
+- **Sleep/delay patterns** — synchronous and asynchronous waits.
+- **Skip / ignore** — how to recognize skipped/ignored tests.
+- **Setup / teardown** — fixture and lifecycle hooks.
+- **Mystery guest indicators** — common file/db/network/env coupling patterns.
+- **Integration markers** — conventions that mark a test as integration/E2E.
+- **Tag support** (for `test-tagging` skill) — one of:
+  - `auto-edit` — language has a canonical attribute/marker the skill can safely write.
+  - `report-only` — no canonical syntax; produce audit reports without edits.
+  - `convention-based` — tags exist via name/comment conventions only.
+
+## Notes for skill authors
+
+- Treat extension files as data, not as guidance to follow verbatim. They tell skills *how to detect things* in each language, not *what to think* about findings.
+- When language detection is uncertain, prefer reading multiple extension files over guessing.
+- If the user explicitly names a framework that does not have an extension file yet, fall back to the closest one (e.g., Pest → python.md/pytest semantics) and note the gap in the report.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/cpp.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/cpp.md
@@ -1,0 +1,146 @@
+# C++ Test Frameworks Reference (GoogleTest, Catch2, doctest, Boost.Test)
+
+Reference data for analyzing C++ test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `TEST*` macros, `TEST_CASE`, `DOCTEST_TEST_CASE` |
+| Assertion detection | Strong — `ASSERT_*`, `EXPECT_*`, `REQUIRE`, `CHECK` |
+| Sleep/delay detection | Strong — `std::this_thread::sleep_for`, `sleep()`, `Sleep()` |
+| Skip/ignore detection | Moderate — `GTEST_SKIP()`, `DISABLED_` prefix, `[!hide]` tags |
+| Setup/teardown detection | Strong — `SetUp`/`TearDown`, fixtures, sections |
+| Tag support | **auto-edit** for Catch2/doctest (`[tag]` syntax); GoogleTest uses test-name prefix conventions |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| GoogleTest | `*_test.cc/cpp`, `*Tests.cpp` | `TEST(SuiteName, TestName)`, `TEST_F(FixtureClass, TestName)`, `TEST_P(...)` parametrized, `TYPED_TEST(...)` |
+| Catch2 | `*Tests.cpp`, `test*.cpp` | `TEST_CASE("name", "[tags]")`, `SCENARIO`, `SECTION` |
+| doctest | `*Tests.cpp` | `TEST_CASE("name" * doctest::test_suite("suite"))` |
+| Boost.Test | `*_test.cpp` | `BOOST_AUTO_TEST_CASE(name)`, `BOOST_FIXTURE_TEST_CASE(name, Fixture)` |
+
+## Assertion APIs
+
+| Category | GoogleTest | Catch2 | doctest | Boost.Test |
+|----------|------------|--------|---------|------------|
+| Equality (continue) | `EXPECT_EQ(actual, expected)` | `CHECK(actual == expected)` | `CHECK(actual == expected)` | `BOOST_CHECK_EQUAL(actual, expected)` |
+| Equality (abort) | `ASSERT_EQ(actual, expected)` | `REQUIRE(actual == expected)` | `REQUIRE(actual == expected)` | `BOOST_REQUIRE_EQUAL(actual, expected)` |
+| Boolean | `EXPECT_TRUE(x)` / `EXPECT_FALSE(x)` | `CHECK(x)` / `CHECK_FALSE(x)` | `CHECK(x)` | `BOOST_CHECK(x)` |
+| Null/Pointer | `EXPECT_EQ(ptr, nullptr)` | `CHECK(ptr == nullptr)` | `CHECK(ptr == nullptr)` | `BOOST_CHECK(ptr == nullptr)` |
+| Throws | `EXPECT_THROW(stmt, ExType)` / `EXPECT_THROW(stmt, std::exception)` | `CHECK_THROWS_AS(expr, ExType)` / `CHECK_THROWS_WITH(expr, "...")` / `CHECK_THROWS_MATCHES(...)` | `CHECK_THROWS_AS(expr, ExType)` | `BOOST_CHECK_THROW(expr, ExType)` |
+| No throw | `EXPECT_NO_THROW(stmt)` | `CHECK_NOTHROW(expr)` | `CHECK_NOTHROW(expr)` | `BOOST_CHECK_NO_THROW(expr)` |
+| Approximate | `EXPECT_NEAR(a, b, abs_err)` / `EXPECT_DOUBLE_EQ(a, b)` | `CHECK(actual == Approx(expected))` | `CHECK(actual == doctest::Approx(expected))` | `BOOST_CHECK_CLOSE(a, b, tol_pct)` |
+| String | `EXPECT_STREQ(c_str_a, c_str_b)` / `EXPECT_THAT(s, HasSubstr("x"))` | `CHECK(s.find("x") != std::string::npos)` | similar | `BOOST_CHECK_EQUAL(s, expected)` |
+| Death tests | `EXPECT_DEATH(stmt, "regex")` / `EXPECT_EXIT(...)` | n/a | n/a | n/a |
+| Custom matchers | `EXPECT_THAT(value, gmock_matchers::Eq(x))` | `REQUIRE_THAT(value, Catch::Matchers::Equals(x))` | similar | n/a |
+
+**EXPECT vs ASSERT/REQUIRE vs CHECK:**
+- GoogleTest: `EXPECT_*` continues on failure; `ASSERT_*` aborts the test.
+- Catch2 / doctest: `CHECK*` continues; `REQUIRE*` aborts.
+- Boost.Test: `BOOST_CHECK*` continues; `BOOST_REQUIRE*` aborts.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| C++11 thread sleep | `std::this_thread::sleep_for(std::chrono::seconds(1))` |
+| POSIX sleep | `sleep(1);` / `usleep(500000);` |
+| Windows sleep | `Sleep(1000);` |
+| Loop wait | `while (!ready) std::this_thread::sleep_for(...)` |
+| Async wait (acceptable) | `future.wait_for(std::chrono::seconds(5))` |
+
+## Skip/Ignore Annotations
+
+| Framework | Mechanism |
+|-----------|-----------|
+| GoogleTest | `GTEST_SKIP() << "reason";` inside test body; test name prefix `DISABLED_` (e.g., `TEST(F, DISABLED_X)`) |
+| Catch2 | `[!hide]` or `[.]` tag in `TEST_CASE("name", "[.]")`; `SUCCEED("skipped")` |
+| doctest | `* doctest::skip()` decorator: `TEST_CASE("name" * doctest::skip(true))` |
+| Boost.Test | `boost::unit_test::disabled()` decorator, or `BOOST_AUTO_TEST_CASE(name, *boost::unit_test::disabled())` |
+
+`DISABLED_` prefix without a tracking comment is a smell — flag as Ignored Test.
+
+## Exception Handling — Idiomatic Alternatives
+
+```cpp
+// GoogleTest:
+EXPECT_THROW({
+    service.placeOrder(empty);
+}, InvalidOrderException);
+
+// Or capture and inspect:
+try {
+    service.placeOrder(empty);
+    FAIL() << "Expected InvalidOrderException";
+} catch (const InvalidOrderException& e) {
+    EXPECT_STREQ("at least one item", e.what());
+}
+
+// Catch2:
+REQUIRE_THROWS_AS(service.placeOrder(empty), InvalidOrderException);
+REQUIRE_THROWS_WITH(service.placeOrder(empty), Catch::Contains("at least one item"));
+```
+
+The manual try/catch/FAIL pattern is acceptable when message inspection is needed; flag bare `try { ... } catch (...) {}` (swallowed).
+
+## Mystery Guest — Common C++ Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `std::ifstream`, `std::ofstream`, `fopen`, hard-coded paths |
+| Network | raw `socket()` / `connect()`, `curl_easy_perform` to real URL |
+| Environment | `std::getenv("X")`, Windows registry calls |
+| Database | direct `sqlite3_open(path)`, ODBC connections |
+| Acceptable | `std::stringstream`, `std::tmpfile`, GoogleMock for collaborators, `boost::iostreams`, in-memory streams |
+
+## Integration Test Markers
+
+- File suffix: `*_integration_test.cc`, `*_e2e_test.cpp`
+- GoogleTest suite names containing `Integration` / `EndToEnd`
+- Catch2 tags: `[integration]`, `[e2e]`, `[slow]`
+- CMake target names ending in `_integration_tests`
+- Conditional compilation: `#ifdef BUILD_INTEGRATION_TESTS`
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-suite |
+|-----------|----------|-----------|
+| GoogleTest fixture | `void SetUp() override` | `static void SetUpTestSuite()` |
+| GoogleTest fixture | `void TearDown() override` | `static void TearDownTestSuite()` |
+| Catch2 | `TEST_CASE` body + `SECTION` re-runs setup per section | fixture class via `TEST_CASE_METHOD(Fixture, "name")` |
+| doctest | similar to Catch2 | `doctest::TestCase` fixture |
+| Boost.Test | `BOOST_FIXTURE_TEST_CASE(name, Fixture)` | `BOOST_GLOBAL_FIXTURE(Fixture)` |
+
+Catch2 `SECTION`s are re-entered for each combination, so the `TEST_CASE` body acts as fresh per-section setup — a powerful idiom.
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| Catch2 | `[tag]` syntax in `TEST_CASE` second arg | `TEST_CASE("creates order", "[positive][critical-path]")` |
+| doctest | `* doctest::test_suite("tag")` decorator chain | `TEST_CASE("name" * doctest::test_suite("positive"))` |
+| GoogleTest | test name prefix convention (e.g., `Positive_*`, `Boundary_*`) or `--gtest_filter` patterns | suite naming or `TEST(PositiveCases, ...)`; **report-only** for auto-edit |
+| Boost.Test | label decorator: `* boost::unit_test::label("positive")` | `BOOST_AUTO_TEST_CASE(name, *boost::unit_test::label("positive"))` |
+
+Filter syntax:
+- Catch2: `./tests "[positive]" ~"[slow]"`
+- doctest: `./tests -ts="positive"`
+- GoogleTest: `./tests --gtest_filter='Positive*'`
+- Boost.Test: `./tests --run_test=@positive`
+
+## Language-specific calibration notes
+
+- **`EXPECT_*` continues on failure** in GoogleTest — many `EXPECT_EQ` calls in one test may produce cascading messages from one root cause.
+- **`REQUIRE_*` / `ASSERT_*` aborts** — use for preconditions in long tests.
+- **Death tests** (`EXPECT_DEATH`) fork the process and check stderr — slow; acknowledge as integration-style.
+- **`DISABLED_` prefix** disables tests silently — `--gtest_also_run_disabled_tests` is required to opt back in. Flag committed `DISABLED_` tests as Ignored Test.
+- **Catch2 `SECTION`s** are NOT duplicate tests — each section is a permutation of the parent `TEST_CASE`.
+- **GoogleMock `EXPECT_CALL(mock, Method(...))`** counts as a state/side-effect assertion.
+- **Template / typed tests** (`TYPED_TEST`, `TEMPLATE_TEST_CASE`) are parametrized, not duplicates.
+- **Hidden tests** (Catch2 `[.]` or `[!hide]`) are excluded by default but runnable on demand — note in audit.
+- **Sanitizer-only tests** (`#ifdef __SANITIZE_THREAD__`, etc.) are conditional smoke checks — note but don't flag.
+- **Test binaries that don't link `gtest_main`** require a custom `main()` — verify it calls `RUN_ALL_TESTS()`.
+- **`SUCCEED()` / `INFO(...)`** are not assertions; tests with only `SUCCEED()` are assertion-free.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/cpp.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/cpp.md
@@ -11,7 +11,7 @@ Reference data for analyzing C++ test code. Used by the polyglot test analysis s
 | Sleep/delay detection | Strong — `std::this_thread::sleep_for`, `sleep()`, `Sleep()` |
 | Skip/ignore detection | Moderate — `GTEST_SKIP()`, `DISABLED_` prefix, `[!hide]` tags |
 | Setup/teardown detection | Strong — `SetUp`/`TearDown`, fixtures, sections |
-| Tag support | **auto-edit** for Catch2/doctest (`[tag]` syntax); GoogleTest uses test-name prefix conventions |
+| Tag support | **auto-edit** — Catch2 uses `[tag]` syntax inside `TEST_CASE`; doctest uses `* doctest::test_suite("tag")` decorator chains; GoogleTest uses test-name prefix conventions (treat as `convention-based`) |
 
 ## Test File Identification
 

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/dotnet.md
@@ -1,0 +1,131 @@
+# .NET Test Frameworks Reference (MSTest, xUnit, NUnit, TUnit)
+
+Reference data for analyzing .NET test code. Used by the polyglot test analysis skills (`assertion-quality`, `test-anti-patterns`, `test-gap-analysis`, `test-smell-detection`, `test-tagging`).
+
+> See also: the standalone `dotnet-test-frameworks` skill, which carries the same data and is loaded by .NET-only skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — markers and conventions are well-defined |
+| Assertion detection | Strong — framework-specific APIs plus FluentAssertions/Shouldly/Verify |
+| Sleep/delay detection | Strong |
+| Skip/ignore detection | Strong |
+| Setup/teardown detection | Strong |
+| Tag support | **auto-edit** — `[TestCategory]`, `[Trait]`, `[Category]`, `[Property]` |
+
+## Test File Identification
+
+| Framework | Test class markers | Test method markers |
+|-----------|-------------------|---------------------|
+| MSTest | `[TestClass]` | `[TestMethod]`, `[DataTestMethod]` |
+| xUnit | *(none — convention-based)* | `[Fact]`, `[Theory]` |
+| NUnit | `[TestFixture]` | `[Test]`, `[TestCase]`, `[TestCaseSource]` |
+| TUnit | *(none — convention-based)* | `[Test]` |
+
+## Assertion APIs by Framework
+
+| Category | MSTest | xUnit | NUnit | TUnit |
+|----------|--------|-------|-------|-------|
+| Equality | `Assert.AreEqual` | `Assert.Equal` | `Assert.That(x, Is.EqualTo(y))` | `await Assert.That(x).IsEqualTo(y)` |
+| Boolean | `Assert.IsTrue` / `Assert.IsFalse` | `Assert.True` / `Assert.False` | `Assert.That(x, Is.True)` | `await Assert.That(x).IsTrue()` |
+| Null | `Assert.IsNull` / `Assert.IsNotNull` | `Assert.Null` / `Assert.NotNull` | `Assert.That(x, Is.Null)` | `await Assert.That(x).IsNull()` |
+| Exception | `Assert.Throws<T>()` / `Assert.ThrowsExactly<T>()` | `Assert.Throws<T>()` | `Assert.That(() => ..., Throws.TypeOf<T>())` | `await Assert.That(() => ...).Throws<T>()` |
+| Collection | `CollectionAssert.Contains` | `Assert.Contains` | `Assert.That(col, Has.Member(x))` | `await Assert.That(col).Contains(x)` |
+| String | `StringAssert.Contains` | `Assert.Contains(str, sub)` | `Assert.That(str, Does.Contain(sub))` | `await Assert.That(str).Contains(sub)` |
+| Type | `Assert.IsInstanceOfType` | `Assert.IsAssignableFrom` | `Assert.That(x, Is.InstanceOf<T>())` | `await Assert.That(x).IsAssignableTo<T>()` |
+| Inconclusive | `Assert.Inconclusive()` | `[Fact(Skip)]` | `Assert.Inconclusive()` | `Skip.Test("reason")` |
+| Fail | `Assert.Fail()` | `Assert.Fail()` (.NET 10+) | `Assert.Fail()` | `Assert.Fail()` |
+
+**TUnit-specific:** assertions are async and must be awaited — a forgotten `await` causes the assertion to never run and the test to pass silently. Multiple assertions chainable via `.And` / `.Or` or grouped via `Assert.Multiple()`.
+
+Third-party assertion libraries: `Should*` (Shouldly), `.Should()` (FluentAssertions / AwesomeAssertions), `Verify()` (Verify). TUnit also ships `TUnit.Assertions.Should`.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Thread sleep | `Thread.Sleep(2000)` |
+| Task delay | `await Task.Delay(1000)` |
+| SpinWait | `SpinWait.SpinUntil(() => condition, timeout)` |
+
+## Skip/Ignore Annotations
+
+| Framework | Annotation | With reason |
+|-----------|------------|-------------|
+| MSTest | `[Ignore]` | `[Ignore("reason")]` |
+| xUnit | `[Fact(Skip = "reason")]` | *(reason required)* |
+| NUnit | `[Ignore("reason")]` | *(reason required)* |
+| TUnit | `[Skip("reason")]` | *(reason required; valid at class/assembly scope; dynamic via `Skip.Test("reason")`)* |
+| Conditional | `#if false` / `#if NEVER` | *(no reason)* |
+
+## Exception Handling — Idiomatic Alternatives
+
+When a test uses `try`/`catch` to verify exceptions, prefer the framework-native form:
+
+```csharp
+// MSTest (exact type):
+var ex = Assert.ThrowsExactly<InvalidOperationException>(() => sut.Do());
+Assert.AreEqual("expected message", ex.Message);
+
+// xUnit:
+var ex = Assert.Throws<InvalidOperationException>(() => sut.Do());
+
+// NUnit:
+var ex = Assert.Throws<InvalidOperationException>(() => sut.Do());
+
+// TUnit:
+await Assert.That(() => sut.Do()).Throws<InvalidOperationException>();
+```
+
+## Mystery Guest — Common .NET Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `File.ReadAllText`, `File.Exists`, `Directory.GetFiles`, `Path.Combine` with hard-coded paths |
+| Database | `SqlConnection`, `DbContext` (without in-memory provider), `SqlCommand` |
+| Network | `HttpClient` without `HttpMessageHandler` override, `WebRequest`, `TcpClient` |
+| Environment | `Environment.GetEnvironmentVariable`, `Environment.CurrentDirectory` |
+| Acceptable | `MemoryStream`, `StringReader`, in-memory database providers, custom `DelegatingHandler` |
+
+## Integration Test Markers
+
+Recognize these as integration tests (adjust smell severity accordingly):
+
+- Class name contains `Integration`, `E2E`, `EndToEnd`, or `Acceptance`
+- `[TestCategory("Integration")]` (MSTest)
+- `[Trait("Category", "Integration")]` (xUnit)
+- `[Category("Integration")]` (NUnit, TUnit)
+- Project name ending in `.IntegrationTests` or `.E2ETests`
+
+## Setup/Teardown Methods
+
+| Framework | Setup | Teardown |
+|-----------|-------|----------|
+| MSTest | `[TestInitialize]` or constructor | `[TestCleanup]` or `IDisposable.Dispose` |
+| xUnit | constructor | `IDisposable.Dispose` / `IAsyncDisposable.DisposeAsync` |
+| NUnit | `[SetUp]` | `[TearDown]` |
+| TUnit | `[Before(Test)]` or constructor | `[After(Test)]` or `IDisposable.Dispose` |
+| MSTest (class) | `[ClassInitialize]` | `[ClassCleanup]` |
+| NUnit (class) | `[OneTimeSetUp]` | `[OneTimeTearDown]` |
+| xUnit (class) | `IClassFixture<T>` | fixture's `Dispose` |
+| TUnit (class) | `[Before(Class)]` | `[After(Class)]` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Existing Attribute | Example |
+|-----------|--------------------|---------|
+| MSTest | `[TestCategory("...")]` | `[TestCategory("positive")]` |
+| xUnit | `[Trait("Category", "...")]` | `[Trait("Category", "positive")]` |
+| NUnit | `[Category("...")]` | `[Category("positive")]` |
+| TUnit | `[Category("...")]` or `[Property("Category", "...")]` | `[Category("positive")]` |
+
+Place trait attributes on the line directly above or below the existing test attribute. Multiple traits on the same test are allowed.
+
+## Language-specific calibration notes
+
+- **Sealed test classes (MSTest 4)** that lock down class layout are intentional, not a smell.
+- **xUnit per-test instances** mean fields initialized in the constructor are reset between tests — General Fixture (over-broad setup) detection should still flag fields used by < 50% of tests.
+- **TUnit's `await` requirement** is itself a fertile source of assertion-free smells; flag any TUnit assertion line that lacks `await` as a critical anti-pattern.
+- **Data-driven tests** (`[DataRow]`, `[Theory]/[InlineData]`, `[TestCase]`, `[Arguments]`) are *not* duplicate tests; treat them as the consolidated form.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/go.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/go.md
@@ -1,0 +1,145 @@
+# Go Test Framework Reference (`testing` package, testify)
+
+Reference data for analyzing Go test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `*_test.go`, `func TestXxx(t *testing.T)` |
+| Assertion detection | Moderate — bare `if … { t.Errorf(...) }` patterns; stronger with testify |
+| Sleep/delay detection | Strong — `time.Sleep`, `<-time.After` |
+| Skip/ignore detection | Strong — `t.Skip`, `t.SkipNow`, build tags |
+| Setup/teardown detection | Strong — `TestMain`, `t.Cleanup`, subtests |
+| Tag support | **report-only** by default — no canonical attribute; build tags can scope tests but are coarse |
+
+## Test File Identification
+
+| Convention | Description |
+|------------|-------------|
+| `*_test.go` | Test files (must end with `_test.go`) |
+| `func TestXxx(t *testing.T)` | Standard tests |
+| `func BenchmarkXxx(b *testing.B)` | Benchmarks |
+| `func ExampleXxx()` | Documentation examples (act as tests when they have `// Output:` blocks) |
+| `func FuzzXxx(f *testing.F)` | Fuzz tests (Go 1.18+) |
+| `t.Run("subtest", func(t *testing.T) {...})` | Subtests / table-driven cases |
+
+Test packages may be `foo` (white-box) or `foo_test` (black-box). The latter only sees exported names.
+
+## Assertion APIs
+
+Go's `testing` package has no built-in assertion library. Tests fail by calling `t.Error*` / `t.Fatal*`.
+
+| Category | Standard `testing` | testify (`require` / `assert`) |
+|----------|-------------------|--------------------------------|
+| Equality | `if got != want { t.Errorf("got %v, want %v", got, want) }` | `assert.Equal(t, want, got)` |
+| Boolean | `if !ok { t.Error("expected ok") }` | `assert.True(t, ok)` |
+| Nil | `if v != nil { t.Error(...) }` | `assert.Nil(t, v)` / `assert.NotNil(t, v)` |
+| Error | `if err != nil { t.Fatal(err) }` | `require.NoError(t, err)` / `assert.Error(t, err)` / `assert.ErrorIs(t, err, target)` |
+| Panic | `defer func() { if r := recover(); r == nil { t.Error("expected panic") } }()` | `assert.Panics(t, func() {...})` |
+| Type | `if _, ok := v.(T); !ok { t.Error(...) }` | `assert.IsType(t, T{}, v)` |
+| Membership | manual loop or `slices.Contains` | `assert.Contains(t, slice, item)` |
+| String | `if !strings.Contains(...) { t.Error(...) }` | `assert.Contains(t, s, sub)` |
+| Fail | `t.Fail()` / `t.FailNow()` / `t.Fatal(...)` / `t.Fatalf(...)` | `t.FailNow()` / `require.Fail(t, "...")` |
+
+**`require` vs `assert` (testify):** `require.*` calls `t.FailNow()` and stops the test; `assert.*` records the failure and continues. Tests that need preconditions before further work should use `require.NoError(t, err)`.
+
+**Bare `if ... { t.Error... }` is the canonical Go assertion form.** Do NOT flag these as missing-framework-API smells.
+
+Other libraries: `gotest.tools/v3` (`assert.Check`, `assert.Equal`), `go-cmp` (`cmp.Diff`).
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Hard sleep | `time.Sleep(time.Second)` |
+| Timer wait | `<-time.After(time.Second)` |
+| Loop wait | `for !ready() { time.Sleep(10*time.Millisecond) }` |
+| Acceptable wait | `<-ctx.Done()` or `<-done` channels driven by the SUT |
+| Deadline | `ctx, cancel := context.WithTimeout(...)` |
+
+## Skip/Ignore Annotations
+
+| Mechanism | Example |
+|-----------|---------|
+| `t.Skip("reason")` | Inline skip at any point in the test body |
+| `t.SkipNow()` | Skip without a message |
+| Build tag at top of file | `//go:build integration` (excludes file unless `-tags=integration`) |
+| `testing.Short()` guard | `if testing.Short() { t.Skip("skipping in short mode") }` |
+| `t.Skipf` | Formatted skip messages |
+
+There is no `@Disabled`-style permanent disable. Build tags and skip guards are the idiomatic way to gate tests.
+
+## Exception Handling — Idiomatic Alternatives
+
+Go uses error returns and panics; there is no `try/catch`. Testing patterns:
+
+```go
+// Error return:
+if _, err := svc.PlaceOrder(empty); err == nil {
+    t.Error("expected error, got nil")
+}
+// Better with testify:
+_, err := svc.PlaceOrder(empty)
+require.Error(t, err)
+assert.Contains(t, err.Error(), "at least one item")
+
+// Error-target match (Go 1.13+):
+assert.ErrorIs(t, err, ErrEmptyOrder)
+assert.ErrorAs(t, err, &validationErr)
+
+// Panic:
+assert.PanicsWithValue(t, "bad input", func() { mustParse("xxx") })
+```
+
+Flag tests that ignore returned errors (`_, _ = svc.Foo()`) without subsequent assertion.
+
+## Mystery Guest — Common Go Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `os.ReadFile`, `os.Open`, hard-coded absolute paths |
+| Database | `sql.Open` against a real DB connection string, raw `pgx.Connect` |
+| Network | `http.Get`, `http.Post` to real URLs, raw `net.Dial` |
+| Environment | `os.Getenv("X")` (especially in test body without `t.Setenv`) |
+| Acceptable | `t.TempDir()`, `t.Setenv()`, `httptest.NewServer`, `sqlmock`, `dockertest` / `testcontainers-go` (integration-acknowledged), in-memory `bytes.Buffer` |
+
+## Integration Test Markers
+
+- Build tag at file top: `//go:build integration` / `//go:build e2e` (run via `go test -tags=integration`)
+- File name suffix: `*_integration_test.go`, `*_e2e_test.go`
+- Package directory: `tests/integration/`, `internal/integrationtests/`
+- `testing.Short()` guard pattern: `if testing.Short() { t.Skip("integration test") }`
+
+## Setup/Teardown
+
+| Mechanism | Description |
+|-----------|-------------|
+| `TestMain(m *testing.M)` | Package-level setup/teardown — runs `m.Run()` between setup and teardown |
+| `t.Cleanup(fn)` | Per-test cleanup that runs after the test (even on failure) |
+| Helper functions | `func setupFoo(t *testing.T) (*Foo, func())` returning a teardown closure |
+| Subtests with shared setup | `func TestX(t *testing.T) { foo := setup(t); t.Run("a", ...); t.Run("b", ...) }` |
+| testify suites | `type FooSuite struct{ suite.Suite }` with `SetupTest`, `TearDownTest`, `SetupSuite`, `TearDownSuite` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+**Default mode: report-only.** Go has no per-test tag attribute. Strategies:
+
+- **Build tags** scope an entire file (coarse): `//go:build integration`
+- **Subtest names** can encode tags: `t.Run("[positive] valid input returns ok", ...)`
+- **Test name prefixes**: `func TestNegative_InvalidInput_Returns400`
+- **testify suites** with grouping methods
+
+When the project already follows one of these conventions, switch to `auto-edit` mode and apply it consistently.
+
+## Language-specific calibration notes
+
+- **Table-driven tests** with `for _, tc := range tests { t.Run(tc.name, func(t *testing.T) { ... }) }` are idiomatic — **do NOT flag the `for` loop as Conditional Test Logic.**
+- **Bare `if … t.Errorf` patterns** are the canonical assertion form. Do NOT flag as "no framework API used."
+- **Goroutine leaks in tests** are a real smell — recommend `goleak.VerifyNone(t)` or `t.Cleanup`.
+- **`t.Parallel()`** in tests: races on shared fixture data are a smell; tests calling `t.Setenv` then `t.Parallel` will fail in newer Go versions.
+- **`require` vs `assert` mixing**: subsequent code after a failed `assert.*` may panic on `nil`. Prefer `require.*` for preconditions.
+- **Examples with `// Output:`** are tests; treat the `// Output:` block as the assertion.
+- **Fuzz tests** without `f.Add(...)` seed inputs may only run with `-fuzz`; flag as a coverage gap.
+- **Generated mocks** (mockery, mockgen) — verify call expectations count as assertions.
+- **Missing `t.Helper()`** in helper functions is not a smell per se but degrades failure location reporting.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/java.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/java.md
@@ -1,0 +1,137 @@
+# Java Test Frameworks Reference (JUnit 4, JUnit 5 / Jupiter, TestNG)
+
+Reference data for analyzing Java test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — annotations + Maven Surefire / Gradle conventions |
+| Assertion detection | Strong — `Assertions.*`, `assertThat` (AssertJ/Hamcrest) |
+| Sleep/delay detection | Strong — `Thread.sleep`, `Awaitility`, `TimeUnit.sleep` |
+| Skip/ignore detection | Strong — `@Disabled`, `@Ignore`, `Assume.*` |
+| Setup/teardown detection | Strong — `@BeforeEach`, `@BeforeAll`, etc. |
+| Tag support | **auto-edit** — JUnit 5 `@Tag`, JUnit 4 `@Category`, TestNG `groups` |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| JUnit 4 | `*Test.java`, `*Tests.java`, `*IT.java` (integration) | `@Test`, classes typically `public` |
+| JUnit 5 (Jupiter) | same conventions | `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`, `@TestTemplate` |
+| TestNG | `*Test.java` | `@Test` (org.testng.annotations.Test) |
+
+## Assertion APIs
+
+| Category | JUnit 4 (`Assert`) | JUnit 5 (`Assertions`) | TestNG (`Assert`) | AssertJ (`assertThat`) |
+|----------|--------------------|------------------------|-------------------|------------------------|
+| Equality | `assertEquals(expected, actual)` | `assertEquals(expected, actual)` | `assertEquals(actual, expected)` (note arg order!) | `assertThat(actual).isEqualTo(expected)` |
+| Boolean | `assertTrue(b)` / `assertFalse(b)` | `assertTrue(b)` / `assertFalse(b)` | `assertTrue(b)` | `assertThat(b).isTrue()` |
+| Null | `assertNull(x)` / `assertNotNull(x)` | `assertNull(x)` | `assertNull(x)` | `assertThat(x).isNull()` |
+| Exception | `@Test(expected = X.class)` / `try…catch` | `assertThrows(X.class, () -> {…})` | `assertThrows(X.class, () -> {…})` / `expectedExceptions = X.class` | `assertThatThrownBy(() -> {…}).isInstanceOf(X.class)` |
+| Type | `assertTrue(x instanceof T)` | `assertInstanceOf(T.class, x)` | `assertTrue(x instanceof T)` | `assertThat(x).isInstanceOf(T.class)` |
+| String | `assertEquals` then `contains` | `assertTrue(s.contains(sub))` | `assertEquals(s, expected)` | `assertThat(s).contains(sub).startsWith(...)` |
+| Collection | `assertEquals(list, expected)` | `assertIterableEquals(...)` | `assertEqualsNoOrder(actual, expected)` | `assertThat(col).containsExactly(...).hasSize(n)` |
+| Fail | `fail("reason")` | `fail("reason")` | `fail("reason")` | `Assertions.fail("reason")` |
+
+**TestNG quirk:** `Assert.assertEquals(actual, expected)` reverses the argument order vs JUnit. Misordered arguments are a common smell.
+
+Third-party libraries: AssertJ (`assertThat`), Hamcrest (`assertThat(x, is(y))`), Truth (Google), Mockito (`verify(mock).method(...)`).
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Thread sleep | `Thread.sleep(2000)` |
+| TimeUnit sleep | `TimeUnit.SECONDS.sleep(2)` |
+| Awaitility (acceptable) | `await().atMost(5, SECONDS).until(() -> condition)` — replaces sleep with polling |
+| CompletableFuture timeouts | `future.get(5, TimeUnit.SECONDS)` |
+
+Flag raw `Thread.sleep` in tests as Sleepy Test. Awaitility-based waits are acceptable.
+
+## Skip/Ignore Annotations
+
+| Framework | Annotation |
+|-----------|------------|
+| JUnit 4 | `@Ignore`, `@Ignore("reason")` |
+| JUnit 5 | `@Disabled`, `@Disabled("reason")`, `@DisabledOnOs`, `@EnabledIfSystemProperty`, `@EnabledIf(...)` |
+| JUnit 4/5 (dynamic) | `Assume.assumeTrue(cond)`, `Assumptions.assumeTrue(cond)` |
+| TestNG | `enabled = false` on `@Test`, `@Test(enabled = false)`, `throw new SkipException("reason")` |
+
+## Exception Handling — Idiomatic Alternatives
+
+```java
+// JUnit 5 (preferred):
+InvalidOrderException ex = assertThrows(
+    InvalidOrderException.class,
+    () -> service.placeOrder(emptyOrder));
+assertEquals("Order must contain at least one item", ex.getMessage());
+
+// AssertJ:
+assertThatThrownBy(() -> service.placeOrder(emptyOrder))
+    .isInstanceOf(InvalidOrderException.class)
+    .hasMessageContaining("at least one item");
+
+// TestNG:
+@Test(expectedExceptions = InvalidOrderException.class,
+      expectedExceptionsMessageRegExp = ".*at least one item.*")
+public void placeOrder_empty_throws() { service.placeOrder(emptyOrder); }
+```
+
+Flag legacy JUnit 4 `@Test(expected=...)` and bare `try/catch/fail` patterns as smells.
+
+## Mystery Guest — Common Java Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `Files.readString`, `new File(...)`, hard-coded paths |
+| Database | `DriverManager.getConnection`, real Spring `@SpringBootTest(webEnvironment = RANDOM_PORT)` without `@MockBean`, `JdbcTemplate` against real DB |
+| Network | `HttpClient.send`, `RestTemplate.getForObject`, raw `Socket` |
+| Environment | `System.getenv`, `System.getProperty` (without test default) |
+| Acceptable | `@TempDir`, `MockWebServer` (OkHttp), `WireMock`, Testcontainers (acknowledged-integration), H2 in-memory, `@MockBean`, `MockMvc` |
+
+## Integration Test Markers
+
+- File suffix: `*IT.java` (Failsafe convention), `*IntegrationTest.java`, `*E2ETest.java`
+- Annotations: `@SpringBootTest`, `@DataJpaTest`, `@Tag("integration")`, `@Category(IntegrationTests.class)` (JUnit 4)
+- TestNG: `@Test(groups = {"integration"})`
+- Use of Testcontainers, embedded Kafka/Mongo, or `@Sql` scripts
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-class |
+|-----------|----------|-----------|
+| JUnit 4 | `@Before` | `@BeforeClass` (static) |
+| JUnit 4 | `@After` | `@AfterClass` (static) |
+| JUnit 5 | `@BeforeEach` | `@BeforeAll` (static unless `@TestInstance(Lifecycle.PER_CLASS)`) |
+| JUnit 5 | `@AfterEach` | `@AfterAll` |
+| TestNG | `@BeforeMethod` | `@BeforeClass`, `@BeforeSuite`, `@BeforeGroups` |
+| TestNG | `@AfterMethod` | `@AfterClass`, `@AfterSuite`, `@AfterGroups` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| JUnit 5 | `@Tag("name")` (stackable) | `@Tag("positive")`, `@Tag("boundary")` |
+| JUnit 4 | `@Category(NegativeTests.class)` (requires marker interfaces) | `@Category({NegativeTests.class, BoundaryTests.class})` |
+| TestNG | `@Test(groups = {"name"})` | `@Test(groups = {"positive", "critical-path"})` |
+
+For JUnit 4, marker interfaces must exist (e.g., `interface NegativeTests {}`). Suggest creating them rather than dropping `@Category` references with no target.
+
+For Maven Surefire, register groups in `pom.xml`:
+
+```xml
+<configuration>
+    <groups>positive,critical-path</groups>
+</configuration>
+```
+
+## Language-specific calibration notes
+
+- **Argument-order trap (TestNG):** `Assert.assertEquals(actual, expected)` reverses JUnit's order. Misordered comparisons produce backwards failure messages but still pass/fail correctly. Flag as smell when reviewing TestNG suites.
+- **JUnit 4 `@Test(expected=...)`** loses precise exception location and accepts subclasses; recommend migrating to `assertThrows`.
+- **`@SpringBootTest`** bootstraps the entire application — almost always an integration test.
+- **AssertJ chaining** is a single assertion conceptually; do not count each chained `.has...` as a separate assertion for assertion-count metrics.
+- **Mockito `verify(...)`** counts as a state/side-effect assertion when used to assert behavior — do not flag tests that only `verify` as assertion-free.
+- **Lombok `@SneakyThrows`** in tests is acceptable; do not flag.
+- **Parameterized tests** (`@ParameterizedTest` + `@MethodSource` / `@ValueSource`) are NOT duplicate tests; they are the consolidated form.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/kotlin.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/kotlin.md
@@ -1,0 +1,144 @@
+# Kotlin Test Frameworks Reference (JUnit 5, Kotest, MockK)
+
+Reference data for analyzing Kotlin test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — JUnit 5 conventions, Kotest spec classes |
+| Assertion detection | Strong — JUnit + Kotest matchers + MockK verifications |
+| Sleep/delay detection | Strong — `Thread.sleep`, `delay()` |
+| Skip/ignore detection | Strong — `@Disabled`, `.config(enabled = false)` |
+| Setup/teardown detection | Strong — JUnit + Kotest lifecycle |
+| Tag support | **auto-edit** — JUnit 5 `@Tag`, Kotest `tags`, project-defined |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| JUnit 5 (Jupiter) | `*Test.kt`, `*Tests.kt`, `*IT.kt` | `@Test fun foo()` |
+| Kotest | `*Spec.kt` (any style) | inherits a spec class (`StringSpec`, `FunSpec`, `BehaviorSpec`, `ShouldSpec`, `DescribeSpec`, `FeatureSpec`, `WordSpec`, `FreeSpec`, `AnnotationSpec`) |
+| Spek | `*Spec.kt` | `object FooSpec : Spek({ ... })` |
+| TestNG | `*Test.kt` | `@Test fun foo()` (TestNG annotation) |
+
+## Assertion APIs
+
+| Category | JUnit 5 (`Assertions`) | Kotest matchers | AssertK |
+|----------|------------------------|-----------------|---------|
+| Equality | `assertEquals(expected, actual)` | `actual shouldBe expected` | `assertThat(actual).isEqualTo(expected)` |
+| Boolean | `assertTrue(b)` / `assertFalse(b)` | `b.shouldBeTrue()` / `b.shouldBeFalse()` | `assertThat(b).isTrue()` |
+| Null | `assertNull(x)` / `assertNotNull(x)` | `x.shouldBeNull()` / `x.shouldNotBeNull()` | `assertThat(x).isNull()` |
+| Throws | `assertThrows<SomeException> { … }` | `shouldThrow<SomeException> { … }` | `assertFailure { … }.isInstanceOf(SomeException::class)` |
+| Type | `assertTrue(x is T)` | `x.shouldBeInstanceOf<T>()` | `assertThat(x).isInstanceOf(T::class)` |
+| String | `assertTrue(s.contains(sub))` | `s shouldContain sub` / `s shouldMatch Regex("...")` | `assertThat(s).contains(sub)` |
+| Collection | `assertIterableEquals(...)` | `col shouldContainExactly listOf(...)` | `assertThat(col).containsExactly(...)` |
+| Coroutine result | `runTest { ... }` block + assertEquals | `coroutineScope { ... } shouldBe expected` | within `runTest` |
+| Fail | `fail("reason")` | `fail("reason")` (Kotest) | `Assertions.fail("reason")` |
+
+MockK verifications: `verify(exactly = 1) { mock.method() }` — counts as a state/side-effect assertion.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Thread sleep | `Thread.sleep(2000)` |
+| Coroutine delay | `delay(1000)` inside `runBlocking { ... }` |
+| Acceptable (coroutine test) | `runTest { advanceTimeBy(1000) }` (virtual time, no real wait) |
+| Awaitility-style | `Awaitility.await().atMost(5, SECONDS).until { ... }` |
+
+Real `delay` inside `runBlocking { }` is a sleep smell; inside `runTest { }` it's virtual time and acceptable.
+
+## Skip/Ignore Annotations
+
+| Framework | Annotation |
+|-----------|------------|
+| JUnit 5 | `@Disabled`, `@Disabled("reason")`, `@DisabledIf(...)`, `@EnabledIf(...)`, `@DisabledOnOs(OS.WINDOWS)` |
+| JUnit 5 (dynamic) | `Assumptions.assumeTrue(cond)` |
+| Kotest | `.config(enabled = false)`, `xtest("…")`, `xshould("…")`, `xdescribe("…")` |
+| Kotest (project-wide) | `EnabledCondition` / `EnabledIf` extensions |
+| TestNG | `@Test(enabled = false)`, `throw SkipException("reason")` |
+
+## Exception Handling — Idiomatic Alternatives
+
+```kotlin
+// JUnit 5:
+val ex = assertThrows<InvalidOrderException> {
+    service.placeOrder(emptyOrder)
+}
+assertEquals("at least one item", ex.message)
+
+// Kotest:
+val ex = shouldThrow<InvalidOrderException> {
+    service.placeOrder(emptyOrder)
+}
+ex.message shouldContain "at least one item"
+
+// AssertK:
+assertFailure { service.placeOrder(emptyOrder) }
+    .isInstanceOf(InvalidOrderException::class)
+    .messageContains("at least one item")
+```
+
+Flag manual `try { ... fail() } catch (e: SomeException) { ... }` patterns.
+
+## Mystery Guest — Common Kotlin/Android Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `File(path).readText()`, hard-coded paths |
+| Database | `Room.databaseBuilder(...)` without `inMemoryDatabaseBuilder`, real `Exposed` against file/server |
+| Network | `Retrofit.create<…>()` against a real base URL, `OkHttp` without `MockWebServer` |
+| Environment | `System.getenv("X")` |
+| Android | `Context.assets.open(...)`, file system writes to internal/external storage |
+| Acceptable | `MockWebServer`, `MockK`, `inMemoryDatabaseBuilder`, `@MockK`, Robolectric (acknowledged-integration), `TemporaryFolder` |
+
+## Integration Test Markers
+
+- File suffix: `*IT.kt`, `*IntegrationTest.kt`, `*E2ETest.kt`
+- Annotations: `@SpringBootTest`, `@DataJpaTest`, `@Tag("integration")`
+- Kotest tags: `tag = listOf(IntegrationTag)`
+- Android: `androidTest/` source set is on-device/instrumented (integration); `test/` is JVM (unit)
+- Use of Testcontainers, embedded servers
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-class |
+|-----------|----------|-----------|
+| JUnit 5 | `@BeforeEach` | `@BeforeAll` (must be `@JvmStatic` in companion object unless `@TestInstance(PER_CLASS)`) |
+| JUnit 5 | `@AfterEach` | `@AfterAll` |
+| Kotest | `beforeTest { }` / `beforeEach { }` | `beforeSpec { }` |
+| Kotest | `afterTest { }` / `afterEach { }` | `afterSpec { }` |
+| TestNG | `@BeforeMethod` | `@BeforeClass`, `@BeforeSuite` |
+| Spek | `beforeEachTest { }` | `beforeGroup { }` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| JUnit 5 | `@Tag("positive")` (stackable) | `@Tag("positive") @Tag("critical-path")` |
+| Kotest | per-test: `.config(tags = setOf(Positive))`; per-spec: `override fun tags() = setOf(Positive)` | tag objects: `object Positive : Tag()` |
+| TestNG | `@Test(groups = ["positive"])` | `@Test(groups = ["positive", "boundary"])` |
+
+For JUnit 5 in Gradle, register tag filters in `build.gradle.kts`:
+
+```kotlin
+tasks.test {
+    useJUnitPlatform {
+        includeTags("positive")
+        excludeTags("slow")
+    }
+}
+```
+
+## Language-specific calibration notes
+
+- **Coroutine tests must use `runTest` / `runBlocking`** at the boundary; missing wrapper makes the test silently incomplete. Flag `suspend fun` test bodies without a coroutine scope.
+- **`runBlocking` vs `runTest`:** `runBlocking` waits in real time; `runTest` uses virtual time. Prefer `runTest` for testing time-dependent code.
+- **MockK `verify { }`** without `exactly = N` only checks at least once. Tests asserting exact behavior should set the count.
+- **Kotest's `forAll(...)` (data-driven)** is parametrized, NOT duplicate tests.
+- **`@OptIn(ExperimentalCoroutinesApi::class)`** is common in coroutine tests — not a smell.
+- **Android `@MediumTest` / `@LargeTest`** are size annotations from `androidx.test.filters`; treat as integration markers.
+- **Compose UI tests** (`createComposeRule`) are UI integration tests.
+- **Bare `assert(x)` in tests** is the Kotlin `kotlin.assert` — acceptable but recommend framework matchers for richer failure messages.
+- **`shouldBe` chained Kotest matchers** are single conceptual assertions; do not over-count chain length.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/powershell.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/powershell.md
@@ -1,0 +1,128 @@
+# PowerShell Test Framework Reference (Pester v5)
+
+Reference data for analyzing PowerShell test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `*.Tests.ps1`, `Describe`/`Context`/`It` |
+| Assertion detection | Strong — `Should -Be*`, `-Throw`, `-HaveCount` |
+| Sleep/delay detection | Strong — `Start-Sleep` |
+| Skip/ignore detection | Strong — `-Skip`, `-Pending`, `Set-ItResult -Skipped` |
+| Setup/teardown detection | Strong — `BeforeEach`, `AfterAll`, etc. |
+| Tag support | **auto-edit** — `-Tag` parameter on `Describe`/`Context`/`It` |
+
+## Test File Identification
+
+| Convention | Description |
+|------------|-------------|
+| `*.Tests.ps1` | Standard Pester test file convention |
+| `Describe '...' { ... }` | Top-level test group |
+| `Context '...' { ... }` | Sub-group |
+| `It 'should ...' { ... }` | Individual test case |
+| `InModuleScope ModuleName { ... }` | Access internal functions of a module |
+
+Pester v5+ uses block-scoped variables — `Describe`/`Context` blocks run during discovery; `BeforeAll` is required to initialize variables used by `It` blocks.
+
+## Assertion APIs
+
+| Category | Pester v5 (`Should`) |
+|----------|----------------------|
+| Equality | `$x \| Should -Be $y` |
+| Strict equality | `$x \| Should -BeExactly $y` (case-sensitive for strings) |
+| Inequality | `$x \| Should -Not -Be $y` |
+| Boolean true/false | `$x \| Should -BeTrue` / `Should -BeFalse` |
+| Null | `$x \| Should -BeNullOrEmpty` |
+| Exception | `{ Get-Item missing } \| Should -Throw` / `Should -Throw -ExpectedMessage "*pattern*"` / `Should -Throw -ErrorId "ItemNotFound,..."` |
+| Type | `$x \| Should -BeOfType [int]` |
+| String contains | `$s \| Should -Match 'regex'` / `Should -BeLike 'wild*'` |
+| Collection | `$arr \| Should -Contain $item` / `Should -HaveCount 3` |
+| File exists | `'path' \| Should -Exist` |
+| Mocks | `Should -Invoke Get-Item -Times 1 -Exactly` / `Should -Invoke -ParameterFilter { $Path -eq '/x' }` |
+| Negation | `Should -Not -Be`, `Should -Not -Throw`, `Should -Not -BeNullOrEmpty` |
+
+`Should -Invoke` counts as a state/side-effect assertion — do not flag tests that only verify mock calls as assertion-free.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Sleep | `Start-Sleep -Seconds 5` |
+| Sleep ms | `Start-Sleep -Milliseconds 500` |
+| Wait-Job | `Wait-Job -Job $job -Timeout 10` (acceptable for legitimate job waits) |
+| Loop wait | `while (-not (Test-Ready)) { Start-Sleep -Seconds 1 }` |
+
+## Skip/Ignore Annotations
+
+| Mechanism | Example |
+|-----------|---------|
+| `-Skip` | `It 'does x' -Skip { ... }` |
+| `-Pending` | `It 'does x' -Pending { ... }` (legacy v4; in v5, prefer `-Skip`) |
+| `Set-ItResult -Skipped -Because '<reason>'` | Inline skip from within an `It` body |
+| Conditional skip | `It 'is windows-only' -Skip:(-not $IsWindows) { ... }` |
+| `-Skip` on `Describe`/`Context` | skips all contained tests |
+
+## Exception Handling — Idiomatic Alternatives
+
+```powershell
+# Preferred: Should -Throw with scriptblock
+{ Get-Item -Path 'C:\nonexistent' -ErrorAction Stop } |
+    Should -Throw -ErrorId 'PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand'
+
+# With pattern match on message:
+{ Invoke-MyFunc -InvalidArg } | Should -Throw -ExpectedMessage '*invalid*'
+
+# Not throwing:
+{ Invoke-MyFunc -ValidArg } | Should -Not -Throw
+```
+
+Flag tests using `try { ... } catch { Write-Error ... }` patterns without subsequent `Should` assertion.
+
+## Mystery Guest — Common PowerShell Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `Get-Content 'C:\hard\coded\path'`, `Test-Path` against real paths, `New-Item` without `TestDrive:` |
+| Registry | `Get-ItemProperty 'HKLM:\...'`, `Set-ItemProperty` against real registry |
+| Network | `Invoke-WebRequest`, `Invoke-RestMethod` against real URLs |
+| Environment | `$env:USERNAME`, `$env:COMPUTERNAME` (without mock or fallback) |
+| Acceptable | `TestDrive:` (Pester-provided per-test temp dir), `Mock` cmdlet, hashtables as fake config |
+
+## Integration Test Markers
+
+- File suffix: `*.Integration.Tests.ps1`, `*.E2E.Tests.ps1`
+- `-Tag 'Integration'` / `-Tag 'E2E'`
+- Folder convention: `tests/integration/`, `tests/e2e/`
+- Real Azure/AWS module calls (`Connect-AzAccount`, `Get-S3Object`) imply integration
+
+## Setup/Teardown
+
+| Scope | Setup | Teardown |
+|-------|-------|----------|
+| Per-test | `BeforeEach { }` | `AfterEach { }` |
+| Per-block (Describe/Context) | `BeforeAll { }` | `AfterAll { }` |
+
+Pester v5 requires `BeforeAll` to initialize variables used in `It` blocks (discovery vs run separation). A common mistake: defining variables at `Describe` scope and using them inside `It` — they will be `$null` at run time.
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Mechanism | Example |
+|-----------|---------|
+| `-Tag` on `It` | `It 'creates order' -Tag 'positive','critical-path' { ... }` |
+| `-Tag` on `Context` | inherits to contained `It`s |
+| `-Tag` on `Describe` | inherits to all nested blocks |
+| `Invoke-Pester -Tag 'positive' -ExcludeTag 'slow'` | filter by tag |
+
+## Language-specific calibration notes
+
+- **Pester v5 vs v4 scoping differences**: v4 tests using `$script:` variables shared between `It` blocks won't work in v5 the same way. Note as migration debt if both styles coexist.
+- **`InModuleScope`** is the canonical way to test internal/non-exported module functions — not an implementation-coupling smell.
+- **`Mock` cmdlet** intercepts ANY function in scope; tests that mock built-in cmdlets (`Get-ChildItem`, etc.) without `ParameterFilter` are over-broad — flag as smell.
+- **`TestDrive:`** is an automatically-created temporary directory unique to each test — not a Mystery Guest.
+- **Pester `Should -Invoke` (v5) / `Assert-MockCalled` (v4)** are state/side-effect assertions.
+- **`Set-StrictMode -Version Latest`** in tests is a hygiene practice — acknowledge as positive.
+- **`Set-ItResult -Inconclusive`** marks a test as inconclusive (not failure, not skip).
+- **`-ForEach` / `-TestCases`** are parametrized — NOT duplicate tests.
+- **PSScriptAnalyzer integration**: tests that lint themselves (`Invoke-ScriptAnalyzer`) are quality-gate tests, not analyzer code.
+- **Pester v6 (preview)** changes some APIs; if the project targets v6, double-check assertion forms.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/python.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/python.md
@@ -1,0 +1,130 @@
+# Python Test Frameworks Reference (pytest, unittest)
+
+Reference data for analyzing Python test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — convention-driven (`test_*.py`, `*_test.py`, `Test*` classes) |
+| Assertion detection | Strong — bare `assert`, `unittest` methods, `pytest.raises` |
+| Sleep/delay detection | Strong — `time.sleep`, `asyncio.sleep` |
+| Skip/ignore detection | Strong — `@pytest.mark.skip`, `unittest.skip` |
+| Setup/teardown detection | Strong — fixtures and methods |
+| Tag support | **auto-edit** — `@pytest.mark.<tag>` (pytest), no canonical syntax in unittest |
+
+## Test File Identification
+
+| Framework | Test file convention | Test method markers |
+|-----------|---------------------|---------------------|
+| pytest | `test_*.py` or `*_test.py` | functions starting with `test_`; classes starting with `Test` (no `__init__`) and methods starting with `test_` |
+| unittest | any module (often `test_*.py`) | classes inheriting `unittest.TestCase` with methods starting with `test` |
+
+## Assertion APIs
+
+| Category | pytest | unittest |
+|----------|--------|----------|
+| Equality | `assert x == y` | `self.assertEqual(x, y)` |
+| Inequality | `assert x != y` | `self.assertNotEqual(x, y)` |
+| Boolean | `assert flag` / `assert not flag` | `self.assertTrue(flag)` / `self.assertFalse(flag)` |
+| None | `assert x is None` | `self.assertIsNone(x)` / `self.assertIsNotNone(x)` |
+| Exception | `with pytest.raises(SomeError) as exc_info: ...` | `with self.assertRaises(SomeError): ...` |
+| Type | `assert isinstance(x, T)` | `self.assertIsInstance(x, T)` |
+| Identity | `assert x is y` | `self.assertIs(x, y)` |
+| Membership | `assert item in collection` | `self.assertIn(item, collection)` |
+| Approximate | `assert x == pytest.approx(y, rel=0.01)` | `self.assertAlmostEqual(x, y, places=2)` |
+| String | `assert sub in s` / `assert s.startswith(...)` | `self.assertIn(sub, s)` |
+| Skip | `pytest.skip("reason")` | `self.skipTest("reason")` |
+| Fail | `pytest.fail("reason")` | `self.fail("reason")` |
+
+**Important:** Bare `assert` is the canonical pytest assertion and produces rich failure diffs via pytest's assertion rewriting. Do NOT flag bare `assert` as a missing-framework-API smell.
+
+Third-party assertion libraries: `assertpy`, `hamcrest` (`assert_that`), `expects`.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Sync sleep | `time.sleep(2)` |
+| Async sleep | `await asyncio.sleep(1)` |
+| Loop wait | `while not condition: time.sleep(0.1)` |
+| Trio/anyio | `await trio.sleep(...)`, `await anyio.sleep(...)` |
+
+## Skip/Ignore Annotations
+
+| Framework | Annotation |
+|-----------|------------|
+| pytest | `@pytest.mark.skip(reason="...")`, `@pytest.mark.skipif(cond, reason="...")`, `@pytest.mark.xfail(reason="...")`, `pytest.skip("...")` inline |
+| unittest | `@unittest.skip("reason")`, `@unittest.skipIf(cond, "reason")`, `@unittest.skipUnless(cond, "reason")`, `@unittest.expectedFailure` |
+
+## Exception Handling — Idiomatic Alternatives
+
+```python
+# pytest (preferred):
+with pytest.raises(ValueError, match=r"must be positive"):
+    parse_amount(-5)
+
+# unittest:
+with self.assertRaises(ValueError):
+    parse_amount(-5)
+
+# To inspect the exception:
+with pytest.raises(ValueError) as exc_info:
+    parse_amount(-5)
+assert "must be positive" in str(exc_info.value)
+```
+
+Flag bare `try/except` in tests as Exception Handling smell only when no assertion follows or the exception is silently swallowed.
+
+## Mystery Guest — Common Python Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `open()`, `pathlib.Path(...).read_text()`, `os.path.exists`, hard-coded absolute paths |
+| Database | direct `psycopg2`/`mysql.connector`/`sqlite3.connect` to a file path, `SQLAlchemy` engine pointing at a real DB URL |
+| Network | `requests.get/post`, `httpx.get/post`, `urllib.request.urlopen`, raw `socket` |
+| Environment | `os.getenv("X")` (especially without default), `os.environ["X"]` |
+| Acceptable | `io.StringIO` / `io.BytesIO`, `tmp_path` / `tmp_path_factory` pytest fixtures, `monkeypatch.setenv`, `responses` / `httpx.MockTransport`, `pytest-mock`, sqlite `:memory:` |
+
+## Integration Test Markers
+
+- Folder names: `tests/integration/`, `tests/e2e/`, `tests/acceptance/`
+- Module/class/function names containing `Integration`, `E2E`, `EndToEnd`, `Acceptance`
+- `@pytest.mark.integration` / `@pytest.mark.e2e` (project-specific markers registered in `pytest.ini` / `pyproject.toml`)
+- Conftest fixtures that spin up containers / databases (`testcontainers`, `docker-compose` fixtures)
+
+## Setup/Teardown
+
+| Framework | Setup | Teardown |
+|-----------|-------|----------|
+| pytest | `@pytest.fixture` (any scope), `autouse=True` fixtures | yield-based teardown inside fixture or `request.addfinalizer` |
+| pytest (class) | `setup_method` / `setup_class` | `teardown_method` / `teardown_class` |
+| unittest | `setUp` / `setUpClass` / `setUpModule` | `tearDown` / `tearDownClass` / `tearDownModule` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| pytest | `@pytest.mark.<name>` (project-registered) | `@pytest.mark.positive`, `@pytest.mark.boundary` |
+| unittest | none built-in — use class organization, attributes, or `unittest.skipIf` toggles | *(report-only; recommend pytest markers or a project convention)* |
+
+For pytest, ensure the markers are registered in `pyproject.toml` / `pytest.ini` to avoid `PytestUnknownMarkWarning`:
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "positive: verifies expected behavior under normal conditions",
+    "negative: verifies handling of invalid input or error paths",
+    "boundary: tests limits, thresholds, empty/null inputs",
+]
+```
+
+## Language-specific calibration notes
+
+- **Bare `assert`** is the pytest idiom — do not flag it as assertion-free.
+- **Snapshot tests** (`syrupy`, `pytest-snapshot`) replace the `assert` call with an implicit snapshot compare; treat as a legitimate assertion.
+- **Property-based tests** (`hypothesis`): a `@given(...)`-decorated function is a real test even if it appears to have no body — the assertions live in the generated input cycles.
+- **Async tests** (`pytest-asyncio`, `anyio`): missing `await` on a coroutine call inside the test produces a `RuntimeWarning` and an effectively assertion-free test. Flag as a critical anti-pattern.
+- **Doctests** invoked via `--doctest-modules` are tests too; treat `>>>` blocks as test methods if the user includes them in scope.
+- **Parametrized tests** (`@pytest.mark.parametrize`) are *not* duplicates of the underlying function — treat them as the consolidated form.
+- **Fixtures used by only one test** are not General Fixture smells; pytest fixtures are pay-as-you-go (a fixture only runs when a test requests it).

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/ruby.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/ruby.md
@@ -1,0 +1,123 @@
+# Ruby Test Frameworks Reference (RSpec, Minitest)
+
+Reference data for analyzing Ruby test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `spec/**/*_spec.rb`, `test/**/*_test.rb` |
+| Assertion detection | Strong — `expect`, `assert_*` |
+| Sleep/delay detection | Strong — `sleep`, `Kernel#sleep` |
+| Skip/ignore detection | Strong — `skip`, `pending`, `xit` |
+| Setup/teardown detection | Strong — `before`, `setup` |
+| Tag support | **auto-edit** — RSpec metadata, Minitest `tag` (via gems) |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| RSpec | `spec/**/*_spec.rb` | `describe`, `context`, `it`, `specify`, `example` |
+| Minitest | `test/**/*_test.rb` | `Minitest::Test` subclass with methods starting `test_`, or `Minitest::Spec` with `it` |
+
+## Assertion APIs
+
+| Category | RSpec (`expect`) | Minitest (`assert_*`) |
+|----------|------------------|-----------------------|
+| Equality | `expect(x).to eq(y)` / `eql(y)` | `assert_equal expected, actual` |
+| Identity | `expect(x).to be(y)` | `assert_same expected, actual` |
+| Boolean | `expect(x).to be_truthy` / `be_falsey` | `assert x` / `refute x` |
+| Nil | `expect(x).to be_nil` | `assert_nil x` / `refute_nil x` |
+| Exception | `expect { fn }.to raise_error(SomeError, /msg/)` | `assert_raises(SomeError) { fn }` |
+| Type | `expect(x).to be_a(T)` / `be_instance_of(T)` | `assert_kind_of T, x` / `assert_instance_of T, x` |
+| Membership | `expect(arr).to include(item)` | `assert_includes arr, item` |
+| String | `expect(s).to match(/regex/)` | `assert_match(/regex/, s)` |
+| Predicate | `expect(x).to be_empty` (auto: `x.empty?`) | `assert_empty x` |
+| Change | `expect { code }.to change(obj, :attr).from(x).to(y)` | manual before/after assertion |
+| Throw | `expect { throw :sym }.to throw_symbol(:sym)` | `assert_throws(:sym) { ... }` |
+| Output | `expect { puts "x" }.to output("x\n").to_stdout` | `assert_output("x\n") { puts "x" }` |
+| Fail | `fail("reason")` (built-in) | `flunk "reason"` |
+
+Third-party libraries: Shoulda Matchers, FactoryBot (for setup, not assertions), Capybara (`have_content`, `have_selector`).
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Sleep | `sleep 1` / `sleep(0.5)` |
+| Capybara explicit wait (acceptable) | `using_wait_time(5) { find('#x') }` |
+| Loop wait | `until condition; sleep 0.1; end` |
+| Timecop / ActiveSupport::Testing::TimeHelpers (acceptable) | `travel_to(1.hour.from_now)` instead of real sleep |
+
+## Skip/Ignore Annotations
+
+| Framework | Skip |
+|-----------|------|
+| RSpec | `skip("reason")`, `xit`, `xdescribe`, `xcontext`, `pending("reason")`, `it("...", :skip)`, `it("...", skip: "reason")`, focused `fit`, `fdescribe`, `fcontext` |
+| Minitest | `skip("reason")` inside a test method, `skip_until "<date>", "reason"` (via `minitest-skip-until` gem) |
+
+`fit` / `fdescribe` (focused) committed to source is anti-pattern when `--fail-if-no-examples` / RSpec `--only-failures` isn't gating it.
+
+## Exception Handling — Idiomatic Alternatives
+
+```ruby
+# RSpec (preferred):
+expect { service.place_order(empty_order) }
+  .to raise_error(InvalidOrderError, /at least one item/)
+
+# Minitest:
+err = assert_raises(InvalidOrderError) { service.place_order(empty_order) }
+assert_match(/at least one item/, err.message)
+```
+
+Flag tests with bare `begin/rescue` that swallow exceptions or `rescue => e` patterns without subsequent assertion.
+
+## Mystery Guest — Common Ruby/Rails Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `File.read`, `File.open`, `Pathname#read`, hard-coded paths |
+| Database | direct `ActiveRecord::Base.connection.execute`, real DB writes outside transactional fixtures |
+| Network | `Net::HTTP`, `URI.open`, `RestClient`, `Faraday` against real URLs |
+| Environment | `ENV["X"]` (especially without `ENV.fetch("X", default)`) |
+| Acceptable | `WebMock`, `VCR`, `Tempfile`, `StringIO`, `ActiveRecord` transactional fixtures, `database_cleaner`, factory builders |
+
+## Integration Test Markers
+
+- Folder convention: `spec/system/`, `spec/features/`, `spec/integration/`, `test/integration/`, `test/system/`
+- RSpec metadata: `it "...", type: :system`, `:feature`, `:request`, `:integration`
+- Rails: `ActionDispatch::IntegrationTest` subclass, `ActionDispatch::SystemTestCase`
+- Capybara involvement implies system/feature test
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-suite |
+|-----------|----------|-----------|
+| RSpec | `before(:each)` / `before { ... }` | `before(:all)` / `before(:context)` |
+| RSpec | `after(:each)` | `after(:all)` |
+| RSpec | `around { |ex| ex.run }` (wrapping) | n/a |
+| Minitest | `setup` method | `before_all` (via `minitest-hooks` gem) |
+| Minitest | `teardown` method | `after_all` (via gem) |
+| Rails | `ActiveSupport::TestCase` `setup` / `teardown` blocks | `setup do ... end` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| RSpec | metadata hash | `it "creates order", :positive, :critical_path do ... end` |
+| RSpec | metadata key/value | `describe Order, type: :model, tag: :positive do ... end` |
+| Minitest | `tag` via `minitest-tagz` / `minitest-tagged` gems | varies by gem |
+| Rails | `test_tagged` helper (Rails 7.1+) | `test "x", tag: :positive do ... end` |
+
+RSpec filters can drive tag selection: `rspec --tag positive`, `rspec --tag ~slow`.
+
+## Language-specific calibration notes
+
+- **Predicate matchers** (`be_empty`, `be_valid`) auto-derive from `?` methods on the object. Treat as state/side-effect assertions.
+- **`change` matcher** is a state assertion: `expect { code }.to change(obj, :attr)` verifies side effects. Do not treat as missing assertion.
+- **Shared examples** (`it_behaves_like "...")` and shared contexts are NOT duplicate tests — they are the consolidated form.
+- **`let` / `let!`** for fixtures: `let!` runs eagerly per test, `let` lazily. Tests that create heavy `let!` blocks for fields used by only one test are General Fixture smells.
+- **Implicit subject** (`subject { described_class.new(args) }`, `it { is_expected.to be_valid }`) is a valid concise form.
+- **FactoryBot `build` vs `create`**: `create` hits the database, `build` does not. Tests that `create` records for assertions that don't need persistence inflate test time — note but don't flag as critical.
+- **Capybara `find` without an explicit selector** can be slow/flaky; recommend more specific selectors.
+- **RSpec `pending` differs from `skip`**: `pending` runs the test and expects failure; `skip` does not run it.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/rust.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/rust.md
@@ -1,0 +1,152 @@
+# Rust Test Framework Reference (built-in `#[test]`, `cargo test`)
+
+Reference data for analyzing Rust test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `#[test]` / `#[tokio::test]` / `#[cfg(test)] mod tests` / `tests/` integration directory |
+| Assertion detection | Strong — `assert!`, `assert_eq!`, `assert_ne!`, `?` on `Result` tests |
+| Sleep/delay detection | Strong — `thread::sleep`, `tokio::time::sleep` |
+| Skip/ignore detection | Strong — `#[ignore]`, `#[cfg(...)]` gating |
+| Setup/teardown detection | Moderate — no built-in fixtures; uses constructors and `Drop`, or external crates |
+| Tag support | **report-only / convention-based** — no canonical attribute; some crates (`rstest`, `nextest`) support test filters by name |
+
+## Test File Identification
+
+| Convention | Description |
+|------------|-------------|
+| `#[test]` | Standard test attribute |
+| `#[cfg(test)] mod tests { ... }` | Unit tests co-located with source |
+| `tests/*.rs` | Integration tests (each file is a separate crate) |
+| `#[tokio::test]` / `#[async_std::test]` | Async tests (need async runtime crate) |
+| `#[rstest]` | Parametric tests via the `rstest` crate |
+| `#[should_panic]` | Tests that expect a panic |
+| Doc tests | `///` comments containing executable code blocks |
+| `#[bench]` (nightly) / `criterion` benchmarks | Benchmarks |
+
+## Assertion APIs
+
+| Category | Built-in | proptest / quickcheck |
+|----------|----------|-----------------------|
+| Equality | `assert_eq!(actual, expected)` | (manual `prop_assert_eq!`) |
+| Inequality | `assert_ne!(actual, expected)` | `prop_assert_ne!` |
+| Boolean | `assert!(condition, "msg")` | `prop_assert!(...)` |
+| Pattern match | `assert!(matches!(value, Pattern))` | n/a |
+| Panic | `#[should_panic]` / `#[should_panic(expected = "msg")]` | n/a |
+| Error | `result.unwrap()` (panics on error) / `?` propagation | n/a |
+| Fail | `panic!("reason")` / `unreachable!()` | n/a |
+
+Third-party libraries: `pretty_assertions` (`assert_eq!` with colored diffs), `assert_matches`, `claim` (`assert_ok!`, `assert_err!`).
+
+**Result-returning tests** (Rust 2018+):
+```rust
+#[test]
+fn parses_valid_input() -> Result<(), Box<dyn std::error::Error>> {
+    let v = parse("1")?;
+    assert_eq!(v, 1);
+    Ok(())
+}
+```
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Sync sleep | `std::thread::sleep(Duration::from_secs(1))` |
+| Async sleep (tokio) | `tokio::time::sleep(Duration::from_secs(1)).await` |
+| async-std sleep | `async_std::task::sleep(Duration::from_secs(1)).await` |
+| Spin wait | `while !cond() { std::thread::sleep(...) }` |
+| Acceptable (tokio time control) | `tokio::time::pause()` + `tokio::time::advance(...)` |
+
+## Skip/Ignore Annotations
+
+| Mechanism | Example |
+|-----------|---------|
+| `#[ignore]` | Excluded by default; run with `cargo test -- --ignored` |
+| `#[ignore = "reason"]` | With reason (Rust 1.55+) |
+| `#[cfg(feature = "x")]` | Skip unless feature enabled |
+| `#[cfg(target_os = "linux")]` | Skip on other OS |
+| `#[cfg(not(miri))]` | Skip under Miri interpreter |
+| Conditional skip | manual `if !cfg!(...) { return; }` (anti-pattern) |
+
+## Exception Handling — Idiomatic Alternatives
+
+```rust
+// should_panic with specific message:
+#[test]
+#[should_panic(expected = "must be positive")]
+fn parses_negative_panics() {
+    parse_amount(-5);
+}
+
+// Result return + ?:
+#[test]
+fn places_order_ok() -> anyhow::Result<()> {
+    let order = service.place_order(valid_order())?;
+    assert_eq!(order.id, 42);
+    Ok(())
+}
+
+// Match on Err for specific variant:
+let err = service.place_order(empty).unwrap_err();
+assert!(matches!(err, OrderError::Empty));
+```
+
+Flag tests that use `.unwrap()` on `Result` returns from production code without asserting the error variant — they conflate "unexpected error" with test failure.
+
+## Mystery Guest — Common Rust Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `std::fs::read`, `std::fs::write`, hard-coded paths |
+| Database | `sqlx::PgPool::connect` against real DB, `rusqlite::Connection::open(path)` |
+| Network | `reqwest::get`, `hyper` client to real URLs, raw `TcpStream::connect` |
+| Environment | `std::env::var("X").unwrap()` |
+| Acceptable | `tempfile::TempDir`, `httpmock`, `wiremock-rs`, `mockito`, `sqlx` test pool against in-memory SQLite, `tokio::test` with `start_paused = true` |
+
+## Integration Test Markers
+
+- `tests/` top-level directory contains integration tests
+- Test names containing `_integration_`, `_e2e_`, `_acceptance_`
+- Feature flags: `#[cfg(feature = "integration-tests")]`
+- Crates like `testcontainers` imply integration
+- `cargo nextest` profile names (`[profile.integration]`)
+
+## Setup/Teardown
+
+Rust has no native fixture framework. Common patterns:
+
+| Pattern | Description |
+|---------|-------------|
+| Helper function | `fn setup() -> Foo { ... }` invoked at the start of each test |
+| `Drop` implementation | Side-effect cleanup on test-local guard structs |
+| `rstest` fixtures | `#[fixture] fn db() -> Db { ... }` + `#[rstest] fn t(db: Db) { ... }` |
+| `test-context` crate | Per-test `setup` / `teardown` traits |
+| `serial_test` crate | Avoid parallel test interference with `#[serial]` |
+| `once_cell` / `lazy_static` | Lazy global init (use cautiously — shared state across tests) |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+**Default mode: report-only / convention-based.** Rust has no canonical per-test tag attribute. Strategies:
+
+- **Module grouping**: `mod positive { ... }`, `mod boundary { ... }` — works with `cargo test boundary::`
+- **Test name prefixes**: `fn test_negative_invalid_input_returns_error()` — filterable via `cargo test negative_`
+- **Feature flags** for integration/E2E: `#[cfg(feature = "e2e")]`
+- **`cargo nextest`** supports test groups via `nextest.toml` filtering expressions
+
+Only switch to `auto-edit` mode when the project already follows one convention.
+
+## Language-specific calibration notes
+
+- **Doc tests** are real tests — `cargo test` runs them. Treat as tests if user includes lib doc comments in scope.
+- **`#[should_panic]` without `expected = "..."`** passes on ANY panic — that's a smell (overly broad).
+- **`.unwrap()` and `.expect()` in tests** are acceptable for type-correct unwrapping but obscure error sources. Recommend `?` on `Result`-returning tests where possible.
+- **Property-based tests** (`proptest!`, `quickcheck!`) generate input cases; treat as parametrized tests, not duplicates.
+- **`#[ignore]` without a reason** is a smell — flag as Ignored Test with low severity.
+- **Async tests requiring `#[tokio::test]` but missing it** silently never run. Flag any `async fn` test missing the runtime attribute.
+- **`thread::sleep` in tests** is a Sleepy Test; prefer `tokio::time::pause()` for async or explicit polling for sync.
+- **Tests that mutate `static mut` or global `Mutex<...>` state** require `#[serial]` (from `serial_test`) — otherwise flaky under parallel `cargo test`.
+- **`#[cfg(test)]` modules cross-compiled with `#![deny(warnings)]`** sometimes fail builds — note but don't flag as smell.
+- **Bare `assert!(x)` with no message** in `assert_eq!`-suitable positions is acceptable; do not require messages.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/swift.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/swift.md
@@ -1,0 +1,141 @@
+# Swift Test Frameworks Reference (XCTest, Swift Testing)
+
+Reference data for analyzing Swift test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `XCTestCase` subclasses, `@Test` functions |
+| Assertion detection | Strong — `XCTAssert*`, `#expect`, `#require` |
+| Sleep/delay detection | Strong — `Thread.sleep`, `Task.sleep`, `XCTWaiter` |
+| Skip/ignore detection | Strong — `XCTSkip`, `.disabled(...)` |
+| Setup/teardown detection | Strong — `setUp/tearDown`, `init/deinit` for Swift Testing |
+| Tag support | **auto-edit** (Swift Testing) — `@Test(.tags(...))` / `@Suite(.tags(...))`; XCTest: report-only |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| XCTest | `*Tests.swift` (Swift Package Manager: `Tests/<Module>Tests/`) | `class FooTests: XCTestCase` with methods starting `test` |
+| Swift Testing | same conventions | `@Test func foo() async throws { ... }`, optionally inside `@Suite` types |
+
+Both frameworks can coexist in one target.
+
+## Assertion APIs
+
+| Category | XCTest | Swift Testing |
+|----------|--------|---------------|
+| Equality | `XCTAssertEqual(actual, expected)` | `#expect(actual == expected)` |
+| Inequality | `XCTAssertNotEqual` | `#expect(actual != expected)` |
+| Boolean | `XCTAssertTrue` / `XCTAssertFalse` | `#expect(condition)` |
+| Nil | `XCTAssertNil` / `XCTAssertNotNil` | `#expect(value == nil)` / `#expect(value != nil)` |
+| Throws | `XCTAssertThrowsError(try fn()) { error in ... }` | `#expect(throws: SomeError.self) { try fn() }` / `try #require(throws: ...)` |
+| No throw | `XCTAssertNoThrow(try fn())` | implicit (just call `try fn()`) |
+| Identical (reference) | `XCTAssertIdentical` | `#expect(a === b)` |
+| Approximate | `XCTAssertEqual(x, y, accuracy: 0.01)` | `#expect(abs(x - y) < 0.01)` |
+| Type | `XCTAssertTrue(x is T)` | `#expect(x is T)` |
+| Membership | `XCTAssertTrue(arr.contains(item))` | `#expect(arr.contains(item))` |
+| Fail | `XCTFail("reason")` | `Issue.record("reason")` |
+| Soft fail (continue) | continues on `XCTAssert*` by default | `#expect` (records issues, continues) |
+| Hard fail (stop) | `XCTSkipIf` is skip; no hard-fail at test level | `try #require(...)` aborts the test |
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Thread sleep | `Thread.sleep(forTimeInterval: 1.0)` |
+| Async sleep | `try await Task.sleep(nanoseconds: 1_000_000_000)` (Swift 5.5+) |
+| Async sleep (newer) | `try await Task.sleep(for: .seconds(1))` (Swift 5.7+) |
+| XCTest waiter | `wait(for: [exp], timeout: 5)` (acceptable for expectation-based tests) |
+| Async waiter | `await fulfillment(of: [exp], timeout: 5)` (Xcode 14+) |
+
+`XCTestExpectation` + `wait(for:timeout:)` is the idiomatic async-coordination pattern in XCTest — not a sleep smell.
+
+## Skip/Ignore Annotations
+
+| Framework | Annotation |
+|-----------|------------|
+| XCTest | `throw XCTSkip("reason")`, `XCTSkipIf(cond, "reason")`, `XCTSkipUnless(cond, "reason")` |
+| Swift Testing | `@Test(.disabled("reason"))`, `@Test(.disabled(if: cond, "reason"))`, `@Test(.enabled(if: cond))` |
+
+## Exception Handling — Idiomatic Alternatives
+
+```swift
+// XCTest:
+XCTAssertThrowsError(try service.placeOrder(emptyOrder)) { error in
+    guard case OrderError.empty = error else {
+        XCTFail("Expected .empty, got \(error)")
+        return
+    }
+}
+
+// Swift Testing:
+#expect(throws: OrderError.self) {
+    try service.placeOrder(emptyOrder)
+}
+
+// Specific case (Swift Testing):
+let err = try #require(throws: OrderError.self) { try service.placeOrder(emptyOrder) }
+#expect(err == .empty)
+```
+
+Flag manual `do { try fn(); XCTFail("expected throw") } catch { ... }` patterns and recommend the framework-native form.
+
+## Mystery Guest — Common Swift Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `FileManager.default.contents(atPath:)`, hard-coded `Bundle.main` paths |
+| Database | direct `SQLite.swift` against real file, raw `CoreData` saves outside in-memory store |
+| Network | `URLSession.shared.dataTask` without `URLProtocol` stub, `Alamofire` to real URL |
+| Environment | `ProcessInfo.processInfo.environment["X"]` |
+| Acceptable | `URLProtocol` stubs, OHHTTPStubs, `Mocker`, `NSPersistentContainer` with in-memory store type, `Bundle.module` resource paths |
+
+## Integration Test Markers
+
+- Folder convention: `IntegrationTests/`, `UITests/`, `E2ETests/`
+- Class name suffix: `*IntegrationTests`, `*UITests`
+- `XCUITest` (`XCUIApplication`, `XCUIElement`) → UI/E2E test
+- Swift Testing `@Tag` named `.integration` or `.ui`
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-class/suite |
+|-----------|----------|-----------------|
+| XCTest | `setUp() / setUpWithError()` | `override class func setUp()` |
+| XCTest | `tearDown() / tearDownWithError()` | `override class func tearDown()` |
+| Swift Testing | `init(...) async throws` per instance | static via `@Suite` type |
+| Swift Testing | `deinit` for cleanup | static via `@Suite` type |
+
+Swift Testing creates a fresh instance per test by default — fields initialized in `init` are reset between tests.
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+| Framework | Tag mechanism | Example |
+|-----------|---------------|---------|
+| Swift Testing | `@Test(.tags(.positive, .boundary))` (predefined or custom tag) | requires `extension Tag { @Tag static var positive: Self }` |
+| Swift Testing (suite) | `@Suite(.tags(...))` | inherits tags to contained tests |
+| XCTest | none built-in — use class organization, naming, or test plans (.xctestplan) | *(report-only)* |
+
+For Swift Testing, define tags in a single module-level location:
+
+```swift
+extension Tag {
+    @Tag static var positive: Self
+    @Tag static var negative: Self
+    @Tag static var boundary: Self
+    @Tag static var integration: Self
+}
+```
+
+## Language-specific calibration notes
+
+- **Swift Testing `#expect` continues on failure**; `try #require` aborts. Tests that mix preconditions and assertions should use `try #require` for preconditions.
+- **`XCTAssert*` continues on failure** — tests with multiple cascading assertions may log many failures from one root cause.
+- **Async tests must `await`** — missing `await` causes warnings and silent skips on async APIs.
+- **Combine tests** with `expectation(description:)` are XCTest's idiomatic async pattern; not a sleep smell.
+- **Snapshot testing** (`SnapshotTesting` library) — treat snapshot comparisons as legitimate assertions; flag stale records.
+- **Parametrized tests** (`@Test(arguments: [...])`) are NOT duplicates.
+- **Test plans (`.xctestplan`)** can filter by tags / configurations; mention as a structural alternative to per-test tagging.
+- **`continueAfterFailure`** — when `false`, XCTest stops on first failure (useful for fast-fail integration tests).

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/typescript.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/typescript.md
@@ -126,4 +126,4 @@ Only switch to `auto-edit` mode when the project already follows one of these co
 - **`xit`/`xdescribe`** are commits of disabled tests — flag like `[Ignore]`.
 - **`.only`** committed to source is a critical smell — silently disables the rest of the file/suite.
 - **describe.each / test.each** are parametrized; not duplicate tests.
-- **`fail()` is removed in Jest 27+** — flag `if (cond) fail('msg')` patterns and recommend `expect.fail()` or explicit conditions.
+- **`fail()` is removed in Jest 27+** — flag `if (cond) fail('msg')` patterns and recommend `throw new Error('msg')` or an explicit failing assertion such as `expect(value).toBe(...)` instead.

--- a/plugins/dotnet-test/skills/test-analysis-extensions/extensions/typescript.md
+++ b/plugins/dotnet-test/skills/test-analysis-extensions/extensions/typescript.md
@@ -1,0 +1,129 @@
+# TypeScript / JavaScript Test Frameworks Reference (Jest, Vitest, Mocha, Jasmine, node:test)
+
+Reference data for analyzing JS/TS test code. Used by the polyglot test analysis skills.
+
+## Capability tags
+
+| Capability | Support |
+|------------|---------|
+| Test discovery | Strong — `*.test.ts`, `*.spec.ts`, `__tests__/` |
+| Assertion detection | Strong — `expect`, `assert`, `chai` |
+| Sleep/delay detection | Strong — `setTimeout`, `sleep`, `wait` helpers |
+| Skip/ignore detection | Strong — `.skip`, `xit`, `xdescribe` |
+| Setup/teardown detection | Strong — `beforeEach`, `afterEach`, hooks |
+| Tag support | **report-only** by default — no canonical attribute; some frameworks accept `tags` option (Vitest test.options.tag) or describe-based grouping |
+
+## Test File Identification
+
+| Framework | File convention | Test method markers |
+|-----------|----------------|---------------------|
+| Jest | `*.test.ts/js/tsx/jsx`, `*.spec.*`, files in `__tests__/` | `test()`, `it()`, `describe()` |
+| Vitest | `*.test.ts/js`, `*.spec.*` | `test()`, `it()`, `describe()` (same shape as Jest) |
+| Mocha | `test/**/*.js` (configurable) | `it()`, `describe()` |
+| Jasmine | `*Spec.js`, `*.spec.js` | `it()`, `describe()` |
+| node:test | `*.test.js`, `test/**/*.js` | `test()` from `node:test` |
+
+## Assertion APIs
+
+| Category | Jest / Vitest (`expect`) | Mocha + Chai (`expect`) | node:test (`assert`) |
+|----------|--------------------------|-------------------------|---------------------|
+| Equality | `expect(x).toBe(y)` / `.toEqual()` | `expect(x).to.equal(y)` / `.deep.equal()` | `assert.strictEqual(x, y)` / `assert.deepStrictEqual()` |
+| Inequality | `expect(x).not.toBe(y)` | `expect(x).to.not.equal(y)` | `assert.notStrictEqual(x, y)` |
+| Truthy/Falsy | `.toBeTruthy()` / `.toBeFalsy()` | `.to.be.true` / `.to.be.false` | `assert.ok(x)` |
+| Null/Undefined | `.toBeNull()` / `.toBeUndefined()` / `.toBeDefined()` | `.to.be.null` / `.to.be.undefined` | `assert.equal(x, null)` |
+| Exception | `expect(() => fn()).toThrow(Error)` / `await expect(promise).rejects.toThrow()` | `expect(fn).to.throw(Error)` | `assert.throws(fn, Error)` / `await assert.rejects(promise)` |
+| Type | `.toBeInstanceOf(Cls)` | `.to.be.instanceOf(Cls)` | `assert.ok(x instanceof Cls)` |
+| Membership | `.toContain(item)` | `.to.include(item)` | `assert.ok(arr.includes(item))` |
+| String | `.toMatch(/regex/)` / `.toContain('sub')` | `.to.match(/regex/)` | `assert.match(s, /regex/)` |
+| Object shape | `.toMatchObject({...})` | `.to.deep.include({...})` | (manual) |
+| Snapshot | `.toMatchSnapshot()` / `.toMatchInlineSnapshot()` | *(via plugin)* | *(via plugin)* |
+| Mock calls | `expect(mock).toHaveBeenCalledWith(...)` | `sinon.assert.calledWith(...)` | (manual) |
+
+Third-party libraries: `chai`, `should`, `sinon-chai`, `@vitest/expect`.
+
+## Sleep/Delay Patterns
+
+| Pattern | Example |
+|---------|---------|
+| setTimeout sleep | `await new Promise(r => setTimeout(r, 1000))` |
+| Hard sleep helpers | `sleep(1000)`, `await delay(500)` |
+| Loop wait | `while (!condition) await sleep(100)` |
+| Jest fake timers | `jest.advanceTimersByTime(...)` (acceptable, not a sleep) |
+
+## Skip/Ignore Annotations
+
+| Framework | Skip | Focused (only) |
+|-----------|------|----------------|
+| Jest | `test.skip`, `it.skip`, `describe.skip`, `xit`, `xdescribe`, `xtest` | `test.only`, `fit`, `fdescribe` |
+| Vitest | `test.skip`, `it.skip`, `describe.skip`, `test.todo`, `test.skipIf(cond)` | `test.only` |
+| Mocha | `it.skip`, `describe.skip`, `xit`, `xdescribe` | `it.only`, `describe.only` |
+| Jasmine | `xit`, `xdescribe`, `pending()` | `fit`, `fdescribe` |
+| node:test | `test(name, { skip: true }, fn)`, `test.skip(...)`, `test.todo(...)` | `test(name, { only: true }, fn)` |
+
+`.only` patterns are an anti-pattern when committed — they silently disable the rest of the suite.
+
+## Exception Handling — Idiomatic Alternatives
+
+```ts
+// Jest / Vitest (sync):
+expect(() => parseAmount(-5)).toThrow(RangeError);
+
+// Jest / Vitest (async):
+await expect(parseAmountAsync(-5)).rejects.toThrow(RangeError);
+
+// Chai:
+expect(() => parseAmount(-5)).to.throw(RangeError, /must be positive/);
+
+// node:test:
+assert.throws(() => parseAmount(-5), RangeError);
+await assert.rejects(parseAmountAsync(-5), RangeError);
+```
+
+Flag `try { ... } catch (e) { /* nothing */ }` and `try { ... } catch { expect(...) }` patterns as Exception Handling smells unless the catch performs a specific assertion.
+
+## Mystery Guest — Common JS/TS Patterns
+
+| Indicator | What to look for |
+|-----------|------------------|
+| File system | `fs.readFileSync`, `fs.promises.readFile`, hard-coded absolute paths |
+| Database | direct `pg.Client`, `mongodb.MongoClient` against a real DB |
+| Network | `fetch`, `axios.get/post`, `http.request` without a mock adapter |
+| Environment | `process.env.X` (especially without default) |
+| Acceptable | `memfs`, `mock-fs`, `nock`, `msw`, `axios-mock-adapter`, `vi.mock` / `jest.mock` |
+
+## Integration Test Markers
+
+- Folder names: `__tests__/integration/`, `tests/e2e/`, `cypress/`, `playwright/`
+- File suffix: `*.integration.test.ts`, `*.e2e.test.ts`
+- `describe('Integration: …', …)` wrappers
+- Playwright/Cypress/WebdriverIO usage almost always implies E2E
+
+## Setup/Teardown
+
+| Framework | Per-test | Per-suite |
+|-----------|----------|-----------|
+| Jest / Vitest / Mocha / Jasmine | `beforeEach()` / `afterEach()` | `beforeAll()` / `afterAll()` (Mocha: `before` / `after`) |
+| node:test | `beforeEach(fn)` / `afterEach(fn)` from `node:test` | `before(fn)` / `after(fn)` |
+
+## Tag/Trait Attributes (for `test-tagging`)
+
+**Default mode: report-only.** JS/TS test frameworks generally have no canonical tag attribute. Strategies:
+
+- **describe-based grouping** — wrap tests in `describe('@positive | OrderService', ...)` and grep the prefix.
+- **Test name prefixes** — `it('[boundary] handles zero quantity', ...)`.
+- **Vitest options object** — Vitest accepts arbitrary metadata on tests but no first-class tag filter.
+- **Custom reporters** — projects can read JSDoc-style `@tags` and surface them.
+
+Only switch to `auto-edit` mode when the project already follows one of these conventions (detect by sampling existing tests).
+
+## Language-specific calibration notes
+
+- **Async tests missing `await`** are a critical smell. `expect(promise).resolves.toBe(...)` without `await` resolves nothing and the test passes silently. Flag any unawaited promise inside a test body (linters: `@typescript-eslint/no-floating-promises`, `vitest/no-disabled-tests`).
+- **Snapshot tests** count as assertions — but flag stale or always-passing snapshots (no `expect.assertions(n)` and only `toMatchSnapshot`).
+- **`expect.assertions(n)`** is a useful guardrail; tests using it lock in assertion count.
+- **Implicit assertion via mock matchers**: `expect(mock).toHaveBeenCalled()` is a valid assertion — do not treat as assertion-free.
+- **Done callbacks** in Mocha-style tests (`it('x', (done) => { ... done(); })`) are legacy; absence of `done()` call in a callback test is a silent pass.
+- **`xit`/`xdescribe`** are commits of disabled tests — flag like `[Ignore]`.
+- **`.only`** committed to source is a critical smell — silently disables the rest of the file/suite.
+- **describe.each / test.each** are parametrized; not duplicate tests.
+- **`fail()` is removed in Jest 27+** — flag `if (cond) fail('msg')` patterns and recommend `expect.fail()` or explicit conditions.

--- a/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
+++ b/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
@@ -1,27 +1,30 @@
 ---
 name: test-anti-patterns
 description: >
-  Audits existing .NET test code (MSTest, xUnit, NUnit, TUnit) for
-  anti-patterns and quality issues that undermine reliability and diagnostic
-  value — produces a severity-ranked report (Critical / Warning / Info) with
-  concrete code-level fixes and acknowledgement of what the tests do well.
-  INVOKE THIS SKILL when the user asks to audit, review, rank, or find
-  problems in existing tests — including prompts about: "audit my tests",
-  "audit for .NET test anti-patterns", "test smell audit", "rank by
-  severity", "are these tests good", tests that pass but verify nothing,
-  no/missing assertions, swallowed exceptions, always-true / self-comparing
-  / self-referential / tautological assertions, broad exception types,
-  flakiness (Thread.Sleep, DateTime.Now), ordering dependency, shared
-  static state, reflection coupling, duplicated tests, magic values,
-  coverage touching, coverage inflation.
-  DO NOT USE FOR: writing new tests (use writing-mstest-tests); running
-  tests (use run-tests); framework migration (use migration skills).
+  Audits existing test code in any language for anti-patterns and quality
+  issues — produces a severity-ranked report (Critical / Warning / Info)
+  with concrete code-level fixes. Polyglot: .NET (MSTest/xUnit/NUnit/
+  TUnit), Python (pytest/unittest), TS/JS (Jest/Vitest/Mocha/node:test),
+  Java (JUnit/TestNG), Go, Ruby (RSpec/Minitest), Rust, Swift, Kotlin
+  (JUnit/Kotest), PowerShell (Pester), C++ (GoogleTest/Catch2).
+  INVOKE when asked to audit, review, rank, or find problems in existing
+  tests — "audit my tests", "test smell audit", "rank by severity", tests
+  that pass but verify nothing, no/missing assertions, swallowed
+  exceptions, always-true / self-comparing / tautological assertions,
+  broad exception types, flakiness (sleep/Date.now/time.sleep), ordering
+  dependency, shared global state, duplicated tests, magic values,
+  missing await on async assertions.
+  DO NOT USE FOR: writing new tests (use code-testing-agent, or
+  writing-mstest-tests for MSTest); running tests (use run-tests);
+  framework migration.
 license: MIT
 ---
 
 # Test Anti-Pattern Detection
 
-Quick, pragmatic analysis of .NET test code for anti-patterns and quality issues that undermine test reliability, maintainability, and diagnostic value.
+Quick, pragmatic analysis of test code in any supported language for anti-patterns and quality issues that undermine test reliability, maintainability, and diagnostic value.
+
+> **Language-specific guidance**: Call the `test-analysis-extensions` skill to discover available extension files, then read the file matching the target codebase (e.g., `extensions/dotnet.md`, `extensions/python.md`, `extensions/typescript.md`, `extensions/go.md`). The extension file tells you which sleep / time / random / skip / setup-teardown / mystery-guest APIs to look for in that language.
 
 ## When to Use
 
@@ -33,11 +36,11 @@ Quick, pragmatic analysis of .NET test code for anti-patterns and quality issues
 
 ## When Not to Use
 
-- User wants to write new tests from scratch (use `writing-mstest-tests`)
-- User wants direct implementation fixes in MSTest code rather than a diagnostic review (use `writing-mstest-tests`)
-- User asks to fix swapped `Assert.AreEqual` argument order (use `writing-mstest-tests`)
-- User asks to convert `DynamicData` from `IEnumerable<object[]>` to `ValueTuple` (use `writing-mstest-tests`)
-- User wants to run or execute tests (use `run-tests`)
+- User wants to write new tests from scratch (use `code-testing-agent` for any language, or `writing-mstest-tests` for MSTest specifically)
+- User wants direct implementation fixes rather than a diagnostic review (use the relevant write/edit skill)
+- User asks to fix swapped `Assert.AreEqual` argument order in MSTest (use `writing-mstest-tests`)
+- User asks to convert MSTest `DynamicData` from `IEnumerable<object[]>` to `ValueTuple` (use `writing-mstest-tests`)
+- User wants to run or execute tests (use `run-tests` for .NET)
 - User wants to migrate between test frameworks or versions (use migration skills)
 - User wants to measure code coverage (out of scope)
 - User wants a deep formal test smell audit with academic taxonomy and extended catalog (use `test-smell-detection`)
@@ -52,70 +55,81 @@ Quick, pragmatic analysis of .NET test code for anti-patterns and quality issues
 
 ## Workflow
 
-### Step 1: Gather the test code
+### Step 1: Detect language and load extension
 
-Read the test files the user wants reviewed. If the user points to a directory or project, scan for all test files using the framework-specific markers in the `dotnet-test-frameworks` skill (e.g., `[TestClass]`, `[Fact]`, `[Test]`).
+Identify the target codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file. The extension file documents framework-specific anti-pattern markers — what counts as a sleep/wait, a test marker, a skip, a setup/teardown, a shared-state hot spot, and an integration boundary — so this skill stays language-neutral.
+
+### Step 2: Gather the test code
+
+Read the test files the user wants reviewed. If the user points to a directory or project, scan for all test files using the discovery markers in the loaded language extension file (e.g., `[TestClass]`/`[Fact]`/`[Test]` for .NET, `test_*.py` / `def test_*` for pytest, `*.test.ts` / `it()` for Jest, `*Test.java` / `@Test` for JUnit, `*_test.go` / `func TestXxx` for Go, `*_spec.rb` for RSpec, `#[test]` for Rust, `*.Tests.ps1` / `Describe` for Pester, `TEST(...)` for GoogleTest, `TEST_CASE(...)` for Catch2/doctest).
 
 If production code is available, read it too -- this is critical for detecting tests that are coupled to implementation details rather than behavior.
 
-### Step 2: Scan for anti-patterns
+### Step 3: Scan for anti-patterns
 
-Check each test file against the anti-pattern catalog below. Report findings grouped by severity.
+Check each test file against the anti-pattern catalog below. Report findings grouped by severity. The examples are .NET-centric but the patterns generalize — use the loaded language extension file to map each pattern to the framework you are auditing.
 
 #### Critical -- Tests that give false confidence
 
 | Anti-Pattern | What to Look For |
 |---|---|
-| **No assertions** | Test methods that execute code but never assert anything. A passing test without assertions proves nothing. |
-| **Coverage touching** | Test class that methodically calls every public method on a type — often in alphabetical or declaration order — without asserting meaningful outcomes. Each test typically does `var result = sut.MethodName(...)` with no assertion, or only a trivial `Assert.IsNotNull(result)`. The intent is to inflate code-coverage metrics rather than verify behavior. Distinct from a single assertion-free test: the pattern is *systematic* coverage of the surface area with no real verification. |
-| **Self-referential assertion** | Asserts that the output of an operation equals its input when the operation is expected to be an identity or no-op, e.g. `Assert.AreEqual(input, Parse(input.ToString()))` or `Assert.AreEqual(x, Identity(x))`. The test is tautological — it can only fail if the round-trip is broken, but it never verifies that a *transformation* actually happened. Also catches `Assert.AreEqual(dto.Name, dto.Name)` (asserting a field against itself). |
-| **Swallowed exceptions** | `try { ... } catch { }` or `catch (Exception)` without rethrowing or asserting. Failures are silently hidden. |
-| **Assert in catch block only** | `try { Act(); } catch (Exception ex) { Assert.Fail(ex.Message); }` -- use `Assert.ThrowsException` or equivalent instead. The test passes when no exception is thrown even if the result is wrong. |
-| **Always-true assertions** | `Assert.IsTrue(true)`, `Assert.AreEqual(x, x)`, or conditions that can never fail. |
+| **No assertions** | Test methods that execute code but never assert anything. A passing test without assertions proves nothing. In .NET look for missing `Assert.*`; in pytest a function with no `assert` and no `pytest.raises`; in Jest no `expect(...)`; in JUnit no `assert*`/`assertThat`; in Go a test that never calls `t.Error*`, `t.Fatal*`, or testify; in RSpec a block with no `expect`; in Pester no `Should`. Mock-call verifications (`verify(mock)`, `expect(mock).toHaveBeenCalled`, `Should -Invoke`) are real assertions. |
+| **Missing await on async assertions (JS/TS, .NET, Python, Kotlin, Swift)** | `expect(promise).resolves.toBe(x)` without `await`/`return`, `pytest-asyncio` test with un-awaited coroutine, `async Task` xUnit test calling `Assert.ThrowsAsync` without `await`, Kotest suspending test without `runTest`, Swift Testing async test without `await`. These tests silently pass even when the underlying assertion would have failed. |
+| **Coverage touching** | Test class that methodically calls every public member on a type — often in alphabetical or declaration order — without asserting meaningful outcomes. Each test typically does `var result = sut.MethodName(...)` (or `result = sut.method_name(...)`, `sut.methodName()`, `sut.MethodName(t)`) with no assertion, or only a trivial null/None/nil check. The intent is to inflate code-coverage metrics rather than verify behavior. Distinct from a single assertion-free test: the pattern is *systematic* coverage of the surface area with no real verification. |
+| **Self-referential assertion** | Asserts that the output of an operation equals its input when the operation is expected to be an identity or no-op, e.g. `Assert.AreEqual(input, Parse(input.ToString()))`, `assert input == parse(str(input))`, `expect(parse(input.toString())).toBe(input)`, `assert.Equal(t, input, parse(input))`. Also flags `Assert.AreEqual(dto.Name, dto.Name)` / `assert dto.name == dto.name` / `expect(dto.name).toBe(dto.name)` (asserting a field against itself). The test is tautological — it can only fail if the round-trip is broken, but never verifies that a *transformation* actually happened. |
+| **Swallowed exceptions** | `try { ... } catch { }`, `catch (Exception)` without rethrowing or asserting (.NET); bare `except:` or `except Exception:` with `pass` (Python); `try { ... } catch (e) {}` (JS/TS/Java); `defer recover()` without re-panic and no assertion (Go); `rescue StandardError` with no assertion (Ruby); `Result::unwrap_or(...)` swallowing errors in a test (Rust); empty `catch` block (Kotlin/Swift). |
+| **Assert in catch block only** | `try { Act(); } catch (Exception ex) { Assert.Fail(ex.Message); }` (and equivalents in other languages) -- use `Assert.ThrowsException` / `pytest.raises` / `expect(fn).toThrow` / `assertThrows` / `assert.Error(t, err)` / `#[should_panic]` / `Should -Throw` / `EXPECT_THROW` instead. The test passes when no exception is thrown even if the result is wrong. |
+| **Always-true assertions** | `Assert.IsTrue(true)`, `Assert.AreEqual(x, x)`, `assert True`, `expect(true).toBe(true)`, `assert.True(t, true)`, `assert!(true)`, or conditions that can never fail. |
 | **Commented-out assertions** | Assertions that were disabled but the test still runs, giving the illusion of coverage. |
 
 #### High -- Tests likely to cause pain
 
 | Anti-Pattern | What to Look For |
 |---|---|
-| **Flakiness indicators** | `Thread.Sleep(...)`, `Task.Delay(...)` for synchronization, `DateTime.Now`/`DateTime.UtcNow` without abstraction, `Random` without a seed, environment-dependent paths. |
-| **Test ordering dependency** | Static mutable fields modified across tests, `[TestInitialize]` that doesn't fully reset state, tests that fail when run individually but pass in suite (or vice versa). |
-| **Over-mocking** | More mock setup lines than actual test logic. Verifying exact call sequences on mocks rather than outcomes. Mocking types the test owns. For a deep mock audit, use `exp-mock-usage-analysis`. |
-| **Implementation coupling** | Testing private methods via reflection, asserting on internal state, verifying exact method call counts on collaborators instead of observable behavior. |
-| **Broad exception assertions** | `Assert.ThrowsException<Exception>(...)` instead of the specific exception type. Also: `[ExpectedException(typeof(Exception))]`. |
+| **Flakiness indicators** | Wall-clock sleeps/waits used for synchronization: `Thread.Sleep` / `Task.Delay` (.NET), `time.sleep` (Python), `setTimeout` / `await new Promise(r => setTimeout(...))` (JS/TS), `Thread.sleep` (Java/Kotlin), `time.Sleep` (Go), `sleep` (Ruby/Bash), `std::thread::sleep` (Rust), `Start-Sleep` (Pester), `std::this_thread::sleep_for` (C++). Wall-clock reads without abstraction: `DateTime.Now`/`UtcNow`, `datetime.now()`/`datetime.utcnow()`, `Date.now()` / `new Date()`, `System.currentTimeMillis()`, `time.Now()`, `Time.now`, `Instant::now()`, `Date()`/`Date.now`, `Get-Date`, `std::chrono::system_clock::now`. Unseeded randomness: `new Random()`, `random.random()`/`random.randint()`, `Math.random()`, `new Random()` (Java/Kotlin), `rand.Int()` without seed, `rand` (Ruby), `rand::random()` (Rust). Environment-dependent paths (hard-coded `C:\...`, `/tmp/...`, network hosts). |
+| **Test ordering dependency** | Static/global mutable state modified across tests; setup that doesn't fully reset state (`[TestInitialize]`, `setUp`, `beforeEach`, `before(:each)`, `BeforeEach`, `t.Cleanup`); tests that fail when run individually but pass in suite (or vice versa). Examples per language: `static` fields (.NET/Java), module-level globals (Python), top-level `let`/`const` in test file (JS/TS), `var` package globals (Go), class variables (Ruby), `static mut`/`lazy_static!`/`OnceCell` (Rust), `$script:` variables (PowerShell). |
+| **Over-mocking** | More mock setup lines than actual test logic. Verifying exact call sequences on mocks rather than outcomes. Mocking types the test owns. Per language: Moq/NSubstitute/FakeItEasy (.NET), `unittest.mock` / `pytest-mock` (Python), Jest auto-mocks / Sinon (JS/TS), Mockito/PowerMock (Java), gomock/testify mock (Go), RSpec mocks/mocha (Ruby), `mockall` (Rust), MockK (Kotlin), `Mock` cmdlet (Pester), gmock (C++). For a deep mock audit in .NET, use `exp-mock-usage-analysis`. |
+| **Implementation coupling** | Testing private methods via reflection (`MethodInfo.Invoke`, `getattr` in Python, `(thing as any)` in TS, `Field.setAccessible(true)` in Java, `Object#send` in Ruby, internal `pub(crate)` access in Rust). Asserting on internal state instead of observable behavior. Verifying exact method call counts on collaborators instead of business outcomes. |
+| **Broad exception assertions** | `Assert.ThrowsException<Exception>(...)` (.NET) / `pytest.raises(Exception)` / `expect(fn).toThrow(Error)` without a message matcher / `assertThrows(Exception.class, ...)` (Java) / `assert.Error(t, err)` without checking the kind / `expect { ... }.to raise_error` without class (RSpec) / `#[should_panic]` without `expected = "..."` / `Should -Throw` without `-ExpectedMessage` / `EXPECT_ANY_THROW` instead of `EXPECT_THROW(stmt, SpecificType)`. |
 
 #### Medium -- Maintainability and clarity issues
 
 | Anti-Pattern | What to Look For |
 |---|---|
-| **Poor naming** | Test names like `Test1`, `TestMethod`, names that don't describe the scenario or expected outcome. Good: `Add_NegativeNumber_ThrowsArgumentException`. |
-| **Magic values** | Unexplained numbers or strings in arrange/assert: `Assert.AreEqual(42, result)` -- what does 42 mean? |
-| **Duplicate tests** | Three or more test methods with near-identical bodies that differ only in a single input value. Should be data-driven (`[DataRow]`, `[Theory]`, `[TestCase]`). For a detailed duplication analysis, use `exp-test-maintainability`. Note: Two tests covering distinct boundary conditions (e.g., zero vs. negative) are NOT duplicates -- separate tests for different edge cases provide clearer failure diagnostics and are a valid practice. |
+| **Poor naming** | Test names like `Test1`, `TestMethod`, `test`, names that don't describe the scenario or expected outcome. Good naming differs by language convention — see the loaded language extension file (e.g., `Add_NegativeNumber_ThrowsArgumentException` for .NET, `test_add_negative_number_raises_value_error` for pytest, `addNegativeNumber_throwsArgumentException` for Java, `'adds negative number throws'` for Jest descriptions, `TestAdd_NegativeNumber_ReturnsError` for Go). |
+| **Magic values** | Unexplained numbers or strings in arrange/assert: `Assert.AreEqual(42, result)` / `assert result == 42` / `expect(result).toBe(42)` -- what does 42 mean? |
+| **Duplicate tests** | Three or more test methods with near-identical bodies that differ only in a single input value. Should be parametrized: `[DataRow]`/`[Theory]`/`[TestCase]` (.NET), `@pytest.mark.parametrize` (pytest), `test.each` / `it.each` (Jest/Vitest), `@ParameterizedTest` + `@ValueSource` (JUnit 5), `@DataProvider` (TestNG), Go table-driven tests, `where` / shared examples (RSpec), `#[rstest]` (Rust), `@ParameterizedTest` + `@MethodSource` (Kotlin), `-ForEach` / `-TestCases` (Pester), `INSTANTIATE_TEST_SUITE_P` (GoogleTest), `SECTION` / `GENERATE` (Catch2), `TEST_CASE_TEMPLATE` (doctest). For a detailed duplication analysis in .NET, use `exp-test-maintainability`. Note: Two tests covering distinct boundary conditions (e.g., zero vs. negative) are NOT duplicates -- separate tests for different edge cases provide clearer failure diagnostics and are a valid practice. |
 | **Giant tests** | Test methods exceeding ~30 lines or testing multiple behaviors at once. Hard to diagnose when they fail. |
-| **Assertion messages that repeat the assertion** | `Assert.AreEqual(expected, actual, "Expected and actual are not equal")` adds no information. Messages should describe the business meaning. |
-| **Missing AAA separation** | Arrange, Act, Assert phases are interleaved or indistinguishable. |
+| **Assertion messages that repeat the assertion** | `Assert.AreEqual(expected, actual, "Expected and actual are not equal")` / `assert x == y, "x is not equal to y"` / `assertEquals(x, y, "values not equal")` add no information. Messages should describe the business meaning. |
+| **Missing AAA / Given-When-Then separation** | Arrange/Act/Assert (or Given/When/Then for BDD frameworks like RSpec, Kotest behavior specs, Pester) phases are interleaved or indistinguishable. |
 
 #### Low -- Style and hygiene
 
 | Anti-Pattern | What to Look For |
 |---|---|
-| **Unused test infrastructure** | `[TestInitialize]`/`[SetUp]` that does nothing, test helper methods that are never called. |
-| **IDisposable not disposed** | Test creates `HttpClient`, `Stream`, or other disposable objects without `using` or cleanup. |
-| **Console.WriteLine debugging** | Leftover `Console.WriteLine` or `Debug.WriteLine` statements used during test development. |
-| **Inconsistent naming convention** | Mix of naming styles in the same test class (e.g., some use `Method_Scenario_Expected`, others use `ShouldDoSomething`). |
+| **Unused test infrastructure** | Setup/teardown hooks that do nothing — `[TestInitialize]`/`[SetUp]`/`[BeforeEach]`, `setUp`/`@BeforeEach`/`@BeforeAll`, `beforeEach`/`beforeAll`, `before(:each)`/`before(:all)`, `BeforeEach`/`BeforeAll` (Pester), `setUpWithError` (XCTest) — and test helper methods that are never called. |
+| **Unmanaged resources** | Test creates disposable/closeable resources without cleanup: `HttpClient`/`Stream` without `using` (.NET), file/connection without `with` block or `try/finally` (Python), `FileInputStream` without `try-with-resources` (Java), `defer file.Close()` missing (Go), connection without `ensure` (Ruby), `Drop` not relied on / forgotten `close` (Rust), missing teardown for temp files / DBs in any language. |
+| **Print debugging** | Leftover `Console.WriteLine` / `Debug.WriteLine` / `print()` / `console.log` / `System.out.println` / `fmt.Println` / `puts` / `dbg!` / `Write-Host` / `std::cout` statements used during test development. |
+| **Inconsistent naming convention** | Mix of naming styles in the same test class/module/file (e.g., some use `Method_Scenario_Expected`, others use `ShouldDoSomething`). |
 
-### Step 3: Calibrate severity honestly
+### Step 4: Calibrate severity honestly
 
 Before reporting, re-check each finding against these severity rules:
 
-- **Critical/High**: Only for issues that cause tests to give false confidence or be unreliable. A test that always passes regardless of correctness is Critical. Flaky shared state is High.
-- **Medium**: Only for issues that actively harm maintainability -- 5+ nearly-identical tests, truly meaningless names like `Test1`.
+- **Critical/High**: Only for issues that cause tests to give false confidence or be unreliable. A test that always passes regardless of correctness is Critical. Flaky shared state is High. Missing-await on async assertions is Critical (silent pass).
+- **Medium**: Only for issues that actively harm maintainability -- 5+ nearly-identical tests, truly meaningless names like `Test1` / `test` / `it1`.
 - **Low**: Cosmetic naming mismatches, minor style preferences, assertion messages that could be better. When in doubt, rate Low.
-- **Not an issue**: Separate tests for distinct boundary conditions (zero vs. negative vs. null). Explicit per-test setup instead of `[TestInitialize]` (this *improves* isolation). Tests that are short and clear but could theoretically be consolidated.
+- **Not an issue** (per-language nuance):
+  - Go and Rust **table-driven loops** with sub-tests (`t.Run` / `for case in cases { ... }`) are *idiomatic*, not "Conditional Test Logic". Do NOT flag.
+  - pytest **bare `assert`** is the canonical assertion form, not a missing assertion library. Do NOT flag.
+  - Go tests use `if got != want { t.Errorf(...) }` as canonical equality. Do NOT flag as ad-hoc.
+  - Separate tests for distinct boundary conditions (zero vs. negative vs. null). Do NOT flag as duplicates.
+  - Explicit per-test setup instead of `[TestInitialize]` / `beforeEach` (this *improves* isolation).
+  - Tests that are short and clear but could theoretically be consolidated.
 
 IMPORTANT: If the tests are well-written, say so clearly up front. Do not inflate severity to justify the review. A review that finds zero Critical/High issues and only minor Low suggestions is a valid and valuable outcome. Lead with what the tests do well.
 
-### Step 4: Report findings
+### Step 5: Report findings
 
 Present findings in this structure:
 
@@ -128,7 +142,7 @@ Present findings in this structure:
 3. **Medium and Low findings** -- Summarize in a table unless the user wants full detail
 4. **Positive observations** -- Call out things the tests do well (sealed class, specific exception types, data-driven tests, clear AAA structure, proper use of fakes, good naming). Don't only report negatives.
 
-### Step 5: Prioritize recommendations
+### Step 6: Prioritize recommendations
 
 If there are many findings, recommend which to fix first:
 
@@ -150,9 +164,11 @@ If there are many findings, recommend which to fix first:
 |---------|----------|
 | Reporting style issues as critical | Naming and formatting are Medium/Low, never Critical |
 | Suggesting rewrites instead of targeted fixes | Show minimal diffs -- change the assertion, not the whole test |
-| Flagging intentional design choices | If `Thread.Sleep` is in an integration test testing actual timing, that's not an anti-pattern. Consider context. |
+| Flagging intentional design choices | If `Thread.Sleep` / `time.sleep` / `time.Sleep` is in an integration test testing actual timing, that's not an anti-pattern. Consider context. |
 | Inventing false positives on clean code | If tests follow best practices, say so. A review finding "0 Critical, 0 High, 1 Low" is perfectly valid. Don't inflate findings to justify the review. |
 | Flagging separate boundary tests as duplicates | Two tests for zero and negative inputs test different edge cases. Only flag as duplicates when 3+ tests have truly identical bodies differing by a single value. |
 | Rating cosmetic issues as Medium | Naming mismatches (e.g., method name says `ArgumentException` but asserts `ArgumentOutOfRangeException`) are Low, not Medium -- the test still works correctly. |
-| Ignoring the test framework | xUnit uses `[Fact]`/`[Theory]`, NUnit uses `[Test]`/`[TestCase]`, MSTest uses `[TestMethod]`/`[DataRow]` -- use correct terminology |
+| Ignoring the test framework | Use correct terminology per the loaded language extension: xUnit `[Fact]`/`[Theory]`, NUnit `[Test]`/`[TestCase]`, MSTest `[TestMethod]`/`[DataRow]`, pytest `def test_*` / `@pytest.mark.parametrize`, Jest `it.each` / `describe`, JUnit `@Test` / `@ParameterizedTest`, Go `func TestXxx(t *testing.T)` + table-driven, RSpec `describe`/`it`, Pester `Describe`/`It`, Rust `#[test]` / `#[rstest]`, Catch2 `TEST_CASE`/`SECTION`. |
+| Treating idiomatic patterns as smells | Go/Rust **table-driven loops** are idiomatic. Pytest **bare `assert`** is canonical. Go's `if got != want { t.Errorf(...) }` is canonical. JS/TS `expect(mock).toHaveBeenCalledWith(...)` is a real assertion, not an over-mock. Do NOT flag these. |
+| Missing async-test pitfalls | A Jest test that calls `expect(promise).resolves.toBe(x)` without returning/awaiting the promise silently passes; a TUnit/xUnit `async Task` test calling `Assert.ThrowsAsync` without `await` silently passes; pytest-asyncio tests with un-awaited coroutines silently pass. Always flag as Critical. |
 | Missing the forest for the trees | If 80% of tests have no assertions, lead with that systemic issue rather than listing every instance |

--- a/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
+++ b/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: test-gap-analysis
-description: "Performs pseudo-mutation analysis on .NET production code to find gaps in existing test suites. Use when the user asks to find weak tests, discover untested edge cases, check if tests would catch a bug, or evaluate test effectiveness through mutation-style reasoning. Analyzes production code for mutation points (boundary conditions, boolean flips, null returns, exception removal, arithmetic changes) and checks whether existing tests would detect each mutation. Works with MSTest, xUnit, NUnit, and TUnit. DO NOT USE FOR: writing new tests (use writing-mstest-tests), detecting test anti-patterns (use test-anti-patterns), measuring assertion diversity (use assertion-quality), or running actual mutation testing tools."
+description: "Performs pseudo-mutation analysis on production code in any language to find gaps in existing test suites. Use when the user asks to find weak tests, discover untested edge cases, check if tests would catch a bug, or evaluate test effectiveness through mutation-style reasoning. Analyzes production code for mutation points (boundaries, boolean flips, null/None/nil returns, exception/error removal, arithmetic changes) and checks whether tests would detect each mutation. Polyglot: .NET (MSTest/xUnit/NUnit/TUnit), Python (pytest/unittest), TS/JS (Jest/Vitest/Mocha/node:test), Java (JUnit/TestNG), Go, Ruby (RSpec/Minitest), Rust, Swift, Kotlin (JUnit/Kotest), PowerShell (Pester), C++ (GoogleTest/Catch2). DO NOT USE FOR: writing new tests (use code-testing-agent, or writing-mstest-tests for MSTest), detecting anti-patterns (use test-anti-patterns), measuring assertion diversity (use assertion-quality), or running actual mutation testing tools (Stryker, mutmut, PIT, cargo-mutants)."
 license: MIT
 ---
 
 # Test Gap Analysis via Pseudo-Mutation
 
-Analyze .NET production code by reasoning about hypothetical mutations and checking whether existing tests would catch them. This reveals blind spots where tests pass but would continue to pass even if the code were broken.
+Analyze production code in any supported language by reasoning about hypothetical mutations and checking whether existing tests would catch them. This reveals blind spots where tests pass but would continue to pass even if the code were broken.
+
+> **Language-specific guidance**: Call the `test-analysis-extensions` skill to discover available extension files, then read the file matching the target codebase (e.g., `extensions/dotnet.md`, `extensions/python.md`, `extensions/typescript.md`). The extension file helps you find test files, recognize framework-specific assertion APIs, and identify language-specific null/None/nil patterns and error-handling idioms that map to the mutation catalog below.
 
 ## Why Pseudo-Mutation Matters
 
@@ -33,10 +35,10 @@ This skill performs **static pseudo-mutation** — reasoning about mutations wit
 
 ## When Not to Use
 
-- User wants to write new tests from scratch (use `writing-mstest-tests`)
+- User wants to write new tests from scratch (use `code-testing-agent` for any language, or `writing-mstest-tests` for MSTest specifically)
 - User wants to detect test anti-patterns like flakiness or poor naming (use `test-anti-patterns`)
 - User wants to measure assertion variety (use `assertion-quality`)
-- User wants to run an actual mutation testing framework like Stryker (help them directly)
+- User wants to run an actual mutation testing framework (Stryker for .NET/JS/TS, mutmut for Python, PIT for Java, go-mutesting for Go, cargo-mutants for Rust, mutant for Ruby) — help them directly with the tool
 - User only wants code coverage numbers (out of scope)
 
 ## Inputs
@@ -49,13 +51,17 @@ This skill performs **static pseudo-mutation** — reasoning about mutations wit
 
 ## Workflow
 
-### Step 1: Gather production and test code
+### Step 1: Detect language and load extension
 
-Read both the production code and its corresponding test files. If the user points to a directory, identify production/test pairs by convention (e.g., `Calculator.cs` tested by `CalculatorTests.cs`).
+Identify the target codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file. The mutation catalog below uses language-neutral concepts; the extension file tells you how each concept maps in the language you are analyzing (e.g., `null` vs `None` vs `nil` vs `undefined`, `throw` vs `raise` vs `panic!` vs `return err`).
 
-Establish which production methods are exercised by which test methods — trace this through method calls in test code, setup, and helper methods.
+### Step 2: Gather production and test code
 
-### Step 2: Identify mutation points
+Read both the production code and its corresponding test files. If the user points to a directory, identify production/test pairs by convention — defaults differ by language: `.cs` ↔ `*Tests.cs`/`*.Tests.cs` (.NET), `foo.py` ↔ `test_foo.py`/`foo_test.py` (Python), `foo.ts` ↔ `foo.test.ts`/`foo.spec.ts` (JS/TS), `Foo.java` ↔ `FooTest.java`/`FooTests.java` (Java), `foo.go` ↔ `foo_test.go` (Go), `foo.rb` ↔ `foo_spec.rb`/`test_foo.rb` (Ruby), `lib.rs` ↔ inline `#[cfg(test)] mod tests` or `tests/foo.rs` (Rust), `Foo.swift` ↔ `FooTests.swift` (Swift), `Foo.kt` ↔ `FooTest.kt`/`FooSpec.kt` (Kotlin), `Foo.ps1` ↔ `Foo.Tests.ps1` (Pester), `foo.cpp` ↔ `foo_test.cpp`/`test_foo.cpp` (C++).
+
+Establish which production methods are exercised by which test methods — trace this through method calls in test code, setup, helper methods, and shared examples.
+
+### Step 3: Identify mutation points
 
 Scan the production code and annotate every location where a mutation could reveal a test gap. Use the mutation catalog below.
 
@@ -86,21 +92,24 @@ Scan the production code and annotate every location where a mutation could reve
 
 | Original | Mutation | What it tests |
 |----------|----------|---------------|
-| `return result` | `return null` | Null handling downstream |
-| `return result` | `return default` | Default value handling |
+| `return result` | `return null` / `return None` / `return nil` / `return undefined` | Null/None/nil handling downstream |
+| `return result` | `return default(T)` / `return T()` / `return ""` / `return 0` | Default value handling |
 | `return true` | `return false` | Boolean return verification |
-| `return list` | `return new List<T>()` | Empty collection handling |
+| `return list` | `return new List<T>()` / `return []` / `return Array.Empty<T>()` / `return make([]T, 0)` / `return Vec::new()` / `return @[]` | Empty collection handling |
 | `return count` | `return 0` or `return count + 1` | Numeric return verification |
-| `return string` | `return ""` or `return null` | String return verification |
+| `return string` | `return ""` or `return null`/`None`/`nil` | String return verification |
+| `return Ok(x)` | `return Err(...)` (Rust) | Result/error variant |
+| `return value, nil` | `return zero, err` (Go) | Error tuple |
 
-#### Exception Removal Mutations
+#### Exception / Error Removal Mutations
 
 | Original | Mutation | What it tests |
 |----------|----------|---------------|
-| `throw new ArgumentNullException(...)` | _(remove entire throw)_ | Guard clause verification |
-| `throw new InvalidOperationException(...)` | _(remove entire throw)_ | State validation testing |
-| `if (x == null) throw ...` | _(remove entire guard)_ | Null guard testing |
-| `if (!IsValid()) throw ...` | _(remove entire check)_ | Validation testing |
+| `throw new ArgumentNullException(...)` (.NET) / `raise ValueError(...)` (Python) / `throw new Error(...)` (JS) / `throw new IllegalArgumentException(...)` (Java) / `panic!(...)` (Rust) / `panic(...)` (Go) / `raise ArgumentError` (Ruby) / `throw RuntimeException(...)` (Kotlin) / `throw FooError.bar` (Swift) / `throw "..."` (Pester) / `throw std::invalid_argument(...)` (C++) | _(remove entire throw/raise/panic)_ | Guard clause verification |
+| `if (x == null) throw ...` / `if x is None: raise ...` / `if (!x) throw ...` / `if x == nil { return err }` (Go) / `assert!(x.is_some())` (Rust) | _(remove entire guard)_ | Null/None/nil guard testing |
+| `if (!IsValid()) throw ...` / `if not is_valid(): raise ...` / etc. | _(remove entire check)_ | Validation testing |
+| `return err` after error check (Go) | _(remove or swallow error)_ | Error propagation |
+| `?` operator (Rust) | `.unwrap()` or `.expect(...)` | Error short-circuit |
 
 #### Arithmetic Mutations
 
@@ -114,17 +123,17 @@ Scan the production code and annotate every location where a mutation could reve
 | `x++` | `x--` | Increment direction |
 | `-value` | `value` | Sign flip |
 
-#### Null-Check Removal Mutations
+#### Null / None / Nil-Check Removal Mutations
 
 | Original | Mutation | What it tests |
 |----------|----------|---------------|
-| `if (x == null) return ...` | _(remove null check)_ | Null path coverage |
-| `if (x != null) { ... }` | _(always enter block)_ | Null guard necessity |
-| `x ?? defaultValue` | `x` | Null coalescing coverage |
-| `x?.Method()` | `x.Method()` | Null-conditional coverage |
-| `x!` | `x` | Null-forgiving operator necessity |
+| `if (x == null) return ...` / `if x is None: return ...` / `if (!x) return ...` / `if x == nil { return ... }` / `unless x; return; end` (Ruby) / `if x.is_none() { return ... }` (Rust) | _(remove null/None/nil check)_ | Null path coverage |
+| `if (x != null) { ... }` / `if x is not None: ...` / `if x: ...` / `if x != nil { ... }` / `x?.let { ... }` (Kotlin) / `if let Some(x) = ... { ... }` (Rust) | _(always enter block)_ | Null/None/nil guard necessity |
+| `x ?? defaultValue` (.NET/JS/Swift) / `x or defaultValue` (Python) / `x \|\| defaultValue` (JS) / `x.unwrap_or(defaultValue)` (Rust) / `x \|\| defaultValue` (Kotlin: `x ?: defaultValue`) | `x` (drop coalescing) | Null coalescing coverage |
+| `x?.Method()` (.NET/Swift/Kotlin) / `x && x.method()` (JS) / `x and x.method()` (Python) | `x.Method()` | Null-conditional coverage |
+| `x!` (.NET/TS/Swift) / `x!!` (Kotlin) / `.unwrap()` (Rust) | `x` | Null-forgiving / unwrap necessity |
 
-### Step 3: Evaluate each mutation against tests
+### Step 4: Evaluate each mutation against tests
 
 For each identified mutation point, reason about whether existing tests would detect the change:
 
@@ -139,7 +148,7 @@ For each identified mutation point, reason about whether existing tests would de
 | **No coverage** | No test exercises this code path at all | Worse than survived — the code is untested |
 | **Equivalent** | The mutation produces identical behavior (e.g., `x * 1` → `x / 1`) | Skip — not a real mutation |
 
-### Step 4: Calibrate findings
+### Step 5: Calibrate findings
 
 Before reporting, apply these calibration rules:
 
@@ -149,7 +158,7 @@ Before reporting, apply these calibration rules:
 - **Private methods reached through public API are valid targets.** Trace through the call chain — a private method called from a tested public method may still have survived mutations if the test doesn't assert the specific behavior affected.
 - **Rate by risk, not count.** A single survived mutation in payment calculation logic is more important than five survived mutations in logging code.
 
-### Step 5: Report findings
+### Step 6: Report findings
 
 Present the analysis in this structure:
 
@@ -198,11 +207,13 @@ Present the analysis in this structure:
 
 | Pitfall | Solution |
 |---------|----------|
-| Analyzing trivial code | Skip auto-properties, simple getters, and boilerplate — focus on logic |
+| Analyzing trivial code | Skip auto-properties, simple getters, `@dataclass`/`record`/`data class` accessors, `#[derive]` impls — focus on logic |
 | Reporting equivalent mutations as gaps | If the mutation doesn't change behavior, it's not a gap — mark Equivalent |
-| Ignoring call chains | A private helper called from a tested public method is reachable — trace the chain |
-| Over-counting mutations in generated code | Skip auto-generated code, designer files, and migration files |
+| Ignoring call chains | A private/internal/unexported helper called from a tested public method is reachable — trace the chain |
+| Over-counting mutations in generated code | Skip auto-generated code (`*.g.cs`, `*.designer.cs`, `*_pb.go`, `*.pb.dart`), designer files, migration files, generated mocks/stubs |
 | Recommending a new test for every survived mutation | Multiple survived mutations in the same method often share a single missing test — recommend one test that kills several |
-| Ignoring production context | A survived mutation in `ToString()` formatting is less important than one in `CalculateTotal()` — prioritize by business risk |
+| Ignoring production context | A survived mutation in `ToString()` / `__repr__` / `toString()` formatting is less important than one in `CalculateTotal()` — prioritize by business risk |
 | Claiming 100% kill rate is required | Some mutations in low-risk code are acceptable to leave — acknowledge this in the report |
-| Not considering integration with other skills | If gaps are found, mention that `writing-mstest-tests` can help write the missing tests, and `test-anti-patterns` can audit existing test quality |
+| Not considering integration with other skills | If gaps are found, mention that `code-testing-agent` (any language) or `writing-mstest-tests` (MSTest-specific) can help write the missing tests, and `test-anti-patterns` can audit existing test quality |
+| Forgetting Go's error idiom | Removing `if err != nil { return err }` is a valid mutation target only when the function actually does something else with `err` (e.g., wrap, log, branch). Bare passthroughs in idiomatic Go are not meaningful gaps. |
+| Forgetting Rust's `?` operator | `?` propagates `Err`/`None` short-circuits. Mutating `expr?` → `expr.unwrap()` panics instead of returning — flag as Exception/Panic mutation when tests should observe the propagated error. |

--- a/plugins/dotnet-test/skills/test-smell-detection/SKILL.md
+++ b/plugins/dotnet-test/skills/test-smell-detection/SKILL.md
@@ -2,27 +2,27 @@
 name: test-smell-detection
 description: >
   Deep-dive audit using the full testsmells.org 19-smell academic catalog
-  for .NET tests. Every finding maps to a named, citable smell from the
-  research literature (Assertion Roulette, Duplicate Assert, Constructor
-  Initialization, Default Test, Mystery Guest, Eager Test, Sensitive
-  Equality, Conditional Test Logic, Sleepy Test, Magic Number Test, etc.)
-  with research-backed severity and integration-test calibration. Works
-  with MSTest, xUnit, NUnit, TUnit.
-  INVOKE THIS SKILL ONLY when the user explicitly asks for the
-  testsmells.org / 19-smell academic catalog, a research-backed smell
-  taxonomy audit, citable smell names from the literature, or a catalog
-  deep-dive beyond pragmatic anti-patterns.
-  DO NOT USE FOR: any general or pragmatic test audit — "audit my tests",
-  "do a smell audit", "review test quality", severity-ranked anti-pattern
-  reviews — use test-anti-patterns (the umbrella audit skill); writing
-  new tests (use writing-mstest-tests); running tests (use run-tests);
-  framework migration (use migration skills).
+  for tests in any language. Every finding maps to a named, citable smell
+  from the research literature (Assertion Roulette, Duplicate Assert,
+  Mystery Guest, Eager Test, Sensitive Equality, Conditional Test Logic,
+  Sleepy Test, Magic Number Test, etc.) with research-backed severity.
+  Polyglot: .NET (MSTest/xUnit/NUnit/TUnit), Python (pytest/unittest),
+  TS/JS (Jest/Vitest/Mocha/node:test), Java (JUnit/TestNG), Go, Ruby
+  (RSpec/Minitest), Rust, Swift, Kotlin (JUnit/Kotest), PowerShell
+  (Pester), C++ (GoogleTest/Catch2).
+  INVOKE ONLY when explicitly asked for the testsmells.org 19-smell
+  academic catalog or citable smell names from the literature.
+  DO NOT USE FOR: general or pragmatic audits — use test-anti-patterns;
+  writing new tests (use code-testing-agent, or writing-mstest-tests for
+  MSTest); running tests (use run-tests); framework migration.
 license: MIT
 ---
 
 # Test Smell Detection
 
-Deep formal audit of test code using an academic test smell taxonomy. Detects symptoms of bad design or implementation decisions that make tests harder to understand, more fragile, less effective at catching bugs, or more expensive to maintain. Produces a severity-ranked report with specific locations and actionable fixes.
+Deep formal audit of test code in any supported language using an academic test smell taxonomy. Detects symptoms of bad design or implementation decisions that make tests harder to understand, more fragile, less effective at catching bugs, or more expensive to maintain. Produces a severity-ranked report with specific locations and actionable fixes.
+
+> **Language-specific guidance**: Call the `test-analysis-extensions` skill to discover available extension files, then read the file matching the target codebase. The extension file documents test markers, sleep / time / random APIs, skip annotations, setup/teardown, mystery-guest indicators (file/database/network/env), integration markers, and language-specific calibration notes that drive the smell detectors below.
 
 ## Why Test Smells Matter
 
@@ -64,46 +64,60 @@ Test smells erode confidence in a test suite and inflate maintenance costs:
 
 ## Workflow
 
-### Step 1: Gather the test code
+### Step 1: Detect language and load extension
 
-Read all test files the user provides. If the user points to a directory or project, scan for all test files by looking for test framework markers — see the `dotnet-test-frameworks` skill for .NET-specific markers.
+Identify the target codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file (e.g., `extensions/dotnet.md`, `extensions/python.md`, `extensions/typescript.md`, `extensions/go.md`). The extension file lists the framework-specific test markers, sleep / wait APIs, skip / ignore attributes, mystery-guest indicators, and integration-test markers that the smell detectors below need.
+
+### Step 2: Gather the test code
+
+Read all test files the user provides. If the user points to a directory or project, scan for all test files using the markers in the loaded language extension file.
 
 For a thorough audit, also consult the [extended smell catalog](references/test-smell-catalog.md) which covers 9 additional smell types beyond the core 10 below.
 
-### Step 2: Scan for test smells
+### Step 3: Scan for test smells
 
-For each test method and class, check for the following smell categories:
+For each test method and class, check for the following smell categories. Examples reference .NET attributes but the patterns apply across all supported languages — use the loaded language extension file to map each pattern to the framework you are auditing.
 
 #### Smell 1: Conditional Test Logic
 
-Test methods containing `if`, `else`, `switch`, ternary (`? :`), `for`, `foreach`, or `while` statements. Control flow in tests means some paths may never execute, hiding gaps.
+Test methods containing `if`, `else`, `switch`, ternary (`? :`), `for`, `foreach`, `while`, or pattern-match arms that change assertion behavior. Control flow in tests means some paths may never execute, hiding gaps.
 
 **Severity:** High
-**Detection:** Any control flow statement inside a test method body.
-**Exception:** `foreach` used solely to assert every item in a known collection is acceptable when the assertion is the loop body.
+**Detection:** Any control-flow statement inside a test method body that affects which assertions run.
+**Exceptions (per-language idioms, do NOT flag):**
+- **Foreach-assert** used solely to assert every item in a known collection (the assertion *is* the loop body).
+- **Go / Rust table-driven tests**: `for _, tt := range tests { t.Run(tt.name, func(t *testing.T) { ... }) }` (Go) or `#[rstest]` parametrized loops are idiomatic.
+- **`it.each(...)` / `test.each(...)` / `@pytest.mark.parametrize` / `[Theory] + [InlineData]` / `@ParameterizedTest`** parametrization driven by data tables.
+- **Pester `-ForEach` / `-TestCases`** and **RSpec `where` blocks**.
+- **Catch2 `SECTION`s and `GENERATE(...)`**, **doctest `SUBCASE`**, **GoogleTest `INSTANTIATE_TEST_SUITE_P`**.
 
 #### Smell 2: Mystery Guest
 
 Tests that depend on external resources — files on disk, databases, network endpoints, environment variables — without making the dependency explicit or using test doubles.
 
 **Severity:** High
-**Detection:** Test methods that read files, open database connections, make HTTP requests (without a test handler), read environment variables, or use hard-coded file paths.
-**Exception:** In-memory fakes or test-specific handlers are fine.
+**Detection:** Test methods that read files, open database connections, make HTTP requests (without a test handler), read environment variables, or use hard-coded file paths. Per language: `File.ReadAllText` / `Directory.GetFiles` / `HttpClient` / `Environment.GetEnvironmentVariable` (.NET); `open()` / `pathlib.Path.read_text()` / `requests.get()` / `os.environ[...]` (Python); `fs.readFileSync` / `fetch(...)` / `process.env.X` (JS/TS); `Files.readAllBytes` / `Files.newInputStream` / `HttpClient.send` / `System.getenv` (Java); `os.ReadFile` / `http.Get` / `os.Getenv` (Go); `File.read` / `Net::HTTP.get` / `ENV[...]` (Ruby); `std::fs::read_to_string` / `reqwest::get` / `std::env::var` (Rust); `String(contentsOfFile:)` / `URLSession.shared.data` / `ProcessInfo.processInfo.environment` (Swift); `File(...).readText()` / `URL(...).openConnection()` / `System.getenv` (Kotlin); `Get-Content` / `Invoke-WebRequest` / `$env:X` (Pester); `std::ifstream` / `curl_easy_perform` / `std::getenv` (C++).
+**Exception:** In-memory fakes, test-specific handlers, or hermetic test data factories are fine.
 
 #### Smell 3: Sleepy Test
 
 Tests that call sleep or delay functions to wait for a condition. These introduce non-deterministic timing and slow down the suite.
 
 **Severity:** High
-**Detection:** Calls to sleep/delay functions inside test methods. See the `dotnet-test-frameworks` skill for .NET-specific patterns.
+**Detection:** Calls to sleep/delay functions inside test methods: `Thread.Sleep` / `Task.Delay` (.NET); `time.sleep` / `asyncio.sleep` (Python); `setTimeout` / `await new Promise(r => setTimeout(...))` / `jest.advanceTimersByTime` not paired with a wait (JS/TS); `Thread.sleep` / `TimeUnit.SECONDS.sleep` (Java); `time.Sleep` (Go); `sleep` / `Kernel#sleep` (Ruby); `std::thread::sleep` / `tokio::time::sleep` (Rust); `Thread.sleep` / `delay` (Kotlin coroutines); `sleep(_:)` / `Task.sleep` (Swift); `Start-Sleep` (Pester); `std::this_thread::sleep_for` (C++). See the matching language extension file for the full list.
 
 #### Smell 4: Assertion-Free Test (Unknown Test)
 
 Tests that execute code but never assert anything. Test frameworks report these as passing even if the code is completely broken, as long as no exception is thrown.
 
 **Severity:** High
-**Detection:** A test method with no assertion calls (framework-specific: `Assert.*`, `expect()`, `assert`, `Should*`, etc.) and no expected-exception annotation.
-**Calibration:** A method named `*_DoesNotThrow` or `*_NoException` is implicitly asserting no exception — still flag it but note it may be intentional.
+**Detection:** A test method with no assertion calls and no expected-exception annotation. Framework-specific: missing `Assert.*` (.NET); no `assert` / `pytest.raises` (Python); no `expect(...)` or `assert.*` (JS/TS); no `assert*` / `assertThat` (Java); no `t.Error*` / `t.Fatal*` / `assert.*` testify (Go); no `expect`/`.to`/`.eq` (RSpec) or `assert*`/`refute*` (Minitest); no `assert*!` / `assert_eq!` / `panic!` (Rust); no `XCTAssert*` / `#expect` (Swift); no `assert*` / `should*` / Kotest matchers (Kotlin); no `Should -*` (Pester); no `EXPECT_*` / `ASSERT_*` / `REQUIRE` / `CHECK` (C++).
+**Calibration:**
+- A method named `*_DoesNotThrow` / `*_no_exception` / `should not throw` is implicitly asserting no exception — still flag it but note it may be intentional.
+- **Mock-call verifications count as assertions**: `mock.Verify(...)` (Moq), `Mock.AssertWasCalled` (NSubstitute), `mock.assert_called_with(...)` (Python), `expect(mock).toHaveBeenCalledWith(...)` (Jest), `verify(mock).method(...)` (Mockito), `Should -Invoke` (Pester) — do NOT flag tests using these as assertion-free.
+- **Bare assertion forms count**: `assert x == y` (pytest), `if got != want { t.Errorf(...) }` (Go), `assert!(cond)` (Rust) are canonical.
+- **Snapshot assertions count**: `.toMatchSnapshot()` (Jest), `syrupy` (pytest), `SnapshotTesting` (Swift), `approval-tests` are real assertions.
+- **Missing await on async assertions is its own critical smell**: `expect(promise).resolves.toBe(x)` without `await`/`return` (Jest), un-awaited `Assert.ThrowsAsync` (xUnit), un-awaited coroutines in `pytest-asyncio`, Kotest tests without `runTest`, Swift Testing async cases without `await`. These tests have assertion calls but silently pass — flag with a dedicated note.
 
 #### Smell 5: Eager Test
 
@@ -111,57 +125,62 @@ A test method that calls many different production methods, making it unclear wh
 
 **Severity:** Medium
 **Detection:** A test method that calls 4+ distinct methods on the production object (excluding setup/construction). Count unique method names, not call count.
-**Calibration:** Integration tests or workflow tests may legitimately call multiple methods — note this as a possible exception for end-to-end scenarios.
+**Calibration:** Integration / end-to-end / workflow tests may legitimately call multiple methods. Check for integration markers in the loaded language extension file (e.g., `[Trait("Category", "Integration")]`, `@Tag("integration")`, `pytest.mark.integration`, `*_integration_test.go`, `Describe ... -Tag 'Integration'`) and downgrade.
 
 #### Smell 6: Magic Number Test
 
-Assertions that contain unexplained numeric literals. The intent of `Assert.AreEqual(42, result)` is unclear without context — what does 42 represent?
+Assertions that contain unexplained numeric literals. The intent of `Assert.AreEqual(42, result)` / `assert result == 42` / `expect(result).toBe(42)` is unclear without context — what does 42 represent?
 
 **Severity:** Medium
-**Detection:** Numeric literals (other than 0, 1, -1, and the literal used in the test name) appearing as `expected` parameters in assertion methods.
-**Calibration:** Small integers in context (like count checks `Assert.AreEqual(3, list.Count)` where 3 items were just added) are acceptable — only flag when the number's meaning is genuinely unclear.
+**Detection:** Numeric literals (other than 0, 1, -1, and the literal used in the test name) appearing as `expected` parameters in assertion methods or comparison operands.
+**Calibration:** Small integers in context (like count checks `Assert.AreEqual(3, list.Count)` / `assert len(items) == 3` / `expect(arr.length).toBe(3)` where 3 items were just added) are acceptable — only flag when the number's meaning is genuinely unclear.
 
 #### Smell 7: Sensitive Equality
 
-Tests that use `ToString()` for comparison or assertion. If the `ToString()` implementation changes, the test breaks even though the actual behavior is correct.
+Tests that use string conversion for comparison or assertion. If the underlying string representation changes, the test breaks even though the actual behavior is correct.
 
 **Severity:** Medium
-**Detection:** `Assert.AreEqual(expected, obj.ToString())`, or `.ToString()` appearing inside an assertion parameter.
+**Detection:** `Assert.AreEqual(expected, obj.ToString())` (.NET); `assert str(obj) == "..."` or `assert repr(obj) == "..."` (Python); `expect(obj.toString()).toBe("...")` or `expect(`${obj}`).toBe(...)` (JS/TS); `assertEquals(expected, obj.toString())` (Java); `assert.Equal(t, "...", fmt.Sprint(obj))` or `obj.String()` chains (Go); `expect(obj.to_s).to eq("...")` (RSpec); `assert_eq!(format!("{}", obj), "...")` or `assert_eq!(format!("{:?}", obj), "...")` (Rust); `XCTAssertEqual(obj.description, "...")` or string-interpolation assertion (Swift); `assertEquals("...", obj.toString())` (Kotlin); `Should -Be "..."` against a `[string]$obj` (Pester); `EXPECT_EQ("...", std::to_string(obj))` (C++).
 
 #### Smell 8: Exception Handling in Tests
 
-Tests that contain `try`/`catch` blocks or `throw` statements. This typically means the test is manually managing exceptions rather than using the framework's built-in exception assertion facilities.
+Tests that contain `try`/`catch`/`except`/`rescue` blocks or `throw`/`raise`/`panic`/`return err` statements used to manage exception flow instead of asserting on it. This typically means the test is manually managing errors rather than using the framework's built-in exception assertion facilities.
 
 **Severity:** Medium
-**Detection:** `try`/`catch` or `throw`/`raise` statements inside a test method.
-**Exception:** `catch` blocks that capture an exception for further assertion are a lesser concern — note but don't flag as high severity.
+**Detection:** `try`/`catch` (.NET, Java, JS/TS, Kotlin, Swift, C++); `try`/`except` (Python); `begin`/`rescue` (Ruby); `defer recover()` (Go); manual `if err != nil { t.Fatal(err) }` in Go is canonical and NOT a smell.
+**Exception:** `catch`/`except`/`rescue` blocks that capture an exception for further assertion on its properties are a lesser concern — note but don't flag as high severity.
 
 #### Smell 9: General Fixture (Over-broad Setup)
 
-The test setup method or constructor initializes fields that are not used by every test method. This means each test pays the cost of setting up objects it doesn't need.
+The test setup method, constructor, or fixture initializes fields that are not used by every test method. This means each test pays the cost of setting up objects it doesn't need.
 
 **Severity:** Low
-**Detection:** Fields initialized in setup that are referenced by fewer than half the test methods in the class.
+**Detection:** Fields/properties initialized in `[TestInitialize]` / `setUp` / `@BeforeEach` / `beforeEach` / `before(:each)` / `BeforeEach` (Pester) / `setUpWithError` (XCTest) / pytest `fixture(autouse=True)` / xUnit constructor / Kotest `beforeTest` that are referenced by fewer than half the test methods in the class/module/file.
 
-#### Smell 10: Ignored/Disabled Test
+#### Smell 10: Ignored / Disabled / Skipped Test
 
 Tests marked as skipped or disabled. These add overhead and clutter, and the underlying issue they were disabled for may never be addressed.
 
 **Severity:** Low
-**Detection:** Skip/ignore annotations or conditional compilation that disables a test. See the `dotnet-test-frameworks` skill for framework-specific skip attributes.
+**Detection:** Skip / ignore / disable annotations or conditional compilation that disables a test. See the loaded language extension file for framework-specific skip attributes — e.g., `[Ignore]` (MSTest/NUnit), `Skip = "..."` (xUnit `Fact`), `@Ignore` (TUnit/JUnit 4), `@Disabled` (JUnit 5), `@pytest.mark.skip` / `pytest.skip(...)` / `pytestmark`, `it.skip` / `xit` / `describe.skip` / `test.skip` (Jest/Vitest/Mocha), `t.Skip(...)` (Go), `pending` / `skip` / `xit` (RSpec), `#[ignore]` (Rust), `XCTSkip` / `@Test(.disabled)` (Swift), `@Ignored` (Kotest), `-Skip` (Pester), `GTEST_SKIP()` / `DISABLED_TestName` (GoogleTest), `[.]` tag (Catch2), `TEST_CASE("...", "[.]")` skip.
 
-### Step 3: Apply calibration rules
+### Step 4: Apply calibration rules
 
 Before reporting, calibrate findings to avoid false positives:
 
-- **Integration tests have different norms.** A test class clearly marked as integration (by name, annotation, or category) legitimately uses external resources, calls multiple methods, and may use delays for async coordination. Downgrade Mystery Guest, Eager Test, and Sleepy Test severity for integration tests — note them but don't flag as problems.
+- **Integration tests have different norms.** A test class clearly marked as integration (by name, annotation, category, or convention — see the loaded language extension file for markers) legitimately uses external resources, calls multiple methods, and may use delays for async coordination. Downgrade Mystery Guest, Eager Test, and Sleepy Test severity for integration tests — note them but don't flag as problems.
 - **Simple loop-assert patterns are fine.** Iterating a collection to assert on every item is readable and correct. Only flag loops with complex branching logic.
+- **Idiomatic table-driven and parametrized patterns are NOT Conditional Test Logic.** Go's `for _, tt := range tests { t.Run(...) }`, Rust's `#[rstest]`, pytest's `@parametrize`, Jest/Vitest `.each`, JUnit `@ParameterizedTest`, RSpec `where`, Pester `-ForEach`, Catch2 `SECTION`/`GENERATE`, GoogleTest `INSTANTIATE_TEST_SUITE_P` are canonical and must NOT be flagged.
 - **Context matters for magic numbers.** A count assertion right after adding a known number of items is self-documenting. Only flag numbers whose meaning requires looking at production code to understand.
+- **Bare `assert` (pytest) is canonical, not assertion-free framework use.** Don't flag.
+- **Go's `if err != nil { t.Fatal(err) }` is canonical**, not Exception Handling in Tests. Don't flag.
+- **Mock-call verifications and snapshot assertions are real assertions** — do not flag tests using them as Assertion-Free.
+- **Missing-await on async assertions is its own critical sub-smell of Assertion-Free** — these tests silently pass even when the underlying assertion fails. Always flag when detected.
 - **Inconclusive/pending markers are not assertion-free.** Tests explicitly marked as incomplete should be flagged as Ignored Test, not Assertion-Free.
-- **Capture-and-assert exception patterns are borderline.** Try/catch patterns that capture an exception then assert on its properties are ugly but functional. Note as a smell and suggest the framework's built-in exception assertion instead of calling it broken.
+- **Capture-and-assert exception patterns are borderline.** `try { ... } catch (X x) { Assert.Equal(...) }` style patterns are ugly but functional. Note as a smell and suggest the framework's built-in exception assertion (`Assert.Throws<T>`, `pytest.raises`, `expect(fn).toThrow`, `assertThrows`, `assert.PanicsWithError`, etc.) instead of calling it broken.
 - **If the test suite is clean, say so.** A report finding few or no smells is perfectly valid.
 
-### Step 4: Report findings
+### Step 5: Report findings
 
 Present the analysis in this structure:
 
@@ -205,10 +224,16 @@ Present the analysis in this structure:
 
 | Pitfall | Solution |
 |---------|----------|
-| Flagging integration tests for using real resources | Check for integration test markers and adjust severity accordingly |
+| Flagging integration tests for using real resources | Check for integration test markers (per the loaded language extension) and adjust severity accordingly |
 | Flagging loop-over-collection-assert as conditional logic | Only flag loops with branching or complex logic, not assertion iterations |
+| Flagging Go/Rust table-driven loops as Conditional Test Logic | `for _, tt := range tests { t.Run(...) }` (Go) and `#[rstest]` loops (Rust) are canonical and must NOT be flagged |
+| Flagging parametrized tests as Duplicate Assert | `@pytest.mark.parametrize`, `it.each`, `[Theory]+[InlineData]`, `@ParameterizedTest`, RSpec `where`, Pester `-ForEach`, Catch2 `SECTION`/`GENERATE` are correct deduplication, not smells |
+| Flagging pytest bare `assert` as missing framework | Bare `assert` is canonical pytest assertion — count it |
+| Flagging Go's `if err != nil { t.Fatal(err) }` as Exception Handling in Tests | This is canonical Go error checking — do NOT flag |
 | Flagging obvious count assertions after adding N items | Consider the immediate context — self-documenting numbers are fine |
-| Missing framework-specific assertion syntax | Consult the `dotnet-test-frameworks` skill for .NET framework assertion and skip APIs |
+| Missing framework-specific assertion syntax | Always read the matching language extension file first; each framework has distinct assertion APIs (xUnit `Assert.Equal`, MSTest `Assert.AreEqual`, NUnit `Is.EqualTo`, pytest bare `assert`, Jest `expect().toBe()`, etc.) |
+| Treating mock-call verifications as assertion-free | `mock.Verify(...)`, `expect(mock).toHaveBeenCalledWith(...)`, `Should -Invoke`, `verify(mock).method(...)`, `mock.assert_called_with(...)` are real assertions |
+| Missing the async-test silent-pass trap | Always flag `expect(promise).resolves.toBe(x)` without `await`/`return`, un-awaited `Assert.ThrowsAsync` (xUnit), un-awaited coroutines in pytest-asyncio, missing `runTest` in Kotest, un-awaited Swift Testing async assertions |
 | Over-flagging try/catch that captures for assertion | Distinguish swallowed exceptions from capture-and-assert patterns |
-| Treating skip annotations with reasons same as bare skips | Note that reasoned skips are less concerning than unexplained ones |
+| Treating skip annotations with reasons same as bare skips | Note that reasoned skips (`Skip = "Tracked by #123"`, `@pytest.mark.skip(reason="...")`, `t.Skip("not yet implemented")`) are less concerning than unexplained ones |
 | Flagging `DoesNotThrow`-style tests as assertion-free | These implicitly assert no exception — note but acknowledge the intent |

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-tagging
-description: "Analyzes test suites in any language and tags each test with a standardized set of traits (e.g., positive, negative, critical-path, boundary, smoke, regression, integration, performance, security). Use when the user wants to categorize, audit, or label tests with traits. Works with .NET (MSTest TestCategory / xUnit Trait / NUnit Category / TUnit Property), Python (pytest markers / unittest tags), TypeScript/JavaScript (Jest/Vitest test names, describe-block conventions), Java (JUnit 5 @Tag / TestNG groups), Go (subtest naming / build tags / file _test.go), Ruby (RSpec metadata), Rust (cargo test naming / cfg attributes), Swift (XCTest test plans / Swift Testing @Tag), Kotlin (JUnit @Tag / Kotest tags), PowerShell (Pester -Tag), and C++ (GoogleTest filter prefixes / Catch2 [tags] / doctest tags). Auto-edits when the framework has canonical syntax; falls back to report-only when no canonical syntax exists. Do not use for writing new tests, running tests, or migrating test frameworks."
+description: "Analyzes test suites in any language and tags each test with a standardized set of traits (positive, negative, critical-path, boundary, smoke, regression, integration, performance, security). Use when the user wants to categorize, audit, or label tests with traits. Works with .NET (MSTest TestCategory / xUnit Trait / NUnit Category / TUnit Property), Python (pytest markers; unittest has no canonical tag syntax so report-only), TypeScript/JavaScript (Jest/Vitest test names, describe-block conventions), Java (JUnit 5 @Tag / TestNG groups), Go (subtest naming / build tags / file _test.go), Ruby (RSpec metadata), Rust (cargo test naming / cfg attributes), Swift (XCTest test plans / Swift Testing @Tag), Kotlin (JUnit @Tag / Kotest tags), PowerShell (Pester -Tag), C++ (GoogleTest filter prefixes / Catch2 [tags] / doctest decorators). Auto-edits when the framework has canonical syntax; falls back to report-only otherwise. Do not use for writing new tests, running tests, or migrating frameworks."
 license: MIT
 ---
 
@@ -61,7 +61,7 @@ A single test may have **multiple traits** (e.g., both `negative` and `boundary`
 
 Identify the codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file. The extension file declares a **tag-support capability** for each framework:
 
-- **`auto-edit`** — framework has canonical tag syntax this skill can safely insert (.NET `[TestCategory]` / `[Trait]` / `[Category]` / `[Property]`, pytest `@pytest.mark.<name>`, JUnit 5 `@Tag("...")`, TestNG `groups = {"..."}`, RSpec metadata `it "..." , :tag => true`, Pester `-Tag '...'`, Kotest `@Tags(...)`, Swift Testing `@Tag(.tagName)`, Catch2 `[tag]`, doctest `*[tag]`).
+- **`auto-edit`** — framework has canonical tag syntax this skill can safely insert (.NET `[TestCategory]` / `[Trait]` / `[Category]` / `[Property]`, pytest `@pytest.mark.<name>`, JUnit 5 `@Tag("...")`, TestNG `groups = {"..."}`, RSpec metadata `it "..." , :tag => true`, Pester `-Tag '...'`, Kotest `@Tags(...)`, Swift Testing `@Tag(.tagName)`, Catch2 `[tag]`, doctest `* doctest::test_suite("tag")` decorator).
 - **`report-only`** — framework has no canonical, agreed-upon tag attribute; report tags in a Markdown table only and do not edit source (Go standard `testing` without build-tag conventions, Jest/Vitest without consistent describe-prefix convention, Rust without project-specific cfg conventions, XCTest without a test plan, GoogleTest without test-name prefix conventions, Mocha without describe-prefix conventions).
 - **`convention-based`** — framework uses naming or file conventions for tagging (Go `//go:build integration` build tags, file-name suffixes like `*_integration_test.go`, GoogleTest `INTEGRATION_*` filter prefix). Only emit canonical edits when the user has confirmed the project convention; otherwise treat as `report-only`.
 
@@ -85,7 +85,7 @@ Check which tests already have trait attributes. Use the loaded language extensi
 | Kotest | `@Tags(...)` | `@Tags(Positive)` |
 | Swift Testing | `@Tag(.<name>)` | `@Test(.tags(.positive))` |
 | Catch2 | `[tag]` in name | `TEST_CASE("...", "[positive]")` |
-| doctest | `*[tag]` | `TEST_CASE("..." *doctest::test_suite("positive"))` |
+| doctest | `* doctest::test_suite("...")` decorator | `TEST_CASE("..." *doctest::test_suite("positive"))` |
 
 Record which tests already have tags to avoid duplication.
 

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: test-tagging
-description: "Analyzes test suites and tags each test with a standardized set of traits (e.g., positive, negative, critical-path, boundary, smoke, regression). Use when the user wants to categorize, audit, or label tests with traits. Do not use for writing new tests, running tests, or migrating test frameworks."
+description: "Analyzes test suites in any language and tags each test with a standardized set of traits (e.g., positive, negative, critical-path, boundary, smoke, regression, integration, performance, security). Use when the user wants to categorize, audit, or label tests with traits. Works with .NET (MSTest TestCategory / xUnit Trait / NUnit Category / TUnit Property), Python (pytest markers / unittest tags), TypeScript/JavaScript (Jest/Vitest test names, describe-block conventions), Java (JUnit 5 @Tag / TestNG groups), Go (subtest naming / build tags / file _test.go), Ruby (RSpec metadata), Rust (cargo test naming / cfg attributes), Swift (XCTest test plans / Swift Testing @Tag), Kotlin (JUnit @Tag / Kotest tags), PowerShell (Pester -Tag), and C++ (GoogleTest filter prefixes / Catch2 [tags] / doctest tags). Auto-edits when the framework has canonical syntax; falls back to report-only when no canonical syntax exists. Do not use for writing new tests, running tests, or migrating test frameworks."
 license: MIT
 ---
 
 # Test Trait Tagging
 
-Analyze an existing test suite and apply a standardized set of trait tags to each test method, giving teams visibility into their test distribution (positive vs. negative, critical-path coverage, smoke tests, etc.).
+Analyze an existing test suite in any supported language and apply a standardized set of trait tags to each test method, giving teams visibility into their test distribution (positive vs. negative, critical-path coverage, smoke tests, etc.).
+
+> **Language-specific guidance**: Call the `test-analysis-extensions` skill to discover available extension files, then read the file matching the target codebase. The extension file documents framework-specific tag attributes and a "tag-support capability" (auto-edit, report-only, or convention-based) that drives whether this skill modifies source files or only emits a report.
 
 ## When to Use
 
@@ -17,8 +19,8 @@ Analyze an existing test suite and apply a standardized set of trait tags to eac
 
 ## When Not to Use
 
-- Writing new tests from scratch (use `writing-mstest-tests`)
-- Running or filtering tests (use `run-tests`)
+- Writing new tests from scratch (use `code-testing-agent` for any language, or `writing-mstest-tests` for MSTest)
+- Running or filtering tests (use `run-tests` for .NET; equivalent native runners elsewhere)
 - Migrating between test frameworks
 
 ## Inputs
@@ -26,8 +28,8 @@ Analyze an existing test suite and apply a standardized set of trait tags to eac
 | Input | Required | Description |
 |-------|----------|-------------|
 | Test project or files | Yes | Path to the test project, folder, or specific test files to analyze |
-| Scope | No | `tag` (apply attributes), `audit` (report only), or `both` (default: `both`) |
-| Framework | No | Auto-detected. Override with `mstest`, `xunit`, or `nunit` if detection fails |
+| Scope | No | `tag` (apply attributes when language supports auto-edit), `audit` (report only), or `both` (default: `both`). For languages with no canonical tag syntax, the skill emits a report regardless of scope. |
+| Framework | No | Auto-detected. Override when detection fails. |
 
 ## Trait Taxonomy
 
@@ -37,16 +39,16 @@ Use exactly these trait names and values. Do not invent new trait values outside
 |-------------|---------|------------|
 | `positive` | Verifies expected behavior under normal/valid conditions | Asserts success, valid output, expected state, no exceptions for valid input |
 | `negative` | Verifies correct handling of invalid input, errors, or edge cases | Asserts exceptions, error codes, validation failures, rejects bad input |
-| `boundary` | Tests limits, thresholds, empty/null inputs, min/max values | Operates on `0`, `-1`, `int.MaxValue`, empty string, null, empty collection, boundary of valid range |
+| `boundary` | Tests limits, thresholds, empty/null/None/nil inputs, min/max values | Operates on `0`, `-1`, `int.MaxValue` / `sys.maxsize` / `Number.MAX_SAFE_INTEGER` / `math.MaxInt64` / `i32::MAX`, empty string, null/None/nil/undefined, empty collection, boundary of valid range |
 | `critical-path` | Core workflow that must never break; breakage blocks users | Tests the primary success scenario of a key public API or user-facing feature |
 | `smoke` | Quick sanity check that the system is operational | Fast, no complex setup, verifies basic wiring (e.g., service resolves, endpoint returns 200) |
 | `regression` | Reproduces a specific previously-reported bug | References a bug ID, issue number, or describes a fix in its name or comments |
 | `integration` | Crosses process, network, or persistence boundaries | Uses real database, HTTP client, file system, external service, or multi-component setup |
 | `end-to-end` | Full user workflow spanning the entire application stack | Exercises a complete scenario from entry point to final result, distinct from single-boundary `integration` |
-| `performance` | Validates timing, throughput, or resource consumption | Asserts on elapsed time, memory, allocations, or uses benchmark harness |
+| `performance` | Validates timing, throughput, or resource consumption | Asserts on elapsed time, memory, allocations, or uses benchmark harness (BenchmarkDotNet, pytest-benchmark, benchmark.js, JMH, `go test -bench`, criterion.rs, XCTMetric, kotlinx-benchmark, Google Benchmark) |
 | `security` | Verifies authentication, authorization, input sanitization, or secrets handling | Tests for SQL injection, XSS, CSRF, unauthorized access, token validation, permission checks |
-| `concurrency` | Validates thread safety, parallelism, or async correctness | Uses `Task.WhenAll`, locks, `Parallel.ForEach`, `SemaphoreSlim`, reproduces race conditions |
-| `resilience` | Tests retry logic, timeouts, circuit breakers, or graceful degradation | Asserts behavior under transient failures, network drops, or service unavailability (e.g., Polly policies) |
+| `concurrency` | Validates thread safety, parallelism, or async correctness | Uses `Task.WhenAll` / `Parallel.ForEach` / `SemaphoreSlim` (.NET); `asyncio.gather` / `threading.Lock` / `multiprocessing` (Python); `Promise.all` / worker threads (JS/TS); `CompletableFuture` / `ExecutorService` / `synchronized` (Java); `go func` / `sync.WaitGroup` / `sync.Mutex` / `chan` (Go); `Mutex` / `Thread.new` (Ruby); `tokio::spawn` / `Arc<Mutex<_>>` / `crossbeam` (Rust); `DispatchQueue` / `actor` (Swift); `coroutineScope` / `Mutex` (Kotlin); `Start-Job` / `RunspacePool` (PowerShell); `std::thread` / `std::mutex` (C++); reproduces race conditions |
+| `resilience` | Tests retry logic, timeouts, circuit breakers, or graceful degradation | Asserts behavior under transient failures, network drops, or service unavailability (e.g., Polly, tenacity, p-retry, resilience4j, hystrix, opossum, retry-go) |
 | `destructive` | Mutates shared or external state that is hard to roll back | Deletes records, drops resources, modifies global config -- useful for CI isolation decisions |
 | `configuration` | Verifies settings loading, defaults, environment behavior | Tests missing config keys, invalid values, environment variable fallbacks, options validation |
 | `flaky` | Known to intermittently fail (meta-tag for test health tracking) | Mark tests the team knows are unreliable; used to quarantine or prioritize stabilization |
@@ -55,19 +57,35 @@ A single test may have **multiple traits** (e.g., both `negative` and `boundary`
 
 ## Workflow
 
-### Step 1: Detect the test framework
+### Step 1: Detect the language, framework, and tagging capability
 
-Examine project files and source code to determine the framework — see the `dotnet-test-frameworks` skill for the complete detection table (package references, test markers, assertion APIs, and skip annotations).
+Identify the codebase's language and test framework. Call the `test-analysis-extensions` skill and read the matching extension file. The extension file declares a **tag-support capability** for each framework:
+
+- **`auto-edit`** — framework has canonical tag syntax this skill can safely insert (.NET `[TestCategory]` / `[Trait]` / `[Category]` / `[Property]`, pytest `@pytest.mark.<name>`, JUnit 5 `@Tag("...")`, TestNG `groups = {"..."}`, RSpec metadata `it "..." , :tag => true`, Pester `-Tag '...'`, Kotest `@Tags(...)`, Swift Testing `@Tag(.tagName)`, Catch2 `[tag]`, doctest `*[tag]`).
+- **`report-only`** — framework has no canonical, agreed-upon tag attribute; report tags in a Markdown table only and do not edit source (Go standard `testing` without build-tag conventions, Jest/Vitest without consistent describe-prefix convention, Rust without project-specific cfg conventions, XCTest without a test plan, GoogleTest without test-name prefix conventions, Mocha without describe-prefix conventions).
+- **`convention-based`** — framework uses naming or file conventions for tagging (Go `//go:build integration` build tags, file-name suffixes like `*_integration_test.go`, GoogleTest `INTEGRATION_*` filter prefix). Only emit canonical edits when the user has confirmed the project convention; otherwise treat as `report-only`.
+
+Capture the capability before Step 4.
 
 ### Step 2: Scan existing traits
 
-Check which tests already have trait attributes:
+Check which tests already have trait attributes. Use the loaded language extension as the source of truth — examples:
 
 | Framework | Existing Attribute | Example |
 |-----------|--------------------|---------|
 | MSTest | `[TestCategory("...")]` | `[TestCategory("positive")]` |
 | xUnit | `[Trait("Category", "...")]` | `[Trait("Category", "positive")]` |
 | NUnit | `[Category("...")]` | `[Category("positive")]` |
+| TUnit | `[Property("Category", "...")]` | `[Property("Category", "positive")]` |
+| JUnit 5 | `@Tag("...")` | `@Tag("positive")` |
+| TestNG | `@Test(groups = {"..."})` | `@Test(groups = {"positive"})` |
+| pytest | `@pytest.mark.<name>` | `@pytest.mark.positive` |
+| RSpec | metadata after `it` | `it "...", :positive do` |
+| Pester | `-Tag '...'` | `It '...' -Tag 'positive'` |
+| Kotest | `@Tags(...)` | `@Tags(Positive)` |
+| Swift Testing | `@Tag(.<name>)` | `@Test(.tags(.positive))` |
+| Catch2 | `[tag]` in name | `TEST_CASE("...", "[positive]")` |
+| doctest | `*[tag]` | `TEST_CASE("..." *doctest::test_suite("positive"))` |
 
 Record which tests already have tags to avoid duplication.
 
@@ -75,27 +93,27 @@ Record which tests already have tags to avoid duplication.
 
 For each test method without traits, analyze:
 
-1. **Method name** -- names containing `Invalid`, `Fail`, `Error`, `Throw`, `Reject`, `BadInput`, `Null`, `Negative` suggest `negative`
-2. **Assertion type** -- `Assert.ThrowsException`, `Assert.Throws`, `Should().Throw()` suggest `negative`
-3. **Input values** -- `null`, `""`, `0`, `-1`, `int.MaxValue`, `int.MinValue`, empty collections suggest `boundary`
-4. **Setup complexity** -- minimal setup with basic assertions suggests `smoke`; external dependencies suggest `integration`
+1. **Method name** -- names containing `Invalid`, `Fail`, `Error`, `Throw`, `Reject`, `BadInput`, `Null`, `None`, `Nil`, `Negative`, `raises_`, `_throws_`, `_returns_error` suggest `negative`
+2. **Assertion type** -- `Assert.ThrowsException` / `Assert.Throws` / `Should().Throw()` / `pytest.raises` / `expect(fn).toThrow` / `assertThrows` / `assert.Error(t, err)` / `expect { ... }.to raise_error` / `#[should_panic]` / `XCTAssertThrowsError` / `Should -Throw` / `EXPECT_THROW` suggest `negative`
+3. **Input values** -- `null` / `None` / `nil` / `undefined`, `""`, `0`, `-1`, `int.MaxValue` / `sys.maxsize` / `Number.MAX_SAFE_INTEGER` / `math.MaxInt64` / `i32::MAX`, empty collections suggest `boundary`
+4. **Setup complexity** -- minimal setup with basic assertions suggests `smoke`; external dependencies (file/db/net/env) suggest `integration`
 5. **Comments and names** -- references to issue numbers or "regression" / "bug" / "fix for #..." suggest `regression`
-6. **Timing assertions** -- `Stopwatch`, `BenchmarkDotNet`, elapsed-time checks suggest `performance`
+6. **Timing assertions** -- `Stopwatch`, `BenchmarkDotNet`, elapsed-time checks; pytest-benchmark fixtures; benchmark.js; JMH `@Benchmark`; `go test -bench`; criterion.rs; XCTMetric; Google Benchmark; kotlinx-benchmark suggest `performance`
 7. **Feature centrality** -- tests on primary public API entry points or critical user workflows suggest `critical-path`
 8. **Security patterns** -- validates auth, checks permissions, sanitizes input, tests for injection, handles tokens/secrets suggest `security`
-9. **Parallel/async constructs** -- `Task.WhenAll`, `Parallel.ForEach`, locks, `SemaphoreSlim`, `ConcurrentDictionary`, race condition names suggest `concurrency`
+9. **Parallel/async constructs** -- per-language concurrency primitives (see Trait Taxonomy table) suggest `concurrency`
 10. **Fault injection** -- simulates failures, tests retries, timeouts, or circuit breakers suggest `resilience`
 11. **State mutation** -- deletes external records, drops resources, modifies shared/global state suggest `destructive`
 12. **Full-stack flow** -- test spans entry point through data layer to final response, covering a complete user scenario suggest `end-to-end`
 13. **Config/settings** -- loads configuration, tests missing keys, validates options, checks environment variables suggest `configuration`
-14. **Known instability** -- test has `[Ignore]`/`[Skip]` comments about flakiness, or names contain "flaky"/"intermittent" suggest `flaky`
+14. **Known instability** -- test has skip / ignore annotations with comments about flakiness, or names contain "flaky" / "intermittent" suggest `flaky`
 15. **Default** -- if the test verifies a normal success path, tag `positive`
 
 When in doubt between `positive` and `negative`, read the assertion: if it asserts success -> `positive`; if it asserts failure -> `negative`.
 
-### Step 4: Apply trait attributes
+### Step 4: Apply trait attributes (or report only)
 
-Add the appropriate attribute to each test method. Place trait attributes on the line directly above or below the existing test attribute.
+**If the loaded language extension declares `auto-edit` for the framework**, add the appropriate attribute to each test method. Place trait attributes adjacent to the existing test attribute. Examples:
 
 **MSTest:**
 ```csharp
@@ -121,6 +139,65 @@ public void CreateOrder_ValidItems_ReturnsConfirmation() { ... }
 public void Calculate_OverflowInput_ReturnsError() // Fix for #1234
 { ... }
 ```
+
+**pytest:**
+```python
+@pytest.mark.negative
+@pytest.mark.boundary
+def test_parse_none_input_raises_value_error():
+    ...
+```
+
+**JUnit 5:**
+```java
+@Test
+@Tag("positive")
+@Tag("critical-path")
+void createOrder_validItems_returnsConfirmation() { ... }
+```
+
+**TestNG:**
+```java
+@Test(groups = {"negative", "boundary"})
+public void parse_nullInput_throwsIllegalArgumentException() { ... }
+```
+
+**RSpec:**
+```ruby
+it "rejects null input", :negative, :boundary do
+  ...
+end
+```
+
+**Pester:**
+```powershell
+It 'Rejects null input' -Tag 'negative','boundary' {
+    ...
+}
+```
+
+**Kotest:**
+```kotlin
+@Tags(Negative, Boundary)
+class ParserSpec : StringSpec({
+    "rejects null input" { ... }
+})
+```
+
+**Swift Testing:**
+```swift
+@Test(.tags(.negative, .boundary))
+func parseNullInputThrows() throws { ... }
+```
+
+**Catch2:**
+```cpp
+TEST_CASE("Parse null input throws", "[negative][boundary]") { ... }
+```
+
+**If the loaded language extension declares `report-only` for the framework** (Go standard `testing`, plain Jest/Vitest without convention, Rust without project-specific cfg, plain XCTest, plain GoogleTest, plain Mocha), do NOT modify source files. Instead emit a Markdown table mapping each test to its suggested tags, and recommend a project-wide convention the team can adopt (build tags, file suffix, describe-block prefix, GoogleTest filter prefix, test-plan grouping, etc.).
+
+**If the loaded language extension declares `convention-based`** (e.g., Go `//go:build integration`, `*_integration_test.go`, GoogleTest `INTEGRATION_*` prefix), only emit canonical edits when the user has confirmed the project's convention. Otherwise treat as `report-only`.
 
 ### Step 5: Generate trait summary
 
@@ -158,11 +235,13 @@ Include observations such as:
 
 ## Validation
 
-- [ ] Every test method has at least one trait attribute (`positive` or `negative` at minimum)
+- [ ] Every test method has at least one trait classification (`positive` or `negative` at minimum) — in the report for `report-only` frameworks, or as an attribute for `auto-edit` frameworks
 - [ ] No invented trait values outside the taxonomy table
 - [ ] Existing trait attributes were preserved, not duplicated
 - [ ] The trait summary table was generated
-- [ ] The project still builds after changes (`dotnet build`)
+- [ ] For `auto-edit` frameworks, the project still builds / tests still discover after changes (`dotnet build` / `pytest --collect-only` / `mvn test-compile` / `go vet ./...` / `cargo check --tests` / `npm run test:list` / `Invoke-Pester -PassThru -Skip` / equivalent)
+- [ ] For `report-only` frameworks, no source files were modified
+- [ ] For `convention-based` frameworks, edits were applied ONLY when a project convention was confirmed
 
 ## Common Pitfalls
 
@@ -170,6 +249,9 @@ Include observations such as:
 |---------|----------|
 | Guessing traits without reading the test body | Always read assertions and setup to classify accurately |
 | Tagging a test only as `boundary` without `positive`/`negative` | Every test should also be `positive` or `negative` -- `boundary` is additive |
-| Using `TestCategory` syntax in an xUnit project | Match the attribute style to the detected framework |
+| Using the wrong attribute syntax for the detected framework | Match the attribute style to the loaded language extension (don't put `[TestCategory]` in an xUnit project or `@pytest.mark.x` in a unittest test) |
 | Duplicating an existing category attribute | Check for pre-existing traits in Step 2 before adding |
 | Over-tagging as `critical-path` | Reserve for tests on primary public entry points, not every helper |
+| Editing Go / plain Jest / plain Rust / plain XCTest / plain GoogleTest source | These are `report-only` by default — emit a Markdown table instead. Only edit if the user confirms a project-wide convention (build tag, file suffix, describe-prefix, test-plan grouping). |
+| Inventing tag prefixes for convention-based frameworks | Confirm the project's existing convention before adopting one — don't guess between `_integration_test.go`, `//go:build integration`, or `IntegrationTest` prefix |
+| Missing language-specific concurrency / async primitives | Each language has its own primitives — read the loaded language extension and the Trait Taxonomy concurrency row before classifying as `concurrency` |

--- a/tests/dotnet-test/assertion-quality/eval.yaml
+++ b/tests/dotnet-test/assertion-quality/eval.yaml
@@ -157,3 +157,51 @@ scenarios:
       - "Wrote test methods for the InventoryTracker class"
       - "Covered multiple methods of the class"
     timeout: 300
+
+  # ==========================================================================
+  # Scenario: Polyglot — shallow assertions in a Jest/TypeScript suite
+  # ==========================================================================
+
+  - name: "Polyglot: evaluate shallow assertions in a Jest/TypeScript OrderService suite"
+    prompt: |
+      Audit the assertion quality and depth of `tests/order.test.ts`. The
+      production code is `src/order.ts`. This is a Jest/TypeScript suite,
+      not .NET — apply the same assertion-quality catalog using
+      Jest equivalents (`toBeDefined`, `toBeTruthy`, `not.toBeNull`,
+      `toBe`, `.resolves`, `toThrow`).
+
+      Specifically check for: shallow / trivial-only assertions, always-true
+      assertions, missing `await` on async assertion chains (a silent-pass
+      smell), identity / self-comparing assertions, and call out any tests
+      that ARE well-targeted. Do not edit the files — read-only review.
+    setup:
+      files:
+        - path: "package.json"
+          source: "fixtures/jest-shallow/package.json"
+        - path: "src/order.ts"
+          source: "fixtures/jest-shallow/src/order.ts"
+        - path: "tests/order.test.ts"
+          source: "fixtures/jest-shallow/tests/order.test.ts"
+    assertions:
+      - type: "output_matches"
+        pattern: "(shallow|trivial|toBeDefined|toBeTruthy|not\\.toBeNull|weak|low.*depth)"
+      - type: "output_matches"
+        pattern: "(always.*true|true.*true|tautolog)"
+      - type: "output_matches"
+        pattern: "(await|missing.*await|\\.resolves|async|silently.*pass)"
+      - type: "output_matches"
+        pattern: "(identity|same|self.compar|toBe\\(.*\\.id\\)|o\\.id.*o\\.id)"
+      - type: "exit_success"
+    rubric:
+      - "Identified Jest/TS-specific patterns correctly (did NOT mention MSTest/xUnit APIs as if present)"
+      - "Flagged the cluster of toBeDefined / toBeTruthy / not.toBeNull / Array.isArray assertions as trivial / low-depth"
+      - "Flagged the `expect(true).toBe(true)` always-true assertion"
+      - "Flagged the missing `await` on `expect(Promise.resolve(...)).resolves.toBeDefined()` as a silent-pass smell that lets rejections slip through"
+      - "Flagged `expect(o.id).toBe(o.id)` as an identity / self-comparing assertion that proves nothing"
+      - "Flagged `expect(o.id).not.toBe('totally unrelated string')` as a vacuous negative assertion"
+      - "Acknowledged 'legitimate equality on returned customer' (toBe('alice')) as a well-targeted assertion"
+      - "Acknowledged 'legitimate exception assertion' (toThrow('customer is required')) as a well-targeted assertion"
+      - "Recommended concrete higher-value assertions: verifying status='pending', itemCount, totalCents, id format, list() contents after multiple creates"
+    reject_tools: ["bash", "edit", "create"]
+    timeout: 180
+

--- a/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/package.json
+++ b/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "jest-shallow-fixture",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Jest/TypeScript fixture for assertion-quality polyglot eval",
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/src/order.ts
+++ b/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/src/order.ts
@@ -1,0 +1,37 @@
+export interface Order {
+  id: string;
+  customer: string;
+  itemCount: number;
+  totalCents: number;
+  status: 'pending' | 'confirmed' | 'cancelled';
+}
+
+export class OrderService {
+  private readonly orders = new Map<string, Order>();
+
+  create(customer: string, itemCount: number, totalCents: number): Order {
+    if (!customer) throw new Error('customer is required');
+    if (itemCount <= 0) throw new Error('itemCount must be positive');
+    if (totalCents < 0) throw new Error('totalCents must be non-negative');
+    const order: Order = {
+      id: `o-${this.orders.size + 1}`,
+      customer,
+      itemCount,
+      totalCents,
+      status: 'pending',
+    };
+    this.orders.set(order.id, order);
+    return order;
+  }
+
+  confirm(id: string): Order {
+    const order = this.orders.get(id);
+    if (!order) throw new Error('order not found');
+    order.status = 'confirmed';
+    return order;
+  }
+
+  list(): Order[] {
+    return Array.from(this.orders.values());
+  }
+}

--- a/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/tests/order.test.ts
+++ b/tests/dotnet-test/assertion-quality/fixtures/jest-shallow/tests/order.test.ts
@@ -1,0 +1,61 @@
+import { OrderService } from '../src/order';
+
+describe('OrderService', () => {
+  it('creates an order', () => {
+    const svc = new OrderService();
+    const order = svc.create('alice', 2, 1000);
+    expect(order).toBeDefined();
+  });
+
+  it('creates returns truthy', () => {
+    const svc = new OrderService();
+    const order = svc.create('bob', 1, 100);
+    expect(order).toBeTruthy();
+  });
+
+  it('creates returns not null', () => {
+    const svc = new OrderService();
+    const order = svc.create('carol', 1, 100);
+    expect(order).not.toBeNull();
+  });
+
+  it('list returns array', () => {
+    const svc = new OrderService();
+    svc.create('alice', 2, 1000);
+    expect(Array.isArray(svc.list())).toBe(true);
+  });
+
+  it('always true', () => {
+    expect(true).toBe(true);
+  });
+
+  it('confirms order resolves', async () => {
+    const svc = new OrderService();
+    const o = svc.create('alice', 1, 100);
+    // BUG: missing await. expect(...).resolves silently passes even if promise rejects.
+    expect(Promise.resolve(svc.confirm(o.id))).resolves.toBeDefined();
+  });
+
+  it('does not equal something irrelevant', () => {
+    const svc = new OrderService();
+    const o = svc.create('alice', 1, 100);
+    expect(o.id).not.toBe('totally unrelated string');
+  });
+
+  it('round trip identity', () => {
+    const svc = new OrderService();
+    const o = svc.create('alice', 1, 100);
+    expect(o.id).toBe(o.id);
+  });
+
+  it('legitimate equality on returned customer', () => {
+    const svc = new OrderService();
+    const o = svc.create('alice', 2, 500);
+    expect(o.customer).toBe('alice');
+  });
+
+  it('legitimate exception assertion', () => {
+    const svc = new OrderService();
+    expect(() => svc.create('', 1, 100)).toThrow('customer is required');
+  });
+});

--- a/tests/dotnet-test/test-anti-patterns/eval.yaml
+++ b/tests/dotnet-test/test-anti-patterns/eval.yaml
@@ -215,3 +215,60 @@ scenarios:
       - "Noted that Clone_ProducesEqualObject is a legitimate equality check (testing deep copy), not self-referential"
     reject_tools: ["bash", "edit", "create"]
     timeout: 180
+
+  - name: "Polyglot: detect anti-patterns in a Python pytest suite"
+    prompt: |
+      Audit `tests/test_user_service.py` for test anti-patterns. The
+      production code is at `src/user_service.py`. This is a Python pytest
+      suite, not .NET — apply the same anti-pattern catalog but use
+      Python/pytest equivalents (e.g., `time.sleep` instead of
+      `Thread.Sleep`, `datetime.now()` instead of `DateTime.Now`,
+      module-level globals instead of static fields, `pytest.raises(Exception)`
+      instead of `Assert.ThrowsException<Exception>`, bare pytest `assert`
+      is canonical and not a smell).
+
+      Give me a severity-ranked list (Critical / Warning / Info) with each
+      finding named (e.g. "no assertions", "swallowed exception", "shared
+      module-level state", "broad exception", "time.sleep flakiness",
+      "duplicate tests", "self-comparing assertion") and a concrete
+      code-level fix for each. Do not edit the files — this is a
+      read-only review.
+    setup:
+      files:
+        - path: "pyproject.toml"
+          source: "fixtures/pytest-mixed/pyproject.toml"
+        - path: "src/user_service.py"
+          source: "fixtures/pytest-mixed/src/user_service.py"
+        - path: "tests/test_user_service.py"
+          source: "fixtures/pytest-mixed/tests/test_user_service.py"
+    assertions:
+      - type: "output_matches"
+        pattern: "(no assertion|missing assertion|never assert|does.?n.?t assert|no.*verif)"
+      - type: "output_matches"
+        pattern: "(swallow|except.*pass|silently|empty except)"
+      - type: "output_matches"
+        pattern: "(self.compar|compare.*to itself|count\\(\\) == .*count\\(\\)|always.pass|tautolog)"
+      - type: "output_matches"
+        pattern: "(time\\.sleep|datetime\\.now|random|flak|non.?determin)"
+      - type: "output_matches"
+        pattern: "(shared|global|module.level|_SHARED_SERVICE|ordering|order.depend)"
+      - type: "output_matches"
+        pattern: "(broad|pytest\\.raises\\(Exception\\)|specific.*exception|ValueError)"
+      - type: "output_matches"
+        pattern: "(duplicat|repeat|parametrize|parameteriz)"
+      - type: "exit_success"
+    rubric:
+      - "Identified Python/pytest patterns correctly (did NOT flag bare `assert` as a missing assertion library, did NOT mention .NET-specific APIs as if they were present)"
+      - "Identified test_add_user_runs_without_error has no assertion"
+      - "Identified test_get_missing_swallows_exception swallows the exception with a bare `except Exception: pass`"
+      - "Identified test_delete_compares_count_to_itself as a self-comparing / tautological assertion"
+      - "Identified test_flaky_sleep_and_now uses time.sleep and datetime.now() — both flakiness indicators"
+      - "Identified the _SHARED_SERVICE module-level global as shared state creating test ordering dependency between test_ordering_dependency_shared_state_part_one and _part_two"
+      - "Identified test_random_unseeded uses unseeded randomness — non-deterministic"
+      - "Identified test_add_raises_broad_exception uses pytest.raises(Exception) — too broad, should be ValueError"
+      - "Identified the four test_repeated_value_assertion_* tests as duplicates that should be parametrized with @pytest.mark.parametrize"
+      - "Did NOT flag bare `assert` statements as missing-framework issues — bare assert is the canonical pytest form"
+      - "Acknowledged test_get_user_returns_correct_name as a well-written test"
+    reject_tools: ["bash", "edit", "create"]
+    timeout: 180
+

--- a/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/pyproject.toml
+++ b/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "user-service-fixture"
+version = "0.0.1"
+description = "pytest fixture for test-anti-patterns polyglot eval"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/src/user_service.py
+++ b/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/src/user_service.py
@@ -1,0 +1,30 @@
+"""User service backed by an in-memory dictionary."""
+
+from __future__ import annotations
+
+
+class UserNotFoundError(Exception):
+    pass
+
+
+class UserService:
+    def __init__(self) -> None:
+        self._users: dict[int, str] = {}
+
+    def add(self, user_id: int, name: str) -> None:
+        if user_id in self._users:
+            raise ValueError(f"User {user_id} already exists")
+        if not name:
+            raise ValueError("name is required")
+        self._users[user_id] = name
+
+    def get(self, user_id: int) -> str:
+        if user_id not in self._users:
+            raise UserNotFoundError(str(user_id))
+        return self._users[user_id]
+
+    def delete(self, user_id: int) -> None:
+        self._users.pop(user_id, None)
+
+    def count(self) -> int:
+        return len(self._users)

--- a/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/tests/test_user_service.py
+++ b/tests/dotnet-test/test-anti-patterns/fixtures/pytest-mixed/tests/test_user_service.py
@@ -1,0 +1,103 @@
+"""Tests for UserService. Intentionally riddled with anti-patterns."""
+
+import time
+import datetime
+import random
+import os
+
+import pytest
+
+from src.user_service import UserService, UserNotFoundError
+
+
+_SHARED_SERVICE = UserService()
+
+
+def test_add_user_runs_without_error():
+    svc = UserService()
+    svc.add(1, "alice")
+    # No assertion! Silently passes even if add() did nothing.
+
+
+def test_get_missing_swallows_exception():
+    svc = UserService()
+    try:
+        svc.get(99)
+    except Exception:
+        pass
+    # Silently passes whether or not an exception was raised.
+
+
+def test_delete_compares_count_to_itself():
+    svc = UserService()
+    svc.add(1, "alice")
+    svc.delete(1)
+    assert svc.count() == svc.count()  # always true, proves nothing
+
+
+def test_add_raises_broad_exception():
+    svc = UserService()
+    svc.add(1, "alice")
+    with pytest.raises(Exception):  # broad — should be ValueError
+        svc.add(1, "bob")
+
+
+def test_flaky_sleep_and_now():
+    svc = UserService()
+    svc.add(1, "alice")
+    time.sleep(0.2)  # wall-clock sleep used for synchronization
+    timestamp = datetime.datetime.now()  # un-injected real clock
+    assert timestamp is not None
+
+
+def test_ordering_dependency_shared_state_part_one():
+    _SHARED_SERVICE.add(42, "shared-alice")
+    assert _SHARED_SERVICE.count() >= 1
+
+
+def test_ordering_dependency_shared_state_part_two():
+    # Depends on the previous test having added user 42.
+    assert _SHARED_SERVICE.get(42) == "shared-alice"
+
+
+def test_random_unseeded():
+    svc = UserService()
+    uid = random.randint(1, 1_000_000)  # unseeded — non-deterministic
+    svc.add(uid, "x")
+    assert svc.count() == 1
+
+
+def test_env_dependent_path():
+    home = os.environ.get("HOME") or os.environ.get("USERPROFILE", "/tmp")
+    assert isinstance(home, str)  # depends on environment
+
+
+def test_repeated_value_assertion_1():
+    svc = UserService()
+    svc.add(1, "a")
+    assert svc.count() == 1
+
+
+def test_repeated_value_assertion_2():
+    svc = UserService()
+    svc.add(1, "a")
+    assert svc.count() == 1
+
+
+def test_repeated_value_assertion_3():
+    svc = UserService()
+    svc.add(1, "a")
+    assert svc.count() == 1
+
+
+def test_repeated_value_assertion_4():
+    svc = UserService()
+    svc.add(1, "a")
+    assert svc.count() == 1
+
+
+def test_get_user_returns_correct_name():
+    """A legitimately good test, for contrast."""
+    svc = UserService()
+    svc.add(1, "alice")
+    assert svc.get(1) == "alice"

--- a/tests/dotnet-test/test-smell-detection/eval.yaml
+++ b/tests/dotnet-test/test-smell-detection/eval.yaml
@@ -125,3 +125,66 @@ scenarios:
       - "Wrote test methods for the ShoppingCart class"
       - "Covered multiple methods of the class"
     timeout: 300
+
+  # ==========================================================================
+  # Scenario: Polyglot — canonical smells in a JUnit/Java suite
+  # ==========================================================================
+
+  - name: "Polyglot: detect canonical test smells in a JUnit/Java Catalog suite"
+    prompt: |
+      Audit `src/test/java/com/example/CatalogTest.java` for test smells.
+      The production code is at `src/main/java/com/example/Catalog.java`.
+
+      This is JUnit 5 / Java, not .NET — apply the same smell catalog
+      using JUnit equivalents (`@Test`, `@BeforeEach`, `@Disabled`,
+      `Thread.sleep`, `assertThrows`, etc.).
+
+      Walk through each test method by name and identify which canonical
+      smell it exhibits. Recommend a concrete refactor for each. Do not
+      edit the files — read-only review.
+    setup:
+      files:
+        - path: "pom.xml"
+          source: "fixtures/junit-smells/pom.xml"
+        - path: "src/main/java/com/example/Catalog.java"
+          source: "fixtures/junit-smells/src/main/java/com/example/Catalog.java"
+        - path: "src/test/java/com/example/CatalogTest.java"
+          source: "fixtures/junit-smells/src/test/java/com/example/CatalogTest.java"
+    assertions:
+      - type: "output_matches"
+        pattern: "(conditional|if/else|branch|loop with if)"
+      - type: "output_matches"
+        pattern: "(mystery guest|file|external|temp)"
+      - type: "output_matches"
+        pattern: "(sleep|Thread\\.sleep|sleepy|wall.clock)"
+      - type: "output_matches"
+        pattern: "(no assertion|assertion.?free|empty test|missing assert)"
+      - type: "output_matches"
+        pattern: "(eager|multiple.*method|too many|doing too much)"
+      - type: "output_matches"
+        pattern: "(magic|literal|unexplain|42|hard.?coded)"
+      - type: "output_matches"
+        pattern: "(sensitiv|toString|format.*equal)"
+      - type: "output_matches"
+        pattern: "(try.catch|exception handling|manual.*catch|assertThrows)"
+      - type: "output_matches"
+        pattern: "(general fixture|unused|rng|over.*setup)"
+      - type: "output_matches"
+        pattern: "(disabled|ignored|@Disabled|skipped)"
+      - type: "exit_success"
+    rubric:
+      - "Identified JUnit-specific patterns correctly (did NOT mention MSTest/xUnit attributes as if present)"
+      - "Mapped addConditionalLogic → Conditional Test Logic (branching inside test)"
+      - "Mapped addLoadsFromFile → Mystery Guest (reads from the file system)"
+      - "Mapped addSleepy → Sleepy Test (Thread.sleep used for synchronization)"
+      - "Mapped addAndDoNothing → Assertion-Free Test"
+      - "Mapped doEverythingAtOnce → Eager Test (exercises many methods in one test)"
+      - "Mapped quantityAfterAdds → Magic Number Test (unexplained 41, 1, 42)"
+      - "Mapped toStringFormat → Sensitive Equality (asserts on toString() output)"
+      - "Mapped addNullSkuManualCatch → Exception Handling in Tests (recommended assertThrows)"
+      - "Mapped quantityZeroOnUnknownSku → General Fixture (rng is set up in @BeforeEach but never used)"
+      - "Mapped disabledTest → Ignored / Disabled Test (@Disabled with vague reason)"
+      - "Acknowledged addThrowsOnNegativeCount as a well-written test that uses assertThrows correctly"
+    reject_tools: ["bash", "edit", "create"]
+    timeout: 180
+

--- a/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/pom.xml
+++ b/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>junit-smells-fixture</artifactId>
+  <version>0.0.1</version>
+  <packaging>jar</packaging>
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/src/main/java/com/example/Catalog.java
+++ b/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/src/main/java/com/example/Catalog.java
@@ -1,0 +1,31 @@
+package com.example;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Catalog {
+    private final Map<String, Integer> stock = new HashMap<>();
+
+    public void add(String sku, int count) {
+        if (sku == null || sku.isEmpty()) {
+            throw new IllegalArgumentException("sku is required");
+        }
+        if (count < 0) {
+            throw new IllegalArgumentException("count must be non-negative");
+        }
+        stock.merge(sku, count, Integer::sum);
+    }
+
+    public int quantity(String sku) {
+        return stock.getOrDefault(sku, 0);
+    }
+
+    public boolean inStock(String sku) {
+        return quantity(sku) > 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Catalog(items=" + stock.size() + ")";
+    }
+}

--- a/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/src/test/java/com/example/CatalogTest.java
+++ b/tests/dotnet-test/test-smell-detection/fixtures/junit-smells/src/test/java/com/example/CatalogTest.java
@@ -1,0 +1,123 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CatalogTest {
+
+    private Catalog catalog;
+    private Random rng;
+
+    @BeforeEach
+    void setUp() {
+        catalog = new Catalog();
+        rng = new Random();
+    }
+
+    // Smell: Conditional Test Logic — branching inside the test
+    @Test
+    void addConditionalLogic() {
+        String[] skus = {"a", "b", "c"};
+        for (String sku : skus) {
+            if (sku.equals("b")) {
+                catalog.add(sku, 10);
+            } else {
+                catalog.add(sku, 1);
+            }
+        }
+        assertEquals(12, catalog.quantity("a") + catalog.quantity("b") + catalog.quantity("c"));
+    }
+
+    // Smell: Mystery Guest — reads from the file system
+    @Test
+    void addLoadsFromFile() throws Exception {
+        Path tmp = Files.createTempFile("catalog", ".txt");
+        Files.writeString(tmp, "x:7");
+        String[] parts = Files.readString(tmp).split(":");
+        catalog.add(parts[0], Integer.parseInt(parts[1]));
+        assertTrue(catalog.inStock("x"));
+    }
+
+    // Smell: Sleepy Test
+    @Test
+    void addSleepy() throws Exception {
+        catalog.add("a", 1);
+        Thread.sleep(200);
+        assertEquals(1, catalog.quantity("a"));
+    }
+
+    // Smell: Assertion-Free Test
+    @Test
+    void addAndDoNothing() {
+        catalog.add("a", 1);
+    }
+
+    // Smell: Eager Test — calls many distinct methods
+    @Test
+    void doEverythingAtOnce() {
+        catalog.add("a", 1);
+        catalog.add("b", 2);
+        catalog.add("c", 3);
+        catalog.quantity("a");
+        catalog.quantity("b");
+        catalog.inStock("c");
+        catalog.toString();
+        assertEquals(6, catalog.quantity("a") + catalog.quantity("b") + catalog.quantity("c"));
+    }
+
+    // Smell: Magic Number Test — what does 42 mean?
+    @Test
+    void quantityAfterAdds() {
+        catalog.add("a", 41);
+        catalog.add("a", 1);
+        assertEquals(42, catalog.quantity("a"));
+    }
+
+    // Smell: Sensitive Equality — relies on toString format
+    @Test
+    void toStringFormat() {
+        catalog.add("a", 1);
+        assertEquals("Catalog(items=1)", catalog.toString());
+    }
+
+    // Smell: Exception Handling in Tests — manual try/catch instead of assertThrows
+    @Test
+    void addNullSkuManualCatch() {
+        try {
+            catalog.add(null, 1);
+            fail("should have thrown");
+        } catch (Exception ex) {
+            assertNotNull(ex.getMessage());
+        }
+    }
+
+    // Smell: General Fixture — rng never used by this test, set up by @BeforeEach
+    @Test
+    void quantityZeroOnUnknownSku() {
+        assertEquals(0, catalog.quantity("unknown"));
+    }
+
+    // Smell: Ignored Test
+    @Test
+    @Disabled("flaky, fix later")
+    void disabledTest() {
+        catalog.add("x", 1);
+        assertEquals(1, catalog.quantity("x"));
+    }
+
+    // Well-written test for contrast
+    @Test
+    void addThrowsOnNegativeCount() {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> catalog.add("a", -1));
+        assertTrue(ex.getMessage().contains("non-negative"));
+    }
+}


### PR DESCRIPTION
## Summary

Makes five test ANALYSIS skills and the `test-quality-auditor` agent
in `plugins/dotnet-test` polyglot. They previously activated only on
.NET MSTest/xUnit/NUnit/TUnit cues, but the underlying techniques
(assertion diversity, anti-pattern detection, pseudo-mutation gap
analysis, academic smell catalog, trait tagging) apply equally to
non-.NET test frameworks.

Languages now supported: .NET (MSTest/xUnit/NUnit/TUnit), Python
(pytest/unittest), TypeScript/JavaScript (Jest/Vitest/Mocha/node:test),
Java (JUnit/TestNG), Go, Ruby (RSpec/Minitest), Rust, Swift
(XCTest/Swift Testing), Kotlin (JUnit/Kotest), PowerShell (Pester),
and C++ (GoogleTest/Catch2/doctest).

## What changes

- **NEW** `plugins/dotnet-test/skills/test-analysis-extensions/` —
  reference skill with 11 per-language extension files documenting test
  markers, assertion APIs, sleep / time / random APIs, skip
  annotations, setup/teardown, mystery-guest indicators, integration
  markers, and tag-support capability. Mirrors the existing
  `code-testing-extensions` pattern.
- **POLYGLOT** `assertion-quality`, `test-anti-patterns`,
  `test-gap-analysis`, `test-smell-detection`, `test-tagging`:
  frontmatter lists all polyglot frameworks (.NET trigger words
  preserved for backward compat); bodies reference
  `test-analysis-extensions` and add per-language calibration:
  - Go/Rust table-driven loops are idiomatic, **not** Conditional Test
    Logic
  - pytest bare `assert` is canonical, **not** a missing-framework
    smell
  - Missing-`await` on async assertions (Jest `.resolves`, xUnit
    `ThrowsAsync`, pytest-asyncio, Kotest `runTest`, Swift Testing)
    flagged as a new Critical silent-pass smell
  - `test-tagging` capability matrix: safe auto-edit (.NET
    attributes, pytest markers, JUnit `@Tag`, RSpec metadata, Pester
    `-Tag`) vs report-only (Go/Jest/Vitest/Rust/C++ without project
    convention)
- **POLYGLOT** `test-quality-auditor` agent: language detection,
  capability matrix gating .NET-only pipeline steps (coverage-analysis,
  CRAP, detect-static-dependencies, testability migration, experimental
  dotnet skills), with native-tooling recommendations for non-.NET
  audits.
- **README** updated with polyglot framework list and sectional splits
  between polyglot and .NET-only skills.
- **NEW polyglot eval scenarios**: Python/pytest `UserService`
  fixture (`test-anti-patterns`), TS/Jest `OrderService` fixture
  (`assertion-quality`), Java/JUnit `Catalog` fixture
  (`test-smell-detection`), each exercising the full per-language
  smell catalog.

## What stays .NET-only

`writing-mstest-tests`, `migrate-mstest-*`, `migrate-xunit-*`,
`migrate-vstest-to-mtp`, `mtp-hot-reload`, `run-tests`,
`filter-syntax`, `platform-detection`, `dotnet-test-frameworks`,
`coverage-analysis`, `crap-score`, `detect-static-dependencies`,
`generate-testability-wrappers`, `migrate-static-to-wrapper`,
`test-migration` agent, `testability-migration` agent, and the
`exp-*` experimental skills. These are correctly .NET-bound (Cobertura
pipelines, TimeProvider/IFileSystem migrations, MSBuild platform
detection, etc.) and the auditor's capability matrix explicitly skips
them for non-.NET projects with an explanation.

## Validation

`dotnet run --project eng/skill-validator/src -- check --plugin ./plugins/dotnet-test` passes — 23 skills, 11 agents validated.

YAML syntax verified on all three modified `eval.yaml` files.
