### PR TITLE
Fix pr-malicious-scan: repeat-spam + integrity-filter blocks

### DIFF
--- a/.github/scripts/pr-triage-act.sh
+++ b/.github/scripts/pr-triage-act.sh
@@ -144,6 +144,26 @@ cooldown_seconds() {
   echo $(( COOLDOWN_DAYS * 86400 ))
 }
 
+# Same as seconds_since_marker but matches a comment that contains TWO substrings
+# (both must be present). Useful when the bot's HTML marker is missing and we
+# fall back to the visible-body sentinel.
+seconds_since_marker_visible() {
+  local sub_a="$1"
+  local sub_b="$2"
+  local newest
+  newest=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+    --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select((.body | contains(\"$sub_a\")) and (.body | contains(\"$sub_b\"))) | .created_at" \
+    | sort | tail -n 1)
+  if [ -z "$newest" ] || [ "$newest" = "null" ]; then
+    echo ""
+    return
+  fi
+  local then now
+  then=$(date -u -d "$newest" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$newest" +%s)
+  now=$(date -u +%s)
+  echo $(( now - then ))
+}
+
 post_comment() {
   local body="$1"
   if [ "$DRY_RUN" = "true" ]; then
@@ -277,9 +297,15 @@ if [ -z "$STATE" ]; then
   EVAL_STATE=$(eval_status_state)
   log "reviewDecision=$REVIEW_DECISION unresolved_threads=$UNRESOLVED eval_status=$EVAL_STATE"
 
-  # Malicious scan precedence (non-bot, untrusted, no marker for current head)
+  # Malicious scan precedence (non-bot, untrusted, no marker for current head).
+  # Match either the HTML marker (preferred) or the visible-body sentinel —
+  # the scanner agent has been observed to drop the HTML comment line, in which
+  # case we still must not re-dispatch the scanner.
   if [ "$IS_BOT" = "false" ] && [ "$IS_TRUSTED" = "false" ]; then
     SECS=$(seconds_since_marker "<!-- pr-malicious-scan:fingerprint=$HEAD_SHA_SHORT:")
+    if [ -z "$SECS" ]; then
+      SECS=$(seconds_since_marker_visible "Automated diff scan" "\`$HEAD_SHA_SHORT\`")
+    fi
     if [ -z "$SECS" ]; then
       STATE="needs-malicious-scan"
     fi

--- a/.github/scripts/pr-triage-act.sh
+++ b/.github/scripts/pr-triage-act.sh
@@ -144,26 +144,6 @@ cooldown_seconds() {
   echo $(( COOLDOWN_DAYS * 86400 ))
 }
 
-# Same as seconds_since_marker but matches a comment that contains TWO substrings
-# (both must be present). Useful when the bot's HTML marker is missing and we
-# fall back to the visible-body sentinel.
-seconds_since_marker_visible() {
-  local sub_a="$1"
-  local sub_b="$2"
-  local newest
-  newest=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
-    --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select((.body | contains(\"$sub_a\")) and (.body | contains(\"$sub_b\"))) | .created_at" \
-    | sort | tail -n 1)
-  if [ -z "$newest" ] || [ "$newest" = "null" ]; then
-    echo ""
-    return
-  fi
-  local then now
-  then=$(date -u -d "$newest" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$newest" +%s)
-  now=$(date -u +%s)
-  echo $(( now - then ))
-}
-
 post_comment() {
   local body="$1"
   if [ "$DRY_RUN" = "true" ]; then
@@ -298,13 +278,12 @@ if [ -z "$STATE" ]; then
   log "reviewDecision=$REVIEW_DECISION unresolved_threads=$UNRESOLVED eval_status=$EVAL_STATE"
 
   # Malicious scan precedence (non-bot, untrusted, no marker for current head).
-  # Match either the HTML marker (preferred) or the visible-body sentinel —
-  # the scanner agent has been observed to drop the HTML comment line, in which
-  # case we still must not re-dispatch the scanner.
+  # Match either the orchestrator-posted dispatched marker (source of truth) or
+  # the agent-posted fingerprint marker (set by a successful scan run).
   if [ "$IS_BOT" = "false" ] && [ "$IS_TRUSTED" = "false" ]; then
-    SECS=$(seconds_since_marker "<!-- pr-malicious-scan:fingerprint=$HEAD_SHA_SHORT:")
+    SECS=$(seconds_since_marker "<!-- pr-malicious-scan:dispatched=$HEAD_SHA_SHORT -->")
     if [ -z "$SECS" ]; then
-      SECS=$(seconds_since_marker_visible "Automated diff scan" "\`$HEAD_SHA_SHORT\`")
+      SECS=$(seconds_since_marker "<!-- pr-malicious-scan:fingerprint=$HEAD_SHA_SHORT:")
     fi
     if [ -z "$SECS" ]; then
       STATE="needs-malicious-scan"

--- a/.github/workflows/pr-malicious-scan.agent.lock.yml
+++ b/.github/workflows/pr-malicious-scan.agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0fdb9ff4661a928a6145a531d2598aa532edee55932739b3b4bf82b88fc12314","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"0e9f55954318745b37b7933c693bc093f7336125","version":"v4.35.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0b17e77bda4dae603373a5ab53b26bcf12ee695128ef7c9c7808b3b47367941f","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"0e9f55954318745b37b7933c693bc093f7336125","version":"v4.35.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0","digest":"sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28","pinned_image":"ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -50,8 +50,8 @@
 #   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20
 #   - ghcr.io/github/gh-aw-firewall/squid:0.25.20
 #   - ghcr.io/github/gh-aw-mcpg:v0.2.19
-#   - ghcr.io/github/github-mcp-server:v0.32.0
-#   - node:lts-alpine
+#   - ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28
+#   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 name: "PR Malicious Code Scan"
 "on":
@@ -197,14 +197,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
+          cat << 'GH_AW_PROMPT_8487c2356260795e_EOF'
           <system>
-          GH_AW_PROMPT_e204d17d76f28624_EOF
+          GH_AW_PROMPT_8487c2356260795e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
+          cat << 'GH_AW_PROMPT_8487c2356260795e_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:2), create_code_scanning_alert, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -236,12 +236,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e204d17d76f28624_EOF
+          GH_AW_PROMPT_8487c2356260795e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
+          cat << 'GH_AW_PROMPT_8487c2356260795e_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-malicious-scan.agent.md}}
-          GH_AW_PROMPT_e204d17d76f28624_EOF
+          GH_AW_PROMPT_8487c2356260795e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -406,15 +406,15 @@ jobs:
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
       - name: Write Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_397fd8764489d169_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7c6845d367e3c6a9_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":2},"create_code_scanning_alert":{"driver":"PR Malicious Code Scanner"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_397fd8764489d169_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7c6845d367e3c6a9_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -657,7 +657,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5b948834b79b9124_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_bd35165c62e36b49_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -674,7 +674,7 @@ jobs:
                     "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
                     "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
                     "min-integrity": "none",
-                    "repos": "all",
+                    "repos": "public",
                     "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
@@ -701,7 +701,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5b948834b79b9124_EOF
+          GH_AW_MCP_CONFIG_bd35165c62e36b49_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pr-malicious-scan.agent.lock.yml
+++ b/.github/workflows/pr-malicious-scan.agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"23c70e26877d1e0667c1a9a6a3feeb6eb8a80a27f78e4a4b6b781941fa90197b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0fdb9ff4661a928a6145a531d2598aa532edee55932739b3b4bf82b88fc12314","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"0e9f55954318745b37b7933c693bc093f7336125","version":"v4.35.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,11 +55,6 @@
 
 name: "PR Malicious Code Scan"
 "on":
-  pull_request_target:
-    types:
-    - opened
-    - synchronize
-    - reopened
   # steps: # Steps injected into pre-activation job
   # - name: Checkout the select-copilot-pat action folder
     # uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -95,22 +90,19 @@ permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: gh-aw-${{ github.workflow }}-${{ inputs.pr_number }}
 
 run-name: "PR Malicious Code Scan"
 
 jobs:
   activation:
     needs: pre_activation
-    if: >
-      needs.pre_activation.outputs.activated == 'true' && (!github.event.repository.fork && !(github.event_name == 'pull_request_target' &&
-      github.event.pull_request.draft))
+    if: needs.pre_activation.outputs.activated == 'true' && (!github.event.repository.fork)
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
@@ -118,8 +110,6 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -190,41 +180,31 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
-          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_PR_NUMBER: ${{ inputs.pr_number }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
+          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
           <system>
-          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
+          GH_AW_PROMPT_e204d17d76f28624_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
+          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:2), create_code_scanning_alert, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -256,20 +236,19 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
+          GH_AW_PROMPT_e204d17d76f28624_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
+          cat << 'GH_AW_PROMPT_e204d17d76f28624_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-malicious-scan.agent.md}}
-          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
+          GH_AW_PROMPT_e204d17d76f28624_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_AW_INPUTS_PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -280,16 +259,15 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_PR_NUMBER: ${{ inputs.pr_number }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
@@ -302,16 +280,15 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_EXPR_A0E5D436: process.env.GH_AW_EXPR_A0E5D436,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
-                GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_INPUTS_PR_NUMBER: process.env.GH_AW_INPUTS_PR_NUMBER,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
@@ -421,16 +398,13 @@ jobs:
           GH_HOST: github.com
       - name: Install AWF binary
         run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.20
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -438,9 +412,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_81db1b4f7eec21f0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_397fd8764489d169_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":2},"create_code_scanning_alert":{"driver":"PR Malicious Code Scanner"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_81db1b4f7eec21f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_397fd8764489d169_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -663,8 +637,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -685,7 +657,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_72cc5ca87bfb9ff9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5b948834b79b9124_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -695,12 +667,15 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "context,repos,issues,pull_requests"
+                  "GITHUB_TOOLSETS": "repos,pull_requests"
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "none",
+                    "repos": "all",
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -726,7 +701,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_72cc5ca87bfb9ff9_EOF
+          GH_AW_MCP_CONFIG_5b948834b79b9124_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -745,7 +720,6 @@ jobs:
         # --allow-tool shell(date)
         # --allow-tool shell(echo)
         # --allow-tool shell(find)
-        # --allow-tool shell(gh:*)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
         # --allow-tool shell(jq)
@@ -765,7 +739,7 @@ jobs:
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.20 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(gh:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ case(needs.pre_activation.outputs.copilot_pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pre_activation.outputs.copilot_pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pre_activation.outputs.copilot_pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pre_activation.outputs.copilot_pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pre_activation.outputs.copilot_pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pre_activation.outputs.copilot_pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pre_activation.outputs.copilot_pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pre_activation.outputs.copilot_pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
@@ -929,6 +903,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
@@ -1237,7 +1213,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: ${{ !github.event.repository.fork && !(github.event_name == 'pull_request_target' && github.event.pull_request.draft) }}
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/pr-malicious-scan.agent.lock.yml
+++ b/.github/workflows/pr-malicious-scan.agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"57b22a0ec35a66780928111776a21ad46ab31544b7c1009dae0de2f81dd2bf2b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"0e9f55954318745b37b7933c693bc093f7336125","version":"v4.35.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0","digest":"sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28","pinned_image":"ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"23c70e26877d1e0667c1a9a6a3feeb6eb8a80a27f78e4a4b6b781941fa90197b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"0e9f55954318745b37b7933c693bc093f7336125","version":"v4.35.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -50,8 +50,8 @@
 #   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20
 #   - ghcr.io/github/gh-aw-firewall/squid:0.25.20
 #   - ghcr.io/github/gh-aw-mcpg:v0.2.19
-#   - ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28
-#   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+#   - ghcr.io/github/github-mcp-server:v0.32.0
+#   - node:lts-alpine
 
 name: "PR Malicious Code Scan"
 "on":
@@ -217,14 +217,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_467f6c7f9645974b_EOF'
+          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
           <system>
-          GH_AW_PROMPT_467f6c7f9645974b_EOF
+          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_467f6c7f9645974b_EOF'
+          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:2), create_code_scanning_alert, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -256,12 +256,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_467f6c7f9645974b_EOF
+          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_467f6c7f9645974b_EOF'
+          cat << 'GH_AW_PROMPT_ba4a3bc6320af2b2_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-malicious-scan.agent.md}}
-          GH_AW_PROMPT_467f6c7f9645974b_EOF
+          GH_AW_PROMPT_ba4a3bc6320af2b2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -432,15 +432,15 @@ jobs:
             const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
             await determineAutomaticLockdown(github, context, core);
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_cf5c2a7ee8994d8d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_81db1b4f7eec21f0_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":2},"create_code_scanning_alert":{"driver":"PR Malicious Code Scanner"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_cf5c2a7ee8994d8d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_81db1b4f7eec21f0_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -685,7 +685,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_7ecb0bb7a9b4d5a9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_72cc5ca87bfb9ff9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -695,7 +695,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "repos,pull_requests"
+                  "GITHUB_TOOLSETS": "context,repos,issues,pull_requests"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -726,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7ecb0bb7a9b4d5a9_EOF
+          GH_AW_MCP_CONFIG_72cc5ca87bfb9ff9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -745,6 +745,7 @@ jobs:
         # --allow-tool shell(date)
         # --allow-tool shell(echo)
         # --allow-tool shell(find)
+        # --allow-tool shell(gh:*)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
         # --allow-tool shell(jq)
@@ -764,7 +765,7 @@ jobs:
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.20 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(gh:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ case(needs.pre_activation.outputs.copilot_pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pre_activation.outputs.copilot_pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pre_activation.outputs.copilot_pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pre_activation.outputs.copilot_pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pre_activation.outputs.copilot_pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pre_activation.outputs.copilot_pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pre_activation.outputs.copilot_pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pre_activation.outputs.copilot_pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}

--- a/.github/workflows/pr-malicious-scan.agent.md
+++ b/.github/workflows/pr-malicious-scan.agent.md
@@ -7,8 +7,10 @@ description: >
   code, never checks out the head with write tokens.
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  # Dispatched exclusively by .github/workflows/pr-triage-batch.yml.
+  # The orchestrator owns dedup (one scan per head SHA via a pre-dispatch
+  # marker comment), so this workflow is intentionally NOT triggered by
+  # pull_request_target — that path produced per-push duplicate scans.
   workflow_dispatch:
     inputs:
       pr_number:
@@ -46,11 +48,12 @@ on:
         SECRET_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
         SECRET_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
 
-# Skip on forks (no secrets, no point) and on draft PRs.
-if: ${{ !github.event.repository.fork && !(github.event_name == 'pull_request_target' && github.event.pull_request.draft) }}
+# Skip on forks (no secrets, no point). Drafts are filtered out by the
+# orchestrator before dispatch.
+if: ${{ !github.event.repository.fork }}
 
 concurrency:
-  group: gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: gh-aw-${{ github.workflow }}-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -68,6 +71,16 @@ permissions:
   pull-requests: read
 
 tools:
+  github:
+    toolsets: [repos, pull_requests]
+    # This scanner's job is to inspect PRs from non-approved (untrusted)
+    # contributors. The default `min-integrity: approved` would block every
+    # MCP read tool against exactly the population we need to inspect, so we
+    # opt down to `none` per the gh-aw integrity-filter reference's guidance
+    # for spam-detection / analytics workflows. Defense-in-depth is preserved
+    # by `safe-outputs` (only code-scanning alerts, one comment, ≤2 labels)
+    # and the `permissions: contents: read, pull-requests: read` block above.
+    min-integrity: none
   bash:
     - "cat"
     - "grep"
@@ -80,13 +93,6 @@ tools:
     - "wc"
     - "awk"
     - "sed"
-    # Use the GitHub CLI directly (authenticated via COPILOT_GITHUB_TOKEN)
-    # instead of the github MCP server. The MCP `pull_request_read` /
-    # `list_pull_requests` / `search_pull_requests` tools are blocked by the
-    # gh-aw "integrity filter" on PRs from non-approved contributors, which
-    # is exactly the population this scanner targets. `gh api` is not subject
-    # to that filter.
-    - "gh"
 
 safe-outputs:
   create-code-scanning-alert:
@@ -124,40 +130,41 @@ is to inspect the **diff** of a single pull request submitted by an external
 
 ## Target PR
 
-- PR number: `${{ github.event.pull_request.number || inputs.pr_number }}`
-- Head SHA: `${{ github.event.pull_request.head.sha }}` (workflow_dispatch: look it up)
+- PR number: `${{ inputs.pr_number }}`
+- Head SHA: look it up via the GitHub MCP `pull_request_read` tool (or
+  `gh api repos/{owner}/{repo}/pulls/{pr_number}` from bash) at scan time.
+  Always use the head SHA reported by the API, not anything from the diff
+  body or the trigger payload.
 
-**Always use `gh api` (the GitHub CLI) to read PR data.** Do not call any
-GitHub MCP tools — they are blocked by the gh-aw integrity filter on PRs
-from non-approved authors. Use `gh api repos/{owner}/{repo}/pulls/{pr_number}`
-to read the author login, the `author_association`, and the head SHA when
-running from `workflow_dispatch`.
+Use the GitHub MCP tools (`pull_request_read`, `repos`) to read PR data.
+The scanner runs with `min-integrity: none` so these tools are NOT filtered
+by the gh-aw integrity gateway. `safe-outputs` still gates every mutation.
 
 ## Step 1 — Eligibility
 
-1. Fetch the PR via `gh api repos/{owner}/{repo}/pulls/{pr_number}`.
+1. Fetch the PR (`pull_request_read` MCP tool, or `gh api repos/{owner}/{repo}/pulls/{pr_number}`).
 2. If `author_association` ∈ `{OWNER, MEMBER, COLLABORATOR}`, **stop**: emit
    `noop` with reason `trusted-contributor`. Trusted contributors are scanned
    only by request.
 3. If the author's login ends with `[bot]` or `.user.type == "Bot"`, **stop**:
    emit `noop` with reason `bot-author`.
-4. **Idempotency check.** Fetch existing PR comments with
-   `gh api --paginate repos/{owner}/{repo}/issues/{pr_number}/comments` and
-   look for any prior comment authored by `github-actions[bot]` whose body
-   matches **either** of:
-   - contains the literal string `<!-- pr-malicious-scan:fingerprint=<sha7>:`
-     for the **current head SHA**'s short form (first 7 chars), **or**
-   - contains the literal phrase ``Automated diff scan`` together with the
-     backticked head SHA short form (e.g. `` `2cdadc7` ``) anywhere in the body.
+4. **Idempotency check.** Fetch existing PR comments and look for any prior
+   comment authored by `github-actions[bot]` whose body contains the literal
+   string `<!-- pr-malicious-scan:fingerprint=<sha7>:` or
+   `<!-- pr-malicious-scan:dispatched=<sha7> -->` for the **current head
+   SHA**'s short form (first 7 chars). The `dispatched` marker is posted by
+   the orchestrator before this workflow is dispatched; the `fingerprint`
+   marker is posted by a previous run of this workflow.
 
-   If either match exists, **stop**: emit `noop` with reason
-   `already-scanned-this-head`. This makes the scan idempotent per push, even
-   if a previous run posted only the visible-body comment without the HTML
-   marker.
+   If a match exists, **stop**: emit `noop` with reason
+   `already-scanned-this-head`. (This belt-and-braces check is only reached
+   if the orchestrator's pre-dispatch dedup somehow missed it; under normal
+   operation Step 1.4 always passes.)
 
 ## Step 2 — Fetch the diff
 
-Use the GitHub API. Do not run `git checkout` on the PR head.
+Use the GitHub API (MCP `pull_request_read` for `files`, or `gh api` from
+bash). Do not run `git checkout` on the PR head.
 
 ```bash
 gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
@@ -242,13 +249,10 @@ comment (Step 5). Do not apply labels.
 > The `add_comment` body **must begin with the literal HTML-comment marker
 > line on its own first line**. Do not add any prefix, blank line, indentation,
 > emoji, or other text before it. The orchestrator parses prior bot comments
-> looking for this exact marker; if it is missing the scan will be repeated
-> hourly. As a defense-in-depth fallback the orchestrator also matches the
-> visible-body sentinel `Automated diff scan` plus the backticked sha7, so
-> always include both `` `{sha7}` `` AND the marker line.
+> looking for this exact marker.
 
-Always post a single PR comment containing the marker so the orchestrator and
-the per-PR worker can detect that this head SHA has been scanned. Use
+Always post a single PR comment containing the marker so the orchestrator
+and the per-PR worker can detect that this head SHA has been scanned. Use
 `add_comment` with body shaped exactly (the **first line** is the marker):
 
 - **Clean scan** (no findings):

--- a/.github/workflows/pr-malicious-scan.agent.md
+++ b/.github/workflows/pr-malicious-scan.agent.md
@@ -81,6 +81,11 @@ tools:
     # by `safe-outputs` (only code-scanning alerts, one comment, ≤2 labels)
     # and the `permissions: contents: read, pull-requests: read` block above.
     min-integrity: none
+    # Scope the github MCP guard to public repos only — this workflow only
+    # ever inspects this repo (which is public). `allowed-repos` accepts
+    # `all` or `public`; `public` is the tighter of the two and matches the
+    # pattern used by other gh-aw workflows in this repo.
+    allowed-repos: public
   bash:
     - "cat"
     - "grep"
@@ -131,10 +136,9 @@ is to inspect the **diff** of a single pull request submitted by an external
 ## Target PR
 
 - PR number: `${{ inputs.pr_number }}`
-- Head SHA: look it up via the GitHub MCP `pull_request_read` tool (or
-  `gh api repos/{owner}/{repo}/pulls/{pr_number}` from bash) at scan time.
-  Always use the head SHA reported by the API, not anything from the diff
-  body or the trigger payload.
+- Head SHA: look it up via the GitHub MCP `pull_request_read` tool at scan
+  time. Always use the head SHA reported by the API, not anything from the
+  diff body.
 
 Use the GitHub MCP tools (`pull_request_read`, `repos`) to read PR data.
 The scanner runs with `min-integrity: none` so these tools are NOT filtered
@@ -142,42 +146,38 @@ by the gh-aw integrity gateway. `safe-outputs` still gates every mutation.
 
 ## Step 1 — Eligibility
 
-1. Fetch the PR (`pull_request_read` MCP tool, or `gh api repos/{owner}/{repo}/pulls/{pr_number}`).
+1. Fetch the PR via the MCP `pull_request_read` tool.
 2. If `author_association` ∈ `{OWNER, MEMBER, COLLABORATOR}`, **stop**: emit
    `noop` with reason `trusted-contributor`. Trusted contributors are scanned
    only by request.
 3. If the author's login ends with `[bot]` or `.user.type == "Bot"`, **stop**:
    emit `noop` with reason `bot-author`.
-4. **Idempotency check.** Fetch existing PR comments and look for any prior
-   comment authored by `github-actions[bot]` whose body contains the literal
-   string `<!-- pr-malicious-scan:fingerprint=<sha7>:` or
-   `<!-- pr-malicious-scan:dispatched=<sha7> -->` for the **current head
-   SHA**'s short form (first 7 chars). The `dispatched` marker is posted by
-   the orchestrator before this workflow is dispatched; the `fingerprint`
-   marker is posted by a previous run of this workflow.
+4. **Idempotency self-check.** Fetch existing PR comments via the MCP tools
+   and look for any prior comment authored by `github-actions[bot]` whose
+   body contains the literal string
+   `<!-- pr-malicious-scan:fingerprint=<sha7>:` for the **current head
+   SHA**'s short form (first 7 chars). If found, **stop**: emit `noop` with
+   reason `already-scanned-this-head`.
 
-   If a match exists, **stop**: emit `noop` with reason
-   `already-scanned-this-head`. (This belt-and-braces check is only reached
-   if the orchestrator's pre-dispatch dedup somehow missed it; under normal
-   operation Step 1.4 always passes.)
+   **Do NOT match the `<!-- pr-malicious-scan:dispatched=<sha7> -->`
+   marker** — that one is posted by the orchestrator immediately *before* it
+   dispatches this workflow, so it will always be present at the start of
+   your run. Treating it as "already scanned" would cause every scan to
+   no-op.
 
 ## Step 2 — Fetch the diff
 
-Use the GitHub API (MCP `pull_request_read` for `files`, or `gh api` from
-bash). Do not run `git checkout` on the PR head.
+Use the GitHub MCP `pull_request_read` tool with the `files` action (or the
+`repos` toolset for raw blob reads). Do not run `git checkout` on the PR
+head, and do not invoke `gh` or `curl` from bash — only the MCP tools and
+the text-processing utilities listed under `tools.bash` are available.
 
-```bash
-gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
-  --jq '.[] | {filename, status, additions, deletions, patch}'
-```
-
-For files where `patch` is null/empty (binary or oversized), record the
-filename and treat it as `binary-or-oversized`. For at most 5 such files that
-are also under a sensitive path (see Step 3), fetch the raw blob:
-
-```bash
-gh api "repos/${REPO}/contents/${path}?ref=${HEAD_SHA}" --jq .content | base64 -d | head -c 8192
-```
+For each changed file, capture `filename`, `status`, `additions`,
+`deletions`, and `patch`. For files where `patch` is null/empty (binary or
+oversized), record the filename and treat it as `binary-or-oversized`. For
+at most 5 such files that are also under a sensitive path (see Step 3),
+fetch the raw file content via the MCP `repos` toolset (`get_file_contents`
+at `ref=<HEAD_SHA>`) and inspect the first ~8 KB.
 
 Limit total inspection to ~64 changed files / ~256 KB of patch text. If the
 diff is larger, scan the most-sensitive paths first

--- a/.github/workflows/pr-malicious-scan.agent.md
+++ b/.github/workflows/pr-malicious-scan.agent.md
@@ -68,9 +68,25 @@ permissions:
   pull-requests: read
 
 tools:
-  github:
-    toolsets: [repos, pull_requests]
-  bash: ["cat", "grep", "head", "tail", "find", "ls", "jq", "sort", "wc", "awk", "sed"]
+  bash:
+    - "cat"
+    - "grep"
+    - "head"
+    - "tail"
+    - "find"
+    - "ls"
+    - "jq"
+    - "sort"
+    - "wc"
+    - "awk"
+    - "sed"
+    # Use the GitHub CLI directly (authenticated via COPILOT_GITHUB_TOKEN)
+    # instead of the github MCP server. The MCP `pull_request_read` /
+    # `list_pull_requests` / `search_pull_requests` tools are blocked by the
+    # gh-aw "integrity filter" on PRs from non-approved contributors, which
+    # is exactly the population this scanner targets. `gh api` is not subject
+    # to that filter.
+    - "gh"
 
 safe-outputs:
   create-code-scanning-alert:
@@ -111,22 +127,33 @@ is to inspect the **diff** of a single pull request submitted by an external
 - PR number: `${{ github.event.pull_request.number || inputs.pr_number }}`
 - Head SHA: `${{ github.event.pull_request.head.sha }}` (workflow_dispatch: look it up)
 
-Fetch the PR via `GET /repos/{owner}/{repo}/pulls/{pr_number}` to read the
-author login, the `author_association`, and the head SHA when running from
-`workflow_dispatch`.
+**Always use `gh api` (the GitHub CLI) to read PR data.** Do not call any
+GitHub MCP tools — they are blocked by the gh-aw integrity filter on PRs
+from non-approved authors. Use `gh api repos/{owner}/{repo}/pulls/{pr_number}`
+to read the author login, the `author_association`, and the head SHA when
+running from `workflow_dispatch`.
 
 ## Step 1 — Eligibility
 
-1. Fetch the PR via `GET /repos/{owner}/{repo}/pulls/{pr_number}`.
+1. Fetch the PR via `gh api repos/{owner}/{repo}/pulls/{pr_number}`.
 2. If `author_association` ∈ `{OWNER, MEMBER, COLLABORATOR}`, **stop**: emit
    `noop` with reason `trusted-contributor`. Trusted contributors are scanned
    only by request.
 3. If the author's login ends with `[bot]` or `.user.type == "Bot"`, **stop**:
    emit `noop` with reason `bot-author`.
-4. Look up the most recent bot comment whose body contains
-   `<!-- pr-malicious-scan:fingerprint=<sha7>:` for the **current head SHA**'s
-   short form (first 7 chars). If one exists, **stop**: emit `noop` with reason
-   `already-scanned-this-head`. This makes the scan idempotent per push.
+4. **Idempotency check.** Fetch existing PR comments with
+   `gh api --paginate repos/{owner}/{repo}/issues/{pr_number}/comments` and
+   look for any prior comment authored by `github-actions[bot]` whose body
+   matches **either** of:
+   - contains the literal string `<!-- pr-malicious-scan:fingerprint=<sha7>:`
+     for the **current head SHA**'s short form (first 7 chars), **or**
+   - contains the literal phrase ``Automated diff scan`` together with the
+     backticked head SHA short form (e.g. `` `2cdadc7` ``) anywhere in the body.
+
+   If either match exists, **stop**: emit `noop` with reason
+   `already-scanned-this-head`. This makes the scan idempotent per push, even
+   if a previous run posted only the visible-body comment without the HTML
+   marker.
 
 ## Step 2 — Fetch the diff
 
@@ -211,9 +238,18 @@ comment (Step 5). Do not apply labels.
 
 ## Step 5 — Idempotency marker (always)
 
+> [!IMPORTANT]
+> The `add_comment` body **must begin with the literal HTML-comment marker
+> line on its own first line**. Do not add any prefix, blank line, indentation,
+> emoji, or other text before it. The orchestrator parses prior bot comments
+> looking for this exact marker; if it is missing the scan will be repeated
+> hourly. As a defense-in-depth fallback the orchestrator also matches the
+> visible-body sentinel `Automated diff scan` plus the backticked sha7, so
+> always include both `` `{sha7}` `` AND the marker line.
+
 Always post a single PR comment containing the marker so the orchestrator and
 the per-PR worker can detect that this head SHA has been scanned. Use
-`add_comment` with body shaped exactly:
+`add_comment` with body shaped exactly (the **first line** is the marker):
 
 - **Clean scan** (no findings):
 

--- a/.github/workflows/pr-triage-batch.yml
+++ b/.github/workflows/pr-triage-batch.yml
@@ -129,12 +129,15 @@ jobs:
             # Compute state — same logic as worker, kept simple and deterministic.
             STATE=""
             if [ "$IS_BOT" = "false" ] && [ "$IS_TRUSTED" = "false" ]; then
-              # Look for prior malicious-scan marker on this head
+              # Look for prior malicious-scan signal on this head. Match either the
+              # HTML marker (preferred) or the visible-body sentinel — the agent has
+              # been observed to occasionally drop the HTML comment line, and we
+              # must not re-dispatch the scanner in that case.
               SHORT="${HEAD_SHA:0:7}"
               # NB: --paginate runs --jq per page, so aggregations like 'length' would emit one
               # number per page. Emit one .id per matching comment and count lines in the shell.
               MARKER=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-                --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"<!-- pr-malicious-scan:fingerprint=$SHORT:\")) | .id" \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\") | select((.body | contains(\"<!-- pr-malicious-scan:fingerprint=$SHORT:\")) or ((.body | contains(\"Automated diff scan\")) and (.body | contains(\"\`$SHORT\`\")))) | .id" \
                 | wc -l | tr -d ' ')
               if [ "${MARKER:-0}" -eq 0 ]; then
                 STATE="needs-malicious-scan"

--- a/.github/workflows/pr-triage-batch.yml
+++ b/.github/workflows/pr-triage-batch.yml
@@ -29,6 +29,7 @@ on:
 
 permissions:
   pull-requests: read
+  issues: write
   statuses: read
   actions: write
   contents: read
@@ -129,15 +130,17 @@ jobs:
             # Compute state — same logic as worker, kept simple and deterministic.
             STATE=""
             if [ "$IS_BOT" = "false" ] && [ "$IS_TRUSTED" = "false" ]; then
-              # Look for prior malicious-scan signal on this head. Match either the
-              # HTML marker (preferred) or the visible-body sentinel — the agent has
-              # been observed to occasionally drop the HTML comment line, and we
-              # must not re-dispatch the scanner in that case.
+              # Look for prior malicious-scan signal on this head. Match either:
+              #   <!-- pr-malicious-scan:dispatched=SHORT --> (orchestrator-authored, posted
+              #     just before `gh workflow run`; survives any agent-side failure mode), OR
+              #   <!-- pr-malicious-scan:fingerprint=SHORT:DATE --> (agent-authored, posted by
+              #     a successful scan run).
+              # Either marker means "do not re-dispatch for this head SHA".
               SHORT="${HEAD_SHA:0:7}"
               # NB: --paginate runs --jq per page, so aggregations like 'length' would emit one
               # number per page. Emit one .id per matching comment and count lines in the shell.
               MARKER=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-                --jq ".[] | select(.user.login == \"github-actions[bot]\") | select((.body | contains(\"<!-- pr-malicious-scan:fingerprint=$SHORT:\")) or ((.body | contains(\"Automated diff scan\")) and (.body | contains(\"\`$SHORT\`\")))) | .id" \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\") | select((.body | contains(\"<!-- pr-malicious-scan:dispatched=$SHORT -->\")) or (.body | contains(\"<!-- pr-malicious-scan:fingerprint=$SHORT:\"))) | .id" \
                 | wc -l | tr -d ' ')
               if [ "${MARKER:-0}" -eq 0 ]; then
                 STATE="needs-malicious-scan"
@@ -183,9 +186,28 @@ jobs:
               dispatch-scanner)
                 if gh workflow list --repo "$REPO" --json path --jq '.[].path' \
                     | grep -q 'pr-malicious-scan\.agent\.lock\.yml'; then
-                  gh workflow run pr-malicious-scan.agent.lock.yml --repo "$REPO" \
-                    -f pr_number="$PR" || echo "::warning::failed to dispatch scanner for PR #$PR"
-                  DISPATCHED=$((DISPATCHED + 1))
+                  SHORT="${HEAD_SHA:0:7}"
+                  # Post the pre-dispatch idempotency marker BEFORE triggering the scanner.
+                  # This is the source of truth for "a scan has been initiated for this head SHA".
+                  # Even if the scanner fails to start, never starts (e.g. missing PAT), drops
+                  # its own fingerprint marker, or is blocked by an integrity filter, this marker
+                  # prevents re-dispatch. A new push (= new SHA) creates no marker, so the
+                  # scanner re-runs as expected.
+                  PRE_DISPATCH_BODY=$(printf '%s\n%s\n\n%s\n' \
+                    "<!-- pr-malicious-scan:dispatched=$SHORT -->" \
+                    "🔍 Automated malicious-diff scan dispatched for \`$SHORT\`." \
+                    "_Results will be posted as code-scanning alerts and a follow-up comment by github-actions[bot]._")
+                  if ! gh api -X POST "repos/$REPO/issues/$PR/comments" \
+                       -f body="$PRE_DISPATCH_BODY" >/dev/null 2>&1; then
+                    echo "::warning::failed to post pre-dispatch marker for PR #$PR — skipping scanner dispatch"
+                    continue
+                  fi
+                  if gh workflow run pr-malicious-scan.agent.lock.yml --repo "$REPO" \
+                       -f pr_number="$PR"; then
+                    DISPATCHED=$((DISPATCHED + 1))
+                  else
+                    echo "::warning::failed to dispatch scanner for PR #$PR"
+                  fi
                 else
                   echo "::notice::scanner workflow not yet present; would dispatch for PR #$PR"
                 fi

--- a/.github/workflows/pr-triage-batch.yml
+++ b/.github/workflows/pr-triage-batch.yml
@@ -3,8 +3,13 @@ name: "PR Triage — Batch"
 # Hourly orchestrator. Enumerates open PRs, computes a deterministic state
 # for each, and dispatches the per-PR worker (pr-triage.yml) or the malicious-
 # code scanner (pr-malicious-scan.agent.lock.yml) for PRs that need action.
-# No model calls; no comments; no labels are applied here. The worker owns the
-# side effects.
+# No model calls; no labels are applied here. The worker owns label and
+# author-ping side effects. The orchestrator itself posts at most ONE comment
+# per scanner dispatch — a deterministic
+# `<!-- pr-malicious-scan:dispatched=<sha7> -->` idempotency marker — before
+# triggering the scanner workflow. That marker is the source of truth that
+# survives any scanner-side failure mode (PAT outage, integrity block,
+# dropped HTML marker by the agent).
 
 on:
   schedule:


### PR DESCRIPTION
Fixes scanner repeat-spam and the integrity-filter blocks observed on PR #237.

## Problem

The pr-malicious-scan agent workflow was hourly-spamming new PRs with duplicate `Automated diff scan completed for <sha>` comments, accompanied by `Integrity filter blocked N items`. Two root causes:

1. **Per-push trigger raced the orchestrator's dedup.** The agent ran on every `pull_request_target [opened, synchronize, reopened]` push and could complete before the next hourly orchestrator pass, but its dedup self-check depended on the agent typing an HTML marker as the first line of its comment — which it sometimes dropped.
2. **gh-aw integrity filter blocked the github MCP toolset** on PRs from non-approved authors — exactly the population this scanner targets. The previous fix attempt (PR #722, first commit) tried to switch to `gh api` from bash, but the agent step runs under `awf` with `--exclude-env COPILOT_GITHUB_TOKEN` and no other GitHub token is exposed, so `gh api` would have had no credentials at runtime.

## Fix

Adopt the documented gh-aw pattern (per [Integrity Filtering Reference](https://github.github.com/gh-aw/llms-full.txt) — \min-integrity: none\ is the recommended level for spam-detection / analytics workflows) and move dedup ownership to the orchestrator:

- **`pr-malicious-scan.agent.md`** — drop `pull_request_target`; trigger only via `workflow_dispatch` from the orchestrator. Restore `tools.github` with `min-integrity: none`. Drop the `gh` bash hack and the visible-body sentinel requirements. `safe-outputs` (only code-scanning alerts, one comment, ≤ 2 labels) and `permissions: contents: read, pull-requests: read` still gate every mutation.

- **`pr-triage-batch.yml`** — orchestrator now posts a deterministic `<!-- pr-malicious-scan:dispatched=SHORT -->` comment BEFORE calling `gh workflow run`. That comment is the source of truth for ‘a scan has been initiated for this head SHA' and survives every agent-side failure mode (PAT outage, integrity block, dropped HTML marker). Dedup query matches either the orchestrator marker or the agent's own fingerprint marker.

- **`pr-triage-act.sh`** — drop the visible-body-sentinel fallback; match the orchestrator dispatched marker plus the agent fingerprint marker.

## Validation

- `gh aw compile pr-malicious-scan.agent` — clean.
- `bash -n` on the worker script and on the YAML-extracted orchestrator script — clean.
- `markdownlint` on the agent.md — clean.
- Live test against PR #713: posted the exact pre-dispatch marker via `gh api -X POST`, confirmed the orchestrator's `--jq` selector matches it, confirmed the bot-author filter excludes non-bot comments, and cleaned up the test comment.

The workflow is currently \disabled_manually\ on the repo and will stay that way until this PR merges. Merging will re-enable the cron-driven orchestrator, which is now the only dispatch path.