### PR TITLE
Add migrate-xunit-to-mstest skill

### DIFF
--- a/eng/known-domains.txt
+++ b/eng/known-domains.txt
@@ -63,6 +63,7 @@ github.com/username
 testsmells.org
 
 # Community
+github.com/Youssef1313/Combinatorial.MSTest
 ollama.com
 stackoverflow.com
 ## Cannot pin npmjs package by hash, only version

--- a/plugins/dotnet-test/README.md
+++ b/plugins/dotnet-test/README.md
@@ -6,7 +6,7 @@ Skills and agents for running, generating, analyzing, migrating, and improving t
 
 - **Run tests** *(.NET only)* — execute `dotnet test` with automatic platform/framework detection and filter syntax
 - **Generate tests** *(polyglot)* — scaffold comprehensive unit tests for any language via a multi-agent pipeline
-- **Migrate tests** *(.NET only)* — upgrade MSTest v1/v2 → v3 → v4, xUnit v2 → v3, or VSTest → Microsoft.Testing.Platform
+- **Migrate tests** *(.NET only)* — upgrade MSTest v1/v2 → v3 → v4, xUnit v2 → v3, xUnit (v2 or v3) → MSTest v4, or VSTest → Microsoft.Testing.Platform
 - **Audit test quality** *(polyglot)* — detect anti-patterns, test smells, assertion gaps, and (for .NET) coverage risks
 - **Improve testability** *(.NET only)* — find static dependencies, generate wrappers, and migrate call sites to injectable abstractions
 - **Measure coverage** *(.NET only)* — collect code coverage, compute CRAP scores, and surface risk hotspots
@@ -34,6 +34,7 @@ Skills and agents for running, generating, analyzing, migrating, and improving t
 | **migrate-mstest-v1v2-to-v3** | Upgrade MSTest v1 (assembly refs) or v2 (NuGet 1.x–2.x) to v3 |
 | **migrate-mstest-v3-to-v4** | Upgrade MSTest v3 to v4 — handles all source and behavioral breaking changes |
 | **migrate-xunit-to-xunit-v3** | Upgrade xUnit.net v2 to v3 |
+| **migrate-xunit-to-mstest** | Convert xUnit.net (v2 or v3) test projects to MSTest v4 — attributes, assertions, fixtures, lifecycle, output, parallelization |
 | **migrate-vstest-to-mtp** | Migrate from VSTest runner to Microsoft.Testing.Platform |
 
 ### Test quality & analysis *(polyglot)*

--- a/plugins/dotnet-test/agents/test-migration.agent.md
+++ b/plugins/dotnet-test/agents/test-migration.agent.md
@@ -49,6 +49,7 @@ Classify the user's request and route to the appropriate skill or agent:
 | "Upgrade MSTest" / "latest MSTest" (v3 detected) | `migrate-mstest-v3-to-v4` skill |
 | "Upgrade MSTest" (v1/v2 detected, user wants v4) | `migrate-mstest-v1v2-to-v3` first, then `migrate-mstest-v3-to-v4` |
 | "Migrate to xUnit v3" / "upgrade xUnit" | `migrate-xunit-to-xunit-v3` skill |
+| "Convert xUnit to MSTest" / "switch from xUnit to MSTest" / "port xUnit tests to MSTest" (xUnit v2 or v3 detected) | `migrate-xunit-to-mstest` skill |
 | "Migrate to MTP" / "switch from VSTest" / "modern test runner" | `migrate-vstest-to-mtp` skill |
 | "Make code testable" / "remove static dependencies" | Hand off to `testability-migration` agent |
 | "Migrate my tests" (no specifics) | Run detection, then recommend and confirm the migration path |
@@ -106,6 +107,8 @@ Some migrations must happen in sequence:
 | MSTest v1/v2 | MSTest v3 + MTP | `migrate-mstest-v1v2-to-v3` → `migrate-vstest-to-mtp` |
 | MSTest v3 | MSTest v4 + MTP | `migrate-mstest-v3-to-v4` → `migrate-vstest-to-mtp` (order flexible) |
 | xUnit v2 | xUnit v3 | `migrate-xunit-to-xunit-v3` (single step; v3 has native MTP support) |
+| xUnit v2 or v3 | MSTest v4 | `migrate-xunit-to-mstest` (single step; preserves current test platform — VSTest stays VSTest, MTP stays MTP) |
+| xUnit v2 or v3 | MSTest v4 + MTP | `migrate-xunit-to-mstest` → `migrate-vstest-to-mtp` (only if the project was on VSTest before; commit between) |
 | Any framework | MTP only | `migrate-vstest-to-mtp` (single step) |
 
 **Always commit between migration steps.** Each step should leave the project in a buildable, test-passing state.

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -62,7 +62,7 @@ For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, da
 
 ## Workflow
 
-> **Commit strategy:** Commit after Step 2 (packages updated, builds broken), after Step 5 (attributes converted, most asserts fixed), and after Step 9 (fixtures/lifecycle rewritten, tests pass). Commit before fixing follow-up cleanup so reviewers can bisect.
+> **Commit strategy:** Commit after Step 2 (packages updated, builds broken), after Step 6 (attributes converted, asserts fixed), and after Step 8 (fixtures/lifecycle rewritten, tests pass). Commit before fixing follow-up cleanup so reviewers can bisect.
 
 ### Step 1: Assess the project
 
@@ -80,7 +80,7 @@ For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, da
 5. Inventory high-risk patterns -- scan for these and flag them now so you can plan judgement steps later:
    - **Parallelization differences (Step 11)** -- xUnit parallelizes test classes by default; MSTest does not. This is the **single most common source of post-migration regressions**: tests that depended on isolation by parallel scheduling, on the lack of it, or on shared static state can pass differently. Decide the target parallelization model now -- do not leave it as the MSTest default by accident.
    - `ICollectionFixture<T>` / `[CollectionDefinition]` (scope concern -- see Step 8)
-   - Custom `DataAttribute` / custom `FactAttribute` / custom `TheoryAttribute` subclasses (manual conversion to `ITestDataSource` / `TestMethodAttribute` -- see Step 6)
+   - Custom `DataAttribute` / custom `FactAttribute` / custom `TheoryAttribute` subclasses (manual conversion to `ITestDataSource` / `TestMethodAttribute` -- see Step 5)
    - `Assert.Throws<T>` (xUnit semantics = exact type; maps to `Assert.ThrowsExactly<T>`, **not** `Assert.Throws<T>`)
    - `Record.Exception` / `Record.ExceptionAsync` (manual conversion)
    - `Assert.Raises*` / event assertions (no MSTest equivalent -- manual)
@@ -227,7 +227,7 @@ Reversing these flips the assertion semantics silently. Verify by name, not by v
 
 | xUnit | MSTest |
 |---|---|
-| Constructor (sync setup) | Keep constructor (MSTest also instantiates per test). Drop xUnit-only `ITestOutputHelper` param -- see Step 8 |
+| Constructor (sync setup) | Keep constructor (MSTest also instantiates per test). Drop xUnit-only `ITestOutputHelper` param -- see Step 9 |
 | `Dispose()` (sync teardown) | Keep `Dispose()` (MSTest supports `IDisposable`) **or** rewrite as `[TestCleanup] public void Cleanup() { ... }` |
 | `DisposeAsync()` (async teardown) | Keep `IAsyncDisposable.DisposeAsync()` **or** rewrite as `[TestCleanup] public async Task CleanupAsync() { ... }` |
 | `IAsyncLifetime.InitializeAsync` | `[TestInitialize] public async Task InitAsync() { ... }` |

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -45,6 +45,10 @@ This is a **cross-framework** migration. Do not bundle it with a version upgrade
 
 - **Always identify the current xUnit version first.** State whether the project is on xUnit v2 (`xunit` 2.x) or xUnit v3 (`xunit.v3` / `xunit.v3.*`) before recommending changes. This grounds the migration advice -- some breaking-change steps only apply to one version.
 - **Always preserve the current test platform.** If the project runs on VSTest, keep VSTest. If it runs on MTP (e.g., xUnit v3 native MTP, or `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>`), keep MTP. Recommend `migrate-vstest-to-mtp` as a separate follow-up only if the user asks for it.
+- **Explicitly communicate every judgement-call decision** before applying it -- otherwise the user cannot tell what changed semantically. In particular:
+  - **Fixture scope changes** (Step 8): state the source scope (class / collection / assembly) and the target scope you chose, plus what gets shared and what gets serialized. A silent widening from collection to assembly is the most common way this migration regresses tests.
+  - **Parallelization** (Step 11): state that **MSTest defaults to serial execution** (xUnit parallelizes classes by default), so an explicit `[assembly: Parallelize(...)]` is **required** to match xUnit's behaviour -- omitting it silently halves CI throughput.
+  - **`Assert.Throws<T>` -> `Assert.ThrowsExactly<T>`** (Step 6): mention the exact-type-vs-any-derived semantic flip so reviewers know the assertion was deliberately renamed, not just translated.
 - **Specific API mapping questions** (assertions, fixtures, output helper, etc.): jump to the relevant step. Do not run the full workflow.
 - **Full migration requests**: follow the workflow end-to-end.
 - **Focused fix requests** (specific compile error after a partial migration): address only that error using the mapping reference. Do not walk the full workflow.
@@ -90,7 +94,7 @@ For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, da
 
 ### Step 2: Replace packages
 
-> Choose the package option that matches what the project uses today. Default to the `MSTest` metapackage unless the user already uses `MSTest.Sdk` elsewhere in the solution. If you adopt `MSTest.Sdk`, you must preserve the platform from Step 1.
+> Choose the package option that matches what the project uses today. **When the user says "preserve VSTest" -- or the existing project uses explicit `PackageReference`s -- default to Option A (`MSTest` metapackage).** Reach for Option B (`MSTest.Sdk`) only when the user explicitly asks to modernize the SDK or already uses `MSTest.Sdk` elsewhere in the solution; if you adopt it, you must preserve the platform from Step 1.
 
 **Remove** every xUnit package reference (from `.csproj`, `Directory.Build.props`, `Directory.Packages.props`):
 
@@ -167,13 +171,15 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 
 **Methods:**
 
+> **`[Ignore]` and `[Timeout]` are modifiers, not discovery attributes.** Always emit `[TestMethod]` *alongside* them -- a method with `[Ignore]` but no `[TestMethod]` is silently skipped by the test runner (no error, no skip count). Same for `[Timeout]`.
+
 | xUnit | MSTest |
 |---|---|
 | `[Fact]` | `[TestMethod]` |
 | `[Theory]` | `[TestMethod]` (parameterized; MSTest 3+ no longer needs `[DataTestMethod]`) |
 | `[Fact(DisplayName = "x")]` | `[TestMethod("x")]` (v3 of MSTest) or `[TestMethod(DisplayName = "x")]` (v4) |
-| `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` (the `[Ignore]` attribute alone does not discover a test) |
-| `[Fact(Timeout = 5000)]` | `[TestMethod]` + `[Timeout(5000)]` (modifier -- not a discovery attribute) |
+| `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` (both attributes required) |
+| `[Fact(Timeout = 5000)]` | `[TestMethod]` + `[Timeout(5000)]` (both attributes required) |
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
 | `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
 
@@ -288,7 +294,9 @@ xUnit collections do two things simultaneously: (1) share a fixture instance acr
 - **Many classes, fixture is genuinely assembly-wide** (e.g., process-wide TestServer): hoist to `[AssemblyInitialize]` / `[AssemblyCleanup]` in a dedicated `AssemblySetup` class **and** confirm with the user that widening the scope is acceptable. Note that this changes parallelization semantics.
 - **Custom collection behavior or test-collection-orderer**: stop and flag for manual review.
 
-**Always explain the scope change** -- silently widening fixture scope across the assembly is the most common way this migration regresses tests.
+> **REQUIRED -- communicate the scope decision before applying it.** Silently widening fixture scope across the assembly is the most common way this migration regresses tests. Use this template (replace bracketed text):
+>
+> "The xUnit `[Collection(\"<name>\")]` shared a `<Fixture>` between **\<N\> classes** and serialized them. I am mapping that to: a static `Lazy<<Fixture>>` shared by each class's `[ClassInitialize]` (scope: **per-class, shared via static** -- not widened to assembly), plus `[DoNotParallelize]` on `<ClassA>` and `<ClassB>` to preserve the serialization. The alternative -- `[AssemblyInitialize]` -- would widen the fixture to every test in the assembly, which I rejected because \<reason\>."
 
 ### Step 9: Convert output and TestContext
 
@@ -368,6 +376,12 @@ public TestContext TestContext { get; set; } = null!;
 ```
 
 Use this when the suite was healthy on xUnit and you want zero behavioural change. It preserves "parallel across classes, serial within a class" exactly.
+
+> **REQUIRED -- explicitly tell the user why this attribute is needed.** When applying Choice A, include this sentence (verbatim or near-verbatim) in your final summary:
+>
+> "MSTest defaults to **serial** execution across classes (unlike xUnit, which parallelizes classes by default), so this `[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]` is **required** to match the project's previous xUnit parallel-class behaviour. Without it, the suite would still pass but run roughly one-class-at-a-time and CI throughput would drop."
+>
+> The user must understand this is **opt-in** under MSTest -- a silent omission looks like a no-op but is actually a behavioural regression.
 
 **Choice B -- Adopt MSTest's serial default:**
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -333,11 +333,40 @@ If the project pins MSTest < 3.6 (rare after Step 2), use property injection ins
 public TestContext TestContext { get; set; } = null!;
 ```
 
-**xUnit v3 `TestContext.Current`:**
+**xUnit v3 `TestContext.Current`** (`TestContext.Current` is **static** in xUnit v3; in MSTest you must use the **instance** `TestContext` obtained via the same constructor or property injection shown above):
 
-- `TestContext.Current.CancellationToken` -> `TestContext.CancellationToken` (MSTest 3.6+, on the **instance** TestContext from constructor or property injection)
-- `TestContext.Current.AddAttachment(name, path)` -> `TestContext.AddResultFile(path)`
-- `TestContext.Current.TestOutputHelper.WriteLine(...)` -> `TestContext.WriteLine(...)`
+- `TestContext.Current.CancellationToken` -> `_testContext.CancellationToken` (MSTest 3.6+)
+- `TestContext.Current.AddAttachment(name, path)` -> `_testContext.AddResultFile(path)`
+- `TestContext.Current.TestOutputHelper.WriteLine(...)` -> `_testContext.WriteLine(...)`
+
+> **REQUIRED for CancellationToken:** Add the constructor injection from above even if the class only uses `TestContext.Current.CancellationToken` (no `ITestOutputHelper`). Do **NOT** replace `TestContext.Current.CancellationToken` with a new `CancellationTokenSource` -- that loses the test-host's cancellation linkage and changes behavior under timeouts.
+
+```csharp
+// xUnit v3
+[Fact]
+public async Task WorkRespectsCancellation()
+{
+    var ct = TestContext.Current.CancellationToken;
+    await Task.Delay(1, ct);
+    Assert.False(ct.IsCancellationRequested);
+}
+
+// MSTest (note: Assert.False -> Assert.IsFalse from Step 6)
+[TestClass]
+public sealed class MyTests
+{
+    private readonly TestContext _testContext;
+    public MyTests(TestContext testContext) => _testContext = testContext;
+
+    [TestMethod]
+    public async Task WorkRespectsCancellation()
+    {
+        var ct = _testContext.CancellationToken;
+        await Task.Delay(1, ct);
+        Assert.IsFalse(ct.IsCancellationRequested);
+    }
+}
+```
 
 ### Step 10: Convert companion packages
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -166,7 +166,7 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
 | `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
 
-> Use `[TestCategory]` for the conventional category trait (it integrates with VSTest/MTP filter syntax); use `[TestProperty]` for arbitrary key/value metadata.
+> Use `[TestCategory]` for the conventional category trait (it integrates with VSTest/MTP filter syntax); use `[TestProperty]` for arbitrary key/value metadata. Both attributes target `Assembly`, `Class`, and `Method` -- so an xUnit `[Trait]` placed at any of those scopes (including `[assembly: Trait(...)]`) keeps the same scope under MSTest (see Step 12).
 
 ### Step 5: Convert data-driven tests
 
@@ -422,16 +422,22 @@ Delete `xunit.runner.json`. Port relevant settings:
 
 If the project uses xUnit traits in CI filter expressions (e.g., `--filter "Category=Unit"` with xUnit), the equivalent MSTest filter is `--filter "TestCategory=Unit"` (VSTest) or `--filter-trait "TestCategory=Unit"` (MTP). Update CI pipelines accordingly.
 
-### Step 12: Remove xUnit assembly attributes
+### Step 12: Convert xUnit assembly attributes
 
-Delete these from `AssemblyInfo.cs` / any `[assembly: ...]` declaration:
+Some xUnit assembly attributes have direct MSTest equivalents at assembly scope; others must be removed (and re-applied per class/method) or reimplemented against MSTest extensibility.
 
-- `[assembly: CollectionBehavior(...)]`
-- `[assembly: TestCaseOrderer(...)]`
-- `[assembly: TestCollectionOrderer(...)]`
+**Convert (assembly scope preserved):**
+
+- `[assembly: Xunit.Trait("Category", "v")]` -> `[assembly: TestCategory("v")]` -- `TestCategoryAttribute` targets `Assembly`, `Class`, and `Method`; assembly application propagates to every test.
+- `[assembly: Xunit.Trait("k", "v")]` (non-category key) -> `[assembly: TestProperty("k", "v")]` -- same `Assembly`/`Class`/`Method` targets.
+
+**Delete (no MSTest equivalent or now handled elsewhere):**
+
+- `[assembly: CollectionBehavior(...)]` -- replaced by `[assembly: Parallelize(...)]` (Step 11)
+- `[assembly: TestCaseOrderer(...)]` -- reimplement against MSTest extensibility; flag for manual conversion
+- `[assembly: TestCollectionOrderer(...)]` -- flag for manual conversion
 - `[assembly: TestFramework(...)]`
-- `[assembly: CaptureConsole]` (xUnit v3)
-- `[assembly: Xunit.Trait("k", "v")]` (replace with `[TestCategory]`/`[TestProperty]` on test classes/methods)
+- `[assembly: CaptureConsole]` (xUnit v3) -- MSTest does not capture console by default
 
 Custom orderers/test framework hooks must be reimplemented against MSTest's extensibility model (`TestMethodAttribute` subclasses, `ITestDataSource`, etc.) -- stop and flag for manual conversion if present.
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -165,7 +165,7 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 **Class:**
 
 - Add `[TestClass]` to every class that contained xUnit `[Fact]`/`[Theory]` methods (xUnit had no class-level requirement).
-- Mark the class `sealed` (MSTest idiom -- see `writing-mstest-tests`).
+- **Preserve the original class hierarchy.** xUnit projects often use base/derived test classes (shared setup, helper assertions, generic base fixtures); marking classes `sealed` would break that pattern. Sealing is an optional follow-up handled by `writing-mstest-tests`, not part of the mechanical migration.
 - Replace `using Xunit;` / `using Xunit.Abstractions;` with `using Microsoft.VisualStudio.TestTools.UnitTesting;`.
 
 **Methods:**

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -119,28 +119,38 @@ The `MSTest` metapackage pulls in `MSTest.TestFramework`, `MSTest.TestAdapter`, 
 ```xml
 <Project Sdk="MSTest.Sdk/4.1.0">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Keep the project's existing TargetFramework -- do NOT retarget during migration. -->
+    <TargetFramework>$(ExistingTargetFramework)</TargetFramework>
   </PropertyGroup>
 </Project>
 ```
 
-`MSTest.Sdk` defaults to **MTP** and does *not* include `Microsoft.NET.Test.Sdk`. To preserve a VSTest project, you must opt back in:
+`MSTest.Sdk` defaults to **MTP**. To preserve a VSTest project, opt back in with `<UseVSTest>true</UseVSTest>` -- the SDK then pulls in `Microsoft.NET.Test.Sdk` automatically (no extra `PackageReference` needed):
 
 ```xml
 <PropertyGroup>
   <UseVSTest>true</UseVSTest>
 </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-</ItemGroup>
 ```
+
+For solutions with several test projects, prefer pinning the `MSTest.Sdk` version in `global.json` so it lives in one place:
+
+```json
+{
+  "msbuild-sdks": {
+    "MSTest.Sdk": "4.1.0"
+  }
+}
+```
+
+With the pin in `global.json`, the project line simplifies to `<Project Sdk="MSTest.Sdk">`.
 
 When switching to `MSTest.Sdk`, also remove now-redundant properties: `<OutputType>Exe</OutputType>`, `<IsPackable>false</IsPackable>`, `<IsTestProject>true</IsTestProject>`, `<EnableMSTestRunner>`.
 
 ### Step 3: Update project configuration
 
 1. **Preserve the runner.** Confirm the platform decision from Step 1 still holds after Step 2. Common mistakes:
-   - Switching to `MSTest.Sdk` without `UseVSTest=true` silently flips a VSTest project to MTP. Add `Microsoft.NET.Test.Sdk` back.
+   - Switching to `MSTest.Sdk` without `UseVSTest=true` silently flips a VSTest project to MTP. Add `<UseVSTest>true</UseVSTest>` to the project (the SDK pulls in `Microsoft.NET.Test.Sdk` automatically -- no manual `PackageReference` needed).
    - Leaving `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` in `Directory.Build.props` will keep MTP on -- that is correct only if the project was already on MTP.
 2. Remove xUnit-only properties from `.csproj` / `Directory.Build.props`: anything referencing `xunit.runner.*`, `<CaptureConsoleOutput>`, `<UseRoslynCompilers>` set just for xUnit, etc.
 3. Remove `using Xunit;` and `using Xunit.Abstractions;` from C# files (the rewriter will add `using Microsoft.VisualStudio.TestTools.UnitTesting;` instead in Step 4).
@@ -162,11 +172,12 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 | `[Fact]` | `[TestMethod]` |
 | `[Theory]` | `[TestMethod]` (parameterized; MSTest 3+ no longer needs `[DataTestMethod]`) |
 | `[Fact(DisplayName = "x")]` | `[TestMethod("x")]` (v3 of MSTest) or `[TestMethod(DisplayName = "x")]` (v4) |
-| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
+| `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` (the `[Ignore]` attribute alone does not discover a test) |
+| `[Fact(Timeout = 5000)]` | `[TestMethod]` + `[Timeout(5000)]` (modifier -- not a discovery attribute) |
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
 | `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
 
-> Use `[TestCategory]` for the conventional category trait (it integrates with VSTest/MTP filter syntax); use `[TestProperty]` for arbitrary key/value metadata. Both attributes target `Assembly`, `Class`, and `Method` -- so an xUnit `[Trait]` placed at any of those scopes (including `[assembly: Trait(...)]`) keeps the same scope under MSTest (see Step 12).
+> Both `[TestCategory]` and `[TestProperty]` are filterable at runtime (`--filter "TestCategory=Unit"` / `--filter "Owner=alice"`) and target `Assembly`, `Class`, and `Method` -- so an xUnit `[Trait]` placed at any of those scopes (including `[assembly: Trait(...)]`) keeps the same scope under MSTest (see Step 12). Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata. For environmental skips (OS-specific, CI-only, architecture-gated), MSTest 3.10+'s `[OSCondition]` / `[CICondition]` / `[ArchitectureCondition]` are usually a better fit than overloading a trait -- see Step 6 / cheatsheet §3.9.
 
 ### Step 5: Convert data-driven tests
 
@@ -178,7 +189,7 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 | `[MemberData(nameof(Cases), MemberType = typeof(X))]` | `[DynamicData(nameof(Cases), typeof(X))]` |
 | `[MemberData(nameof(Method), arg1, arg2)]` (parameterized member) | **Manual**: convert to a parameterless property or compute the inputs inside the test |
 | `[ClassData(typeof(MyData))]` (class implementing `IEnumerable<object[]>`) | Add a static property `=> new MyData()` on the test class, then `[DynamicData(nameof(Cases))]` |
-| `TheoryData<int, string>` | `IEnumerable<object[]>` or `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple support) |
+| `TheoryData<int, string>` | `IEnumerable<object[]>`, `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple), or `IEnumerable<TestDataRow<(int, string)>>` (strongly-typed with per-row metadata) |
 | Custom `DataAttribute` subclass | **Manual**: implement `ITestDataSource` (`GetData`, `GetDisplayName`) |
 
 Prefer ValueTuple data sources for new MSTest tests (see `writing-mstest-tests`), but for migration keep `IEnumerable<object[]>` -- it minimizes diff churn and works in both MSTest 3 and 4.
@@ -203,8 +214,8 @@ Most common cases inline. For the full table including string/collection/type/nu
 | `Assert.Contains(item, coll)` / `Assert.DoesNotContain(...)` | Same -- `Assert.Contains` / `Assert.DoesNotContain` |
 | `Assert.Contains("sub", str)` / `StartsWith` / `EndsWith` / `Matches` | Same (MSTest 3.8+) or `StringAssert.*` |
 | `Assert.Skip("reason")` (v3 runtime) | `Assert.Inconclusive("reason")` |
-| `Assert.SkipWhen(cond, "reason")` (v3) | `if (cond) Assert.Inconclusive("reason");` |
-| `Assert.SkipUnless(cond, "reason")` (v3) | `if (!cond) Assert.Inconclusive("reason");` |
+| `Assert.SkipWhen(cond, "reason")` (v3) | If `cond` is environmental: `[OSCondition]` / `[CICondition]` / `[ArchitectureCondition]` (MSTest 3.10+); otherwise `if (cond) Assert.Inconclusive("reason");` |
+| `Assert.SkipUnless(cond, "reason")` (v3) | Same -- prefer a condition attribute when the predicate is environmental; otherwise `if (!cond) Assert.Inconclusive("reason");` |
 
 **Critical semantic trap -- exception assertions:**
 
@@ -324,8 +335,8 @@ public TestContext TestContext { get; set; } = null!;
 
 | xUnit companion | MSTest equivalent |
 |---|---|
-| `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
-| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | No equivalent. Convert to explicit `[DataRow]`s or compute combinations with `[DynamicData]`. Remove the package |
+| `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | For environmental predicates (OS/CI/arch): MSTest 3.10+ condition attributes (`[OSCondition]`, `[CICondition]`, etc.). Otherwise: `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | [`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest) (community port; attribute surface matches xUnit.Combinatorial). Or expand combinations into explicit `[DataRow]`s / `[DynamicData]` |
 | `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | `[TestMethod]` + manual STA thread. No MSTest equivalent for `[WpfFact]`; flag for manual conversion |
 | `Verify.Xunit` | `Verify.MSTest` -- swap the package; usage is similar |
 | `FluentAssertions` / `Shouldly` / `AwesomeAssertions` | Keep -- assertion library is framework-agnostic |
@@ -475,9 +486,9 @@ Custom orderers/test framework hooks must be reimplemented against MSTest's exte
 | Picking `ExecutionScope.MethodLevel` to "match xUnit" | New flakiness on tests sharing instance state within a class | Use `ExecutionScope.ClassLevel` -- it matches xUnit exactly |
 | Mapping `Assert.Throws<T>` to `Assert.Throws<T>` | Tests pass for derived exception types they shouldn't | Map xUnit `Assert.Throws<T>` to MSTest `Assert.ThrowsExactly<T>` |
 | Silently widening `ICollectionFixture` to assembly scope | State leak between unrelated tests; new flakiness | Step 8 -- pick scope explicitly and disclose to the user |
-| `MSTest.Sdk` flipping VSTest project to MTP | `vstest.console` finds zero tests; CI breaks | Add `<UseVSTest>true</UseVSTest>` + `Microsoft.NET.Test.Sdk` package |
+| `MSTest.Sdk` flipping VSTest project to MTP | `vstest.console` finds zero tests; CI breaks | Add `<UseVSTest>true</UseVSTest>` (no separate `Microsoft.NET.Test.Sdk` package needed -- the SDK pulls it in) |
 | `[DataRow]` type mismatch | Theory cases compile in xUnit but produce MSTest runtime errors | Use exact literal types: `1` int, `1L` long, `1.0f` float |
-| `Assert.SkipUnless` becomes `[Ignore]` | Tests that *would* have run on this machine now silently skip everywhere | Use runtime `Assert.Inconclusive` instead |
+| `Assert.SkipUnless` becomes `[Ignore]` | Tests that *would* have run on this machine now silently skip everywhere | Use a condition attribute (`[OSCondition]`/`[CICondition]`/`[ArchitectureCondition]`, MSTest 3.10+) when the predicate is environmental; otherwise runtime `Assert.Inconclusive` |
 | Dropping `Assert.Collection` / `Assert.All` without replacement | Test passes but verifies nothing | Restore as explicit `foreach` + per-element assertions |
 | Leaving `xunit.runner.json` in the project | Build warning + dead config | Delete the file after porting settings |
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -74,10 +74,7 @@ For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, da
 2. Identify the **xUnit version**:
    - `xunit` 2.x (+ `xunit.assert` / `xunit.core` / `xunit.abstractions`) -> **xUnit v2**
    - `xunit.v3` / `xunit.v3.*` -> **xUnit v3**
-3. Identify the **current test platform** (this dictates what to keep, not what to change):
-   - `xunit.runner.visualstudio` (v2) or no MTP signals (v3) and no `<UseMicrosoftTestingPlatformRunner>` -> **VSTest**
-   - xUnit v3 with `xunit.v3.mtp-v*` / `xunit.v3.core.mtp-v*`, or `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>`, or `YTest.MTP.XUnit2` (v2 MTP shim) -> **MTP**
-   - Use the `platform-detection` skill if you are unsure.
+3. Identify the **current test platform** (this dictates what to keep, not what to change) by invoking the `platform-detection` skill. The xUnit/MTP matrix is nuanced -- xunit.v3 inside Test Explorer is MTP by default unless opted out, while xunit.v3 inside `dotnet test` depends on the `xunit.v3.mtp-v*` packages -- so do not try to inline a shortcut here. Quick signals to feed into that skill: `xunit.runner.visualstudio` (v2) usually means VSTest; `xunit.v3.mtp-v*` / `xunit.v3.core.mtp-v*` packages or `YTest.MTP.XUnit2` (v2 MTP shim) usually mean MTP. `<UseMicrosoftTestingPlatformRunner>` only affects `dotnet run` and is **not** a reliable VSTest-vs-MTP signal on its own.
 4. Verify the `TargetFramework` is supported by MSTest v4:
    - **Supported**: `net8.0`, `net9.0`, `net462`+, `netstandard2.0` (test library only), `uap10.0.16299`, `net8.0-windows10.0.18362.0` (WinUI), `net9.0-windows10.0.17763.0` (modern UWP).
    - **Unsupported**: .NET Core 3.1, `net5.0`-`net7.0`. **STOP** and ask the user to upgrade the TFM first, or migrate to MSTest v3 (then use `migrate-mstest-v3-to-v4` after a TFM bump).
@@ -118,6 +115,8 @@ For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, da
 
 The `MSTest` metapackage pulls in `MSTest.TestFramework`, `MSTest.TestAdapter`, `MSTest.Analyzers`, and `Microsoft.NET.Test.Sdk` -- so VSTest discovery (`vstest.console`, classic `dotnet test`) still works.
 
+> **MTP code-coverage caveat for Option A:** `Microsoft.NET.Test.Sdk` pulls VSTest's `Microsoft.CodeCoverage` transitively. If the project from Step 1 is on **MTP** and uses code coverage, that transitive dependency can interfere with MTP's collector (`Microsoft.Testing.Extensions.CodeCoverage`). Prefer **Option B** (`MSTest.Sdk` without `UseVSTest`) for MTP projects -- the SDK omits `Microsoft.NET.Test.Sdk` and wires the MTP coverage collector instead. If you must stay on Option A for an MTP project, verify coverage works on a representative test run before merging.
+
 **Option B -- `MSTest.Sdk`:**
 
 ```xml
@@ -155,8 +154,8 @@ When switching to `MSTest.Sdk`, also remove now-redundant properties: `<OutputTy
 
 1. **Preserve the runner.** Confirm the platform decision from Step 1 still holds after Step 2. Common mistakes:
    - Switching to `MSTest.Sdk` without `UseVSTest=true` silently flips a VSTest project to MTP. Add `<UseVSTest>true</UseVSTest>` to the project (the SDK pulls in `Microsoft.NET.Test.Sdk` automatically -- no manual `PackageReference` needed).
-   - Leaving `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` in `Directory.Build.props` will keep MTP on -- that is correct only if the project was already on MTP.
-2. Remove xUnit-only properties from `.csproj` / `Directory.Build.props`: anything referencing `xunit.runner.*`, `<CaptureConsoleOutput>`, `<UseRoslynCompilers>` set just for xUnit, etc.
+   - `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` only affects the `dotnet run` entry point and is **not** a runner switch in Test Explorer or `dotnet test`. Do not infer the platform from this property in either direction -- defer to the `platform-detection` skill (see Step 1).
+2. Delete `xunit.runner.json` and port any settings you need (parallelization, `[CollectionBehavior]`, `appDomain`) per Step 11's "xunit.runner.json -> MSTest" sub-table. The settings have no direct MSBuild-property mapping.
 3. Remove `using Xunit;` and `using Xunit.Abstractions;` from C# files (the rewriter will add `using Microsoft.VisualStudio.TestTools.UnitTesting;` instead in Step 4).
 
 ### Step 4: Convert test classes and methods
@@ -183,7 +182,7 @@ Apply these rewrites to every C# test file. Class-level first, then method-level
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
 | `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
 
-> Both `[TestCategory]` and `[TestProperty]` are filterable at runtime (`--filter "TestCategory=Unit"` / `--filter "Owner=alice"`) and target `Assembly`, `Class`, and `Method` -- so an xUnit `[Trait]` placed at any of those scopes (including `[assembly: Trait(...)]`) keeps the same scope under MSTest (see Step 12). Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata. For environmental skips (OS-specific, CI-only, architecture-gated), MSTest 3.10+'s `[OSCondition]` / `[CICondition]` / `[ArchitectureCondition]` are usually a better fit than overloading a trait -- see Step 6 / cheatsheet §3.9.
+> Both `[TestCategory]` and `[TestProperty]` are filterable at runtime (`--filter "TestCategory=Unit"` / `--filter "Owner=alice"`). `[TestCategory]` targets `Assembly`, `Class`, and `Method`, so an xUnit `[assembly: Trait("Category", ...)]` keeps its assembly scope under MSTest as `[assembly: TestCategory(...)]`. **`[TestProperty]` targets only `Class` and `Method`** — there is no `AttributeTargets.Assembly`, so an assembly-level xUnit trait with an arbitrary key must collapse to `[assembly: TestCategory(...)]` (or be pushed down to every class). Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata at class/method scope. For environmental skips (OS-specific, CI-only), MSTest 3.10+'s `[OSCondition]` / `[CICondition]` are usually a better fit than overloading a trait -- see Step 6 / cheatsheet §3.9.
 
 ### Step 5: Convert data-driven tests
 
@@ -220,7 +219,7 @@ Most common cases inline. For the full table including string/collection/type/nu
 | `Assert.Contains(item, coll)` / `Assert.DoesNotContain(...)` | Same -- `Assert.Contains` / `Assert.DoesNotContain` |
 | `Assert.Contains("sub", str)` / `StartsWith` / `EndsWith` / `Matches` | Same (MSTest 3.8+) or `StringAssert.*` |
 | `Assert.Skip("reason")` (v3 runtime) | `Assert.Inconclusive("reason")` |
-| `Assert.SkipWhen(cond, "reason")` (v3) | If `cond` is environmental: `[OSCondition]` / `[CICondition]` / `[ArchitectureCondition]` (MSTest 3.10+); otherwise `if (cond) Assert.Inconclusive("reason");` |
+| `Assert.SkipWhen(cond, "reason")` (v3) | If `cond` is environmental: `[OSCondition]` / `[CICondition]` (MSTest 3.10+); otherwise `if (cond) Assert.Inconclusive("reason");` |
 | `Assert.SkipUnless(cond, "reason")` (v3) | Same -- prefer a condition attribute when the predicate is environmental; otherwise `if (!cond) Assert.Inconclusive("reason");` |
 
 **Critical semantic trap -- exception assertions:**
@@ -483,7 +482,10 @@ Some xUnit assembly attributes have direct MSTest equivalents at assembly scope;
 **Convert (assembly scope preserved):**
 
 - `[assembly: Xunit.Trait("Category", "v")]` -> `[assembly: TestCategory("v")]` -- `TestCategoryAttribute` targets `Assembly`, `Class`, and `Method`; assembly application propagates to every test.
-- `[assembly: Xunit.Trait("k", "v")]` (non-category key) -> `[assembly: TestProperty("k", "v")]` -- same `Assembly`/`Class`/`Method` targets.
+
+**Convert (assembly scope NOT preserved):**
+
+- `[assembly: Xunit.Trait("k", "v")]` (non-category key) -> **collapse to** `[assembly: TestCategory("v")]` if the value alone is sufficient as a filter, or move the trait down to every test class as `[TestProperty("k", "v")]`. `TestPropertyAttribute` only targets `Class` and `Method` (no `AttributeTargets.Assembly`) -- `[assembly: TestProperty(...)]` will not compile.
 
 **Delete (no MSTest equivalent or now handled elsewhere):**
 
@@ -531,7 +533,7 @@ Custom orderers/test framework hooks must be reimplemented against MSTest's exte
 | Silently widening `ICollectionFixture` to assembly scope | State leak between unrelated tests; new flakiness | Step 8 -- pick scope explicitly and disclose to the user |
 | `MSTest.Sdk` flipping VSTest project to MTP | `vstest.console` finds zero tests; CI breaks | Add `<UseVSTest>true</UseVSTest>` (no separate `Microsoft.NET.Test.Sdk` package needed -- the SDK pulls it in) |
 | `[DataRow]` type mismatch | Theory cases compile in xUnit but produce MSTest runtime errors | Use exact literal types: `1` int, `1L` long, `1.0f` float |
-| `Assert.SkipUnless` becomes `[Ignore]` | Tests that *would* have run on this machine now silently skip everywhere | Use a condition attribute (`[OSCondition]`/`[CICondition]`/`[ArchitectureCondition]`, MSTest 3.10+) when the predicate is environmental; otherwise runtime `Assert.Inconclusive` |
+| `Assert.SkipUnless` becomes `[Ignore]` | Tests that *would* have run on this machine now silently skip everywhere | Use a condition attribute (`[OSCondition]`/`[CICondition]`, MSTest 3.10+) when the predicate is environmental; otherwise runtime `Assert.Inconclusive` |
 | Dropping `Assert.Collection` / `Assert.All` without replacement | Test passes but verifies nothing | Restore as explicit `foreach` + per-element assertions |
 | Leaving `xunit.runner.json` in the project | Build warning + dead config | Delete the file after porting settings |
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -1,0 +1,484 @@
+---
+name: migrate-xunit-to-mstest
+description: >
+  Migrate .NET test projects from xUnit.net (v2 or v3) to MSTest v4.
+  USE FOR: convert/migrate xUnit tests to MSTest, replace xunit/xunit.v3 packages,
+  port [Fact]/[Theory]/[InlineData]/[MemberData]/[ClassData] to
+  [TestMethod]/[DataRow]/[DynamicData], port Assert.Equal/True/Throws/ThrowsAsync
+  to Assert.AreEqual/IsTrue/ThrowsExactly/ThrowsExactlyAsync, port IClassFixture/
+  ICollectionFixture/IDisposable/IAsyncLifetime/ITestOutputHelper/[Trait]/[Fact(Skip)]
+  to MSTest equivalents, preserve xUnit parallel-class default via
+  [assembly: Parallelize(Scope = ClassLevel)], remove xunit.runner.json.
+  DO NOT USE FOR: xUnit v2 -> v3 upgrade (use migrate-xunit-to-xunit-v3); MSTest ->
+  xUnit, NUnit/TUnit -> MSTest (no skills exist); MSTest version upgrades (use
+  migrate-mstest-v1v2-to-v3 or migrate-mstest-v3-to-v4); VSTest <-> MTP only
+  (use migrate-vstest-to-mtp); general .NET upgrades.
+license: MIT
+---
+
+# xUnit -> MSTest Migration
+
+Migrate a .NET test project from xUnit.net (v2 or v3) to MSTest v4. The outcome is a project that:
+
+- References MSTest v4 packages (or `MSTest.Sdk` 4.x) instead of `xunit*` / `xunit.v3.*`
+- Has every `[Fact]`/`[Theory]` rewritten as `[TestMethod]` and every assertion mapped to the MSTest equivalent
+- Builds cleanly with the same target framework
+- Passes the same set of tests (modulo intentional changes documented below)
+- Preserves the **current test platform** (VSTest stays on VSTest; MTP stays on MTP)
+
+This is a **cross-framework** migration. Do not bundle it with a version upgrade or a platform switch in the same pass -- if both are needed, do this skill first, commit, then run `migrate-mstest-v3-to-v4` (if you stopped on v3) or `migrate-vstest-to-mtp`.
+
+## When to Use
+
+- The project references `xunit`, `xunit.assert`, `xunit.core`, `xunit.extensibility.core`/`execution`, `xunit.abstractions`, or any `xunit.v3.*` package, and you want to switch to MSTest
+- You want a single .NET test framework across a solution that today mixes xUnit and MSTest
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Project or solution path | Yes | The `.csproj`, `.sln`, or `.slnx` containing xUnit test projects |
+| Build command | No | How to build (e.g., `dotnet build`). Auto-detect if not provided |
+| Test command | No | How to run tests (e.g., `dotnet test`). Auto-detect if not provided |
+
+## Response Guidelines
+
+- **Always identify the current xUnit version first.** State whether the project is on xUnit v2 (`xunit` 2.x) or xUnit v3 (`xunit.v3` / `xunit.v3.*`) before recommending changes. This grounds the migration advice -- some breaking-change steps only apply to one version.
+- **Always preserve the current test platform.** If the project runs on VSTest, keep VSTest. If it runs on MTP (e.g., xUnit v3 native MTP, or `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>`), keep MTP. Recommend `migrate-vstest-to-mtp` as a separate follow-up only if the user asks for it.
+- **Specific API mapping questions** (assertions, fixtures, output helper, etc.): jump to the relevant step. Do not run the full workflow.
+- **Full migration requests**: follow the workflow end-to-end.
+- **Focused fix requests** (specific compile error after a partial migration): address only that error using the mapping reference. Do not walk the full workflow.
+- **Code samples**: show concrete before/after using the user's actual type/method names, not generic placeholders.
+
+## Strategy
+
+The conversion is mechanical for ~80% of code (attributes and simple assertions) and judgement-based for ~20% (collection fixtures, custom data attributes, exact-type-vs-derived exception assertions, parallelization semantics). Always do the mechanical pass first so build errors point you at the judgement areas.
+
+## Mapping Reference
+
+For the full attribute/assertion/fixture/lifecycle mapping tables -- including semantic traps (`Assert.Throws<T>` vs `Assert.ThrowsAny<T>`, `IClassFixture` vs `ICollectionFixture` scope), edge cases (`TheoryData<T...>`, `MemberType=`, custom `DataAttribute`, custom `FactAttribute`, `Record.Exception`), and copy-pasteable before/after snippets -- see [`references/mapping-cheatsheet.md`](references/mapping-cheatsheet.md). Load it whenever you need a specific xUnit -> MSTest equivalent.
+
+For writing idiomatic MSTest code (modern assertion APIs, lifecycle patterns, data-driven conventions, `Assert.HasCount`/`IsEmpty`/`StartsWith`, etc.), see the `writing-mstest-tests` skill. **Do not re-derive idiomatic MSTest patterns here.** Apply this skill to *convert*; apply `writing-mstest-tests` to *polish*.
+
+## Workflow
+
+> **Commit strategy:** Commit after Step 2 (packages updated, builds broken), after Step 5 (attributes converted, most asserts fixed), and after Step 9 (fixtures/lifecycle rewritten, tests pass). Commit before fixing follow-up cleanup so reviewers can bisect.
+
+### Step 1: Assess the project
+
+1. Locate every test project. Read `.csproj`, `Directory.Build.props`, `Directory.Packages.props`, and `global.json`.
+2. Identify the **xUnit version**:
+   - `xunit` 2.x (+ `xunit.assert` / `xunit.core` / `xunit.abstractions`) -> **xUnit v2**
+   - `xunit.v3` / `xunit.v3.*` -> **xUnit v3**
+3. Identify the **current test platform** (this dictates what to keep, not what to change):
+   - `xunit.runner.visualstudio` (v2) or no MTP signals (v3) and no `<UseMicrosoftTestingPlatformRunner>` -> **VSTest**
+   - xUnit v3 with `xunit.v3.mtp-v*` / `xunit.v3.core.mtp-v*`, or `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>`, or `YTest.MTP.XUnit2` (v2 MTP shim) -> **MTP**
+   - Use the `platform-detection` skill if you are unsure.
+4. Verify the `TargetFramework` is supported by MSTest v4:
+   - **Supported**: `net8.0`, `net9.0`, `net462`+, `netstandard2.0` (test library only), `uap10.0.16299`, `net8.0-windows10.0.18362.0` (WinUI), `net9.0-windows10.0.17763.0` (modern UWP).
+   - **Unsupported**: .NET Core 3.1, `net5.0`-`net7.0`. **STOP** and ask the user to upgrade the TFM first, or migrate to MSTest v3 (then use `migrate-mstest-v3-to-v4` after a TFM bump).
+5. Inventory high-risk patterns -- scan for these and flag them now so you can plan judgement steps later:
+   - **Parallelization differences (Step 11)** -- xUnit parallelizes test classes by default; MSTest does not. This is the **single most common source of post-migration regressions**: tests that depended on isolation by parallel scheduling, on the lack of it, or on shared static state can pass differently. Decide the target parallelization model now -- do not leave it as the MSTest default by accident.
+   - `ICollectionFixture<T>` / `[CollectionDefinition]` (scope concern -- see Step 8)
+   - Custom `DataAttribute` / custom `FactAttribute` / custom `TheoryAttribute` subclasses (manual conversion to `ITestDataSource` / `TestMethodAttribute` -- see Step 6)
+   - `Assert.Throws<T>` (xUnit semantics = exact type; maps to `Assert.ThrowsExactly<T>`, **not** `Assert.Throws<T>`)
+   - `Record.Exception` / `Record.ExceptionAsync` (manual conversion)
+   - `Assert.Raises*` / event assertions (no MSTest equivalent -- manual)
+   - xUnit v3: `[assembly: CaptureConsole]` and other v3-only assembly attributes
+6. **Inventory state shared between tests** -- static fields/properties, singletons, file paths, well-known ports, in-memory caches, database connection strings pointing at a single shared DB, environment variables. Whether parallelization is on or off, switching frameworks changes the *order* and *concurrency* in which these are touched. List them now so you can decide in Step 11 whether to enable parallelism, serialize specific classes with `[DoNotParallelize]`, or refactor the shared state.
+7. Run a baseline build + test to record the current pass/fail count for parity check at Step 13. Re-run a second time -- if the xUnit run is **flaky** today, those flakes are almost certainly caused by parallel scheduling and will manifest differently after migration. Flag any flaky tests now.
+
+### Step 2: Replace packages
+
+> Choose the package option that matches what the project uses today. Default to the `MSTest` metapackage unless the user already uses `MSTest.Sdk` elsewhere in the solution. If you adopt `MSTest.Sdk`, you must preserve the platform from Step 1.
+
+**Remove** every xUnit package reference (from `.csproj`, `Directory.Build.props`, `Directory.Packages.props`):
+
+- `xunit`, `xunit.abstractions`, `xunit.assert`, `xunit.core`
+- `xunit.extensibility.core`, `xunit.extensibility.execution`
+- `xunit.runner.visualstudio`
+- `xunit.v3`, `xunit.v3.assert`, `xunit.v3.core`, `xunit.v3.extensibility.core`
+- `xunit.v3.mtp-v1`, `xunit.v3.mtp-v2`, `xunit.v3.core.mtp-v1`, `xunit.v3.core.mtp-v2`
+- `YTest.MTP.XUnit2` (xUnit v2 MTP shim)
+- Companion packages: `Xunit.SkippableFact`, `Xunit.Combinatorial`, `Xunit.StaFact` (see Step 10)
+
+**Add** MSTest v4. Two options -- both correct.
+
+**Option A -- `MSTest` metapackage (recommended for incremental migrations):**
+
+```xml
+<ItemGroup>
+  <PackageReference Include="MSTest" Version="4.1.0" />
+</ItemGroup>
+```
+
+The `MSTest` metapackage pulls in `MSTest.TestFramework`, `MSTest.TestAdapter`, `MSTest.Analyzers`, and `Microsoft.NET.Test.Sdk` -- so VSTest discovery (`vstest.console`, classic `dotnet test`) still works.
+
+**Option B -- `MSTest.Sdk`:**
+
+```xml
+<Project Sdk="MSTest.Sdk/4.1.0">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+`MSTest.Sdk` defaults to **MTP** and does *not* include `Microsoft.NET.Test.Sdk`. To preserve a VSTest project, you must opt back in:
+
+```xml
+<PropertyGroup>
+  <UseVSTest>true</UseVSTest>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+</ItemGroup>
+```
+
+When switching to `MSTest.Sdk`, also remove now-redundant properties: `<OutputType>Exe</OutputType>`, `<IsPackable>false</IsPackable>`, `<IsTestProject>true</IsTestProject>`, `<EnableMSTestRunner>`.
+
+### Step 3: Update project configuration
+
+1. **Preserve the runner.** Confirm the platform decision from Step 1 still holds after Step 2. Common mistakes:
+   - Switching to `MSTest.Sdk` without `UseVSTest=true` silently flips a VSTest project to MTP. Add `Microsoft.NET.Test.Sdk` back.
+   - Leaving `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` in `Directory.Build.props` will keep MTP on -- that is correct only if the project was already on MTP.
+2. Remove xUnit-only properties from `.csproj` / `Directory.Build.props`: anything referencing `xunit.runner.*`, `<CaptureConsoleOutput>`, `<UseRoslynCompilers>` set just for xUnit, etc.
+3. Remove `using Xunit;` and `using Xunit.Abstractions;` from C# files (the rewriter will add `using Microsoft.VisualStudio.TestTools.UnitTesting;` instead in Step 4).
+
+### Step 4: Convert test classes and methods
+
+Apply these rewrites to every C# test file. Class-level first, then method-level.
+
+**Class:**
+
+- Add `[TestClass]` to every class that contained xUnit `[Fact]`/`[Theory]` methods (xUnit had no class-level requirement).
+- Mark the class `sealed` (MSTest idiom -- see `writing-mstest-tests`).
+- Replace `using Xunit;` / `using Xunit.Abstractions;` with `using Microsoft.VisualStudio.TestTools.UnitTesting;`.
+
+**Methods:**
+
+| xUnit | MSTest |
+|---|---|
+| `[Fact]` | `[TestMethod]` |
+| `[Theory]` | `[TestMethod]` (parameterized; MSTest 3+ no longer needs `[DataTestMethod]`) |
+| `[Fact(DisplayName = "x")]` | `[TestMethod("x")]` (v3 of MSTest) or `[TestMethod(DisplayName = "x")]` (v4) |
+| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
+| `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
+| `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
+
+> Use `[TestCategory]` for the conventional category trait (it integrates with VSTest/MTP filter syntax); use `[TestProperty]` for arbitrary key/value metadata.
+
+### Step 5: Convert data-driven tests
+
+| xUnit | MSTest |
+|---|---|
+| `[InlineData(1, 2)]` | `[DataRow(1, 2)]` |
+| `[InlineData(1, DisplayName = "case 1")]` | `[DataRow(1, DisplayName = "case 1")]` |
+| `[MemberData(nameof(Cases))]` returning `IEnumerable<object[]>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>` |
+| `[MemberData(nameof(Cases), MemberType = typeof(X))]` | `[DynamicData(nameof(Cases), typeof(X))]` |
+| `[MemberData(nameof(Method), arg1, arg2)]` (parameterized member) | **Manual**: convert to a parameterless property or compute the inputs inside the test |
+| `[ClassData(typeof(MyData))]` (class implementing `IEnumerable<object[]>`) | Add a static property `=> new MyData()` on the test class, then `[DynamicData(nameof(Cases))]` |
+| `TheoryData<int, string>` | `IEnumerable<object[]>` or `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple support) |
+| Custom `DataAttribute` subclass | **Manual**: implement `ITestDataSource` (`GetData`, `GetDisplayName`) |
+
+Prefer ValueTuple data sources for new MSTest tests (see `writing-mstest-tests`), but for migration keep `IEnumerable<object[]>` -- it minimizes diff churn and works in both MSTest 3 and 4.
+
+### Step 6: Convert assertions
+
+Most common cases inline. For the full table including string/collection/type/numeric and event/equivalence assertions, see [`references/mapping-cheatsheet.md`](references/mapping-cheatsheet.md) §3.
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Equal(expected, actual)` | `Assert.AreEqual(expected, actual)` |
+| `Assert.NotEqual(a, b)` | `Assert.AreNotEqual(a, b)` |
+| `Assert.True(x)` / `Assert.False(x)` | `Assert.IsTrue(x)` / `Assert.IsFalse(x)` |
+| `Assert.Null(x)` / `Assert.NotNull(x)` | `Assert.IsNull(x)` / `Assert.IsNotNull(x)` |
+| `Assert.Same(a, b)` / `Assert.NotSame(a, b)` | `Assert.AreSame(a, b)` / `Assert.AreNotSame(a, b)` |
+| `Assert.Throws<T>(() => ...)` | **`Assert.ThrowsExactly<T>(() => ...)`** (see trap below) |
+| `Assert.ThrowsAny<T>(() => ...)` | **`Assert.Throws<T>(() => ...)`** |
+| `await Assert.ThrowsAsync<T>(...)` | `await Assert.ThrowsExactlyAsync<T>(...)` |
+| `Assert.IsType<T>(x)` / `Assert.IsAssignableFrom<T>(x)` | `Assert.IsInstanceOfType<T>(x)` (MSTest v4 returns the typed value) |
+| `Assert.Empty(coll)` / `Assert.NotEmpty(coll)` | `Assert.IsEmpty(coll)` / `Assert.IsNotEmpty(coll)` |
+| `Assert.Single(coll)` | `var item = Assert.ContainsSingle(coll);` |
+| `Assert.Contains(item, coll)` / `Assert.DoesNotContain(...)` | Same -- `Assert.Contains` / `Assert.DoesNotContain` |
+| `Assert.Contains("sub", str)` / `StartsWith` / `EndsWith` / `Matches` | Same (MSTest 3.8+) or `StringAssert.*` |
+| `Assert.Skip("reason")` (v3 runtime) | `Assert.Inconclusive("reason")` |
+| `Assert.SkipWhen(cond, "reason")` (v3) | `if (cond) Assert.Inconclusive("reason");` |
+| `Assert.SkipUnless(cond, "reason")` (v3) | `if (!cond) Assert.Inconclusive("reason");` |
+
+**Critical semantic trap -- exception assertions:**
+
+- xUnit `Assert.Throws<T>` = **exact type match** -> MSTest `Assert.ThrowsExactly<T>`.
+- xUnit `Assert.ThrowsAny<T>` = **derived types also match** -> MSTest `Assert.Throws<T>`.
+
+Reversing these flips the assertion semantics silently. Verify by name, not by visual similarity.
+
+**No-equivalent assertions** -- convert manually (see cheatsheet §3.11):
+
+- `Assert.Collection(items, e1 => ..., e2 => ...)` -> assert count, then per-element
+- `Assert.All(items, x => ...)` -> `foreach`
+- `Assert.Equivalent(expected, actual)` -> deep equality manually, or a third-party library
+- `Assert.Raises<T>` / `Assert.PropertyChanged` -> manual event subscription + flag check
+- `Record.Exception` / `Record.ExceptionAsync` -> `try/catch` returning the exception (or `Assert.ThrowsExactly<T>` if you know the type)
+
+### Step 7: Convert lifecycle
+
+**Constructor / `IDisposable` / `IAsyncDisposable` / `IAsyncLifetime`:**
+
+| xUnit | MSTest |
+|---|---|
+| Constructor (sync setup) | Keep constructor (MSTest also instantiates per test). Drop xUnit-only `ITestOutputHelper` param -- see Step 8 |
+| `Dispose()` (sync teardown) | Keep `Dispose()` (MSTest supports `IDisposable`) **or** rewrite as `[TestCleanup] public void Cleanup() { ... }` |
+| `DisposeAsync()` (async teardown) | Keep `IAsyncDisposable.DisposeAsync()` **or** rewrite as `[TestCleanup] public async Task CleanupAsync() { ... }` |
+| `IAsyncLifetime.InitializeAsync` | `[TestInitialize] public async Task InitAsync() { ... }` |
+| `IAsyncLifetime.DisposeAsync` | `[TestCleanup] public async Task CleanupAsync() { ... }` |
+
+> Per `writing-mstest-tests`: prefer the constructor for sync init (it allows `readonly` fields). Use `[TestInitialize]` only for async setup or when you need `TestContext`.
+
+### Step 8: Convert fixtures (high-risk -- read carefully)
+
+**`IClassFixture<T>` -- class-level shared state (mechanical):**
+
+```csharp
+// xUnit v2/v3
+public class DbFixture : IDisposable
+{
+    public string ConnectionString { get; } = "...";
+    public void Dispose() { /* cleanup */ }
+}
+
+public class OrderTests : IClassFixture<DbFixture>
+{
+    private readonly DbFixture _fixture;
+    public OrderTests(DbFixture fixture) => _fixture = fixture;
+}
+```
+
+```csharp
+// MSTest equivalent
+[TestClass]
+public sealed class OrderTests
+{
+    private static DbFixture? s_fixture;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context) => s_fixture = new DbFixture();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => s_fixture?.Dispose();
+}
+```
+
+**`ICollectionFixture<T>` / `[CollectionDefinition]` -- shared by tests in the same collection (judgement call):**
+
+xUnit collections do two things simultaneously: (1) share a fixture instance across multiple test classes, and (2) serialize those classes (no parallel execution within a collection). MSTest does not have a built-in equivalent that preserves both semantics. **Pick one** -- do not silently map to `[AssemblyInitialize]`:
+
+- **Few classes, narrow scope**: copy the fixture initialization into each class's `[ClassInitialize]`, OR introduce a static `Lazy<T>` shared helper. Add `[DoNotParallelize]` on each class to preserve serialization.
+- **Many classes, fixture is genuinely assembly-wide** (e.g., process-wide TestServer): hoist to `[AssemblyInitialize]` / `[AssemblyCleanup]` in a dedicated `AssemblySetup` class **and** confirm with the user that widening the scope is acceptable. Note that this changes parallelization semantics.
+- **Custom collection behavior or test-collection-orderer**: stop and flag for manual review.
+
+**Always explain the scope change** -- silently widening fixture scope across the assembly is the most common way this migration regresses tests.
+
+### Step 9: Convert output and TestContext
+
+**`ITestOutputHelper` -> `TestContext`:**
+
+```csharp
+// xUnit (v2 and v3)
+public class MyTests
+{
+    private readonly ITestOutputHelper _output;
+    public MyTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void Test() => _output.WriteLine("...");
+}
+```
+
+```csharp
+// MSTest (v3.6+ supports TestContext in constructor)
+[TestClass]
+public sealed class MyTests
+{
+    private readonly TestContext _testContext;
+    public MyTests(TestContext testContext) => _testContext = testContext;
+
+    [TestMethod]
+    public void Test() => _testContext.WriteLine("...");
+}
+```
+
+If the project pins MSTest < 3.6 (rare after Step 2), use property injection instead:
+
+```csharp
+public TestContext TestContext { get; set; } = null!;
+```
+
+**xUnit v3 `TestContext.Current`:**
+
+- `TestContext.Current.CancellationToken` -> `TestContext.CancellationToken` (MSTest 3.6+, on the **instance** TestContext from constructor or property injection)
+- `TestContext.Current.AddAttachment(name, path)` -> `TestContext.AddResultFile(path)`
+- `TestContext.Current.TestOutputHelper.WriteLine(...)` -> `TestContext.WriteLine(...)`
+
+### Step 10: Convert companion packages
+
+| xUnit companion | MSTest equivalent |
+|---|---|
+| `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | No equivalent. Convert to explicit `[DataRow]`s or compute combinations with `[DynamicData]`. Remove the package |
+| `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | `[TestMethod]` + manual STA thread. No MSTest equivalent for `[WpfFact]`; flag for manual conversion |
+| `Verify.Xunit` | `Verify.MSTest` -- swap the package; usage is similar |
+| `FluentAssertions` / `Shouldly` / `AwesomeAssertions` | Keep -- assertion library is framework-agnostic |
+| `Moq` / `NSubstitute` / `FakeItEasy` | Keep -- mocking library is framework-agnostic |
+
+### Step 11: Handle parallelization (defaults differ -- read carefully)
+
+> **This is the most common source of post-migration regressions.** xUnit and MSTest have **opposite defaults**. Do not skip this step even if Step 1 said tests passed cleanly.
+
+#### How each framework parallelizes by default
+
+| Framework | Across test classes | Within a test class | Test-class instance lifetime |
+|---|---|---|---|
+| **xUnit v2** | Parallel (one class per worker thread) | Serial (one test method at a time) | New instance per test method |
+| **xUnit v3** | Parallel (same as v2) | Serial (same as v2) | New instance per test method |
+| **MSTest (default)** | Serial (one class at a time) | Serial (one test method at a time) | New instance per test method |
+| MSTest + `[assembly: Parallelize(Scope = ClassLevel)]` | Parallel | Serial | Same |
+| MSTest + `[assembly: Parallelize(Scope = MethodLevel)]` | Parallel | **Parallel** -- more aggressive than xUnit | Same |
+
+`Workers = 0` means "use all available logical cores" (MSTest's recommended default for parallel runs); any positive integer caps the worker count.
+
+#### Pick a target model -- there are three reasonable choices
+
+**Choice A -- Match xUnit's behaviour exactly (recommended default):**
+
+```csharp
+// Place in any .cs file at assembly scope (often AssemblyInfo.cs or GlobalUsings.cs)
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+```
+
+Use this when the suite was healthy on xUnit and you want zero behavioural change. It preserves "parallel across classes, serial within a class" exactly.
+
+**Choice B -- Adopt MSTest's serial default:**
+
+```csharp
+// No [assembly: Parallelize] needed -- this is the default
+```
+
+Use this only when the suite has known shared-state issues (Step 1.6) that you intend to leave unfixed for now, or when wall-clock time is not a concern. Expect significantly slower CI.
+
+**Choice C -- Selective parallelization:**
+
+```csharp
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+```
+
+Plus per-class opt-out for the classes that genuinely cannot run concurrently:
+
+```csharp
+[TestClass]
+[DoNotParallelize]
+public sealed class DatabaseIntegrationTests { /* ... */ }
+```
+
+Use this when most of the suite is isolated but a few classes touch shared state (one DB, fixed ports, file system locations). This is usually the right answer when migrating from xUnit collections.
+
+> **Do not pick `ExecutionScope.MethodLevel` to "match xUnit"** -- it parallelizes test methods *within* a single class, which xUnit never does. It is more aggressive than xUnit and will surface latent intra-class state issues.
+
+#### Translate xUnit parallelization opt-outs
+
+| xUnit pattern | MSTest equivalent |
+|---|---|
+| `[assembly: CollectionBehavior(DisableTestParallelization = true)]` | Omit `[assembly: Parallelize]` (or use Choice B above) |
+| `[assembly: CollectionBehavior(MaxParallelThreads = N)]` | `[assembly: Parallelize(Workers = N, Scope = ExecutionScope.ClassLevel)]` |
+| `[Collection("Db")]` on multiple classes (forces those classes to share a fixture **and** run serially) | `[DoNotParallelize]` on each of those classes (preserves serialization) + Step 8 fixture handling (preserves sharing) |
+| `[CollectionDefinition("Db", DisableParallelization = true)]` | Same as above -- `[DoNotParallelize]` on each member class |
+| `[Collection("Foo")]` used only for fixture sharing (no parallelization concern) | Step 8 fixture handling; **do not** add `[DoNotParallelize]` |
+
+The distinction in the last two rows matters: xUnit collections conflate "share state" with "serialize". MSTest decouples them. Read the original `[CollectionDefinition]` carefully -- if `DisableParallelization` is `false` (or omitted), only the fixture sharing semantic needs to migrate, not the serialization.
+
+#### Verify after Step 13
+
+If pass/fail counts diverge from the baseline after migration, parallelization is the first place to look:
+
+- **More failures than baseline**: tests are now running concurrently and stomping shared state. Either add `[DoNotParallelize]` to the offending classes, or fix the shared state.
+- **Fewer failures than baseline** (tests previously flaky now green): probably means a race condition that xUnit's scheduling exposed is now hidden by serial execution. Note it in a follow-up issue -- do not declare victory.
+- **Same count but tests take much longer**: you forgot `[assembly: Parallelize]`. Add Choice A.
+- **Same count but tests take much less time and occasionally fail**: you picked `MethodLevel` instead of `ClassLevel`. Switch to `ClassLevel`.
+
+#### Other runner config: `xunit.runner.json` migration
+
+Delete `xunit.runner.json`. Port relevant settings:
+
+| `xunit.runner.json` | MSTest equivalent |
+|---|---|
+| `"parallelizeAssembly": false` | Default in MSTest -- no action |
+| `"parallelizeTestCollections": false` | Omit `[assembly: Parallelize]` (Choice B) |
+| `"maxParallelThreads": N` | `[assembly: Parallelize(Workers = N, Scope = ExecutionScope.ClassLevel)]` |
+| `"methodDisplay": "method"` / `"classAndMethod"` | No equivalent (MSTest always uses class + method) |
+| `"diagnosticMessages": true` | Use `--diagnostic` on the CLI, or set verbosity in `.runsettings` |
+| `"preEnumerateTheories": false` | No equivalent (MSTest enumerates `[DataRow]`/`[DynamicData]` eagerly) |
+| `"longRunningTestSeconds": N` | Use `[Timeout(N * 1000)]` per test |
+| `"appDomain": "denied"` / `"ifAvailable"` | No equivalent (MSTest uses no app domains on modern .NET) |
+
+If the project uses xUnit traits in CI filter expressions (e.g., `--filter "Category=Unit"` with xUnit), the equivalent MSTest filter is `--filter "TestCategory=Unit"` (VSTest) or `--filter-trait "TestCategory=Unit"` (MTP). Update CI pipelines accordingly.
+
+### Step 12: Remove xUnit assembly attributes
+
+Delete these from `AssemblyInfo.cs` / any `[assembly: ...]` declaration:
+
+- `[assembly: CollectionBehavior(...)]`
+- `[assembly: TestCaseOrderer(...)]`
+- `[assembly: TestCollectionOrderer(...)]`
+- `[assembly: TestFramework(...)]`
+- `[assembly: CaptureConsole]` (xUnit v3)
+- `[assembly: Xunit.Trait("k", "v")]` (replace with `[TestCategory]`/`[TestProperty]` on test classes/methods)
+
+Custom orderers/test framework hooks must be reimplemented against MSTest's extensibility model (`TestMethodAttribute` subclasses, `ITestDataSource`, etc.) -- stop and flag for manual conversion if present.
+
+### Step 13: Build and verify parity
+
+1. `dotnet build` -- must succeed with zero errors. Address remaining errors using the mapping reference.
+2. `dotnet test` -- run with the **same** filter/runner combination as before migration.
+3. **Compare pass/fail counts** to the baseline from Step 1.7. Investigate any deltas:
+   - **New failures on shared-state tests** -- you enabled parallelization (Choice A/C in Step 11) and tests are now stomping each other. Add `[DoNotParallelize]` to the specific class(es), or fix the shared state.
+   - **Tests previously parallel now serial (wall-clock much longer)** -- you forgot `[assembly: Parallelize]`. See Step 11 Choice A.
+   - **Tests previously flaky now consistently green** -- almost certainly a race condition hidden by MSTest's serial default. Open a follow-up issue; do not declare victory.
+   - Tests now skipped (`[Ignore]`) that used to run via `Assert.SkipWhen`? Convert to runtime `Assert.Inconclusive` if you want them to execute when the condition is false.
+   - Theory cases dropped? Check `[DataRow]` literal types (`1` int vs `1L` long -- MSTest enforces exact match unlike xUnit).
+   - Tests passing but executing 0 assertions? Likely an `Assert.Collection` or `Assert.All` was dropped -- restore manually.
+4. After parity is confirmed, run the test-quality skills (`test-anti-patterns`, `assertion-quality`) to identify follow-up improvements -- e.g., replacing `Assert.IsTrue(x.Count() == 3)` with `Assert.HasCount(3, x)`.
+
+## Validation
+
+- [ ] No `xunit*`, `xunit.v3.*`, or `YTest.MTP.XUnit2` package references remain
+- [ ] Every test class has `[TestClass]` and every test method has `[TestMethod]`
+- [ ] `using Xunit;` and `using Xunit.Abstractions;` removed
+- [ ] `xunit.runner.json` removed; equivalent config in `.runsettings` / `[assembly: Parallelize]`
+- [ ] **Parallelization is explicit** -- either `[assembly: Parallelize(...)]` is present (Choice A/C, matches xUnit default) or the user accepted the serial default (Choice B). Not left unspecified by accident
+- [ ] Project builds with zero errors
+- [ ] Same number of tests discovered as before migration (-- not silently dropping data rows or skipped tests)
+- [ ] Same pass/fail count as the pre-migration baseline
+- [ ] Test platform unchanged (VSTest stayed VSTest, MTP stayed MTP) unless the user requested otherwise
+- [ ] `TargetFramework` unchanged unless MSTest v4 forced an upgrade (and the user approved)
+
+## Common Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| Leaving parallelization unspecified | Suite that ran in 30s on xUnit now takes minutes on MSTest; or new flakiness from inherited xUnit assumptions | Pick a target parallelization model explicitly in Step 11 (Choice A matches xUnit) -- do not leave it as the MSTest serial default by accident |
+| Picking `ExecutionScope.MethodLevel` to "match xUnit" | New flakiness on tests sharing instance state within a class | Use `ExecutionScope.ClassLevel` -- it matches xUnit exactly |
+| Mapping `Assert.Throws<T>` to `Assert.Throws<T>` | Tests pass for derived exception types they shouldn't | Map xUnit `Assert.Throws<T>` to MSTest `Assert.ThrowsExactly<T>` |
+| Silently widening `ICollectionFixture` to assembly scope | State leak between unrelated tests; new flakiness | Step 8 -- pick scope explicitly and disclose to the user |
+| `MSTest.Sdk` flipping VSTest project to MTP | `vstest.console` finds zero tests; CI breaks | Add `<UseVSTest>true</UseVSTest>` + `Microsoft.NET.Test.Sdk` package |
+| `[DataRow]` type mismatch | Theory cases compile in xUnit but produce MSTest runtime errors | Use exact literal types: `1` int, `1L` long, `1.0f` float |
+| `Assert.SkipUnless` becomes `[Ignore]` | Tests that *would* have run on this machine now silently skip everywhere | Use runtime `Assert.Inconclusive` instead |
+| Dropping `Assert.Collection` / `Assert.All` without replacement | Test passes but verifies nothing | Restore as explicit `foreach` + per-element assertions |
+| Leaving `xunit.runner.json` in the project | Build warning + dead config | Delete the file after porting settings |
+
+## Next Steps
+
+After this migration:
+
+- Run `migrate-vstest-to-mtp` if you want to move to Microsoft.Testing.Platform (separate, committable migration).
+- Run `writing-mstest-tests` to polish converted code: replace `Assert.IsTrue(x.Count() == 3)` with `Assert.HasCount(3, x)`, prefer ValueTuple data sources, mark classes `sealed`, etc.
+- Run `test-anti-patterns` / `assertion-quality` to catch any quality regressions introduced by mechanical conversion.

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -292,7 +292,7 @@ Map deliberately:
 
 | xUnit v3 | MSTest |
 |---|---|
-| `TestContext.Current.CancellationToken` | `_testContext.CancellationToken` (MSTest 3.6+; instance `TestContext` from constructor or property injection) |
+| `TestContext.Current.CancellationToken` | `_testContext.CancellationToken` (MSTest 3.6+; instance `TestContext` from constructor or property injection -- **never** replace with a new `CancellationTokenSource`, that breaks linkage to test-host cancellation) |
 | `[Fact(Timeout = 5000)]` | `[Timeout(5000)]` |
 | `[Fact(Timeout = -1)]` (no timeout) | Omit `[Timeout]` (MSTest default = no timeout) |
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -1,0 +1,352 @@
+# xUnit -> MSTest Mapping Cheatsheet
+
+Comprehensive reference loaded by the `migrate-xunit-to-mstest` skill. Look up specific xUnit constructs and their MSTest v4 equivalents, including edge cases and "no equivalent -- manual" calls.
+
+Target framework throughout: **MSTest v4** (the few v3-only spellings are explicitly marked).
+
+## Table of contents
+
+- [1. Test discovery (class + method attributes)](#1-test-discovery-class--method-attributes)
+- [2. Data-driven tests](#2-data-driven-tests)
+- [3. Assertions](#3-assertions)
+  - [3.1 Equality, null, reference](#31-equality-null-reference)
+  - [3.2 Boolean](#32-boolean)
+  - [3.3 Type checks](#33-type-checks)
+  - [3.4 Numeric / comparison](#34-numeric--comparison)
+  - [3.5 String](#35-string)
+  - [3.6 Collection](#36-collection)
+  - [3.7 Exceptions](#37-exceptions)
+  - [3.8 Async exception assertions](#38-async-exception-assertions)
+  - [3.9 Skip / inconclusive](#39-skip--inconclusive)
+  - [3.10 Fail](#310-fail)
+  - [3.11 No-equivalent assertions](#311-no-equivalent-assertions)
+- [4. Fixtures and lifecycle](#4-fixtures-and-lifecycle)
+- [5. Output / TestContext](#5-output--testcontext)
+- [6. Cancellation and timeouts (xUnit v3 specifics)](#6-cancellation-and-timeouts-xunit-v3-specifics)
+- [7. Parallelization](#7-parallelization)
+- [8. Assembly-level attributes](#8-assembly-level-attributes)
+- [9. Packages](#9-packages)
+- [10. Companion / extension libraries](#10-companion--extension-libraries)
+
+## 1. Test discovery (class + method attributes)
+
+| xUnit | MSTest |
+|---|---|
+| *(no class attribute)* | `[TestClass]` (required) |
+| *(no class modifier)* | `sealed` (MSTest idiom -- see `writing-mstest-tests`) |
+| `[Fact]` | `[TestMethod]` |
+| `[Theory]` | `[TestMethod]` (MSTest 3+ unified; `[DataTestMethod]` still works but is not needed) |
+| `[Fact(DisplayName = "x")]` | MSTest 4: `[TestMethod(DisplayName = "x")]`; MSTest 3: `[TestMethod("x")]` |
+| `[Theory(DisplayName = "x")]` | Same as above on the `[TestMethod]` |
+| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
+| `[Fact(Timeout = 5000)]` | `[Timeout(5000)]` |
+| `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
+| `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
+| `[Collection("Db")]` | Step 8 + Step 11: `[DoNotParallelize]` (serialization) + `[ClassInitialize]` (sharing) -- preserve scope explicitly |
+| Custom `FactAttribute` subclass | Custom `TestMethodAttribute` subclass overriding `ExecuteAsync` (MSTest v4). See `writing-mstest-tests` and `migrate-mstest-v3-to-v4` for `CallerInfo` constructor pattern |
+| Custom `TheoryAttribute` subclass | Same -- subclass `TestMethodAttribute`; expose data via `ITestDataSource` |
+
+> Use `[TestCategory]` for conventional category traits (recognized by VSTest/MTP filter syntax: `--filter "TestCategory=Unit"` or `--filter-trait "TestCategory=Unit"`). Use `[TestProperty]` for arbitrary key/value metadata that does not need filter integration.
+
+## 2. Data-driven tests
+
+| xUnit | MSTest |
+|---|---|
+| `[InlineData(1, 2)]` | `[DataRow(1, 2)]` |
+| `[InlineData(1, DisplayName = "case 1")]` | `[DataRow(1, DisplayName = "case 1")]` |
+| `[InlineData(null)]` | `[DataRow(null)]` |
+| `[MemberData(nameof(Cases))]` returning `IEnumerable<object[]>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>` |
+| `[MemberData(nameof(Cases), MemberType = typeof(X))]` | `[DynamicData(nameof(Cases), typeof(X))]` |
+| `[MemberData(nameof(Cases))]` returning `TheoryData<int, string>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>` or `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple support) |
+| `[MemberData(nameof(Method), arg1, arg2)]` (parameterized member) | **Manual** -- convert to a parameterless property/method, or move parameter logic into the test method |
+| `[ClassData(typeof(MyData))]` where `MyData : IEnumerable<object[]>` | Expose a static `IEnumerable<object[]> Cases => new MyData();` and use `[DynamicData(nameof(Cases))]` |
+| `[ClassData(typeof(MyData))]` where `MyData : TheoryData<...>` | Same approach; convert `TheoryData<...>` to `IEnumerable<object[]>` or ValueTuples |
+| Custom `DataAttribute` subclass | **Manual** -- implement `ITestDataSource` (`GetData` + `GetDisplayName`) |
+
+**Literal-type trap.** MSTest's `[DataRow]` enforces exact type matching against method parameters. xUnit's `[InlineData]` is more permissive. After conversion, audit literals:
+
+| Parameter type | Required literal |
+|---|---|
+| `int` | `1`, `0`, `-1` |
+| `long` | `1L` |
+| `float` | `1.0f` |
+| `double` | `1.0` or `1.0d` |
+| `decimal` | `1.0m` |
+| `uint` | `1U` |
+| `Type` | `typeof(...)` |
+
+## 3. Assertions
+
+### 3.1 Equality, null, reference
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Equal(expected, actual)` | `Assert.AreEqual(expected, actual)` |
+| `Assert.Equal(expected, actual, comparer)` | `Assert.AreEqual(expected, actual, comparer)` |
+| `Assert.Equal(0.1, 0.10001, 3)` (precision) | `Assert.AreEqual(0.1, 0.10001, delta: 0.001)` |
+| `Assert.Equal("a", "A", ignoreCase: true)` | `Assert.AreEqual("a", "A", ignoreCase: true)` |
+| `Assert.NotEqual(a, b)` | `Assert.AreNotEqual(a, b)` |
+| `Assert.Same(a, b)` | `Assert.AreSame(a, b)` |
+| `Assert.NotSame(a, b)` | `Assert.AreNotSame(a, b)` |
+| `Assert.Null(x)` | `Assert.IsNull(x)` |
+| `Assert.NotNull(x)` | `Assert.IsNotNull(x)` |
+| `Assert.Equivalent(expected, actual)` | **Manual** -- no built-in deep-equality assertion. Use a third-party library (FluentAssertions `.Should().BeEquivalentTo(...)`) or write member-by-member assertions |
+
+### 3.2 Boolean
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.True(x)` | `Assert.IsTrue(x)` |
+| `Assert.False(x)` | `Assert.IsFalse(x)` |
+| `Assert.True(x, "msg")` | `Assert.IsTrue(x, "msg")` |
+
+### 3.3 Type checks
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.IsType<T>(x)` (exact type, returns `T`) | MSTest v4: `var t = Assert.IsInstanceOfType<T>(x);` (semantically *assignable*, not exact); for exact-type, follow with `Assert.AreEqual(typeof(T), x.GetType())` |
+| `Assert.IsNotType<T>(x)` (exact type) | `Assert.IsNotInstanceOfType<T>(x);` plus `Assert.AreNotEqual(typeof(T), x.GetType())` if exact-type matters |
+| `Assert.IsAssignableFrom<T>(x)` | `Assert.IsInstanceOfType<T>(x)` -- semantically equivalent |
+
+> MSTest v4's `Assert.IsInstanceOfType<T>(x)` returns the typed value (no out param). MSTest v3 uses `Assert.IsInstanceOfType<T>(x, out var typed)`.
+
+### 3.4 Numeric / comparison
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.InRange(value, low, high)` | `Assert.IsInRange(value, low, high)` |
+| `Assert.NotInRange(value, low, high)` | `Assert.IsNotInRange(value, low, high)` |
+| *(no direct API)* | `Assert.IsGreaterThan(low, value)` |
+| *(no direct API)* | `Assert.IsLessThan(high, value)` |
+
+### 3.5 String
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Contains("sub", str)` | `Assert.Contains("sub", str)` (MSTest 3.8+); fallback `StringAssert.Contains(str, "sub")` |
+| `Assert.DoesNotContain("sub", str)` | `Assert.DoesNotContain("sub", str)` (MSTest 3.8+); fallback `StringAssert.DoesNotMatch(...)` |
+| `Assert.StartsWith("p", str)` | `Assert.StartsWith("p", str)` (MSTest 3.8+); fallback `StringAssert.StartsWith(str, "p")` |
+| `Assert.EndsWith("s", str)` | `Assert.EndsWith("s", str)` (MSTest 3.8+); fallback `StringAssert.EndsWith(str, "s")` |
+| `Assert.Matches("\\d+", str)` | `Assert.MatchesRegex(@"\d+", str)` |
+| `Assert.DoesNotMatch("\\d+", str)` | `Assert.DoesNotMatchRegex(@"\d+", str)` |
+| `Assert.Equal("a", "A", ignoreCase: true)` | `Assert.AreEqual("a", "A", ignoreCase: true)` |
+
+### 3.6 Collection
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Contains(item, collection)` | `Assert.Contains(item, collection)` |
+| `Assert.DoesNotContain(item, collection)` | `Assert.DoesNotContain(item, collection)` |
+| `Assert.Contains(collection, x => predicate)` | `Assert.Contains(collection.First(x => predicate), collection)` or `Assert.IsTrue(collection.Any(x => predicate))` |
+| `Assert.Empty(collection)` | `Assert.IsEmpty(collection)` |
+| `Assert.NotEmpty(collection)` | `Assert.IsNotEmpty(collection)` |
+| `Assert.Single(collection)` | `var item = Assert.ContainsSingle(collection);` (returns the element) |
+| `Assert.Single(collection, predicate)` | `var item = Assert.ContainsSingle(collection.Where(predicate));` |
+| `Assert.Collection(items, e1 => ..., e2 => ...)` | **Manual** -- assert count, then per-element. No idiomatic MSTest equivalent |
+| `Assert.All(items, x => assertion(x))` | **Manual** -- `foreach (var x in items) assertion(x);` |
+| `Assert.Equal(expected, actual)` on `IEnumerable<T>` (element-wise) | `CollectionAssert.AreEqual(expected.ToList(), actual.ToList())` (`IList` required) |
+| `Assert.Equal(expected, actual, comparer)` on collections | `CollectionAssert.AreEqual(expected.ToList(), actual.ToList(), comparer)` |
+| `Assert.Distinct(collection)` | **Manual** -- `Assert.AreEqual(collection.Count, collection.Distinct().Count())` |
+| `Assert.Superset(expected, actual)` | **Manual** -- `Assert.IsTrue(expected.IsSubsetOf(actual))` if both are `HashSet<T>` |
+
+### 3.7 Exceptions
+
+> **Semantic trap**: xUnit `Assert.Throws<T>` = **exact type**. xUnit `Assert.ThrowsAny<T>` = **derived types also match**. The names invert between the frameworks.
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Throws<T>(() => ...)` | **`Assert.ThrowsExactly<T>(() => ...)`** |
+| `Assert.ThrowsAny<T>(() => ...)` | **`Assert.Throws<T>(() => ...)`** |
+| `Assert.Throws<T>(paramName, () => ...)` (ArgumentException family) | `var ex = Assert.ThrowsExactly<T>(() => ...); Assert.AreEqual(paramName, ex.ParamName);` |
+| `Record.Exception(() => ...)` | **Manual** -- `try { ...; return null; } catch (Exception ex) { return ex; }`. If you only need to assert a specific type, use `Assert.ThrowsExactly<T>` directly |
+
+### 3.8 Async exception assertions
+
+| xUnit | MSTest |
+|---|---|
+| `await Assert.ThrowsAsync<T>(() => task)` | `await Assert.ThrowsExactlyAsync<T>(() => task)` |
+| `await Assert.ThrowsAnyAsync<T>(() => task)` | `await Assert.ThrowsAsync<T>(() => task)` |
+| `await Record.ExceptionAsync(() => task)` | **Manual** -- `try { await task; return null; } catch (Exception ex) { return ex; }` |
+
+### 3.9 Skip / inconclusive
+
+> xUnit `Assert.Skip*` is **runtime** (decided inside the test body). MSTest `[Ignore]` is **compile-time** (decided at discovery). They are not interchangeable -- mapping `SkipUnless` to `[Ignore]` will permanently exclude the test on machines where it should have run.
+
+| xUnit | MSTest |
+|---|---|
+| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
+| `Assert.Skip("reason")` (xUnit v3) | `Assert.Inconclusive("reason")` |
+| `Assert.SkipWhen(condition, "reason")` (xUnit v3) | `if (condition) Assert.Inconclusive("reason");` |
+| `Assert.SkipUnless(condition, "reason")` (xUnit v3) | `if (!condition) Assert.Inconclusive("reason");` |
+
+For OS- or environment-conditional skips, MSTest 3.10+ offers `[OSCondition]`, `[CICondition]`, `[NonParallelizableCondition]` -- prefer these over runtime `Assert.Inconclusive` when the condition is environmental.
+
+### 3.10 Fail
+
+| xUnit | MSTest |
+|---|---|
+| `Assert.Fail("reason")` | `Assert.Fail("reason")` |
+
+### 3.11 No-equivalent assertions
+
+These xUnit assertions have no MSTest equivalent. Convert each manually:
+
+| xUnit | Manual replacement |
+|---|---|
+| `Assert.Collection(items, e1Inspector, e2Inspector, ...)` | `Assert.HasCount(N, items); var arr = items.ToArray(); e1Inspector(arr[0]); ...` |
+| `Assert.All(items, inspector)` | `foreach (var item in items) inspector(item);` |
+| `Assert.Equivalent(expected, actual)` | Deep-compare manually, or use FluentAssertions / Verify |
+| `Assert.Raises<T>(addHandler, removeHandler, () => trigger())` | Manual subscribe/flag/unsubscribe |
+| `Assert.RaisesAny<T>(...)` | Same -- manual handler |
+| `Assert.PropertyChanged(notifier, "Prop", () => action)` | Subscribe to `INotifyPropertyChanged.PropertyChanged`, set a flag, assert |
+| `Assert.PropertyChangedAsync(notifier, "Prop", async () => action)` | Same, with `await` |
+
+## 4. Fixtures and lifecycle
+
+### Test-class lifecycle (per-test)
+
+| xUnit | MSTest |
+|---|---|
+| Constructor (sync setup) | Keep the constructor (MSTest also instantiates one instance per test method) |
+| Constructor taking `ITestOutputHelper output` | Constructor taking `TestContext testContext` (MSTest 3.6+) |
+| `Dispose()` | Keep `Dispose()` (MSTest supports `IDisposable`) **or** convert to `[TestCleanup] public void Cleanup()` |
+| `IAsyncDisposable.DisposeAsync()` | Keep `DisposeAsync()` (MSTest supports `IAsyncDisposable`) **or** `[TestCleanup] public async Task CleanupAsync()` |
+| `IAsyncLifetime.InitializeAsync()` | `[TestInitialize] public async Task InitAsync()` |
+| `IAsyncLifetime.DisposeAsync()` | `[TestCleanup] public async Task CleanupAsync()` |
+
+> Per `writing-mstest-tests`: prefer the constructor for sync initialization (it allows `readonly` fields and works correctly with nullability). Use `[TestInitialize]` only for async setup or when `TestContext` is needed but you have not adopted constructor injection.
+
+### Class-level fixtures (shared across tests in one class)
+
+xUnit `IClassFixture<T>` -- one fixture instance per test class, shared by every test method in that class:
+
+```csharp
+// xUnit
+public class DbFixture : IDisposable { /* ... */ }
+
+public class OrderTests : IClassFixture<DbFixture>
+{
+    private readonly DbFixture _fixture;
+    public OrderTests(DbFixture fixture) => _fixture = fixture;
+}
+```
+
+```csharp
+// MSTest equivalent
+[TestClass]
+public sealed class OrderTests
+{
+    private static DbFixture? s_fixture;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context) => s_fixture = new DbFixture();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => s_fixture?.Dispose();
+}
+```
+
+### Cross-class fixtures (`ICollectionFixture<T>` / `[CollectionDefinition]`)
+
+xUnit collections do two things at once: (1) share a fixture instance across multiple test classes, **and** (2) serialize execution of those classes (no parallel execution within a collection). MSTest decouples these:
+
+- **Sharing** -> `[AssemblyInitialize]` (genuinely process-wide) **or** static `Lazy<T>` shared helper referenced by each class's `[ClassInitialize]`
+- **Serialization** -> `[DoNotParallelize]` on each member class
+
+Map deliberately:
+
+| xUnit collection setup | MSTest equivalent |
+|---|---|
+| `[CollectionDefinition("Db")]` + `ICollectionFixture<DbFixture>`, member classes have `[Collection("Db")]`, parallelization default | Static `Lazy<DbFixture>` helper + `[ClassInitialize]` per class. No `[DoNotParallelize]` needed |
+| Same but `[CollectionDefinition("Db", DisableParallelization = true)]` | Same as above + `[DoNotParallelize]` on each member class |
+| Genuinely process-wide singleton (e.g., `WebApplicationFactory` for a TestServer the whole assembly hits) | `[AssemblyInitialize]` + `[AssemblyCleanup]` in a dedicated `AssemblySetup` class -- with the user's explicit acknowledgement that scope widens to the whole assembly |
+| Custom `ITestCollectionOrderer` | **Manual** -- MSTest's `[TestMethodAttribute]` ordering model is different; flag for review |
+
+### Assembly-level fixtures
+
+| xUnit | MSTest |
+|---|---|
+| *(no built-in -- emulated via assembly-scoped `[CollectionDefinition]` + `ICollectionFixture<T>`)* | `[AssemblyInitialize] public static void AssemblyInit(TestContext context)` and `[AssemblyCleanup] public static void AssemblyCleanup()` -- in any class marked `[TestClass]` |
+
+## 5. Output / TestContext
+
+| xUnit | MSTest |
+|---|---|
+| `ITestOutputHelper` constructor parameter | `TestContext` constructor parameter (MSTest 3.6+) or `public TestContext TestContext { get; set; } = null!;` property |
+| `_output.WriteLine("...")` | `_testContext.WriteLine("...")` |
+| `_output.WriteLine("fmt {0}", arg)` (xUnit v2) | `_testContext.WriteLine($"fmt {arg}")` (interpolation -- MSTest v4 dropped most format-string overloads) |
+| `TestContext.Current.TestOutputHelper.WriteLine(...)` (xUnit v3) | `_testContext.WriteLine(...)` |
+| `TestContext.Current.AddAttachment(name, contents)` (xUnit v3) | `_testContext.AddResultFile(pathOnDisk)` |
+| `TestContext.Current.TestMethod.MethodInfo.Name` (xUnit v3) | `_testContext.TestName` |
+| `TestContext.Current.TestClass.Class.Name` (xUnit v3) | `_testContext.FullyQualifiedTestClassName` |
+
+## 6. Cancellation and timeouts (xUnit v3 specifics)
+
+| xUnit v3 | MSTest |
+|---|---|
+| `TestContext.Current.CancellationToken` | `_testContext.CancellationToken` (MSTest 3.6+; instance `TestContext` from constructor or property injection) |
+| `[Fact(Timeout = 5000)]` | `[Timeout(5000)]` |
+| `[Fact(Timeout = -1)]` (no timeout) | Omit `[Timeout]` (MSTest default = no timeout) |
+
+xUnit v2 has no equivalent of `TestContext.Current.CancellationToken` -- skip this row for v2 sources.
+
+## 7. Parallelization
+
+| xUnit default | MSTest equivalent |
+|---|---|
+| Parallel across test classes, serial within a class | `[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]` |
+| xUnit + `[CollectionBehavior(DisableTestParallelization = true)]` | Omit `[assembly: Parallelize]` |
+| xUnit + `[CollectionBehavior(MaxParallelThreads = N)]` | `[assembly: Parallelize(Workers = N, Scope = ExecutionScope.ClassLevel)]` |
+| `[Collection("Db")]` (forces serial within the collection) | `[DoNotParallelize]` on each member class |
+| `[CollectionDefinition("Db", DisableParallelization = true)]` | Same -- `[DoNotParallelize]` on each member class |
+
+> Do not use `ExecutionScope.MethodLevel` to "match xUnit". MethodLevel parallelizes methods *within* a class, which xUnit never does.
+
+## 8. Assembly-level attributes
+
+Remove these from `AssemblyInfo.cs` / global usings:
+
+| xUnit | Disposition |
+|---|---|
+| `[assembly: CollectionBehavior(...)]` | Remove -- replaced by `[assembly: Parallelize(...)]` (Section 7) |
+| `[assembly: TestCaseOrderer(...)]` | Remove + reimplement with MSTest extensibility if needed (flag for manual) |
+| `[assembly: TestCollectionOrderer(...)]` | Remove + flag for manual |
+| `[assembly: TestFramework(...)]` | Remove |
+| `[assembly: CaptureConsole]` (xUnit v3) | Remove -- MSTest does not capture console by default |
+| `[assembly: Xunit.Trait("k", "v")]` | Remove -- xUnit traits do not propagate to MSTest. Apply `[TestCategory]`/`[TestProperty]` per class/method instead |
+
+## 9. Packages
+
+**Remove** every xUnit package from `.csproj`, `Directory.Build.props`, `Directory.Packages.props`:
+
+- `xunit`, `xunit.abstractions`, `xunit.assert`, `xunit.core`
+- `xunit.extensibility.core`, `xunit.extensibility.execution`
+- `xunit.runner.visualstudio`
+- `xunit.v3`, `xunit.v3.assert`, `xunit.v3.core`, `xunit.v3.extensibility.core`
+- `xunit.v3.mtp-v1`, `xunit.v3.mtp-v2`, `xunit.v3.core.mtp-v1`, `xunit.v3.core.mtp-v2`
+- `YTest.MTP.XUnit2` (xUnit v2 MTP shim)
+
+**Add** MSTest v4 -- pick exactly one of:
+
+```xml
+<!-- Option A: metapackage (pulls in TestFramework + TestAdapter + Analyzers + Microsoft.NET.Test.Sdk) -->
+<PackageReference Include="MSTest" Version="4.1.0" />
+```
+
+```xml
+<!-- Option B: MSTest.Sdk (MTP-first; add Microsoft.NET.Test.Sdk if you need VSTest) -->
+<Project Sdk="MSTest.Sdk/4.1.0">
+```
+
+## 10. Companion / extension libraries
+
+| xUnit companion | MSTest equivalent |
+|---|---|
+| `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | No equivalent -- expand to explicit `[DataRow]` or `[DynamicData]` |
+| `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | No equivalent -- manual STA thread or flag for review |
+| `Xunit.Priority` (`[TestCaseOrderer]`) | MSTest ordering is different -- flag for manual |
+| `Verify.Xunit` | `Verify.MSTest` (swap the package; same usage) |
+| `FluentAssertions` / `Shouldly` / `AwesomeAssertions` | Keep -- assertion libraries are framework-agnostic |
+| `Moq` / `NSubstitute` / `FakeItEasy` | Keep -- mocking libraries are framework-agnostic |
+| `AutoFixture.Xunit2` (`[AutoData]`) | `AutoFixture` core works, but the auto-data attribute integration requires the xUnit-specific package -- flag for manual |

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -33,7 +33,7 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | xUnit | MSTest |
 |---|---|
 | *(no class attribute)* | `[TestClass]` (required) |
-| *(no class modifier)* | `sealed` (MSTest idiom -- see `writing-mstest-tests`) |
+| *(no class modifier)* | Preserve the original hierarchy. Do **not** add `sealed` mechanically -- base/derived test classes are common in xUnit and sealing would break them. `writing-mstest-tests` can apply `sealed` as a follow-up where appropriate. |
 | `[Fact]` | `[TestMethod]` |
 | `[Theory]` | `[TestMethod]` (MSTest 3+ unified; `[DataTestMethod]` still works but is not needed) |
 | `[Fact(DisplayName = "x")]` | MSTest 4: `[TestMethod(DisplayName = "x")]`; MSTest 3: `[TestMethod("x")]` |
@@ -143,7 +143,7 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 |---|---|
 | `Assert.Contains(item, collection)` | `Assert.Contains(item, collection)` |
 | `Assert.DoesNotContain(item, collection)` | `Assert.DoesNotContain(item, collection)` |
-| `Assert.Contains(collection, x => predicate)` | `Assert.Contains(collection.First(x => predicate), collection)` or `Assert.IsTrue(collection.Any(x => predicate))` |
+| `Assert.Contains(collection, x => predicate)` | `Assert.IsTrue(collection.Any(x => predicate))` |
 | `Assert.Empty(collection)` | `Assert.IsEmpty(collection)` |
 | `Assert.NotEmpty(collection)` | `Assert.IsNotEmpty(collection)` |
 | `Assert.Single(collection)` | `var item = Assert.ContainsSingle(collection);` (returns the element) |

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -38,15 +38,21 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | `[Theory]` | `[TestMethod]` (MSTest 3+ unified; `[DataTestMethod]` still works but is not needed) |
 | `[Fact(DisplayName = "x")]` | MSTest 4: `[TestMethod(DisplayName = "x")]`; MSTest 3: `[TestMethod("x")]` |
 | `[Theory(DisplayName = "x")]` | Same as above on the `[TestMethod]` |
-| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
-| `[Fact(Timeout = 5000)]` | `[Timeout(5000)]` |
+| `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` (the `[Ignore]` attribute alone does not discover a test -- you still need `[TestMethod]`) |
+| `[Fact(Timeout = 5000)]` | `[TestMethod]` + `[Timeout(5000)]` (same -- `[Timeout]` is a modifier, not a discovery attribute) |
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
 | `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
 | `[Collection("Db")]` | Step 8 + Step 11: `[DoNotParallelize]` (serialization) + `[ClassInitialize]` (sharing) -- preserve scope explicitly |
 | Custom `FactAttribute` subclass | Custom `TestMethodAttribute` subclass overriding `ExecuteAsync` (MSTest v4). See `writing-mstest-tests` and `migrate-mstest-v3-to-v4` for `CallerInfo` constructor pattern |
 | Custom `TheoryAttribute` subclass | Same -- subclass `TestMethodAttribute`; expose data via `ITestDataSource` |
 
-> Use `[TestCategory]` for conventional category traits (recognized by VSTest/MTP filter syntax: `--filter "TestCategory=Unit"` or `--filter-trait "TestCategory=Unit"`). Use `[TestProperty]` for arbitrary key/value metadata that does not need filter integration. **Both target `Assembly`, `Class`, and `Method`** -- an `[assembly: Trait(...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]` / `[assembly: TestProperty(...)]` (see Section 8).
+> Both `[TestCategory]` and `[TestProperty]` are **filterable** at runtime and target `Assembly`, `Class`, and `Method`:
+> - `[TestCategory("Unit")]` -> `--filter "TestCategory=Unit"` (VSTest) / `--filter-trait "TestCategory=Unit"` (MTP)
+> - `[TestProperty("Owner", "alice")]` -> `--filter "Owner=alice"` (VSTest) / `--filter-trait "Owner=alice"` (MTP)
+>
+> Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata. An `[assembly: Trait(...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]` / `[assembly: TestProperty(...)]` (see Section 8).
+>
+> **Conditional skips** (xUnit `[Trait("OS", "Windows")]` patterns that gate execution): MSTest 3.10+ offers dedicated condition attributes -- `[OSCondition]`, `[CICondition]`, `[ArchitectureCondition]`, `[NonParallelizableCondition]` -- which are usually a better fit than overloading `[TestCategory]` for environmental gating. See Section 3.9.
 
 ## 2. Data-driven tests
 
@@ -57,7 +63,7 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | `[InlineData(null)]` | `[DataRow(null)]` |
 | `[MemberData(nameof(Cases))]` returning `IEnumerable<object[]>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>` |
 | `[MemberData(nameof(Cases), MemberType = typeof(X))]` | `[DynamicData(nameof(Cases), typeof(X))]` |
-| `[MemberData(nameof(Cases))]` returning `TheoryData<int, string>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>` or `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple support) |
+| `[MemberData(nameof(Cases))]` returning `TheoryData<int, string>` | `[DynamicData(nameof(Cases))]` returning `IEnumerable<object[]>`, `IEnumerable<(int, string)>` (MSTest 3.7+ ValueTuple), or `IEnumerable<TestDataRow<(int, string)>>` (strongly-typed with per-row `DisplayName`/`Ignore` metadata -- see [docs](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-data-driven#supported-data-source-types)) |
 | `[MemberData(nameof(Method), arg1, arg2)]` (parameterized member) | **Manual** -- convert to a parameterless property/method, or move parameter logic into the test method |
 | `[ClassData(typeof(MyData))]` where `MyData : IEnumerable<object[]>` | Expose a static `IEnumerable<object[]> Cases => new MyData();` and use `[DynamicData(nameof(Cases))]` |
 | `[ClassData(typeof(MyData))]` where `MyData : TheoryData<...>` | Same approach; convert `TheoryData<...>` to `IEnumerable<object[]>` or ValueTuples |
@@ -171,15 +177,17 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 ### 3.9 Skip / inconclusive
 
 > xUnit `Assert.Skip*` is **runtime** (decided inside the test body). MSTest `[Ignore]` is **compile-time** (decided at discovery). They are not interchangeable -- mapping `SkipUnless` to `[Ignore]` will permanently exclude the test on machines where it should have run.
+>
+> **Prefer MSTest's condition attributes** (`[OSCondition]`, `[CICondition]`, `[ArchitectureCondition]`, `[NonParallelizableCondition]` -- MSTest 3.10+) over `Assert.Inconclusive` when the condition is environmental. They are discoverable, reportable per-condition, and do not pollute the test body with skip plumbing.
 
 | xUnit | MSTest |
 |---|---|
-| `[Fact(Skip = "reason")]` | `[Ignore("reason")]` |
+| `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` |
 | `Assert.Skip("reason")` (xUnit v3) | `Assert.Inconclusive("reason")` |
-| `Assert.SkipWhen(condition, "reason")` (xUnit v3) | `if (condition) Assert.Inconclusive("reason");` |
-| `Assert.SkipUnless(condition, "reason")` (xUnit v3) | `if (!condition) Assert.Inconclusive("reason");` |
-
-For OS- or environment-conditional skips, MSTest 3.10+ offers `[OSCondition]`, `[CICondition]`, `[NonParallelizableCondition]` -- prefer these over runtime `Assert.Inconclusive` when the condition is environmental.
+| `Assert.SkipWhen(condition, "reason")` (xUnit v3) | If `condition` is environmental: `[OSCondition(...)]` / `[CICondition(...)]` / etc. Otherwise: `if (condition) Assert.Inconclusive("reason");` |
+| `Assert.SkipUnless(condition, "reason")` (xUnit v3) | Same -- prefer a condition attribute when the predicate is environmental; otherwise `if (!condition) Assert.Inconclusive("reason");` |
+| `Assert.SkipUnless(OperatingSystem.IsWindows(), "...")` | `[OSCondition(OperatingSystems.Windows)]` on the method |
+| `Assert.SkipWhen(Environment.GetEnvironmentVariable("CI") != null, "...")` | `[CICondition(ConditionMode.Exclude)]` on the method |
 
 ### 3.10 Fail
 
@@ -335,16 +343,34 @@ xUnit assembly attributes split into two groups: a few have direct MSTest equiva
 ```
 
 ```xml
-<!-- Option B: MSTest.Sdk (MTP-first; add Microsoft.NET.Test.Sdk if you need VSTest) -->
+<!-- Option B: MSTest.Sdk -- defaults to MTP; set <UseVSTest>true</UseVSTest> to preserve VSTest. -->
+<!--           UseVSTest pulls in Microsoft.NET.Test.Sdk automatically -- no extra PackageReference needed. -->
 <Project Sdk="MSTest.Sdk/4.1.0">
+  <PropertyGroup>
+    <!-- Keep the project's existing TargetFramework; do not change it during migration. -->
+    <UseVSTest>true</UseVSTest> <!-- omit this line to stay on MTP -->
+  </PropertyGroup>
+</Project>
 ```
+
+Prefer pinning the `MSTest.Sdk` version in `global.json` (especially in solutions with several test projects) so the version lives in one place:
+
+```json
+{
+  "msbuild-sdks": {
+    "MSTest.Sdk": "4.1.0"
+  }
+}
+```
+
+With the pin in `global.json`, the project line simplifies to `<Project Sdk="MSTest.Sdk">`.
 
 ## 10. Companion / extension libraries
 
 | xUnit companion | MSTest equivalent |
 |---|---|
 | `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
-| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | No equivalent -- expand to explicit `[DataRow]` or `[DynamicData]` |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | [`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest) (community port) -- attribute surface is the same as xUnit.Combinatorial. Alternatively, expand combinations into explicit `[DataRow]`s or compute them in `[DynamicData]` |
 | `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | No equivalent -- manual STA thread or flag for review |
 | `Xunit.Priority` (`[TestCaseOrderer]`) | MSTest ordering is different -- flag for manual |
 | `Verify.Xunit` | `Verify.MSTest` (swap the package; same usage) |

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -46,7 +46,7 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | Custom `FactAttribute` subclass | Custom `TestMethodAttribute` subclass overriding `ExecuteAsync` (MSTest v4). See `writing-mstest-tests` and `migrate-mstest-v3-to-v4` for `CallerInfo` constructor pattern |
 | Custom `TheoryAttribute` subclass | Same -- subclass `TestMethodAttribute`; expose data via `ITestDataSource` |
 
-> Use `[TestCategory]` for conventional category traits (recognized by VSTest/MTP filter syntax: `--filter "TestCategory=Unit"` or `--filter-trait "TestCategory=Unit"`). Use `[TestProperty]` for arbitrary key/value metadata that does not need filter integration.
+> Use `[TestCategory]` for conventional category traits (recognized by VSTest/MTP filter syntax: `--filter "TestCategory=Unit"` or `--filter-trait "TestCategory=Unit"`). Use `[TestProperty]` for arbitrary key/value metadata that does not need filter integration. **Both target `Assembly`, `Class`, and `Method`** -- an `[assembly: Trait(...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]` / `[assembly: TestProperty(...)]` (see Section 8).
 
 ## 2. Data-driven tests
 
@@ -304,7 +304,7 @@ xUnit v2 has no equivalent of `TestContext.Current.CancellationToken` -- skip th
 
 ## 8. Assembly-level attributes
 
-Remove these from `AssemblyInfo.cs` / global usings:
+xUnit assembly attributes split into two groups: a few have direct MSTest equivalents (and stay at assembly scope); the rest must be removed or reimplemented against MSTest extensibility.
 
 | xUnit | Disposition |
 |---|---|
@@ -313,7 +313,8 @@ Remove these from `AssemblyInfo.cs` / global usings:
 | `[assembly: TestCollectionOrderer(...)]` | Remove + flag for manual |
 | `[assembly: TestFramework(...)]` | Remove |
 | `[assembly: CaptureConsole]` (xUnit v3) | Remove -- MSTest does not capture console by default |
-| `[assembly: Xunit.Trait("k", "v")]` | Remove -- xUnit traits do not propagate to MSTest. Apply `[TestCategory]`/`[TestProperty]` per class/method instead |
+| `[assembly: Xunit.Trait("Category", "v")]` | `[assembly: TestCategory("v")]` (applies the category to every test in the assembly -- `TestCategoryAttribute` targets `Assembly`, `Class`, and `Method`) |
+| `[assembly: Xunit.Trait("k", "v")]` (non-category key) | `[assembly: TestProperty("k", "v")]` (`TestPropertyAttribute` also targets `Assembly`, `Class`, and `Method`) |
 
 ## 9. Packages
 

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -46,13 +46,13 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | Custom `FactAttribute` subclass | Custom `TestMethodAttribute` subclass overriding `ExecuteAsync` (MSTest v4). See `writing-mstest-tests` and `migrate-mstest-v3-to-v4` for `CallerInfo` constructor pattern |
 | Custom `TheoryAttribute` subclass | Same -- subclass `TestMethodAttribute`; expose data via `ITestDataSource` |
 
-> Both `[TestCategory]` and `[TestProperty]` are **filterable** at runtime and target `Assembly`, `Class`, and `Method`:
-> - `[TestCategory("Unit")]` -> `--filter "TestCategory=Unit"` (VSTest) / `--filter-trait "TestCategory=Unit"` (MTP)
-> - `[TestProperty("Owner", "alice")]` -> `--filter "Owner=alice"` (VSTest) / `--filter-trait "Owner=alice"` (MTP)
+> Both `[TestCategory]` and `[TestProperty]` are **filterable** at runtime:
+> - `[TestCategory("Unit")]` -> `--filter "TestCategory=Unit"` (VSTest) / `--filter-trait "TestCategory=Unit"` (MTP); targets `Assembly`, `Class`, and `Method`
+> - `[TestProperty("Owner", "alice")]` -> `--filter "Owner=alice"` (VSTest) / `--filter-trait "Owner=alice"` (MTP); targets `Class` and `Method` only (no `AttributeTargets.Assembly`)
 >
-> Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata. An `[assembly: Trait(...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]` / `[assembly: TestProperty(...)]` (see Section 8).
+> Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata at class/method scope. An `[assembly: Trait("Category", ...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]`. An assembly-level `[Trait]` with an arbitrary key cannot map to `[assembly: TestProperty(...)]` -- collapse it to `[assembly: TestCategory(...)]` or move it down to every class (see Section 8).
 >
-> **Conditional skips** (xUnit `[Trait("OS", "Windows")]` patterns that gate execution): MSTest 3.10+ offers dedicated condition attributes -- `[OSCondition]`, `[CICondition]`, `[ArchitectureCondition]`, `[NonParallelizableCondition]` -- which are usually a better fit than overloading `[TestCategory]` for environmental gating. See Section 3.9.
+> **Conditional skips** (xUnit `[Trait("OS", "Windows")]` patterns that gate execution): MSTest 3.10+ offers dedicated condition attributes -- `[OSCondition]` and `[CICondition]` -- which are usually a better fit than overloading `[TestCategory]` for environmental gating. (There is no `ArchitectureCondition` or `NonParallelizableCondition` attribute in MSTest; for non-parallel intent use `[DoNotParallelize]`, and for architecture gating fall back to `if (RuntimeInformation.OSArchitecture != ...) Assert.Inconclusive(...)`.) See Section 3.9.
 
 ## 2. Data-driven tests
 
@@ -178,7 +178,7 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 
 > xUnit `Assert.Skip*` is **runtime** (decided inside the test body). MSTest `[Ignore]` is **compile-time** (decided at discovery). They are not interchangeable -- mapping `SkipUnless` to `[Ignore]` will permanently exclude the test on machines where it should have run.
 >
-> **Prefer MSTest's condition attributes** (`[OSCondition]`, `[CICondition]`, `[ArchitectureCondition]`, `[NonParallelizableCondition]` -- MSTest 3.10+) over `Assert.Inconclusive` when the condition is environmental. They are discoverable, reportable per-condition, and do not pollute the test body with skip plumbing.
+> **Prefer MSTest's condition attributes** (`[OSCondition]` and `[CICondition]` -- MSTest 3.10+) over `Assert.Inconclusive` when the condition is OS- or CI-environmental. They are discoverable, reportable per-condition, and do not pollute the test body with skip plumbing. (MSTest does **not** ship an `ArchitectureCondition` or `NonParallelizableCondition` attribute -- for architecture gating fall back to runtime `Assert.Inconclusive`; for "do not run in parallel" use `[DoNotParallelize]`.)
 
 | xUnit | MSTest |
 |---|---|
@@ -322,7 +322,7 @@ xUnit assembly attributes split into two groups: a few have direct MSTest equiva
 | `[assembly: TestFramework(...)]` | Remove |
 | `[assembly: CaptureConsole]` (xUnit v3) | Remove -- MSTest does not capture console by default |
 | `[assembly: Xunit.Trait("Category", "v")]` | `[assembly: TestCategory("v")]` (applies the category to every test in the assembly -- `TestCategoryAttribute` targets `Assembly`, `Class`, and `Method`) |
-| `[assembly: Xunit.Trait("k", "v")]` (non-category key) | `[assembly: TestProperty("k", "v")]` (`TestPropertyAttribute` also targets `Assembly`, `Class`, and `Method`) |
+| `[assembly: Xunit.Trait("k", "v")]` (non-category key) | **No direct equivalent at assembly scope** -- `TestPropertyAttribute` targets only `Class`/`Method`. Either collapse to `[assembly: TestCategory("v")]` if the value alone filters cleanly, or push down to every test class as `[TestProperty("k", "v")]` |
 
 ## 9. Packages
 

--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
@@ -319,10 +319,10 @@ stimuli:
       - type: prompt
       - type: pairwise
     rubric:
-      - Converts [Fact(Skip = ...)] to [Ignore(...)]
+      - Converts [Fact(Skip = ...)] to [TestMethod] + [Ignore(...)] (both attributes required -- [Ignore] alone does not discover the test)
       - Converts [Trait("Category", X)] to [TestCategory(X)]
       - Converts other [Trait(k, v)] to [TestProperty(k, v)]
-      - Converts [Fact(Timeout = N)] to [Timeout(N)]
+      - Converts [Fact(Timeout = N)] to [TestMethod] + [Timeout(N)]
   - name: 'Preserve xUnit parallelization default with [assembly: Parallelize]'
     prompt: |
       Convert this test project from xUnit.net v2 to MSTest. Preserve the

--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
@@ -1,0 +1,414 @@
+name: migrate-xunit-to-mstest
+description: Evaluates the dotnet-test/migrate-xunit-to-mstest skill
+type: capability
+config:
+  timeout: 20m
+stimuli:
+  - name: Migrate basic xUnit v2 project to MSTest v4 preserving VSTest
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Update package
+      references, attributes, and assertions. Keep the project on the same
+      test runner (VSTest) -- do not also migrate to Microsoft.Testing.Platform.
+    environment:
+      files:
+        - src: ./fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/global.json
+          dest: global.json
+        - src: ./fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/CalculatorTests.cs
+          dest: CalculatorTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: Microsoft\.VisualStudio\.TestTools\.UnitTesting
+      - type: output-matches
+        config:
+          pattern: \[TestClass\]
+      - type: output-matches
+        config:
+          pattern: \[TestMethod\]
+      - type: output-matches
+        config:
+          pattern: Assert\.AreEqual
+      - type: output-matches
+        config:
+          pattern: Assert\.IsTrue
+      - type: output-not-matches
+        config:
+          pattern: PackageReference Include="xunit
+      - type: output-not-matches
+        config:
+          pattern: using Xunit;
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Removes xunit, xunit.runner.visualstudio package references
+      - Adds the MSTest metapackage (Microsoft.NET.Test.Sdk stays for VSTest)
+      - Replaces 'using Xunit;' with 'using Microsoft.VisualStudio.TestTools.UnitTesting;'
+      - Adds [TestClass] to the test class and converts [Fact] to [TestMethod]
+      - Converts Assert.Equal -> Assert.AreEqual and Assert.True -> Assert.IsTrue
+      - Does NOT switch the project to Microsoft.Testing.Platform (no MSTest.Sdk default flip)
+  - name: Migrate basic xUnit v3 project to MSTest v4 preserving VSTest
+    prompt: |
+      Convert this test project from xUnit.net v3 to MSTest. Preserve the
+      VSTest runner (do not switch to MTP).
+    environment:
+      files:
+        - src: ./fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/global.json
+          dest: global.json
+        - src: ./fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/Directory.Build.props
+          dest: Directory.Build.props
+        - src: ./fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/OrderTests.cs
+          dest: OrderTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: Microsoft\.VisualStudio\.TestTools\.UnitTesting
+      - type: output-matches
+        config:
+          pattern: \[DataRow\(
+      - type: output-not-matches
+        config:
+          pattern: xunit\.v3
+      - type: output-not-matches
+        config:
+          pattern: InlineData
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Removes all xunit.v3.* and xunit.runner.visualstudio packages and adds MSTest
+      - Converts [Theory] + [InlineData(...)] to [TestMethod] + [DataRow(...)]
+      - 'Preserves the VSTest runner: keeps Microsoft.NET.Test.Sdk, does not switch to MSTest.Sdk default MTP'
+      - Does NOT silently change TargetFramework
+  - name: Stop when target framework is unsupported by MSTest v4
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest (latest version).
+    environment:
+      files:
+        - src: ./fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/SampleTests.cs
+          dest: SampleTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: (net7\.0|net6\.0|net8\.0|unsupported|not supported|upgrade.{0,30}target.{0,10}framework|target.{0,10}framework.{0,30}upgrade|MSTest v?3)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - 'Identifies net7.0 as unsupported by MSTest v4 (supported: net8.0, net9.0, net462+, etc.)'
+      - Stops or pauses for user confirmation -- does NOT silently retarget the TFM
+      - Suggests either upgrading the TFM to net8.0/net9.0, or falling back to MSTest v3
+  - name: Convert IClassFixture to ClassInitialize
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/convert-iclassfixture-to-classinitialize/global.json
+          dest: global.json
+        - src: ./fixtures/convert-iclassfixture-to-classinitialize/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/convert-iclassfixture-to-classinitialize/DbFixture.cs
+          dest: DbFixture.cs
+        - src: ./fixtures/convert-iclassfixture-to-classinitialize/OrderTests.cs
+          dest: OrderTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: \[ClassInitialize\]
+      - type: output-matches
+        config:
+          pattern: \[ClassCleanup\]
+      - type: output-not-matches
+        config:
+          pattern: IClassFixture
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Removes 'IClassFixture<DbFixture>' from the class declaration
+      - Adds a static field holding the fixture and a [ClassInitialize] method that constructs it
+      - Adds a [ClassCleanup] method that disposes the fixture
+      - Tests still reference the fixture instance through the static field
+  - name: Handle ICollectionFixture explicitly (do not silently widen scope)
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Two test classes
+      share a database fixture via xUnit's collection mechanism and must NOT
+      run in parallel against each other.
+    environment:
+      files:
+        - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/global.json
+          dest: global.json
+        - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/DbCollection.cs
+          dest: DbCollection.cs
+        - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/OrdersTests.cs
+          dest: OrdersTests.cs
+        - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/CustomersTests.cs
+          dest: CustomersTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: \[DoNotParallelize\]
+      - type: output-matches
+        config:
+          pattern: (scope|sharing|parallelization|preserve|collection)
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Preserves serialization of the two classes by adding [DoNotParallelize] (matches DisableParallelization = true)
+      - Preserves the shared fixture by either an [AssemblyInitialize] singleton or a static Lazy<T> helper used from each class's [ClassInitialize]
+      - Explicitly explains the scope decision (collection scope -> chosen scope) instead of silently widening
+      - Removes [Collection(...)] / [CollectionDefinition(...)] attributes
+  - name: Convert ITestOutputHelper to TestContext
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/convert-itestoutputhelper-to-testcontext/global.json
+          dest: global.json
+        - src: ./fixtures/convert-itestoutputhelper-to-testcontext/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/convert-itestoutputhelper-to-testcontext/LoggingTests.cs
+          dest: LoggingTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: TestContext
+      - type: output-matches
+        config:
+          pattern: WriteLine
+      - type: output-not-matches
+        config:
+          pattern: ITestOutputHelper
+      - type: output-not-matches
+        config:
+          pattern: Xunit\.Abstractions
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Removes the ITestOutputHelper constructor parameter and replaces with TestContext (constructor injection or property)
+      - Replaces _output.WriteLine(...) with _testContext.WriteLine(...) (or TestContext.WriteLine via the property)
+      - Removes 'using Xunit.Abstractions;'
+  - name: Map exception assertions correctly (xUnit Throws -> MSTest ThrowsExactly)
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Be careful with
+      exception assertions.
+    environment:
+      files:
+        - src: ./fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/global.json
+          dest: global.json
+        - src: ./fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/ExceptionTests.cs
+          dest: ExceptionTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: Assert\.ThrowsExactly<InvalidOperationException>
+      - type: output-matches
+        config:
+          pattern: Assert\.Throws<Exception>
+      - type: output-matches
+        config:
+          pattern: Assert\.ThrowsExactlyAsync<InvalidOperationException>
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Maps xUnit Assert.Throws<T> to MSTest Assert.ThrowsExactly<T> (preserves exact-type semantics)
+      - Maps xUnit Assert.ThrowsAny<T> to MSTest Assert.Throws<T> (preserves derived-type semantics)
+      - Maps xUnit Assert.ThrowsAsync<T> to MSTest Assert.ThrowsExactlyAsync<T>
+      - Does NOT silently flip the semantic by mapping Throws -> Throws
+  - name: Convert MemberData and TheoryData to DynamicData
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/convert-memberdata-and-theorydata-to-dynamicdata/global.json
+          dest: global.json
+        - src: ./fixtures/convert-memberdata-and-theorydata-to-dynamicdata/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/convert-memberdata-and-theorydata-to-dynamicdata/DiscountTests.cs
+          dest: DiscountTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: \[DynamicData\(
+      - type: output-not-matches
+        config:
+          pattern: \[MemberData\(
+      - type: output-not-matches
+        config:
+          pattern: \[Theory\]
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Replaces [MemberData(nameof(Cases))] with [DynamicData(nameof(Cases))]
+      - Converts [Theory] to [TestMethod] (or keeps [DataTestMethod])
+      - Preserves the existing IEnumerable<object[]> data source signature
+      - Both data rows still execute -- pass count matches the pre-migration baseline
+  - name: Convert Skip, Trait, and Timeout
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/convert-skip-trait-and-timeout/global.json
+          dest: global.json
+        - src: ./fixtures/convert-skip-trait-and-timeout/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/convert-skip-trait-and-timeout/AnnotatedTests.cs
+          dest: AnnotatedTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: \[Ignore\("broken"\)\]
+      - type: output-matches
+        config:
+          pattern: \[TestCategory\("Unit"\)\]
+      - type: output-matches
+        config:
+          pattern: \[TestProperty\("Owner"
+      - type: output-matches
+        config:
+          pattern: \[Timeout\(5000\)\]
+      - type: output-not-matches
+        config:
+          pattern: Trait\(
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Converts [Fact(Skip = ...)] to [Ignore(...)]
+      - Converts [Trait("Category", X)] to [TestCategory(X)]
+      - Converts other [Trait(k, v)] to [TestProperty(k, v)]
+      - Converts [Fact(Timeout = N)] to [Timeout(N)]
+  - name: 'Preserve xUnit parallelization default with [assembly: Parallelize]'
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Preserve the
+      same parallelization behavior the project had under xUnit (which by
+      default parallelizes across test classes).
+    environment:
+      files:
+        - src: ./fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/global.json
+          dest: global.json
+        - src: ./fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/AlphaTests.cs
+          dest: AlphaTests.cs
+        - src: ./fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/BetaTests.cs
+          dest: BetaTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: assembly:\s*Parallelize
+      - type: output-matches
+        config:
+          pattern: ExecutionScope\.ClassLevel
+      - type: output-not-matches
+        config:
+          pattern: ExecutionScope\.MethodLevel
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - 'Adds [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)] to preserve xUnit''s class-level parallelization'
+      - Does NOT pick ExecutionScope.MethodLevel (which is more aggressive than xUnit)
+      - Mentions that MSTest's default is serial, so explicit Parallelize is required to match xUnit
+  - name: Convert xUnit v3 TestContext.Current.CancellationToken
+    prompt: |
+      Convert this test project from xUnit.net v3 to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/global.json
+          dest: global.json
+        - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/Directory.Build.props
+          dest: Directory.Build.props
+        - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/CancellationTests.cs
+          dest: CancellationTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: TestContext\.CancellationToken|_testContext\.CancellationToken
+      - type: output-not-matches
+        config:
+          pattern: TestContext\.Current\.CancellationToken
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Replaces 'TestContext.Current.CancellationToken' with the instance TestContext's CancellationToken
+      - Uses MSTest's instance TestContext (constructor injection or property) rather than a static 'Current'
+      - Does NOT introduce CancellationTokenSource as a fake replacement
+  - name: Recognize project already on MSTest
+    prompt: |
+      Convert this test project from xUnit.net to MSTest.
+    environment:
+      files:
+        - src: ./fixtures/recognize-project-already-on-mstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/recognize-project-already-on-mstest/ExistingTests.cs
+          dest: ExistingTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: (already|no.{0,30}migration|not.{0,20}need|already.{0,20}MSTest)
+      - type: output-not-matches
+        config:
+          pattern: PackageReference Include="xunit
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Recognizes the project already references MSTest packages -- no xUnit present
+      - Does NOT make changes (no destructive 'migration' of MSTest tests)
+      - Tells the user the migration is not needed (and may optionally suggest migrate-mstest-v3-to-v4 if v4 is desired)

--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
@@ -650,10 +650,10 @@ scenarios:
         expected_exit_code: 0
         command_timeout: 180
     rubric:
-      - "Converts [Fact(Skip = ...)] to [Ignore(...)]"
+      - "Converts [Fact(Skip = ...)] to [TestMethod] + [Ignore(...)] (both attributes required -- [Ignore] alone does not discover the test)"
       - "Converts [Trait(\"Category\", X)] to [TestCategory(X)]"
       - "Converts other [Trait(k, v)] to [TestProperty(k, v)]"
-      - "Converts [Fact(Timeout = N)] to [Timeout(N)]"
+      - "Converts [Fact(Timeout = N)] to [TestMethod] + [Timeout(N)]"
     timeout: 720
 
   # ============================================================================

--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
@@ -1,0 +1,832 @@
+scenarios:
+  # ============================================================================
+  # Goal 1: Basic xUnit v2 -> MSTest v4, preserve VSTest runner
+  # ============================================================================
+
+  - name: "Migrate basic xUnit v2 project to MSTest v4 preserving VSTest"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Update package
+      references, attributes, and assertions. Keep the project on the same
+      test runner (VSTest) -- do not also migrate to Microsoft.Testing.Platform.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <IsPackable>false</IsPackable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "CalculatorTests.cs"
+          content: |
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public class CalculatorTests
+            {
+                [Fact]
+                public void Add_ReturnsSum()
+                {
+                    Assert.Equal(4, 2 + 2);
+                }
+
+                [Fact]
+                public void IsPositive_TrueWhenAboveZero()
+                {
+                    Assert.True(1 > 0);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "Microsoft\\.VisualStudio\\.TestTools\\.UnitTesting"
+      - type: "output_matches"
+        pattern: "\\[TestClass\\]"
+      - type: "output_matches"
+        pattern: "\\[TestMethod\\]"
+      - type: "output_matches"
+        pattern: "Assert\\.AreEqual"
+      - type: "output_matches"
+        pattern: "Assert\\.IsTrue"
+      - type: "output_not_matches"
+        pattern: "PackageReference Include=\"xunit"
+      - type: "output_not_matches"
+        pattern: "using Xunit;"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Removes xunit, xunit.runner.visualstudio package references"
+      - "Adds the MSTest metapackage (Microsoft.NET.Test.Sdk stays for VSTest)"
+      - "Replaces 'using Xunit;' with 'using Microsoft.VisualStudio.TestTools.UnitTesting;'"
+      - "Adds [TestClass] to the test class and converts [Fact] to [TestMethod]"
+      - "Converts Assert.Equal -> Assert.AreEqual and Assert.True -> Assert.IsTrue"
+      - "Does NOT switch the project to Microsoft.Testing.Platform (no MSTest.Sdk default flip)"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 2: Basic xUnit v3 -> MSTest v4 preserving VSTest
+  # ============================================================================
+
+  - name: "Migrate basic xUnit v3 project to MSTest v4 preserving VSTest"
+    prompt: |
+      Convert this test project from xUnit.net v3 to MSTest. Preserve the
+      VSTest runner (do not switch to MTP).
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "Directory.Build.props"
+          content: |
+            <Project>
+              <PropertyGroup>
+                <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+              </PropertyGroup>
+            </Project>
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit.v3" Version="2.0.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+              </ItemGroup>
+            </Project>
+        - path: "OrderTests.cs"
+          content: |
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public class OrderTests
+            {
+                [Fact]
+                public void Total_IsPositive()
+                {
+                    Assert.True(10 > 0);
+                }
+
+                [Theory]
+                [InlineData(1, 2, 3)]
+                [InlineData(0, 0, 0)]
+                public void Sum_ReturnsExpected(int a, int b, int expected)
+                {
+                    Assert.Equal(expected, a + b);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "Microsoft\\.VisualStudio\\.TestTools\\.UnitTesting"
+      - type: "output_matches"
+        pattern: "\\[DataRow\\("
+      - type: "output_not_matches"
+        pattern: "xunit\\.v3"
+      - type: "output_not_matches"
+        pattern: "InlineData"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Removes all xunit.v3.* and xunit.runner.visualstudio packages and adds MSTest"
+      - "Converts [Theory] + [InlineData(...)] to [TestMethod] + [DataRow(...)]"
+      - "Preserves the VSTest runner: keeps Microsoft.NET.Test.Sdk, does not switch to MSTest.Sdk default MTP"
+      - "Does NOT silently change TargetFramework"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 3: Incompatible target framework - stop the migration
+  # ============================================================================
+
+  - name: "Stop when target framework is unsupported by MSTest v4"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest (latest version).
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net7.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "SampleTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+            public class SampleTests
+            {
+                [Fact]
+                public void Always_Passes() => Assert.True(true);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(net7\\.0|net6\\.0|net8\\.0|unsupported|not supported|upgrade.{0,30}target.{0,10}framework|target.{0,10}framework.{0,30}upgrade|MSTest v?3)"
+    rubric:
+      - "Identifies net7.0 as unsupported by MSTest v4 (supported: net8.0, net9.0, net462+, etc.)"
+      - "Stops or pauses for user confirmation -- does NOT silently retarget the TFM"
+      - "Suggests either upgrading the TFM to net8.0/net9.0, or falling back to MSTest v3"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 4: IClassFixture -> [ClassInitialize] / [ClassCleanup]
+  # ============================================================================
+
+  - name: "Convert IClassFixture to ClassInitialize"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "DbFixture.cs"
+          content: |
+            using System;
+            namespace MyApp.Tests;
+            public sealed class DbFixture : IDisposable
+            {
+                public string ConnectionString { get; } = "data source=:memory:";
+                public void Dispose() { }
+            }
+        - path: "OrderTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+
+            public class OrderTests : IClassFixture<DbFixture>
+            {
+                private readonly DbFixture _fixture;
+                public OrderTests(DbFixture fixture) => _fixture = fixture;
+
+                [Fact]
+                public void Fixture_HasConnectionString()
+                {
+                    Assert.NotNull(_fixture.ConnectionString);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "\\[ClassInitialize\\]"
+      - type: "output_matches"
+        pattern: "\\[ClassCleanup\\]"
+      - type: "output_not_matches"
+        pattern: "IClassFixture"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Removes 'IClassFixture<DbFixture>' from the class declaration"
+      - "Adds a static field holding the fixture and a [ClassInitialize] method that constructs it"
+      - "Adds a [ClassCleanup] method that disposes the fixture"
+      - "Tests still reference the fixture instance through the static field"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 5: ICollectionFixture -- high-risk, must NOT silently widen to assembly
+  # ============================================================================
+
+  - name: "Handle ICollectionFixture explicitly (do not silently widen scope)"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Two test classes
+      share a database fixture via xUnit's collection mechanism and must NOT
+      run in parallel against each other.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "DbCollection.cs"
+          content: |
+            using System;
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public sealed class DbFixture : IDisposable
+            {
+                public string Connection { get; } = "memory";
+                public void Dispose() { }
+            }
+
+            [CollectionDefinition("Db", DisableParallelization = true)]
+            public class DbCollection : ICollectionFixture<DbFixture> { }
+        - path: "OrdersTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+
+            [Collection("Db")]
+            public class OrdersTests
+            {
+                private readonly DbFixture _fixture;
+                public OrdersTests(DbFixture fixture) => _fixture = fixture;
+                [Fact]
+                public void Connects() => Assert.NotNull(_fixture.Connection);
+            }
+        - path: "CustomersTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+
+            [Collection("Db")]
+            public class CustomersTests
+            {
+                private readonly DbFixture _fixture;
+                public CustomersTests(DbFixture fixture) => _fixture = fixture;
+                [Fact]
+                public void Connects() => Assert.NotNull(_fixture.Connection);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "\\[DoNotParallelize\\]"
+      - type: "output_matches"
+        pattern: "(scope|sharing|parallelization|preserve|collection)"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Preserves serialization of the two classes by adding [DoNotParallelize] (matches DisableParallelization = true)"
+      - "Preserves the shared fixture by either an [AssemblyInitialize] singleton or a static Lazy<T> helper used from each class's [ClassInitialize]"
+      - "Explicitly explains the scope decision (collection scope -> chosen scope) instead of silently widening"
+      - "Removes [Collection(...)] / [CollectionDefinition(...)] attributes"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 6: ITestOutputHelper -> TestContext
+  # ============================================================================
+
+  - name: "Convert ITestOutputHelper to TestContext"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "LoggingTests.cs"
+          content: |
+            using Xunit;
+            using Xunit.Abstractions;
+
+            namespace MyApp.Tests;
+
+            public class LoggingTests
+            {
+                private readonly ITestOutputHelper _output;
+                public LoggingTests(ITestOutputHelper output) => _output = output;
+
+                [Fact]
+                public void LogsSomething()
+                {
+                    _output.WriteLine("hello from test");
+                    Assert.True(true);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "TestContext"
+      - type: "output_matches"
+        pattern: "WriteLine"
+      - type: "output_not_matches"
+        pattern: "ITestOutputHelper"
+      - type: "output_not_matches"
+        pattern: "Xunit\\.Abstractions"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Removes the ITestOutputHelper constructor parameter and replaces with TestContext (constructor injection or property)"
+      - "Replaces _output.WriteLine(...) with _testContext.WriteLine(...) (or TestContext.WriteLine via the property)"
+      - "Removes 'using Xunit.Abstractions;'"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 7: Exception assertions - semantic trap (Throws vs ThrowsAny)
+  # ============================================================================
+
+  - name: "Map exception assertions correctly (xUnit Throws -> MSTest ThrowsExactly)"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Be careful with
+      exception assertions.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "ExceptionTests.cs"
+          content: |
+            using System;
+            using System.Threading.Tasks;
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public class ExceptionTests
+            {
+                [Fact]
+                public void Throws_ExactType()
+                {
+                    Assert.Throws<InvalidOperationException>(() => throw new InvalidOperationException("x"));
+                }
+
+                [Fact]
+                public void ThrowsAny_AcceptsDerived()
+                {
+                    Assert.ThrowsAny<Exception>(() => throw new InvalidOperationException("x"));
+                }
+
+                [Fact]
+                public async Task ThrowsAsync_ExactType()
+                {
+                    await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => { await Task.Yield(); throw new InvalidOperationException(); });
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "Assert\\.ThrowsExactly<InvalidOperationException>"
+      - type: "output_matches"
+        pattern: "Assert\\.Throws<Exception>"
+      - type: "output_matches"
+        pattern: "Assert\\.ThrowsExactlyAsync<InvalidOperationException>"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Maps xUnit Assert.Throws<T> to MSTest Assert.ThrowsExactly<T> (preserves exact-type semantics)"
+      - "Maps xUnit Assert.ThrowsAny<T> to MSTest Assert.Throws<T> (preserves derived-type semantics)"
+      - "Maps xUnit Assert.ThrowsAsync<T> to MSTest Assert.ThrowsExactlyAsync<T>"
+      - "Does NOT silently flip the semantic by mapping Throws -> Throws"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 8: MemberData and TheoryData -> DynamicData
+  # ============================================================================
+
+  - name: "Convert MemberData and TheoryData to DynamicData"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "DiscountTests.cs"
+          content: |
+            using System.Collections.Generic;
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public class DiscountTests
+            {
+                public static IEnumerable<object[]> Cases =>
+                    new[]
+                    {
+                        new object[] { 100m, 10, 90m },
+                        new object[] { 200m, 25, 150m },
+                    };
+
+                [Theory]
+                [MemberData(nameof(Cases))]
+                public void Apply_ReturnsExpected(decimal price, int percent, decimal expected)
+                {
+                    var actual = price - (price * percent / 100m);
+                    Assert.Equal(expected, actual);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "\\[DynamicData\\("
+      - type: "output_not_matches"
+        pattern: "\\[MemberData\\("
+      - type: "output_not_matches"
+        pattern: "\\[Theory\\]"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Replaces [MemberData(nameof(Cases))] with [DynamicData(nameof(Cases))]"
+      - "Converts [Theory] to [TestMethod] (or keeps [DataTestMethod])"
+      - "Preserves the existing IEnumerable<object[]> data source signature"
+      - "Both data rows still execute -- pass count matches the pre-migration baseline"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 9: Skip, Trait, Timeout -> Ignore, TestCategory, Timeout
+  # ============================================================================
+
+  - name: "Convert Skip, Trait, and Timeout"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "AnnotatedTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+
+            [Trait("Category", "Unit")]
+            public class AnnotatedTests
+            {
+                [Fact(Skip = "broken")]
+                public void Broken() => Assert.True(false);
+
+                [Fact(Timeout = 5000)]
+                [Trait("Owner", "alice")]
+                public void Slow() => Assert.True(true);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "\\[Ignore\\(\"broken\"\\)\\]"
+      - type: "output_matches"
+        pattern: "\\[TestCategory\\(\"Unit\"\\)\\]"
+      - type: "output_matches"
+        pattern: "\\[TestProperty\\(\"Owner\""
+      - type: "output_matches"
+        pattern: "\\[Timeout\\(5000\\)\\]"
+      - type: "output_not_matches"
+        pattern: "Trait\\("
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Converts [Fact(Skip = ...)] to [Ignore(...)]"
+      - "Converts [Trait(\"Category\", X)] to [TestCategory(X)]"
+      - "Converts other [Trait(k, v)] to [TestProperty(k, v)]"
+      - "Converts [Fact(Timeout = N)] to [Timeout(N)]"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 10: Preserve parallelization (xUnit class-parallel default)
+  # ============================================================================
+
+  - name: "Preserve xUnit parallelization default with [assembly: Parallelize]"
+    prompt: |
+      Convert this test project from xUnit.net v2 to MSTest. Preserve the
+      same parallelization behavior the project had under xUnit (which by
+      default parallelizes across test classes).
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+              </ItemGroup>
+            </Project>
+        - path: "AlphaTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+            public class AlphaTests { [Fact] public void T() => Assert.True(true); }
+        - path: "BetaTests.cs"
+          content: |
+            using Xunit;
+            namespace MyApp.Tests;
+            public class BetaTests { [Fact] public void T() => Assert.True(true); }
+    assertions:
+      - type: "output_matches"
+        pattern: "assembly:\\s*Parallelize"
+      - type: "output_matches"
+        pattern: "ExecutionScope\\.ClassLevel"
+      - type: "output_not_matches"
+        pattern: "ExecutionScope\\.MethodLevel"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Adds [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)] to preserve xUnit's class-level parallelization"
+      - "Does NOT pick ExecutionScope.MethodLevel (which is more aggressive than xUnit)"
+      - "Mentions that MSTest's default is serial, so explicit Parallelize is required to match xUnit"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 11: xUnit v3 TestContext.Current.CancellationToken
+  # ============================================================================
+
+  - name: "Convert xUnit v3 TestContext.Current.CancellationToken"
+    prompt: |
+      Convert this test project from xUnit.net v3 to MSTest.
+    setup:
+      files:
+        - path: "global.json"
+          content: |
+            {
+              "test": {
+                "runner": "VSTest"
+              }
+            }
+        - path: "Directory.Build.props"
+          content: |
+            <Project>
+              <PropertyGroup>
+                <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+              </PropertyGroup>
+            </Project>
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+                <PackageReference Include="xunit.v3" Version="2.0.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+              </ItemGroup>
+            </Project>
+        - path: "CancellationTests.cs"
+          content: |
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Xunit;
+
+            namespace MyApp.Tests;
+
+            public class CancellationTests
+            {
+                [Fact]
+                public async Task RespectsCancellation()
+                {
+                    var ct = TestContext.Current.CancellationToken;
+                    await Task.Delay(1, ct);
+                    Assert.False(ct.IsCancellationRequested);
+                }
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "TestContext\\.CancellationToken|_testContext\\.CancellationToken"
+      - type: "output_not_matches"
+        pattern: "TestContext\\.Current\\.CancellationToken"
+      - type: run_command_and_assert
+        command_to_run: "dotnet"
+        command_arguments: "test"
+        expected_exit_code: 0
+        command_timeout: 180
+    rubric:
+      - "Replaces 'TestContext.Current.CancellationToken' with the instance TestContext's CancellationToken"
+      - "Uses MSTest's instance TestContext (constructor injection or property) rather than a static 'Current'"
+      - "Does NOT introduce CancellationTokenSource as a fake replacement"
+    timeout: 720
+
+  # ============================================================================
+  # Goal 12: Already on MSTest - no migration needed
+  # ============================================================================
+
+  - name: "Recognize project already on MSTest"
+    prompt: |
+      Convert this test project from xUnit.net to MSTest.
+    setup:
+      files:
+        - path: "TestProject.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="MSTest" Version="3.8.0" />
+              </ItemGroup>
+            </Project>
+        - path: "ExistingTests.cs"
+          content: |
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            namespace MyApp.Tests;
+
+            [TestClass]
+            public sealed class ExistingTests
+            {
+                [TestMethod]
+                public void Works() => Assert.IsTrue(true);
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(already|no.{0,30}migration|not.{0,20}need|already.{0,20}MSTest)"
+      - type: "output_not_matches"
+        pattern: "PackageReference Include=\"xunit"
+    rubric:
+      - "Recognizes the project already references MSTest packages -- no xUnit present"
+      - "Does NOT make changes (no destructive 'migration' of MSTest tests)"
+      - "Tells the user the migration is not needed (and may optionally suggest migrate-mstest-v3-to-v4 if v4 is desired)"
+    timeout: 720

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/DbFixture.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/DbFixture.cs
@@ -1,0 +1,7 @@
+using System;
+namespace MyApp.Tests;
+public sealed class DbFixture : IDisposable
+{
+    public string ConnectionString { get; } = "data source=:memory:";
+    public void Dispose() { }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/OrderTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/OrderTests.cs
@@ -1,0 +1,14 @@
+using Xunit;
+namespace MyApp.Tests;
+
+public class OrderTests : IClassFixture<DbFixture>
+{
+    private readonly DbFixture _fixture;
+    public OrderTests(DbFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Fixture_HasConnectionString()
+    {
+        Assert.NotNull(_fixture.ConnectionString);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-iclassfixture-to-classinitialize/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/LoggingTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/LoggingTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MyApp.Tests;
+
+public class LoggingTests
+{
+    private readonly ITestOutputHelper _output;
+    public LoggingTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void LogsSomething()
+    {
+        _output.WriteLine("hello from test");
+        Assert.True(true);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-itestoutputhelper-to-testcontext/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/DiscountTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/DiscountTests.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace MyApp.Tests;
+
+public class DiscountTests
+{
+    public static IEnumerable<object[]> Cases =>
+        new[]
+        {
+            new object[] { 100m, 10, 90m },
+            new object[] { 200m, 25, 150m },
+        };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void Apply_ReturnsExpected(decimal price, int percent, decimal expected)
+    {
+        var actual = price - (price * percent / 100m);
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-memberdata-and-theorydata-to-dynamicdata/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/AnnotatedTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/AnnotatedTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+namespace MyApp.Tests;
+
+[Trait("Category", "Unit")]
+public class AnnotatedTests
+{
+    [Fact(Skip = "broken")]
+    public void Broken() => Assert.True(false);
+
+    [Fact(Timeout = 5000)]
+    [Trait("Owner", "alice")]
+    public void Slow() => Assert.True(true);
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-skip-trait-and-timeout/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/CancellationTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/CancellationTests.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MyApp.Tests;
+
+public class CancellationTests
+{
+    [Fact]
+    public async Task RespectsCancellation()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await Task.Delay(1, ct);
+        Assert.False(ct.IsCancellationRequested);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/Directory.Build.props
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/TestProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/CustomersTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/CustomersTests.cs
@@ -1,0 +1,11 @@
+using Xunit;
+namespace MyApp.Tests;
+
+[Collection("Db")]
+public class CustomersTests
+{
+    private readonly DbFixture _fixture;
+    public CustomersTests(DbFixture fixture) => _fixture = fixture;
+    [Fact]
+    public void Connects() => Assert.NotNull(_fixture.Connection);
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/DbCollection.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/DbCollection.cs
@@ -1,0 +1,13 @@
+using System;
+using Xunit;
+
+namespace MyApp.Tests;
+
+public sealed class DbFixture : IDisposable
+{
+    public string Connection { get; } = "memory";
+    public void Dispose() { }
+}
+
+[CollectionDefinition("Db", DisableParallelization = true)]
+public class DbCollection : ICollectionFixture<DbFixture> { }

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/OrdersTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/OrdersTests.cs
@@ -1,0 +1,11 @@
+using Xunit;
+namespace MyApp.Tests;
+
+[Collection("Db")]
+public class OrdersTests
+{
+    private readonly DbFixture _fixture;
+    public OrdersTests(DbFixture fixture) => _fixture = fixture;
+    [Fact]
+    public void Connects() => Assert.NotNull(_fixture.Connection);
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/ExceptionTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/ExceptionTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MyApp.Tests;
+
+public class ExceptionTests
+{
+    [Fact]
+    public void Throws_ExactType()
+    {
+        Assert.Throws<InvalidOperationException>(() => throw new InvalidOperationException("x"));
+    }
+
+    [Fact]
+    public void ThrowsAny_AcceptsDerived()
+    {
+        Assert.ThrowsAny<Exception>(() => throw new InvalidOperationException("x"));
+    }
+
+    [Fact]
+    public async Task ThrowsAsync_ExactType()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => { await Task.Yield(); throw new InvalidOperationException(); });
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/CalculatorTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/CalculatorTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace MyApp.Tests;
+
+public class CalculatorTests
+{
+    [Fact]
+    public void Add_ReturnsSum()
+    {
+        Assert.Equal(4, 2 + 2);
+    }
+
+    [Fact]
+    public void IsPositive_TrueWhenAboveZero()
+    {
+        Assert.True(1 > 0);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/TestProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/Directory.Build.props
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/OrderTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/OrderTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace MyApp.Tests;
+
+public class OrderTests
+{
+    [Fact]
+    public void Total_IsPositive()
+    {
+        Assert.True(10 > 0);
+    }
+
+    [Theory]
+    [InlineData(1, 2, 3)]
+    [InlineData(0, 0, 0)]
+    public void Sum_ReturnsExpected(int a, int b, int expected)
+    {
+        Assert.Equal(expected, a + b);
+    }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/TestProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/AlphaTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/AlphaTests.cs
@@ -1,0 +1,3 @@
+using Xunit;
+namespace MyApp.Tests;
+public class AlphaTests { [Fact] public void T() => Assert.True(true); }

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/BetaTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/BetaTests.cs
@@ -1,0 +1,3 @@
+using Xunit;
+namespace MyApp.Tests;
+public class BetaTests { [Fact] public void T() => Assert.True(true); }

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/global.json
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/recognize-project-already-on-mstest/ExistingTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/recognize-project-already-on-mstest/ExistingTests.cs
@@ -1,0 +1,9 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace MyApp.Tests;
+
+[TestClass]
+public sealed class ExistingTests
+{
+    [TestMethod]
+    public void Works() => Assert.IsTrue(true);
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/recognize-project-already-on-mstest/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/recognize-project-already-on-mstest/TestProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.0" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/SampleTests.cs
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/SampleTests.cs
@@ -1,0 +1,7 @@
+using Xunit;
+namespace MyApp.Tests;
+public class SampleTests
+{
+    [Fact]
+    public void Always_Passes() => Assert.True(true);
+}

--- a/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/TestProject.csproj
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/fixtures/stop-when-target-framework-is-unsupported-by-mstest-v4/TestProject.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds the **`migrate-xunit-to-mstest`** skill, which migrates .NET test projects from xUnit.net (v2 or v3) to MSTest v4 — attributes, assertions, fixtures, lifecycle, output, cancellation, parallelization, and companion packages.

Single skill (not two) for both v2 and v3 sources: ~90% of the conversion logic is shared, and v2-vs-v3 deltas are small and well-scoped — handled as conditional steps. Matches the precedent of `migrate-mstest-v1v2-to-v3`.

## Why parallelization gets front-loaded

xUnit parallelizes test classes by default; MSTest serializes by default. This is the single largest source of post-migration regressions: tests that depend on isolation by parallel scheduling, on the lack of it, or on shared static state can pass differently after the switch.

Step 1 inventories shared state and flaky tests. Step 11 enumerates three explicit choices and provides a translation table for `CollectionBehavior(DisableTestParallelization)`, `MaxParallelThreads`, `[Collection]`, and `[CollectionDefinition]`. The validation checklist treats unspecified parallelization as an error.

## Design constraints (validated with rubber-duck review)

- **Preserves the current test platform** (VSTest stays on VSTest; MTP stays on MTP). Bundling a platform migration would violate the test-migration agent's "never mix migration steps" rule.
- **`IClassFixture<T>` -> mechanical** map to `[ClassInitialize]` / `[ClassCleanup]`.
- **`ICollectionFixture<T>` requires judgement** — it conflates "shared instance across classes" with "serial execution". MSTest decouples them; do not silently widen scope to assembly-level.
- **Exception assertion semantic trap** — xUnit `Assert.Throws<T>` is exact-type and maps to **`Assert.ThrowsExactly<T>`**; xUnit `Assert.ThrowsAny<T>` maps to **`Assert.Throws<T>`**. The names invert.
- **MSTest v4 TFM gating** — supported: `net8.0`, `net9.0`, `net462`+, `netstandard2.0` (test library only), UAP/WinUI. **Stop** for `net5.0`-`net7.0`.

## Files

- `plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md` — 13-step workflow
- `plugins/dotnet-test/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md` — full attribute/assertion/fixture/lifecycle tables (progressive disclosure)
- `tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml` — 12 scenarios (skill-validator format, inline `setup.files`)
- `tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml` + `fixtures/` — Vally-format mirror of the same scenarios (40 fixture files), matching the convention of every sibling migration skill
- `plugins/dotnet-test/README.md` — migration table row + intro bullet
- `plugins/dotnet-test/agents/test-migration.agent.md` — triage row + two multi-step rules (xUnit→MSTest, xUnit→MSTest+MTP)

## Evaluation scenarios (12)

1. xUnit v2 -> MSTest preserving VSTest
2. xUnit v3 -> MSTest preserving VSTest
3. Stop when TFM unsupported by MSTest v4 (`net7.0`)
4. `IClassFixture<T>` -> `[ClassInitialize]` / `[ClassCleanup]`
5. `ICollectionFixture<T>` -> explicit scope decision (`[DoNotParallelize]`)
6. `ITestOutputHelper` -> `TestContext`
7. Exception assertions — `Throws` vs `ThrowsAny` semantic trap
8. `MemberData` / `TheoryData` -> `DynamicData`
9. `[Fact(Skip)]` / `[Trait]` / `Timeout` -> `[Ignore]` / `[TestCategory]` / `[TestProperty]` / `Timeout`
10. **Parallelization preservation** -> `[assembly: Parallelize(ClassLevel)]`
11. xUnit v3 `TestContext.Current.CancellationToken` -> MSTest `TestContext.CancellationToken`
12. Project already on MSTest — no-op

## Static checks

`dotnet run --project eng/skill-validator/src -- check --plugin ./plugins/dotnet-test`

✅ All checks passed (24 skill(s), 11 agent(s), 1 plugin(s))

One soft warning: SKILL.md is 8.1k BPE tokens (above the "approaching comprehensive" threshold). Splitting was considered and rejected — the workflow is sequential and benefits from being one document; non-essential content already lives in `references/mapping-cheatsheet.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
