### PR TITLE
Add .codex-plugin/plugin.json manifests for Codex CLI plugin install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -58,9 +58,19 @@
       "description": "Skills for running, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, and MSTest workflows."
     },
     {
-      "name": "dotnet-aspnet",
-      "source": "./plugins/dotnet-aspnet",
+      "name": "dotnet-aspnetcore",
+      "source": "./plugins/dotnet-aspnetcore",
       "description": "ASP.NET Core web development skills including middleware, endpoints, real-time communication, and API patterns."
+    },
+    {
+      "name": "dotnet-blazor",
+      "source": "./plugins/dotnet-blazor",
+      "description": "Skills for Blazor development: component authoring, interactivity, and web application patterns."
+    },
+    {
+      "name": "dotnet11",
+      "source": "./plugins/dotnet11",
+      "description": "Skills for new .NET 11 APIs and language features."
     }
   ]
 }

--- a/plugins/dotnet-ai/.codex-plugin/plugin.json
+++ b/plugins/dotnet-ai/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-ai",
+  "version": "0.1.0",
+  "description": "AI and ML skills for .NET: technology selection, LLM integration, agentic workflows, RAG pipelines, MCP, and classic ML with ML.NET.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-aspnetcore/.codex-plugin/plugin.json
+++ b/plugins/dotnet-aspnetcore/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-aspnetcore",
+  "version": "0.1.0",
+  "description": "ASP.NET Core web development skills including middleware, endpoints, real-time communication, and API patterns.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-blazor/.codex-plugin/plugin.json
+++ b/plugins/dotnet-blazor/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-blazor",
+  "version": "0.1.0",
+  "description": "Skills for Blazor development: component authoring, interactivity, and web application patterns.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-data/.codex-plugin/plugin.json
+++ b/plugins/dotnet-data/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-data",
+  "version": "0.1.0",
+  "description": "Skills for .NET data access and Entity Framework related tasks.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-diag/.codex-plugin/plugin.json
+++ b/plugins/dotnet-diag/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "dotnet-diag",
+  "version": "0.1.0",
+  "description": "Skills for .NET performance investigations, debugging, and incident analysis.",
+  "skills": ["./skills/"],
+    "agents": ["./agents/optimizing-dotnet-performance.agent.md"]
+}

--- a/plugins/dotnet-experimental/.codex-plugin/plugin.json
+++ b/plugins/dotnet-experimental/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-experimental",
+  "version": "0.1.0",
+  "description": "Experimental skills under active evaluation that may change or graduate to stable plugins.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-maui/.codex-plugin/plugin.json
+++ b/plugins/dotnet-maui/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-maui",
+  "version": "0.1.0",
+  "description": "Skills for .NET MAUI development: environment setup, diagnostics, troubleshooting, navigation, data binding, dependency injection, layout, and theming.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-msbuild/.codex-plugin/plugin.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "dotnet-msbuild",
+  "version": "0.1.0",
+  "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization.",
+  "skills": ["./skills/"],
+  "agents": [
+      "./agents/build-perf.agent.md",
+      "./agents/msbuild-code-review.agent.md",
+      "./agents/msbuild.agent.md"
+  ],
+  "mcpServers": {
+    "binlog": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "Microsoft.AITools.BinlogMcp",
+        "--yes",
+        "--prerelease",
+        "--add-source",
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+      ],
+      "tools": ["*"]
+    }
+  }
+}

--- a/plugins/dotnet-nuget/.codex-plugin/plugin.json
+++ b/plugins/dotnet-nuget/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-nuget",
+  "version": "0.1.0",
+  "description": "NuGet and .NET package management skills: dependency management and modernization.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet-template-engine/.codex-plugin/plugin.json
+++ b/plugins/dotnet-template-engine/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "dotnet-template-engine",
+  "version": "0.1.0",
+  "description": ".NET Template Engine skills for dotnet new: create projects (console app, class library, web API, Blazor, MAUI), discover and search templates, inspect template parameters and frameworks (net8.0, net9.0, net10.0), scaffold solutions, author and validate custom templates, install template packages from NuGet.",
+  "skills": ["./skills/"],
+    "agents": ["./agents/template-engine.agent.md"]
+}

--- a/plugins/dotnet-test/.codex-plugin/plugin.json
+++ b/plugins/dotnet-test/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "dotnet-test",
+  "version": "0.1.0",
+  "description": "Skills for running, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, and MSTest workflows.",
+  "skills": ["./skills/"],
+  "agents": [
+      "./agents/code-testing-generator.agent.md",
+      "./agents/code-testing-researcher.agent.md",
+      "./agents/code-testing-planner.agent.md",
+      "./agents/code-testing-implementer.agent.md",
+      "./agents/code-testing-builder.agent.md",
+      "./agents/code-testing-tester.agent.md",
+      "./agents/code-testing-fixer.agent.md",
+      "./agents/code-testing-linter.agent.md",
+      "./agents/testability-migration.agent.md",
+      "./agents/test-quality-auditor.agent.md",
+      "./agents/test-migration.agent.md"
+  ]
+}

--- a/plugins/dotnet-upgrade/.codex-plugin/plugin.json
+++ b/plugins/dotnet-upgrade/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet-upgrade",
+  "version": "0.1.0",
+  "description": "Skills for migrating and upgrading .NET projects across framework versions, language features, and compatibility targets.",
+  "skills": ["./skills/"]
+}

--- a/plugins/dotnet/.codex-plugin/plugin.json
+++ b/plugins/dotnet/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "dotnet",
+  "version": "0.1.0",
+  "description": "Common everyday C#/.NET coding skills. Expected to be useful to all .NET developers.",
+  "skills": ["./skills/"],
+  "lspServers": "./lsp.json"
+}

--- a/plugins/dotnet11/.codex-plugin/plugin.json
+++ b/plugins/dotnet11/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotnet11",
+  "version": "0.1.0",
+  "description": "Skills for .NET 11 APIs and language features.",
+  "skills": ["./skills/"]
+}


### PR DESCRIPTION
## Summary

The Codex CLI requires `.codex-plugin/plugin.json` as the plugin manifest entry point ([docs](https://developers.openai.com/codex/plugins/build)). Without it, `codex plugin add` fails with `missing plugin.json` even though marketplace listing works fine.

This adds `.codex-plugin/plugin.json` to all 14 plugin directories, with paths relative to the plugin root per the Codex documentation. Also adds missing `dotnet-blazor` and `dotnet11` entries to `.agents/plugins/marketplace.json` for parity with the other marketplace files.

## What changed

- **14 new files**: `plugins/<name>/.codex-plugin/plugin.json` for every plugin
- **1 modified file**: `.agents/plugins/marketplace.json` — added `dotnet-blazor` and `dotnet11` entries

## Useful Context

PR #555 added the `.agents/plugins/marketplace.json` enabling Codex to **discover** plugins. But each plugin directory still only had a root-level `plugin.json` (used by Claude Code and Cursor). The Codex CLI specifically looks for `.codex-plugin/plugin.json` inside the plugin directory pointed to by the marketplace `source` path.

## Validation

- Confirmed against [official Codex plugin build docs](https://developers.openai.com/codex/plugins/build): *"Every plugin has a manifest at `.codex-plugin/plugin.json`"*
- Paths use `./` prefix relative to plugin root per docs: *"Keep manifest paths relative to the plugin root and start them with `./`"*

Fixes #578
Fixes #724