### PR TITLE
writing-mstest-tests: tighten description triggers

### DIFF
--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: writing-mstest-tests
 description: >
-  Write new MSTest unit tests and implement concrete fixes in existing MSTest code using
-  MSTest 3.x/4.x modern APIs and best practices.
-  USE FOR: write unit tests for a class, write MSTest tests, create test class,
-  fix test assertions, MSTest assertion APIs (StartsWith, EndsWith, MatchesRegex,
-  IsGreaterThan, IsInRange, HasCount, IsNull), something seems off with my tests,
-  review tests and fix issues,
-  fix swapped Assert.AreEqual arguments, replace ExpectedException with Assert.Throws, modernize
-  test patterns, convert DynamicData to ValueTuples, data-driven tests, test lifecycle setup,
-  sealed test classes, async test patterns, cancellation token testing,
-  test parallelization, Parallelize, DoNotParallelize, MSTest.Sdk project setup.
-  DO NOT USE FOR: broad test quality audits or test smell detection (use test-anti-patterns),
-  running tests (use run-tests), MSTest version migration (use migrate-mstest-v1v2-to-v3 or
-  migrate-mstest-v3-to-v4), or non-.NET languages (Python/JS/Go/Java/etc.) — this is .NET-only.
+  Write new MSTest unit tests and fix existing MSTest code using MSTest 3.x/4.x
+  modern APIs and best practices.
+  USE FOR: write or create MSTest unit tests, fix or modernize MSTest assertions,
+  better MSTest assertion than Assert.IsTrue, replace hard cast with MSTest type assertion,
+  MSTest assertion APIs (IsInstanceOfType, Contains, ContainsSingle, HasCount,
+  IsEmpty, IsNotEmpty, DoesNotContain, StartsWith, EndsWith, MatchesRegex,
+  IsGreaterThan, IsInRange, IsNull),
+  fix swapped Assert.AreEqual arguments, replace ExpectedException with Assert.Throws,
+  data-driven tests (DataRow, DynamicData, ValueTuples),
+  test lifecycle (sealed classes, TestInitialize, TestCleanup),
+  async tests and cancellation tokens, test parallelization (Parallelize / DoNotParallelize),
+  MSTest.Sdk project setup.
+  DO NOT USE FOR: broad test quality audits (use test-anti-patterns),
+  running tests (use run-tests), MSTest version migration (use migrate-mstest-v1v2-to-v3
+  or migrate-mstest-v3-to-v4), xUnit/NUnit/TUnit, or non-.NET languages.
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary

Tighten the writing-mstest-tests SKILL.md frontmatter description so the skill router has sharper hooks for common MSTest test-writing prompts.

## What changes

- **Concrete intent triggers** — add `better MSTest assertion than Assert.IsTrue` and `replace hard cast with MSTest type assertion` so prompts like *"Can we use a better assertion than `Assert.IsTrue`?"* or *"replace the hard cast with a proper type assertion"* light up the skill.
- **Modern MSTest 3.x/4.x assertion APIs** — surface `IsInstanceOfType`, `Contains`, `ContainsSingle`, `IsEmpty`, `IsNotEmpty`, `DoesNotContain` alongside the previously-listed `StartsWith`/`EndsWith`/`MatchesRegex`/`IsGreaterThan`/`IsInRange`/`HasCount`/`IsNull`. Drops nothing the user could be searching for.
- **Grouped related triggers** — data-driven (`DataRow`, `DynamicData`, `ValueTuples`), lifecycle (sealed classes, `TestInitialize`, `TestCleanup`), parallelization (`Parallelize` / `DoNotParallelize`) — clearer to scan, same surface area.
- **Tightened `DO NOT USE FOR`** — drop redundant clauses (no separate `something seems off` / `review tests and fix issues` line; that's already implied by the assertion-fix triggers) and explicitly exclude `xUnit/NUnit/TUnit` so the router does not grab non-MSTest prompts.

No content changes outside the frontmatter; the rest of SKILL.md is untouched.

## Validation

- dotnet run --project eng/skill-validator/src -- check --plugin ./plugins/dotnet-test — passes locally (description length still under the 1,024-char skill spec limit).
- YAML frontmatter parses cleanly.