### PR TITLE
code-testing-agent: add polyglot pipeline examples for Python/TypeScript/Go/Java

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -157,7 +157,7 @@ Summarize tests created, report any failures or issues, suggest next steps if ne
 - Consider adding integration tests for database layer
 ```
 
-> **Language-specific examples**: For a complete end-to-end walkthrough including sample source code, research output, plan, generated tests, and fix cycles, call the `code-testing-extensions` skill and read `dotnet-examples.md` for .NET.
+> **Language-specific examples**: For a complete end-to-end walkthrough including sample source code, research output, plan, generated tests, and fix cycles, call the `code-testing-extensions` skill and read the matching `<language>-examples.md` file when one exists — `dotnet-examples.md`, `python-examples.md`, `typescript-examples.md`, `go-examples.md`, and `java-examples.md` are currently available. For other languages, follow the base extension file (e.g., `rust.md`, `kotlin.md`) and adapt the pipeline shape shown in the closest example.
 
 ## State Management
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -99,7 +99,7 @@ ISSUES:
 - [Any unresolved issues]
 ```
 
-> **Concrete example**: For a complete generated test file and build-error fix cycle walkthrough, call the `code-testing-extensions` skill and read `dotnet-examples.md` ("Sample Generated Test File" and "Sample Fix Cycle" sections).
+> **Concrete example**: For a complete generated test file and build-error fix cycle walkthrough, call the `code-testing-extensions` skill and read the matching `<language>-examples.md` file when one exists — `dotnet-examples.md`, `python-examples.md`, `typescript-examples.md`, `go-examples.md`, `java-examples.md` ("Sample Generated Test File" and "Sample Fix Cycle" sections). For other languages, adapt the closest example to the project's framework.
 
 ## Rules
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -126,7 +126,7 @@ What this phase accomplishes and why it's first.
 ...
 ```
 
-> **Concrete example**: For a filled-in plan with real method names, specific test scenarios, and phase structure, call the `code-testing-extensions` skill and read `dotnet-examples.md` ("Sample Plan Output" section).
+> **Concrete example**: For a filled-in plan with real method names, specific test scenarios, and phase structure, call the `code-testing-extensions` skill and read the matching `<language>-examples.md` file when one exists — `dotnet-examples.md`, `python-examples.md`, `typescript-examples.md`, `go-examples.md`, `java-examples.md` ("Sample Plan Output" section). For other languages, adapt the closest example.
 
 ## Rules
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -25,22 +25,28 @@ Analyze a codebase and produce a comprehensive research document that will guide
 
 Search for key files:
 
-- Project files: `*.csproj`, `*.vcxproj`, `*.sln`, `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`
+- Project files: `*.csproj`, `*.vcxproj`, `*.sln`, `package.json`, `pyproject.toml`, `setup.cfg`, `setup.py`, `requirements*.txt`, `tox.ini`, `noxfile.py`, `uv.lock`, `poetry.lock`, `pdm.lock`, `Pipfile`, `Pipfile.lock`, `go.mod`, `go.work`, `Cargo.toml`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle*`, `Gemfile`, `Gemfile.lock`, `Package.swift`, `*.xcodeproj`, `CMakeLists.txt`, `BUILD.bazel`, `meson.build`, `Makefile`, `Taskfile.yml`
 - Property and Target files: `*.props`, `*.targets`
-- Source files: `*.cs`, `*.ts`, `*.py`, `*.go`, `*.rs`, `*.cpp`, `*.h`
-- Existing tests: `*test*`, `*Test*`, `*spec*`
-- Config files: `README*`, `Makefile`, `*.config`
+- Source files: `*.cs`, `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.mts`, `*.cts`, `*.py`, `*.go`, `*.rs`, `*.cpp`, `*.cc`, `*.h`, `*.hpp`, `*.java`, `*.kt`, `*.kts`, `*.swift`, `*.rb`, `*.ps1`, `*.psm1`
+- Test runner config: `vitest.config.*`, `jest.config.*`, `mocha.config.*`, `pytest.ini`, `conftest.py`, `phpunit.xml`, `karma.conf.*`, `playwright.config.*`
+- Existing tests: `*test*`, `*Test*`, `*spec*`, `*_test.go`
+- Config files: `README*`, `Makefile`, `*.config`, `*.editorconfig`
 
 ### 2. Identify the Language and Framework
 
 Based on files found:
 
-- **C#/.NET**: `*.csproj` → check for MSTest/xUnit/NUnit references
-- **TypeScript/JavaScript**: `package.json` → check for Jest/Vitest/Mocha
-- **Python**: `pyproject.toml` or `pytest.ini` → check for pytest/unittest
-- **Go**: `go.mod` → tests use `*_test.go` pattern
-- **Rust**: `Cargo.toml` → tests go in same file or `tests/` directory
-- **C++**: `*.vcxproj` → check for GoogleTest (gtest) references
+- **C#/.NET**: `*.csproj` → check for MSTest/xUnit/NUnit/TUnit references
+- **TypeScript/JavaScript**: `package.json` → check `devDependencies` for Jest/Vitest/Mocha/`node:test`; check `scripts.test`; check for `vitest.config.*` / `jest.config.*`
+- **Python**: `pyproject.toml` / `setup.cfg` / `pytest.ini` / `tox.ini` / `noxfile.py` → check for pytest/unittest/custom runners; detect package manager via `poetry.lock` / `pdm.lock` / `uv.lock` / `Pipfile.lock`
+- **Go**: `go.mod` → tests use `*_test.go` pattern; `go.work` indicates a multi-module workspace
+- **Rust**: `Cargo.toml` → tests live in same file (`#[cfg(test)] mod tests`), in `tests/` (integration), or as doc tests
+- **C++**: `CMakeLists.txt` / `BUILD.bazel` / `meson.build` / `*.vcxproj` / `Makefile` → check for GoogleTest (`gtest`), Catch2, doctest, or Boost.Test
+- **Java**: `pom.xml` (Maven) or `build.gradle[.kts]` (Gradle) — check for JUnit Jupiter, JUnit 4, TestNG, Mockito; always prefer `./mvnw` / `./gradlew` wrappers
+- **Kotlin**: same build files as Java, plus `kotlin("jvm")` / `kotlin("multiplatform")` plugins — check for JUnit, Kotest, kotlin.test, MockK
+- **Ruby**: `Gemfile` / `Gemfile.lock` — check for RSpec (`spec/`) or Minitest (`test/`)
+- **Swift**: `Package.swift` (SPM) or `*.xcodeproj`/`*.xcworkspace` (Xcode) — distinguish XCTest vs Swift Testing
+- **PowerShell**: `*.ps1`/`*.psm1` files alongside `*.Tests.ps1` — Pester is the dominant framework
 
 ### 3. Identify the Scope of Testing
 
@@ -160,4 +166,4 @@ For each test project found, list:
 
 Write the research document to `.testagent/research.md` in the workspace root.
 
-> **Concrete example**: For a filled-in research document showing real file paths, detected frameworks, and prioritized file tables, call the `code-testing-extensions` skill and read `dotnet-examples.md` ("Sample Research Output" section).
+> **Concrete example**: For a filled-in research document showing real file paths, detected frameworks, and prioritized file tables, call the `code-testing-extensions` skill and read the matching `<language>-examples.md` file when one exists — `dotnet-examples.md`, `python-examples.md`, `typescript-examples.md`, `go-examples.md`, `java-examples.md` ("Sample Research Output" section). For other languages, adapt the closest example.

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -166,6 +166,12 @@ Given a request like *"Generate unit tests for my InvoiceService"*, the pipeline
 The `code-testing-extensions` skill provides concrete, filled-in examples for each pipeline phase showing real source code, real research output, real plans, and real generated tests. Call the `code-testing-extensions` skill to discover available extension files, then read:
 
 - **`dotnet-examples.md`** — MSTest example with InvoiceService: research output, plan output, generated test file, fix cycle walkthrough, and final report
+- **`python-examples.md`** — pytest example with the same InvoiceService scenario: research, plan, generated test file (parametrized, `unittest.mock`), fix cycles (`ModuleNotFoundError`, patch target, `Mock(spec=...)`), and final report
+- **`typescript-examples.md`** — Vitest example (also applicable to Jest) showing `it.each` parameterization, async tests, fake timers, and ESM/CJS fix cycles
+- **`go-examples.md`** — Standard `testing` package example with table-driven subtests, hand-written fake repository, injected clock, and `-run` regex fix cycle
+- **`java-examples.md`** — JUnit 5 + Mockito example on Maven showing `@ExtendWith(MockitoExtension.class)`, `@ParameterizedTest` + `@CsvSource`, `Clock.fixed(...)` for time, and Surefire fix cycles
+
+For languages without a dedicated examples file (Rust, Ruby, Swift, Kotlin, C++, PowerShell), use the base extension file (`<language>.md`) plus the example file for the closest paradigm — the pipeline shape (research → plan → generate → fix) and the categories of decisions (test layout, mocking strategy, fixed clock for time-dependent code, parameterization style) translate directly.
 
 ## Agent Reference
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/SKILL.md
@@ -29,7 +29,11 @@ This skill provides access to language-specific guidance files used by the code-
 | [extensions/swift.md](extensions/swift.md) | Swift | SPM and Xcode test commands, XCTest vs Swift Testing, `@testable import`, async/throws tests, common errors |
 | [extensions/kotlin.md](extensions/kotlin.md) | Kotlin | Gradle commands, JUnit/Kotest detection, MockK, coroutines test, KMP and Android specifics, common errors |
 | [extensions/dotnet-examples.md](extensions/dotnet-examples.md) | .NET (C#/F#/VB) | Concrete pipeline examples: sample research output, plan, generated tests, fix cycles, final report |
+| [extensions/python-examples.md](extensions/python-examples.md) | Python | Concrete pipeline examples (pytest): research, plan, generated test file, fix cycles, final report |
+| [extensions/typescript-examples.md](extensions/typescript-examples.md) | TypeScript/JavaScript | Concrete pipeline examples (Vitest, applicable to Jest): research, plan, generated test file, fix cycles, final report |
+| [extensions/go-examples.md](extensions/go-examples.md) | Go | Concrete pipeline examples (standard `testing`): research, plan, table-driven test file, fix cycles, final report |
+| [extensions/java-examples.md](extensions/java-examples.md) | Java | Concrete pipeline examples (JUnit 5 + Mockito on Maven): research, plan, generated test file, fix cycles, final report |
 
 ## Usage
 
-Read the appropriate extension file for the target language before writing test code.
+Read the appropriate extension file for the target language before writing test code. When an `<language>-examples.md` file exists for the target language, read it alongside the base extension to see a concrete end-to-end pipeline walkthrough (research output, plan, generated tests, fix cycles, final report).

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
@@ -162,6 +162,7 @@ package billing
 import (
     "context"
     "errors"
+    "strings"
     "testing"
     "time"
 )
@@ -225,7 +226,7 @@ func TestInvoiceService_CalculateTotal(t *testing.T) {
         t.Run(tt.name, func(t *testing.T) {
             got, err := sut.CalculateTotal(tt.invoice)
             if tt.wantErr != "" {
-                if err == nil || !contains(err.Error(), tt.wantErr) {
+                if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
                     t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
                 }
                 return
@@ -257,7 +258,7 @@ func TestInvoiceService_GetByID(t *testing.T) {
         repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return nil, nil }}
         sut := NewInvoiceService(repo)
         _, err := sut.GetByID(ctx, 999)
-        if err == nil || !contains(err.Error(), "999") {
+        if err == nil || !strings.Contains(err.Error(), "999") {
             t.Fatalf("expected error mentioning 999, got %v", err)
         }
     })
@@ -301,7 +302,7 @@ func TestInvoiceService_MarkAsPaid(t *testing.T) {
         invoice := &Invoice{ID: 1, Status: StatusPaid}
         repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return invoice, nil }}
         sut := NewInvoiceService(repo)
-        if err := sut.MarkAsPaid(ctx, 1); err == nil || !contains(err.Error(), "already paid") {
+        if err := sut.MarkAsPaid(ctx, 1); err == nil || !strings.Contains(err.Error(), "already paid") {
             t.Fatalf("expected already-paid error, got %v", err)
         }
         if repo.updated != nil {
@@ -312,23 +313,10 @@ func TestInvoiceService_MarkAsPaid(t *testing.T) {
     t.Run("returns not-found when missing", func(t *testing.T) {
         repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return nil, nil }}
         sut := NewInvoiceService(repo)
-        if err := sut.MarkAsPaid(ctx, 999); err == nil || !contains(err.Error(), "999") {
+        if err := sut.MarkAsPaid(ctx, 999); err == nil || !strings.Contains(err.Error(), "999") {
             t.Fatalf("expected not-found error, got %v", err)
         }
     })
-}
-
-func contains(s, substr string) bool {
-    return len(s) >= len(substr) && (s == substr || (len(substr) > 0 && stringIndex(s, substr) >= 0))
-}
-
-func stringIndex(s, substr string) int {
-    for i := 0; i+len(substr) <= len(s); i++ {
-        if s[i:i+len(substr)] == substr {
-            return i
-        }
-    }
-    return -1
 }
 ```
 
@@ -364,8 +352,9 @@ testing: warning: no tests to run
 **Fix applied:**
 
 ```bash
-# Before
-go test -run TestInvoiceService_CalculateTotal/single item
+# Before — bare name without anchors, and an unquoted space would be parsed
+# by the shell as two separate arguments
+go test -run 'TestInvoiceService_CalculateTotal/single_item'
 
 # After — anchor the subtest name, replace spaces with underscores
 go test -run '^TestInvoiceService_CalculateTotal$/^single_item_with_10%_tax$' ./internal/billing

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
@@ -1,0 +1,407 @@
+# Go Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Go codebase. These show what each pipeline phase produces for a small package.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Go module:
+
+```text
+go.mod                                 (module github.com/contoso/billing)
+internal/billing/
+  invoice.go
+  invoice_repository.go               (defines the InvoiceRepository interface)
+  invoice_service.go
+```
+
+```go
+// internal/billing/invoice_service.go
+package billing
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "math"
+    "time"
+)
+
+type InvoiceService struct {
+    repository InvoiceRepository
+    now        func() time.Time
+}
+
+func NewInvoiceService(repo InvoiceRepository) *InvoiceService {
+    return &InvoiceService{repository: repo, now: time.Now}
+}
+
+func (s *InvoiceService) CalculateTotal(invoice *Invoice) (float64, error) {
+    if invoice == nil {
+        return 0, errors.New("invoice must not be nil")
+    }
+    if len(invoice.LineItems) == 0 {
+        return 0, errors.New("invoice has no line items")
+    }
+    var subtotal float64
+    for _, li := range invoice.LineItems {
+        subtotal += float64(li.Quantity) * li.UnitPrice
+    }
+    tax := subtotal * invoice.TaxRate
+    return math.Round((subtotal+tax)*100) / 100, nil
+}
+
+func (s *InvoiceService) GetByID(ctx context.Context, id int) (*Invoice, error) {
+    invoice, err := s.repository.Find(ctx, id)
+    if err != nil {
+        return nil, err
+    }
+    if invoice == nil {
+        return nil, fmt.Errorf("invoice %d not found", id)
+    }
+    return invoice, nil
+}
+
+func (s *InvoiceService) MarkAsPaid(ctx context.Context, id int) error {
+    invoice, err := s.repository.Find(ctx, id)
+    if err != nil {
+        return err
+    }
+    if invoice == nil {
+        return fmt.Errorf("invoice %d not found", id)
+    }
+    if invoice.Status == StatusPaid {
+        return errors.New("invoice is already paid")
+    }
+    invoice.Status = StatusPaid
+    invoice.PaidDate = s.now()
+    return s.repository.Update(ctx, invoice)
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/billing
+- **Language**: Go 1.22 (from go.mod)
+- **Module**: github.com/contoso/billing
+- **Test Framework**: standard `testing` package (no testify/gomock detected in go.sum)
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Vet**: `go vet ./...`
+- **Build**: `go build ./...`
+- **Compile tests**: `go test -count=1 -run=^$ ./internal/billing`
+- **Test**: `go test -count=1 ./internal/billing`
+
+## Project Structure
+- Source: `internal/billing/`
+- Tests: none
+
+## Files to Test
+
+### High Priority
+| File | Functions | Testability | Notes |
+|------|-----------|-------------|-------|
+| internal/billing/invoice_service.go | InvoiceService.CalculateTotal, GetByID, MarkAsPaid | High | Uses InvoiceRepository interface — easy to fake with a hand-written struct |
+
+## Existing Tests
+- No existing tests found
+
+## Testing Patterns
+- No existing patterns; recommend white-box `package billing` tests with hand-written fake repository (no testify since the repo doesn't use it), table-driven `t.Run` subtests for CalculateTotal, and an injected `now func() time.Time` for MarkAsPaid.
+
+## Recommendations
+- Inject `now` instead of stubbing `time.Now` globally — the struct already supports it
+- Place tests in `internal/billing/invoice_service_test.go` (same package, white-box)
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate standard-library Go tests for InvoiceService using table-driven subtests
+and a hand-written fake repository. Single phase since there is only one source file.
+
+## Commands
+- **Compile tests**: `go test -count=1 -run=^$ ./internal/billing`
+- **Test**: `go test -count=1 -v ./internal/billing`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+
+#### 1. invoice_service.go
+- **Source**: `internal/billing/invoice_service.go`
+- **Test File**: `internal/billing/invoice_service_test.go`
+
+**Functions to Test**:
+1. `CalculateTotal` — Table-driven
+   - Happy paths: single item, multi-item, rounding
+   - Error cases: nil invoice, empty line items
+2. `GetByID` — happy + missing + repo error
+3. `MarkAsPaid` — happy (verifies timestamp via injected clock) + already-paid + missing + repo error
+```
+
+## Sample Generated Test File
+
+```go
+// internal/billing/invoice_service_test.go
+package billing
+
+import (
+    "context"
+    "errors"
+    "testing"
+    "time"
+)
+
+type fakeRepository struct {
+    findFunc   func(ctx context.Context, id int) (*Invoice, error)
+    updateFunc func(ctx context.Context, invoice *Invoice) error
+    updated    *Invoice
+}
+
+func (f *fakeRepository) Find(ctx context.Context, id int) (*Invoice, error) {
+    if f.findFunc != nil {
+        return f.findFunc(ctx, id)
+    }
+    return nil, nil
+}
+
+func (f *fakeRepository) Update(ctx context.Context, invoice *Invoice) error {
+    f.updated = invoice
+    if f.updateFunc != nil {
+        return f.updateFunc(ctx, invoice)
+    }
+    return nil
+}
+
+func TestInvoiceService_CalculateTotal(t *testing.T) {
+    tests := []struct {
+        name    string
+        invoice *Invoice
+        want    float64
+        wantErr string
+    }{
+        {
+            name:    "single item with 10% tax",
+            invoice: &Invoice{TaxRate: 0.10, LineItems: []LineItem{{Quantity: 1, UnitPrice: 100}}},
+            want:    110,
+        },
+        {
+            name:    "multi quantity zero tax",
+            invoice: &Invoice{TaxRate: 0, LineItems: []LineItem{{Quantity: 3, UnitPrice: 25}}},
+            want:    75,
+        },
+        {
+            name:    "rounds half up",
+            invoice: &Invoice{TaxRate: 0.07, LineItems: []LineItem{{Quantity: 2, UnitPrice: 9.99}}},
+            want:    21.38,
+        },
+        {
+            name:    "nil invoice errors",
+            invoice: nil,
+            wantErr: "invoice must not be nil",
+        },
+        {
+            name:    "empty line items errors",
+            invoice: &Invoice{TaxRate: 0, LineItems: []LineItem{}},
+            wantErr: "no line items",
+        },
+    }
+    sut := NewInvoiceService(&fakeRepository{})
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := sut.CalculateTotal(tt.invoice)
+            if tt.wantErr != "" {
+                if err == nil || !contains(err.Error(), tt.wantErr) {
+                    t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+                }
+                return
+            }
+            if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+            if got != tt.want {
+                t.Errorf("CalculateTotal = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+
+func TestInvoiceService_GetByID(t *testing.T) {
+    ctx := context.Background()
+    want := &Invoice{ID: 42}
+
+    t.Run("returns invoice when found", func(t *testing.T) {
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return want, nil }}
+        sut := NewInvoiceService(repo)
+        got, err := sut.GetByID(ctx, 42)
+        if err != nil || got != want {
+            t.Fatalf("got (%v, %v), want (%v, nil)", got, err, want)
+        }
+    })
+
+    t.Run("returns not-found error when missing", func(t *testing.T) {
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return nil, nil }}
+        sut := NewInvoiceService(repo)
+        _, err := sut.GetByID(ctx, 999)
+        if err == nil || !contains(err.Error(), "999") {
+            t.Fatalf("expected error mentioning 999, got %v", err)
+        }
+    })
+
+    t.Run("propagates repository error", func(t *testing.T) {
+        boom := errors.New("boom")
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return nil, boom }}
+        sut := NewInvoiceService(repo)
+        _, err := sut.GetByID(ctx, 1)
+        if !errors.Is(err, boom) {
+            t.Fatalf("expected boom error, got %v", err)
+        }
+    })
+}
+
+func TestInvoiceService_MarkAsPaid(t *testing.T) {
+    ctx := context.Background()
+    fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+    t.Run("transitions pending invoice to paid", func(t *testing.T) {
+        invoice := &Invoice{ID: 1, Status: StatusPending}
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return invoice, nil }}
+        sut := NewInvoiceService(repo)
+        sut.now = func() time.Time { return fixedTime }
+
+        if err := sut.MarkAsPaid(ctx, 1); err != nil {
+            t.Fatalf("unexpected error: %v", err)
+        }
+        if invoice.Status != StatusPaid {
+            t.Errorf("status = %v, want %v", invoice.Status, StatusPaid)
+        }
+        if !invoice.PaidDate.Equal(fixedTime) {
+            t.Errorf("paid date = %v, want %v", invoice.PaidDate, fixedTime)
+        }
+        if repo.updated != invoice {
+            t.Errorf("repository was not updated with the invoice")
+        }
+    })
+
+    t.Run("rejects already-paid invoice", func(t *testing.T) {
+        invoice := &Invoice{ID: 1, Status: StatusPaid}
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return invoice, nil }}
+        sut := NewInvoiceService(repo)
+        if err := sut.MarkAsPaid(ctx, 1); err == nil || !contains(err.Error(), "already paid") {
+            t.Fatalf("expected already-paid error, got %v", err)
+        }
+        if repo.updated != nil {
+            t.Errorf("update should not be called for already-paid invoice")
+        }
+    })
+
+    t.Run("returns not-found when missing", func(t *testing.T) {
+        repo := &fakeRepository{findFunc: func(_ context.Context, _ int) (*Invoice, error) { return nil, nil }}
+        sut := NewInvoiceService(repo)
+        if err := sut.MarkAsPaid(ctx, 999); err == nil || !contains(err.Error(), "999") {
+            t.Fatalf("expected not-found error, got %v", err)
+        }
+    })
+}
+
+func contains(s, substr string) bool {
+    return len(s) >= len(substr) && (s == substr || (len(substr) > 0 && stringIndex(s, substr) >= 0))
+}
+
+func stringIndex(s, substr string) int {
+    for i := 0; i+len(substr) <= len(s); i++ {
+        if s[i:i+len(substr)] == substr {
+            return i
+        }
+    }
+    return -1
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a compile or test-runner issue, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+internal/billing/invoice_service_test.go:14:6: cannot use &fakeRepository{} (value of type *fakeRepository) as type InvoiceRepository in argument to NewInvoiceService:
+        *fakeRepository does not implement InvoiceRepository (missing method Update)
+```
+
+**Fixer diagnosis:** The fake repository only implemented `Find`. Go enforces full interface implementation at compile time. Add the missing method.
+
+**Fix applied:** Add the `Update` method to `fakeRepository` (shown in the test file above).
+
+**Rebuild + rerun:** `go test -count=1 ./internal/billing` → SUCCESS
+
+---
+
+**Another common cycle — wrong test selection regex:**
+
+**Test output:**
+
+```text
+testing: warning: no tests to run
+```
+
+**Fixer diagnosis:** The agent used `go test -run TestInvoiceService_CalculateTotal/single_item` without `^...$` anchors. The Go test runner treats `-run` as a regex; the underscore makes the match too narrow.
+
+**Fix applied:**
+
+```bash
+# Before
+go test -run TestInvoiceService_CalculateTotal/single item
+
+# After — anchor the subtest name, replace spaces with underscores
+go test -run '^TestInvoiceService_CalculateTotal$/^single_item_with_10%_tax$' ./internal/billing
+```
+
+**Rerun:** SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: billing (Go)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 11    |
+| Tests passing  | 11    |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `internal/billing/invoice_service_test.go` (3 top-level tests, 11 subtests including 5 table cases)
+
+### Coverage
+- InvoiceService.CalculateTotal — 3 happy + 2 error cases (table-driven)
+- InvoiceService.GetByID — happy + missing + repo-error
+- InvoiceService.MarkAsPaid — happy (with fixed clock) + already-paid + missing
+
+### Build / Test Validation
+- `go vet ./...`: ✅
+- `go test -count=1 ./internal/billing`: ✅ PASS
+
+### Next Steps
+- Add fuzz test (`FuzzCalculateTotal`) if rounding correctness is critical
+- Consider extracting a `Clock` interface if more time-dependent logic appears
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
@@ -10,7 +10,7 @@ A simple `InvoiceService` in a Maven project using JUnit 5:
 pom.xml
 src/main/java/com/contoso/billing/
   InvoiceService.java
-  Invoice.java                       (record with status, taxRate, lineItems)
+  Invoice.java                       (mutable POJO with status, taxRate, lineItems and setStatus / setPaidDate mutators)
   InvoiceStatus.java                 (enum: PENDING, PAID)
   InvoiceRepository.java             (interface)
 src/test/java/com/contoso/billing/   (exists, empty)

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
@@ -1,0 +1,344 @@
+# Java Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Java codebase using JUnit 5 + Mockito. These show what each pipeline phase produces for a small project.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Maven project using JUnit 5:
+
+```text
+pom.xml
+src/main/java/com/contoso/billing/
+  InvoiceService.java
+  Invoice.java                       (record with status, taxRate, lineItems)
+  InvoiceStatus.java                 (enum: PENDING, PAID)
+  InvoiceRepository.java             (interface)
+src/test/java/com/contoso/billing/   (exists, empty)
+```
+
+```java
+// src/main/java/com/contoso/billing/InvoiceService.java
+package com.contoso.billing;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public class InvoiceService {
+
+    private final InvoiceRepository repository;
+    private final Clock clock;
+
+    public InvoiceService(InvoiceRepository repository) {
+        this(repository, Clock.systemUTC());
+    }
+
+    public InvoiceService(InvoiceRepository repository, Clock clock) {
+        this.repository = repository;
+        this.clock = clock;
+    }
+
+    public BigDecimal calculateTotal(Invoice invoice) {
+        if (invoice == null) {
+            throw new IllegalArgumentException("invoice must not be null");
+        }
+        if (invoice.lineItems().isEmpty()) {
+            throw new IllegalStateException("Invoice has no line items.");
+        }
+        BigDecimal subtotal = invoice.lineItems().stream()
+            .map(li -> li.unitPrice().multiply(BigDecimal.valueOf(li.quantity())))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal tax = subtotal.multiply(invoice.taxRate());
+        return subtotal.add(tax).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public Invoice getById(int id) {
+        Optional<Invoice> invoice = repository.find(id);
+        return invoice.orElseThrow(
+            () -> new IllegalArgumentException("Invoice " + id + " not found."));
+    }
+
+    public void markAsPaid(int id) {
+        Invoice invoice = repository.find(id)
+            .orElseThrow(() -> new IllegalArgumentException("Invoice " + id + " not found."));
+        if (invoice.status() == InvoiceStatus.PAID) {
+            throw new IllegalStateException("Invoice is already paid.");
+        }
+        invoice.setStatus(InvoiceStatus.PAID);
+        invoice.setPaidDate(LocalDateTime.now(clock));
+        repository.update(invoice);
+    }
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/billing
+- **Language**: Java 21 (`<maven.compiler.release>21</maven.compiler.release>`)
+- **Build Tool**: Maven (wrapper `./mvnw` present)
+- **Test Framework**: JUnit 5 (Jupiter 5.10) + Mockito 5.x (detected in pom.xml)
+- **Assertion library**: built-in `Assertions` (no AssertJ/Hamcrest in deps)
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Compile**: `./mvnw -q test-compile`
+- **Test**: `./mvnw -q test`
+- **Single class**: `./mvnw -q test -Dtest=InvoiceServiceTest`
+- **Single method**: `./mvnw -q test -Dtest=InvoiceServiceTest#calculateTotal_validLineItems_returnsExpectedTotal`
+
+## Project Structure
+- Source: `src/main/java/com/contoso/billing/`
+- Tests: `src/test/java/com/contoso/billing/` (exists, empty)
+
+## Files to Test
+
+### High Priority
+| File | Classes/Methods | Testability | Notes |
+|------|-----------------|-------------|-------|
+| InvoiceService.java | calculateTotal, getById, markAsPaid | High | Repository dependency mockable via Mockito; clock injection available for time-dependent test |
+
+## Testing Patterns
+- No existing patterns; recommend JUnit 5 + Mockito with `@ExtendWith(MockitoExtension.class)`, `@Mock` / `@InjectMocks` fields, `@ParameterizedTest` + `@CsvSource` for table-driven `calculateTotal`, and `Clock.fixed(...)` for `markAsPaid` timestamp.
+
+## Recommendations
+- Test class lives in the same package (`com.contoso.billing`) for package-private access if needed
+- Inject `Clock.fixed(...)` rather than mocking `LocalDateTime.now(...)` — the service already accepts a Clock
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate JUnit 5 + Mockito tests for InvoiceService, covering all three public
+methods across happy path, edge case, and error scenarios. Single phase since
+there is only one source file.
+
+## Commands
+- **Compile**: `./mvnw -q test-compile`
+- **Test**: `./mvnw -q test -Dtest=InvoiceServiceTest`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+
+#### 1. InvoiceService.java
+- **Source**: `src/main/java/com/contoso/billing/InvoiceService.java`
+- **Test File**: `src/test/java/com/contoso/billing/InvoiceServiceTest.java`
+
+**Methods to Test**:
+1. `calculateTotal` — pure logic (parameterized)
+   - Happy paths: single item w/ tax, multi-quantity zero tax, rounding-half-up
+   - Error cases: null invoice → IllegalArgumentException; empty line items → IllegalStateException
+2. `getById` — happy + missing
+3. `markAsPaid` — happy (verify status + paid date via fixed clock + verify update) + already-paid + missing
+```
+
+## Sample Generated Test File
+
+```java
+// src/test/java/com/contoso/billing/InvoiceServiceTest.java
+package com.contoso.billing;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InvoiceServiceTest {
+
+    @Mock
+    InvoiceRepository repository;
+
+    @InjectMocks
+    InvoiceService sut;
+
+    // --- calculateTotal ---
+
+    @ParameterizedTest(name = "qty={0} unitPrice={1} taxRate={2} -> {3}")
+    @CsvSource({
+        "1, 100.00, 0.10, 110.00",
+        "3, 25.00,  0.00,  75.00",
+        "2,  9.99,  0.07,  21.38"
+    })
+    void calculateTotal_validLineItems_returnsExpectedTotal(
+        int quantity, BigDecimal unitPrice, BigDecimal taxRate, BigDecimal expected
+    ) {
+        Invoice invoice = new Invoice(1, InvoiceStatus.PENDING, taxRate,
+            List.of(new LineItem(quantity, unitPrice)));
+
+        BigDecimal total = sut.calculateTotal(invoice);
+
+        assertEquals(0, total.compareTo(expected),
+            () -> "expected " + expected + " but got " + total);
+    }
+
+    @Test
+    @DisplayName("null invoice throws IllegalArgumentException")
+    void calculateTotal_nullInvoice_throws() {
+        assertThrows(IllegalArgumentException.class, () -> sut.calculateTotal(null));
+    }
+
+    @Test
+    void calculateTotal_emptyLineItems_throws() {
+        Invoice invoice = new Invoice(1, InvoiceStatus.PENDING, BigDecimal.ZERO, List.of());
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> sut.calculateTotal(invoice));
+        assertEquals("Invoice has no line items.", ex.getMessage());
+    }
+
+    // --- getById ---
+
+    @Test
+    void getById_existingId_returnsInvoice() {
+        Invoice expected = new Invoice(42, InvoiceStatus.PENDING, BigDecimal.ZERO, List.of());
+        when(repository.find(42)).thenReturn(Optional.of(expected));
+
+        assertSame(expected, sut.getById(42));
+    }
+
+    @Test
+    void getById_missingId_throws() {
+        when(repository.find(999)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> sut.getById(999));
+        assertEquals("Invoice 999 not found.", ex.getMessage());
+    }
+
+    // --- markAsPaid (uses an injected fixed Clock instead of @InjectMocks) ---
+
+    @Test
+    void markAsPaid_pendingInvoice_transitionsToPaidAndPersists() {
+        Clock fixed = Clock.fixed(Instant.parse("2025-01-01T12:00:00Z"), ZoneOffset.UTC);
+        InvoiceService service = new InvoiceService(repository, fixed);
+        Invoice invoice = new Invoice(1, InvoiceStatus.PENDING, BigDecimal.ZERO, List.of());
+        when(repository.find(1)).thenReturn(Optional.of(invoice));
+
+        service.markAsPaid(1);
+
+        assertEquals(InvoiceStatus.PAID, invoice.status());
+        assertEquals(LocalDateTime.ofInstant(fixed.instant(), ZoneOffset.UTC), invoice.paidDate());
+        verify(repository).update(invoice);
+    }
+
+    @Test
+    void markAsPaid_alreadyPaid_throwsAndDoesNotUpdate() {
+        Invoice invoice = new Invoice(1, InvoiceStatus.PAID, BigDecimal.ZERO, List.of());
+        when(repository.find(1)).thenReturn(Optional.of(invoice));
+
+        assertThrows(IllegalStateException.class, () -> sut.markAsPaid(1));
+        verify(repository, never()).update(any());
+    }
+
+    @Test
+    void markAsPaid_missingId_throws() {
+        when(repository.find(999)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> sut.markAsPaid(999));
+    }
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a compile or runtime error, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+[ERROR] No tests found for given includes: [com.contoso.billing.InvoiceServiceTest]
+```
+
+**Fixer diagnosis:** Surefire only includes `**/*Test.class` (default). The class is `InvoiceServiceTest` (correct) but it was created under `src/test/java/com/contoso/billing/` with **no** package declaration. Maven compiles it into the default package, so `-Dtest=com.contoso.billing.InvoiceServiceTest` doesn't match.
+
+**Fix applied:** Add `package com.contoso.billing;` at the top of the test file so it lands in the expected package.
+
+**Rebuild + rerun:** `./mvnw -q test -Dtest=InvoiceServiceTest` → SUCCESS
+
+---
+
+**Another common cycle — wrong Mockito setup:**
+
+**Test output:**
+
+```text
+org.mockito.exceptions.misusing.UnnecessaryStubbingException:
+Unnecessary stubbings detected.
+  1. -> at InvoiceServiceTest.calculateTotal_nullInvoice_throws(InvoiceServiceTest.java:55)
+```
+
+**Fixer diagnosis:** `@MockitoExtension` runs in strict mode by default — stubbed calls (`when(repository.find(...)).thenReturn(...)`) must be used. The test stubbed `repository` in a `@BeforeEach` for every test, but `calculateTotal_nullInvoice_throws` never touches the repository.
+
+**Fix applied:** Move stubs into the tests that actually need them (as shown in the generated file above), rather than a single shared `@BeforeEach`.
+
+**Rebuild + rerun:** SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: billing (Java / Maven)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 8     |
+| Tests passing  | 8     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `src/test/java/com/contoso/billing/InvoiceServiceTest.java` (8 tests, 3 parameterized cases via @CsvSource)
+
+### Coverage
+- InvoiceService.calculateTotal — 3 happy path, 2 error cases
+- InvoiceService.getById — happy + missing
+- InvoiceService.markAsPaid — happy (fixed Clock) + already-paid + missing
+
+### Build / Test Validation
+- `./mvnw -q test-compile`: ✅
+- `./mvnw -q test`: ✅ Tests run: 8, Failures: 0, Errors: 0
+
+### Next Steps
+- Add AssertJ if the team standardises on it (more expressive assertions)
+- Consider Testcontainers for true repository integration tests
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/python-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/python-examples.md
@@ -1,0 +1,411 @@
+# Python Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Python codebase using pytest. These show what each pipeline phase produces for a small project.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Python package using pytest:
+
+```text
+src/
+  contoso_billing/
+    __init__.py
+    invoice_service.py
+    invoice.py
+    invoice_repository.py
+tests/
+  __init__.py
+  conftest.py             (empty, just marks tests/ as a package root)
+pyproject.toml
+```
+
+```python
+# src/contoso_billing/invoice_service.py
+from decimal import Decimal, ROUND_HALF_UP
+from .invoice import Invoice, InvoiceStatus
+from .invoice_repository import InvoiceRepository
+
+
+class InvoiceService:
+    def __init__(self, repository: InvoiceRepository) -> None:
+        self._repository = repository
+
+    def calculate_total(self, invoice: Invoice) -> Decimal:
+        if invoice is None:
+            raise ValueError("invoice must not be None")
+        if not invoice.line_items:
+            raise ValueError("Invoice has no line items.")
+
+        subtotal = sum(
+            (li.quantity * li.unit_price for li in invoice.line_items),
+            start=Decimal("0"),
+        )
+        tax = subtotal * invoice.tax_rate
+        return (subtotal + tax).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    def get_by_id(self, invoice_id: int) -> Invoice:
+        invoice = self._repository.find(invoice_id)
+        if invoice is None:
+            raise KeyError(f"Invoice {invoice_id} not found.")
+        return invoice
+
+    def mark_as_paid(self, invoice_id: int) -> None:
+        invoice = self._repository.find(invoice_id)
+        if invoice is None:
+            raise KeyError(f"Invoice {invoice_id} not found.")
+        if invoice.status == InvoiceStatus.PAID:
+            raise ValueError("Invoice is already paid.")
+        invoice.status = InvoiceStatus.PAID
+        invoice.paid_date = _utcnow()
+        self._repository.update(invoice)
+
+
+def _utcnow():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc)
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: Python 3.11
+- **Framework**: pure library (no Flask/Django)
+- **Test Framework**: pytest 8.x (declared in pyproject.toml [project.optional-dependencies].test)
+- **Package Layout**: `src/` layout — production package imports as `contoso_billing`
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Install (editable)**: `python -m pip install -e ".[test]"`
+- **Build/Type-check**: none configured
+- **Test**: `python -m pytest`
+- **Lint**: none configured
+
+## Project Structure
+- Source: `src/contoso_billing/`
+- Tests: `tests/` (exists, empty besides `conftest.py`)
+
+## Files to Test
+
+### High Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| src/contoso_billing/invoice_service.py | InvoiceService: calculate_total, get_by_id, mark_as_paid | High | Core business logic, repository dependency needs mocking |
+
+### Low Priority / Skip
+| File | Reason |
+|------|--------|
+| src/contoso_billing/invoice.py | Dataclass, no logic |
+| src/contoso_billing/invoice_repository.py | Interface/protocol, no implementation |
+
+## Existing Tests
+- No existing tests found
+
+## Testing Patterns
+- No existing patterns; recommend pytest function-style tests in `tests/test_invoice_service.py`, `unittest.mock.Mock(spec=InvoiceRepository)` for repository fakes, and `@pytest.mark.parametrize` for table-driven cases.
+
+## Recommendations
+- Start with `calculate_total` (pure logic, easy to parametrize)
+- Then `get_by_id` and `mark_as_paid` (require mocking the repository)
+- Use `unittest.mock.patch("contoso_billing.invoice_service._utcnow")` to control the timestamp in `mark_as_paid`
+```
+
+## Sample Plan Output
+
+What `code-testing-planner` produces in `.testagent/plan.md`:
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate pytest tests for the Contoso Billing InvoiceService, covering all three
+public methods across happy path, edge case, and error scenarios. Single phase
+since there is only one source file.
+
+## Commands
+- **Install**: `python -m pip install -e ".[test]"`
+- **Test**: `python -m pytest tests/test_invoice_service.py -q`
+- **Test (file-scoped during dev)**: `python -m pytest tests/test_invoice_service.py::test_calculate_total_valid_line_items_returns_expected_total -q`
+
+## Phase Summary
+| Phase | Focus | Files | Est. Tests |
+|-------|-------|-------|------------|
+| 1 | InvoiceService | 1 | 9-12 |
+
+---
+
+## Phase 1: InvoiceService
+
+### Overview
+Cover all public methods of InvoiceService. `calculate_total` is pure logic tested
+with `@pytest.mark.parametrize`. The async-looking methods are synchronous but
+require a mocked InvoiceRepository.
+
+### Files to Test
+
+#### 1. invoice_service.py
+- **Source**: `src/contoso_billing/invoice_service.py`
+- **Test File**: `tests/test_invoice_service.py`
+
+**Methods to Test**:
+1. `calculate_total` — Pure calculation logic
+   - Happy path: single line item returns quantity × price + tax
+   - Happy path: multiple line items summed correctly
+   - Edge case: zero tax rate returns subtotal only
+   - Error case: None invoice raises ValueError
+   - Error case: empty line items raises ValueError
+
+2. `get_by_id` — Repository lookup
+   - Happy path: existing ID returns invoice
+   - Error case: missing ID raises KeyError
+
+3. `mark_as_paid` — State transition
+   - Happy path: pending invoice transitions to PAID with `paid_date` set
+   - Error case: already-paid raises ValueError
+   - Error case: missing ID raises KeyError
+
+### Success Criteria
+- [ ] Test file created at `tests/test_invoice_service.py`
+- [ ] `python -m pytest` reports all tests passed
+- [ ] No real network/IO; repository is mocked with `Mock(spec=InvoiceRepository)`
+```
+
+## Sample Generated Test File
+
+What `code-testing-implementer` produces:
+
+```python
+# tests/test_invoice_service.py
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import Mock, patch
+
+import pytest
+
+from contoso_billing.invoice import Invoice, InvoiceStatus, LineItem
+from contoso_billing.invoice_repository import InvoiceRepository
+from contoso_billing.invoice_service import InvoiceService
+
+
+@pytest.fixture
+def repository() -> Mock:
+    return Mock(spec=InvoiceRepository)
+
+
+@pytest.fixture
+def sut(repository: Mock) -> InvoiceService:
+    return InvoiceService(repository)
+
+
+# --- calculate_total ---
+
+@pytest.mark.parametrize(
+    "quantity, unit_price, tax_rate, expected",
+    [
+        (1, "100.00", "0.10", "110.00"),
+        (3, "25.00", "0.00", "75.00"),
+        (2, "9.99", "0.07", "21.38"),
+    ],
+    ids=["single-item-10pct-tax", "multi-quantity-zero-tax", "rounds-half-up"],
+)
+def test_calculate_total_valid_line_items_returns_expected_total(
+    sut: InvoiceService, quantity: int, unit_price: str, tax_rate: str, expected: str
+) -> None:
+    invoice = Invoice(
+        tax_rate=Decimal(tax_rate),
+        line_items=[LineItem(quantity=quantity, unit_price=Decimal(unit_price))],
+    )
+
+    total = sut.calculate_total(invoice)
+
+    assert total == Decimal(expected)
+
+
+def test_calculate_total_none_invoice_raises_value_error(sut: InvoiceService) -> None:
+    with pytest.raises(ValueError, match="invoice must not be None"):
+        sut.calculate_total(None)
+
+
+def test_calculate_total_empty_line_items_raises_value_error(sut: InvoiceService) -> None:
+    invoice = Invoice(tax_rate=Decimal("0"), line_items=[])
+
+    with pytest.raises(ValueError, match="no line items"):
+        sut.calculate_total(invoice)
+
+
+# --- get_by_id ---
+
+def test_get_by_id_existing_id_returns_invoice(
+    sut: InvoiceService, repository: Mock
+) -> None:
+    expected = Invoice(id=42, tax_rate=Decimal("0"), line_items=[])
+    repository.find.return_value = expected
+
+    result = sut.get_by_id(42)
+
+    assert result is expected
+    repository.find.assert_called_once_with(42)
+
+
+def test_get_by_id_missing_id_raises_key_error(
+    sut: InvoiceService, repository: Mock
+) -> None:
+    repository.find.return_value = None
+
+    with pytest.raises(KeyError, match="999"):
+        sut.get_by_id(999)
+
+
+# --- mark_as_paid ---
+
+def test_mark_as_paid_pending_invoice_sets_status_and_date(
+    sut: InvoiceService, repository: Mock
+) -> None:
+    invoice = Invoice(id=1, status=InvoiceStatus.PENDING, tax_rate=Decimal("0"), line_items=[])
+    repository.find.return_value = invoice
+    fixed_now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    with patch("contoso_billing.invoice_service._utcnow", return_value=fixed_now):
+        sut.mark_as_paid(1)
+
+    assert invoice.status == InvoiceStatus.PAID
+    assert invoice.paid_date == fixed_now
+    repository.update.assert_called_once_with(invoice)
+
+
+def test_mark_as_paid_already_paid_raises_value_error(
+    sut: InvoiceService, repository: Mock
+) -> None:
+    invoice = Invoice(id=1, status=InvoiceStatus.PAID, tax_rate=Decimal("0"), line_items=[])
+    repository.find.return_value = invoice
+
+    with pytest.raises(ValueError, match="already paid"):
+        sut.mark_as_paid(1)
+
+    repository.update.assert_not_called()
+
+
+def test_mark_as_paid_missing_id_raises_key_error(
+    sut: InvoiceService, repository: Mock
+) -> None:
+    repository.find.return_value = None
+
+    with pytest.raises(KeyError, match="999"):
+        sut.mark_as_paid(999)
+```
+
+## Sample Fix Cycle
+
+When the implementer encounters an import or attribute error, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+ModuleNotFoundError: No module named 'contoso_billing'
+```
+
+**Fixer diagnosis:** The package is not installed in editable mode, so the `src/` layout's package is not on `sys.path`.
+
+**Fix applied:**
+
+```bash
+python -m pip install -e ".[test]"
+```
+
+**Rerun:** `python -m pytest tests/test_invoice_service.py -q` → SUCCESS
+
+---
+
+**Another common cycle — patch target wrong:**
+
+**Test output:**
+
+```text
+AttributeError: <module 'datetime'> does not have the attribute '_utcnow'
+```
+
+**Fixer diagnosis:** The test patched `datetime._utcnow` but the production code defines its own `_utcnow` helper inside `contoso_billing.invoice_service`. Patches must target the lookup site, not the definition site.
+
+**Fix applied:**
+
+```python
+# Before (wrong)
+with patch("datetime._utcnow", return_value=fixed_now):
+
+# After (fixed) — patch where the name is looked up
+with patch("contoso_billing.invoice_service._utcnow", return_value=fixed_now):
+```
+
+**Rerun:** SUCCESS
+
+---
+
+**Another common cycle — Mock without spec:**
+
+**Test output:**
+
+```text
+AttributeError: Mock object has no attribute 'find_by_id'
+```
+
+(but the actual repository method is `find`, not `find_by_id`)
+
+**Fixer diagnosis:** `Mock()` happily creates any attribute on access, so a typo in the test went undetected until the production code called `repository.find(...)`. Using `Mock(spec=InvoiceRepository)` would have failed at setup time.
+
+**Fix applied:**
+
+```python
+# Before
+repository = Mock()
+repository.find_by_id.return_value = expected   # typo, silently accepted
+
+# After
+repository = Mock(spec=InvoiceRepository)
+repository.find.return_value = expected         # typos now raise AttributeError
+```
+
+**Rerun:** SUCCESS
+
+## Sample Final Report
+
+What `code-testing-generator` produces at Step 9:
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 9     |
+| Tests passing  | 9     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `tests/test_invoice_service.py` (9 tests, 3 parametrized)
+
+### Coverage
+- InvoiceService.calculate_total — 3 happy path, 2 error cases
+- InvoiceService.get_by_id — 1 happy path, 1 error case
+- InvoiceService.mark_as_paid — 1 happy path, 2 error cases
+
+### Build / Install Validation
+- Editable install: ✅ `python -m pip install -e ".[test]"`
+- Test run: ✅ `python -m pytest` — 9 passed in 0.12s
+
+### Next Steps
+- Add tests for repository implementations if any exist
+- Consider snapshot/property-based testing (`hypothesis`) for `calculate_total` rounding behaviour
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/typescript-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/typescript-examples.md
@@ -1,0 +1,423 @@
+# TypeScript Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a TypeScript codebase using Vitest. These show what each pipeline phase produces for a small project.
+
+> Jest, Mocha, and node:test follow the same shape. Replace `vi.fn()` / `vi.mock()` with `jest.fn()` / `jest.mock()` (Jest) or hand-written stubs (node:test/Mocha) and adjust the runner command accordingly.
+
+## Source Under Test
+
+A simple `InvoiceService` in a TypeScript library using Vitest:
+
+```text
+src/
+  invoiceService.ts
+  invoice.ts
+  invoiceRepository.ts
+  index.ts                (re-exports public API)
+package.json
+tsconfig.json
+vitest.config.ts
+package-lock.json         (committed for reproducible installs)
+```
+
+```typescript
+// src/invoiceService.ts
+import { Invoice, InvoiceStatus } from "./invoice";
+import { InvoiceRepository } from "./invoiceRepository";
+
+export class InvoiceService {
+  constructor(private readonly repository: InvoiceRepository) {}
+
+  calculateTotal(invoice: Invoice): number {
+    if (invoice == null) throw new TypeError("invoice must not be null");
+    if (invoice.lineItems.length === 0) {
+      throw new Error("Invoice has no line items.");
+    }
+
+    const subtotal = invoice.lineItems.reduce(
+      (acc, li) => acc + li.quantity * li.unitPrice,
+      0,
+    );
+    const tax = subtotal * invoice.taxRate;
+    return roundTo2(subtotal + tax);
+  }
+
+  async getById(id: number): Promise<Invoice> {
+    const invoice = await this.repository.find(id);
+    if (invoice == null) {
+      throw new Error(`Invoice ${id} not found.`);
+    }
+    return invoice;
+  }
+
+  async markAsPaid(id: number): Promise<void> {
+    const invoice = await this.repository.find(id);
+    if (invoice == null) {
+      throw new Error(`Invoice ${id} not found.`);
+    }
+    if (invoice.status === InvoiceStatus.Paid) {
+      throw new Error("Invoice is already paid.");
+    }
+    invoice.status = InvoiceStatus.Paid;
+    invoice.paidDate = new Date();
+    await this.repository.update(invoice);
+  }
+}
+
+function roundTo2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: TypeScript 5.4
+- **Module system**: ESM (`"type": "module"` in package.json)
+- **Test Framework**: Vitest 1.x (detected via `vitest.config.ts` and `devDependencies.vitest`)
+- **Package Manager**: npm (lockfile = `package-lock.json`)
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Install**: `npm ci`
+- **Type-check**: `npx tsc --noEmit`
+- **Test**: `npx vitest run` (NEVER bare `vitest` — that starts watch mode)
+- **Lint**: none configured
+
+## Project Structure
+- Source: `src/`
+- Tests: none (will colocate as `src/invoiceService.test.ts` to match Vitest defaults)
+
+## Files to Test
+
+### High Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| src/invoiceService.ts | InvoiceService: calculateTotal, getById, markAsPaid | High | Core business logic, repository dependency needs mocking |
+
+### Low Priority / Skip
+| File | Reason |
+|------|--------|
+| src/invoice.ts | Type definitions and enum |
+| src/invoiceRepository.ts | Interface only |
+| src/index.ts | Re-export barrel |
+
+## Existing Tests
+- No existing tests found
+
+## Testing Patterns
+- No existing patterns; recommend `describe`/`it` blocks, `vi.fn()` stubs for the repository interface, and `it.each` for table-driven cases.
+
+## Recommendations
+- Co-locate test next to source (`src/invoiceService.test.ts`) — matches Vitest defaults and avoids reaching into `../src/`
+- Use a fake-timers helper (`vi.useFakeTimers()`) to control `new Date()` in `markAsPaid`
+- Use a type-narrowed mock object (`{ find: vi.fn(), update: vi.fn() } satisfies InvoiceRepository`) rather than full module mocking
+```
+
+## Sample Plan Output
+
+What `code-testing-planner` produces in `.testagent/plan.md`:
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate Vitest tests for InvoiceService, covering all three public methods
+across happy path, edge case, and error scenarios. Single phase since there is
+only one source file.
+
+## Commands
+- **Install**: `npm ci`
+- **Type-check**: `npx tsc --noEmit`
+- **Test (file-scoped during dev)**: `npx vitest run src/invoiceService.test.ts`
+- **Test (full)**: `npx vitest run`
+
+## Phase Summary
+| Phase | Focus | Files | Est. Tests |
+|-------|-------|-------|------------|
+| 1 | InvoiceService | 1 | 9-12 |
+
+---
+
+## Phase 1: InvoiceService
+
+### Overview
+Cover all public methods of InvoiceService. `calculateTotal` is pure logic tested
+with `it.each`. Async methods require a fake repository.
+
+### Files to Test
+
+#### 1. invoiceService.ts
+- **Source**: `src/invoiceService.ts`
+- **Test File**: `src/invoiceService.test.ts`
+
+**Methods to Test**:
+1. `calculateTotal` — Pure calculation logic
+   - Happy path: single line item returns quantity × price + tax
+   - Happy path: multiple line items summed correctly
+   - Edge case: zero tax rate returns subtotal only
+   - Error case: null invoice throws TypeError
+   - Error case: empty line items throws Error
+
+2. `getById` — Repository lookup
+   - Happy path: existing ID returns invoice
+   - Error case: missing ID rejects with Error
+
+3. `markAsPaid` — State transition
+   - Happy path: pending invoice transitions to Paid with `paidDate` set
+   - Error case: already-paid rejects with Error
+   - Error case: missing ID rejects with Error
+
+### Success Criteria
+- [ ] Test file created at `src/invoiceService.test.ts`
+- [ ] `npx tsc --noEmit` succeeds
+- [ ] `npx vitest run` reports all tests passed
+- [ ] No real network/timers — repository is a `vi.fn()` fake, `new Date()` is controlled via fake timers
+```
+
+## Sample Generated Test File
+
+What `code-testing-implementer` produces:
+
+```typescript
+// src/invoiceService.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Invoice, InvoiceStatus } from "./invoice";
+import type { InvoiceRepository } from "./invoiceRepository";
+import { InvoiceService } from "./invoiceService";
+
+function makeRepository(): InvoiceRepository & { find: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> } {
+  return {
+    find: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+describe("InvoiceService", () => {
+  let repository: ReturnType<typeof makeRepository>;
+  let sut: InvoiceService;
+
+  beforeEach(() => {
+    repository = makeRepository();
+    sut = new InvoiceService(repository);
+  });
+
+  // --- calculateTotal ---
+
+  describe("calculateTotal", () => {
+    it.each([
+      { quantity: 1, unitPrice: 100, taxRate: 0.1, expected: 110 },
+      { quantity: 3, unitPrice: 25, taxRate: 0, expected: 75 },
+      { quantity: 2, unitPrice: 9.99, taxRate: 0.07, expected: 21.38 },
+    ])(
+      "returns $expected for $quantity × $unitPrice with tax $taxRate",
+      ({ quantity, unitPrice, taxRate, expected }) => {
+        const invoice: Invoice = {
+          id: 1,
+          status: InvoiceStatus.Pending,
+          taxRate,
+          lineItems: [{ quantity, unitPrice }],
+        };
+
+        expect(sut.calculateTotal(invoice)).toBe(expected);
+      },
+    );
+
+    it("throws TypeError when invoice is null", () => {
+      expect(() => sut.calculateTotal(null as unknown as Invoice)).toThrow(TypeError);
+    });
+
+    it("throws when line items are empty", () => {
+      const invoice: Invoice = {
+        id: 1,
+        status: InvoiceStatus.Pending,
+        taxRate: 0,
+        lineItems: [],
+      };
+
+      expect(() => sut.calculateTotal(invoice)).toThrow("no line items");
+    });
+  });
+
+  // --- getById ---
+
+  describe("getById", () => {
+    it("returns the invoice for an existing id", async () => {
+      const expected: Invoice = { id: 42, status: InvoiceStatus.Pending, taxRate: 0, lineItems: [] };
+      repository.find.mockResolvedValue(expected);
+
+      await expect(sut.getById(42)).resolves.toBe(expected);
+      expect(repository.find).toHaveBeenCalledWith(42);
+    });
+
+    it("rejects with Error when the id is missing", async () => {
+      repository.find.mockResolvedValue(null);
+
+      await expect(sut.getById(999)).rejects.toThrow(/999/);
+    });
+  });
+
+  // --- markAsPaid ---
+
+  describe("markAsPaid", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("transitions a pending invoice to Paid with paidDate set", async () => {
+      const invoice: Invoice = {
+        id: 1,
+        status: InvoiceStatus.Pending,
+        taxRate: 0,
+        lineItems: [],
+      };
+      repository.find.mockResolvedValue(invoice);
+      repository.update.mockResolvedValue(undefined);
+
+      await sut.markAsPaid(1);
+
+      expect(invoice.status).toBe(InvoiceStatus.Paid);
+      expect(invoice.paidDate).toEqual(new Date("2025-01-01T12:00:00.000Z"));
+      expect(repository.update).toHaveBeenCalledWith(invoice);
+    });
+
+    it("rejects when the invoice is already paid", async () => {
+      const invoice: Invoice = {
+        id: 1,
+        status: InvoiceStatus.Paid,
+        taxRate: 0,
+        lineItems: [],
+      };
+      repository.find.mockResolvedValue(invoice);
+
+      await expect(sut.markAsPaid(1)).rejects.toThrow("already paid");
+      expect(repository.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the id is missing", async () => {
+      repository.find.mockResolvedValue(null);
+
+      await expect(sut.markAsPaid(999)).rejects.toThrow(/999/);
+    });
+  });
+});
+```
+
+## Sample Fix Cycle
+
+When the implementer encounters a runner or type error, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+Error: Vitest failed to access its internal state.
+One of the following is possible:
+- "vitest" is imported directly without running "vitest" command
+```
+
+**Fixer diagnosis:** The agent ran `node src/invoiceService.test.ts` (or bare `vitest`, which is watch-mode). The runner must be invoked via `npx vitest run`.
+
+**Fix applied:**
+
+```bash
+# Wrong — bare vitest starts an interactive watcher in CI
+npx vitest
+
+# Right — `run` is the one-shot command
+npx vitest run
+```
+
+**Rerun:** SUCCESS
+
+---
+
+**Another common cycle — ESM/CJS mismatch:**
+
+**Test output:**
+
+```text
+SyntaxError: Cannot use import statement outside a module
+```
+
+**Fixer diagnosis:** The project's `tsconfig.json` emits ESM (`"module": "NodeNext"`) but `package.json` has no `"type": "module"`. Vitest happens to handle this natively; switching to Jest would require additional configuration. The fix here is to ensure Vitest is the runner being used (as already configured in `vitest.config.ts`) and avoid recompiling test files through a separate non-ESM-aware tool.
+
+**Fix applied:** Use `npx vitest run` (which uses esbuild internally and handles both ESM and CJS) instead of compiling with `tsc` and running the emitted `.js` directly.
+
+**Rerun:** SUCCESS
+
+---
+
+**Another common cycle — wrong mock typing:**
+
+**Build output:**
+
+```text
+src/invoiceService.test.ts:14:5 - error TS2322: Type '{ find: Mock<any, any>; }' is not assignable to type 'InvoiceRepository'.
+  Property 'update' is missing in type '{ find: Mock<any, any>; }' but required in type 'InvoiceRepository'.
+```
+
+**Fixer diagnosis:** The fake repository only stubbed `find`, not `update`. The `InvoiceRepository` interface requires both. TypeScript caught this at compile time.
+
+**Fix applied:**
+
+```typescript
+// Before
+const repository = { find: vi.fn() } as InvoiceRepository;
+
+// After — provide both methods, narrow the return type so the test code keeps autocomplete
+function makeRepository(): InvoiceRepository & { find: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> } {
+  return { find: vi.fn(), update: vi.fn() };
+}
+```
+
+**Rebuild + rerun:** SUCCESS
+
+## Sample Final Report
+
+What `code-testing-generator` produces at Step 9:
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (TypeScript)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 9     |
+| Tests passing  | 9     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `src/invoiceService.test.ts` (9 tests, 3 parameterized via `it.each`)
+
+### Coverage
+- InvoiceService.calculateTotal — 3 happy path, 2 error cases
+- InvoiceService.getById — 1 happy path, 1 error case
+- InvoiceService.markAsPaid — 1 happy path, 2 error cases
+
+### Build / Test Validation
+- Install: ✅ `npm ci`
+- Type-check: ✅ `npx tsc --noEmit`
+- Test run: ✅ `npx vitest run`
+
+### Next Steps
+- Add tests for any HTTP/Express adapters once they exist
+- Consider property-based testing (`fast-check`) for `calculateTotal` rounding
+```


### PR DESCRIPTION
## What
Adds polyglot pipeline examples for the `code-testing-agent` skill family so it can produce idiomatic non-.NET tests (Python, TypeScript, Go, Java) using the same Research → Plan → Implement pattern that `dotnet-examples.md` already demonstrated for MSTest.

## Why
The skill descriptions and agent prompts state `code-testing-agent` is polyglot, but in practice the four pipeline sub-agents (researcher, planner, implementer, generator) all referenced `dotnet-examples.md` as the only concrete walkthrough. That .NET bias hurts scoring on non-.NET benchmarks (e.g. msbench top5-* Python/Flask, TypeScript/Express).

## Changes
- **New example files** (mirror `dotnet-examples.md` shape: source → research → plan → generated test → fix cycle → final report)
  - `python-examples.md` (pytest, `unittest.mock`, `Mock(spec=...)`, `parametrize`)
  - `typescript-examples.md` (Vitest with Jest notes; `it.each`, async tests, fake timers, ESM/CJS fix cycle)
  - `go-examples.md` (standard `testing` package, table-driven subtests, hand-written fake repository, injected clock)
  - `java-examples.md` (JUnit 5 + Mockito on Maven, `@ParameterizedTest` + `@CsvSource`, `Clock.fixed`, Surefire fix cycles)
- **TOC update** in `code-testing-extensions/SKILL.md` to list new files and instruct readers to read the matching `<language>-examples.md` alongside the base extension.
- **Language-agnostic example pointers** in `code-testing-generator.agent.md`, `code-testing-implementer.agent.md`, `code-testing-planner.agent.md`, `code-testing-researcher.agent.md` (each now lists all five available example files instead of hard-coding `dotnet-examples.md`).
- **Expanded language detection** in `code-testing-researcher.agent.md` (Python: `tox.ini`, `noxfile.py`, `requirements*.txt`, `uv.lock`, `poetry.lock`, `pdm.lock`; JS/TS: `.mts`/`.cts`/`.jsx`, `vitest.config.*`, `jest.config.*`; C++: `CMakeLists.txt`, `BUILD.bazel`, `meson.build`; Java/Kotlin/Ruby/Swift/PowerShell entries added too).
- **Examples summary** in `code-testing-agent/SKILL.md` describing each example file.

## Validation
- `dotnet run --project eng/skill-validator/src -- check --plugin ./plugins/dotnet-test` → 23 skills, 11 agents, all checks passed
- `npx markdownlint-cli2` on all modified/added files → 0 errors

## Follow-ups (separate PRs)
- Add polyglot evals for `code-testing-agent` (Python pytest + Flask, TypeScript Vitest) to measure non-.NET scoring.
- Expand `cpp.md` from a 455-byte stub to a full extension covering CMake/Bazel, GoogleTest/Catch2/doctest, gMock, common errors.
