### PR TITLE
Redirect session-data reads/writes to dotnet/skills-data repo

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -874,7 +874,8 @@ jobs:
 
             # Append AGENTVIZ replay link if session data was published
             if [[ "${{ needs.publish-session-data.result }}" == "success" ]]; then
-              MANIFEST_URL="https://raw.githubusercontent.com/${{ github.repository }}/dashboard-session-data/data/manifest.json"
+              # Session data lives in the standalone dotnet/skills-data repo.
+              MANIFEST_URL="https://raw.githubusercontent.com/dotnet/skills-data/dashboard-session-data/data/manifest.json"
               # Derive the Pages base URL from the repository (org.github.io/repo)
               ORG=$(echo "${{ github.repository }}" | cut -d/ -f1)
               REPO=$(echo "${{ github.repository }}" | cut -d/ -f2)
@@ -1112,6 +1113,7 @@ jobs:
   # ==========================================================================
   # PUBLISH SESSION DATA
   # Both scheduled and PR runs: flatten JSONL sessions → dashboard-session-data
+  # branch on dotnet/skills-data (separate repo to keep this one small).
   # ==========================================================================
   publish-session-data:
     needs: [gate, discover, evaluate]
@@ -1179,12 +1181,16 @@ jobs:
             -PrNumber "${{ steps.meta.outputs.pr_number }}"
 
       - name: Clone existing session data branch
+        env:
+          # Cross-repo PAT with contents:write on dotnet/skills-data.
+          # GITHUB_TOKEN cannot push to a different repo, so a fine-grained PAT is required.
+          SKILLS_DATA_TOKEN: ${{ secrets.SKILLS_DATA_TOKEN }}
         run: |
           cd /tmp
-          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          REPO_URL="https://x-access-token:${SKILLS_DATA_TOKEN}@github.com/dotnet/skills-data.git"
 
           if git ls-remote --exit-code --heads "$REPO_URL" dashboard-session-data > /dev/null 2>&1; then
-            git clone --branch dashboard-session-data --single-branch "$REPO_URL" session-deploy
+            git clone --branch dashboard-session-data --single-branch --depth 1 "$REPO_URL" session-deploy
           else
             mkdir session-deploy && cd session-deploy && git init && git checkout -b dashboard-session-data
             git remote add origin "$REPO_URL"
@@ -1204,7 +1210,7 @@ jobs:
             -OutputDir /tmp/session-deploy/data `
             -RetentionDays 7
 
-      - name: Push to dashboard-session-data branch
+      - name: Push to dashboard-session-data branch (dotnet/skills-data)
         run: |
           cd /tmp/session-deploy
           git add data/

--- a/eng/dashboard/dashboard.js
+++ b/eng/dashboard/dashboard.js
@@ -8,7 +8,8 @@
   }
 
   // AGENTVIZ session replay configuration
-  const sessionManifestUrl = 'https://raw.githubusercontent.com/dotnet/skills/dashboard-session-data/data/manifest.json';
+  // Session data lives in the standalone dotnet/skills-data repo to keep this repo small.
+  const sessionManifestUrl = 'https://raw.githubusercontent.com/dotnet/skills-data/dashboard-session-data/data/manifest.json';
   const replayBaseUrl = 'replay/index.html';
 
   // Fetch plugin manifest

--- a/eng/dashboard/purge-replay-sessions.ps1
+++ b/eng/dashboard/purge-replay-sessions.ps1
@@ -10,7 +10,7 @@
     the merged set.
 
 .PARAMETER ExistingDir
-    Path to existing session data from the dashboard-session-data branch.
+    Path to existing session data from the dashboard-session-data branch on dotnet/skills-data.
 
 .PARAMETER NewDir
     Path to new session data from the current pipeline run.


### PR DESCRIPTION
## Summary

The `dashboard-session-data` branch on this repo grew to ~480 MB (~35k files) and was bloating every clone. Session data has been migrated to the standalone [`dotnet/skills-data`](https://github.com/dotnet/skills-data) repo (branch [`dashboard-session-data`](https://github.com/dotnet/skills-data/tree/dashboard-session-data), seeded as a single squashed snapshot). This PR redirects all reads and writes to the new location.

## Changes

- **`eng/dashboard/dashboard.js`** – `sessionManifestUrl` now points at `raw.githubusercontent.com/dotnet/skills-data/...`.
- **`.github/workflows/evaluation.yml`** – PR-comment replay link uses the new manifest URL.
- **`.github/workflows/evaluation.yml`** – `publish-session-data` job now clones/pushes `dotnet/skills-data` using a new `SKILLS_DATA_TOKEN` secret (the default `GITHUB_TOKEN` cannot push to a different repo). Clone is now `--depth 1` so we don't re-import history bloat.
- **`eng/dashboard/purge-replay-sessions.ps1`** – doc comment updated.

## Pre-merge checklist

- [x] Data migrated to `dotnet/skills-data@dashboard-session-data` (commit `c6a055ca`)
- [x] Manifest verified reachable from `raw.githubusercontent.com` with `Access-Control-Allow-Origin: *`
- [x] Sample replay URL works end-to-end: `https://dotnet.github.io/skills/replay/index.html?manifest=https%3A%2F%2Fraw.githubusercontent.com%2Fdotnet%2Fskills-data%2Fdashboard-session-data%2Fdata%2Fmanifest.json&tag=pr-711#/v2/find`
- [x] `SKILLS_DATA_TOKEN` Actions secret added on `dotnet/skills` (fine-grained PAT, `contents:write` on `dotnet/skills-data`)
- [x] dotnet org owner approval of the fine-grained PAT (token will not work until approved)
- [ ] One PR run + one scheduled run successfully push to the new repo
- [ ] After confirmation: delete the old `dashboard-session-data` branch on `dotnet/skills`

## What does NOT change

- `dashboard-token-data` and `dashboard-eval-data` branches (out of scope)
- AGENTVIZ replay HTML/JS – it already accepts an arbitrary manifest URL via query string
- `dotnet.github.io/skills` Pages site

## Follow-ups (separate PRs)

- Periodic squash of `dotnet/skills-data@dashboard-session-data` (e.g. monthly cron) to keep the new repo small
- Long-term: replace the PAT with a GitHub App installation (no expiry, audit logs)
