### PR TITLE
Add find-untested-sources skill (C# parse-only test pairing)

### DIFF
--- a/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: find-untested-sources
+description: >
+  Fast, parse-only static analysis that maps C# source files to the test files
+  that reference them, and lists production source files with **no** test file
+  referencing any of their declared types. Designed to answer the question
+  "which source files have no tests yet?" in seconds, without running a build
+  or coverage. Use as the **first** step before test-generation work to pick
+  the next file to test, or as a sanity check after generating tests to confirm
+  pairing. Emits JSON with `source_to_tests`, an `untested` list ordered by
+  declaration count (highest API surface first), and a `suggested_test_path`
+  derived from `ProjectReference` edges.
+  USE FOR: where should I write tests next, find untested files, list source
+  files without tests, build a test-pairing map, suggest a test-file path for
+  a source file, prioritize test work by API surface, audit which source files
+  any test references.
+  DO NOT USE FOR: measuring branch/line coverage (use `coverage-analysis`),
+  ranking risk by complexity-vs-coverage (use `coverage-analysis` for CRAP),
+  finding weak assertions in existing tests (use `test-gap-analysis` or
+  `assertion-quality`), or running actual mutation testing.
+license: MIT
+---
+
+# Find Untested Sources
+
+## Purpose
+
+Coverage tools answer "which lines were executed?" — they require a green build
+and a passing test run, which is minutes-to-tens-of-minutes on a real repo.
+The question this skill answers is different and much cheaper:
+
+> _Which C# source files have no test file referencing any of their declared types?_
+
+That's the question an agent asks **before** writing a new test — and it can be
+answered statically in a few seconds by parsing every `.cs` file with the
+Roslyn syntax API, with **no `Compilation`, no `MetadataReference`, and no
+binding**. The output is a deterministic test-pairing map that lets the agent
+pick the next file to test without reading the entire codebase first.
+
+## When to Use
+
+- User asks "where should I add tests?", "which files have no tests?", "find
+  untested code", "give me a test gap list", "what's the next file to test".
+- Before invoking a test-generation agent, to produce a prioritized worklist.
+- After generating tests, to verify each new test file pairs to a source file.
+- To enumerate "weakly paired" source files (only one referring test file) for
+  follow-up depth checks.
+
+## When Not to Use
+
+- **Line/branch coverage** — use `coverage-analysis`.
+- **CRAP-score / risk hotspots** — use `coverage-analysis`.
+- **Are existing tests strong?** — use `test-gap-analysis` (mutation reasoning)
+  or `assertion-quality`.
+- **Tests for non-C# code** — this prototype is C#-only.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| Repo root | Yes | — | Directory to scan recursively for `.cs` files. |
+| `--top N` | No | all | Truncate the `untested` list to the top N entries by declaration count. |
+
+### Prerequisites
+
+- .NET SDK that supports file-based apps (`dotnet run script.cs`). Pinned in
+  the repo's `global.json` (SDK 11 preview or later).
+- No internet access required beyond the initial NuGet restore of
+  `Microsoft.CodeAnalysis.CSharp` on first run.
+
+## Usage
+
+```powershell
+# From the skill folder
+dotnet run scripts/Find-UntestedSources.cs -- <repo-root> [--top N]
+
+# Save the report
+dotnet run scripts/Find-UntestedSources.cs -- <repo-root> > pairing.json
+
+# Iterate the untested list, highest-API-surface first
+$report = Get-Content pairing.json | ConvertFrom-Json
+$report.untested | Select-Object -First 10 source, decl_count, suggested_test_path
+```
+
+Diagnostics go to stderr; JSON goes to stdout.
+
+## Output Schema
+
+```jsonc
+{
+  "repo": "<absolute path>",
+  "elapsed_ms": 8883,
+  "counts": {
+    "source_files": 3036,
+    "test_files": 867,
+    "untested_files": 1852,
+    "paired_files": 1184
+  },
+  "untested": [
+    {
+      "source": "src/Foo/Bar.cs",
+      "decl_count": 8,            // # of type declarations in the file
+      "suggested_test_path":      // mirror of source under a discovered test project
+        "tests/Foo.Tests/Bar/BarTests.cs"
+    }
+  ],
+  "source_to_tests": {
+    "src/Foo/Baz.cs": [
+      "tests/Foo.Tests/BazTests.cs",
+      "tests/Foo.IntegrationTests/Scenarios/BazScenarios.cs"
+    ]
+  }
+}
+```
+
+## How It Works
+
+1. **File discovery** — recursive directory walk pruning `bin/`, `obj/`,
+   `node_modules/`, `.git/`, `.vs/`, `packages/`, and any dotted subdir.
+   Skips generated files (`.g.cs`, `.Designer.cs`, `.AssemblyInfo.cs`).
+
+2. **Test vs source classification** — walks up to the nearest `.csproj` and
+   marks it as a test project if (a) the project name ends in `.Tests`,
+   `.Test`, `.UnitTests`, `.IntegrationTests`, `.E2E`, `.EndToEnd`, `.Spec`,
+   `.Specs`, or (b) the file content references `Microsoft.NET.Test.Sdk`,
+   `MSTest.Sdk`, `Microsoft.Testing.Platform`, `xunit`, `NUnit`, `TUnit`, or
+   `<IsTestProject>true</IsTestProject>`.
+
+3. **Source index (parallel)** — for each source file, parse with
+   `CSharpSyntaxTree.ParseText` (syntax only, no compilation). Walk every
+   `BaseTypeDeclarationSyntax` and `DelegateDeclarationSyntax` and record
+   `(ShortName, EnclosingNamespace, FilePath)`.
+
+4. **Test scan (parallel)** — for each test file, parse, collect `using`
+   directives + enclosing namespace, walk every `IdentifierToken`, look it up
+   in the short-name index, and **disambiguate strictly**: an identifier is
+   attributed to a declaration only if the declaration's namespace matches one
+   of the test file's `using` directives, the enclosing namespace, or a
+   prefix of them. Identifiers that don't resolve under that constraint are
+   dropped (avoids the noise where common names like `Settings` or `Context`
+   would otherwise match every project that happens to declare them).
+
+5. **Pairing & suggestion** — invert into `source → [tests]`. Build a
+   production-to-test project map from `<ProjectReference>` entries in test
+   `.csproj` files; for each untested source, mirror its in-project relative
+   path under the referencing test project and append `Tests.cs` to suggest a
+   path.
+
+6. **JSON emit** — ordered by declaration count desc, then alphabetical.
+
+## Limitations (be honest with the agent)
+
+This is a static, parse-only heuristic. It deliberately trades a small amount
+of accuracy for orders-of-magnitude lower cost than coverage. Known gaps:
+
+- **Reflection-driven tests** that exercise a type only via
+  `Type.GetType(...)` / `Activator.CreateInstance` won't be detected — the
+  type's short name never appears in the test source.
+- **DI-resolved types** referenced only by `IServiceProvider.GetRequiredService<T>()`
+  where `T` is an interface and the implementation isn't named in the test.
+- **Extension methods** invoked as instance methods. The extension class is
+  not named, only the method, so the source file declaring the static class
+  is not credited.
+- **`var`, target-typed `new()`, and pattern matching** lose the type token;
+  the file-level union usually still catches it through other references.
+- **Cross-language**: any source file driven by JSON/YAML test fixtures, code
+  generators, or compiled-only references is not detected.
+
+For these cases, run actual coverage (`coverage-analysis`) on the unpaired
+candidates the agent has already triaged.
+
+## Outputs the agent should consume
+
+- `untested[*].source` — pick the next source file to test (highest
+  `decl_count` first).
+- `untested[*].suggested_test_path` — drop-in target for the new test file;
+  honors the test project that already `<ProjectReference>`s the source's
+  project, so `dotnet sln add` is not needed.
+- `source_to_tests` — verify a newly written test file lands in the list for
+  the intended source.

--- a/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
@@ -1,23 +1,13 @@
 ---
 name: find-untested-sources
 description: >
-  Fast, parse-only static analysis that maps C# source files to the test files
-  that reference them, and lists production source files with **no** test file
-  referencing any of their declared types. Designed to answer the question
-  "which source files have no tests yet?" in seconds, without running a build
-  or coverage. Use as the **first** step before test-generation work to pick
-  the next file to test, or as a sanity check after generating tests to confirm
-  pairing. Emits JSON with `source_to_tests`, an `untested` list ordered by
-  declaration count (highest API surface first), and a `suggested_test_path`
-  derived from `ProjectReference` edges.
-  USE FOR: where should I write tests next, find untested files, list source
-  files without tests, build a test-pairing map, suggest a test-file path for
-  a source file, prioritize test work by API surface, audit which source files
-  any test references.
-  DO NOT USE FOR: measuring branch/line coverage (use `coverage-analysis`),
-  ranking risk by complexity-vs-coverage (use `coverage-analysis` for CRAP),
-  finding weak assertions in existing tests (use `test-gap-analysis` or
-  `assertion-quality`), or running actual mutation testing.
+  Parse-only C# analysis that pairs source files with referencing tests and
+  emits JSON: `source_to_tests`, `untested` ordered by declaration count, and
+  `suggested_test_path` from `ProjectReference` edges.
+  USE FOR: where to write tests next, find untested files, list sources
+  without tests, build a test-pairing map.
+  DO NOT USE FOR: coverage (use `coverage-analysis`), CRAP risk ranking,
+  assertion gaps.
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/Find-UntestedSources.cs
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/Find-UntestedSources.cs
@@ -1,0 +1,483 @@
+#:package Microsoft.CodeAnalysis.CSharp@4.14.0
+
+// Find-UntestedSources.cs
+//
+// Static, parse-only analysis (no compilation, no metadata, no test execution)
+// that produces a JSON report of which C# source files have at least one C#
+// test file referencing one of their declared types, and which do not.
+//
+// Pipeline:
+//   1. Walk the repo for *.cs (skip bin/obj/.g.cs/.Designer.cs).
+//   2. Classify each file as test vs source by walking up to the nearest .csproj
+//      and checking for Microsoft.NET.Test.Sdk / MSTest.Sdk / Microsoft.Testing.Platform
+//      references, or a project name ending in .Tests / .Test / .UnitTests /
+//      .IntegrationTests / .E2E / .EndToEnd.
+//   3. Build a source index in parallel: per source file, parse with
+//      CSharpSyntaxTree.ParseText (NO Compilation, NO MetadataReferences),
+//      record every class/record/struct/interface/enum/delegate declaration
+//      as (ShortName, Namespace, File).
+//   4. Scan each test file in parallel: parse, collect `using` directives and
+//      enclosing namespace, walk identifier tokens, look them up in the index,
+//      disambiguate by namespace match against the test file's usings.
+//   5. Invert into source -> [tests] map, identify unreferenced source files,
+//      and emit JSON sorted by declaration count descending (highest API
+//      surface first).
+//
+// Output: JSON to stdout. Diagnostics to stderr.
+//
+// Usage:
+//   dotnet run Find-UntestedSources.cs -- <repo-root> [--top N]
+//
+// Output schema:
+//   {
+//     "repo": "<abs path>",
+//     "counts": { "source_files", "test_files", "untested_files", "paired_files" },
+//     "untested": [ { "source", "decl_count", "suggested_test_path" }, ... ],
+//     "source_to_tests": { "<source>": ["<test1>", "<test2>", ...], ... }
+//   }
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("usage: dotnet run Find-UntestedSources.cs -- <repo-root> [--top N]");
+    return 1;
+}
+
+string root = Path.GetFullPath(args[0]);
+if (!Directory.Exists(root))
+{
+    Console.Error.WriteLine($"Not a directory: {root}");
+    return 1;
+}
+
+int topN = int.MaxValue;
+for (int i = 1; i < args.Length - 1; i++)
+{
+    if (args[i] == "--top" && int.TryParse(args[i + 1], out var n))
+    {
+        topN = n;
+    }
+}
+
+var swTotal = System.Diagnostics.Stopwatch.StartNew();
+
+// 1. Discover .cs files
+var allCs = new List<string>();
+foreach (var f in EnumerateCsFiles(root))
+{
+    allCs.Add(f);
+}
+Log($"Discovered {allCs.Count} .cs files");
+
+// 2. Classify by walking up to nearest .csproj
+var projectForDir = new ConcurrentDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+var isTestProject = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+string? ProjectFor(string filePath)
+{
+    var dir = Path.GetDirectoryName(filePath)!;
+    return projectForDir.GetOrAdd(dir, d =>
+    {
+        var cur = d;
+        while (cur is not null && cur.Length >= root.Length)
+        {
+            var csproj = Directory.EnumerateFiles(cur, "*.csproj").FirstOrDefault();
+            if (csproj is not null)
+            {
+                return csproj;
+            }
+            cur = Path.GetDirectoryName(cur);
+        }
+        return null;
+    });
+}
+
+bool IsTest(string filePath)
+{
+    var proj = ProjectFor(filePath);
+    if (proj is null)
+    {
+        return false;
+    }
+    return isTestProject.GetOrAdd(proj, ClassifyProjectAsTest);
+}
+
+var sourceFiles = new List<string>();
+var testFiles = new List<string>();
+foreach (var f in allCs)
+{
+    if (IsTest(f))
+    {
+        testFiles.Add(f);
+    }
+    else
+    {
+        sourceFiles.Add(f);
+    }
+}
+Log($"Classified: {sourceFiles.Count} source, {testFiles.Count} test");
+
+// 3. Build source index (parse-only, no Compilation)
+var declsByShort = new ConcurrentDictionary<string, List<Decl>>(StringComparer.Ordinal);
+var declsByFile = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+
+var swIndex = System.Diagnostics.Stopwatch.StartNew();
+Parallel.ForEach(sourceFiles, file =>
+{
+    string text;
+    try { text = File.ReadAllText(file); }
+    catch { return; }
+    var tree = CSharpSyntaxTree.ParseText(text);
+    var rootNode = tree.GetRoot();
+    int count = 0;
+    foreach (var node in rootNode.DescendantNodes())
+    {
+        string? name = node switch
+        {
+            BaseTypeDeclarationSyntax t => t.Identifier.ValueText,
+            DelegateDeclarationSyntax d => d.Identifier.ValueText,
+            _ => null,
+        };
+        if (name is null || name.Length == 0)
+        {
+            continue;
+        }
+        var ns = GetNamespaceFor(node);
+        var decl = new Decl(name, ns, file);
+        var list = declsByShort.GetOrAdd(name, _ => new List<Decl>());
+        lock (list)
+        {
+            list.Add(decl);
+        }
+        count++;
+    }
+    declsByFile[file] = count;
+});
+swIndex.Stop();
+Log($"Indexed {sourceFiles.Count} source files in {swIndex.ElapsedMilliseconds} ms ({declsByShort.Count} distinct short names)");
+
+// 4. Scan test files
+var sourceToTests = new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>(StringComparer.Ordinal);
+foreach (var s in sourceFiles)
+{
+    sourceToTests[s] = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+}
+
+var swScan = System.Diagnostics.Stopwatch.StartNew();
+Parallel.ForEach(testFiles, file =>
+{
+    string text;
+    try { text = File.ReadAllText(file); }
+    catch { return; }
+    var tree = CSharpSyntaxTree.ParseText(text);
+    var rootNode = tree.GetRoot();
+
+    var usings = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var u in rootNode.DescendantNodes().OfType<UsingDirectiveSyntax>())
+    {
+        var nm = u.Name?.ToString();
+        if (!string.IsNullOrEmpty(nm))
+        {
+            usings.Add(nm);
+        }
+    }
+    var localNs = rootNode.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
+        .FirstOrDefault()?.Name.ToString() ?? "";
+
+    var ids = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var tok in rootNode.DescendantTokens())
+    {
+        if (tok.IsKind(SyntaxKind.IdentifierToken))
+        {
+            ids.Add(tok.ValueText);
+        }
+    }
+
+    var refs = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var id in ids)
+    {
+        if (!declsByShort.TryGetValue(id, out var decls))
+        {
+            continue;
+        }
+        List<Decl>? preferred = null;
+        foreach (var d in decls)
+        {
+            if (d.Namespace.Length == 0)
+            {
+                continue;
+            }
+            if (usings.Contains(d.Namespace)
+                || d.Namespace == localNs
+                || (localNs.Length > 0 && localNs.StartsWith(d.Namespace + ".", StringComparison.Ordinal))
+                || IsUsingPrefix(usings, d.Namespace))
+            {
+                (preferred ??= new List<Decl>()).Add(d);
+            }
+        }
+        // Strict: skip identifiers whose declarations don't match any namespace
+        // visible to this test file. Avoids the noise where a common identifier
+        // (e.g., a type name shared across unrelated projects) gets attributed
+        // to every file declaring something with the same short name.
+        if (preferred is null)
+        {
+            continue;
+        }
+        foreach (var d in preferred)
+        {
+            refs.Add(d.File);
+        }
+    }
+
+    foreach (var src in refs)
+    {
+        sourceToTests[src][file] = 0;
+    }
+});
+swScan.Stop();
+Log($"Scanned {testFiles.Count} test files in {swScan.ElapsedMilliseconds} ms");
+
+// 5. Build suggested test paths for untested files
+var untested = sourceToTests
+    .Where(kv => kv.Value.IsEmpty)
+    .Select(kv => kv.Key)
+    .OrderBy(s => s, StringComparer.Ordinal)
+    .ToList();
+
+// Cache: source proj -> candidate test project paths
+var testProjectsByProductionProject = BuildProductionToTestProjectMap(root);
+
+string? SuggestTestPath(string srcFile)
+{
+    var proj = ProjectFor(srcFile);
+    if (proj is null)
+    {
+        return null;
+    }
+    if (!testProjectsByProductionProject.TryGetValue(proj, out var testProj))
+    {
+        return null;
+    }
+    var srcProjDir = Path.GetDirectoryName(proj)!;
+    var testProjDir = Path.GetDirectoryName(testProj)!;
+    var rel = Path.GetRelativePath(srcProjDir, srcFile);
+    var relDir = Path.GetDirectoryName(rel) ?? "";
+    var fname = Path.GetFileNameWithoutExtension(rel);
+    return Path.Combine(testProjDir, relDir, fname + "Tests.cs");
+}
+
+// 6. Emit JSON
+var untestedReport = untested.Select(s => new
+{
+    source = ToRel(root, s),
+    decl_count = declsByFile.TryGetValue(s, out var c) ? c : 0,
+    suggested_test_path = SuggestTestPath(s) is string p ? ToRel(root, p) : null,
+})
+.OrderByDescending(x => x.decl_count)
+.ThenBy(x => x.source, StringComparer.Ordinal)
+.Take(topN)
+.ToList();
+
+var pairedReport = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+foreach (var kv in sourceToTests)
+{
+    if (kv.Value.IsEmpty)
+    {
+        continue;
+    }
+    pairedReport[ToRel(root, kv.Key)] = kv.Value.Keys
+        .Select(t => ToRel(root, t))
+        .OrderBy(s => s, StringComparer.Ordinal)
+        .ToList();
+}
+
+swTotal.Stop();
+var result = new
+{
+    repo = root,
+    elapsed_ms = swTotal.ElapsedMilliseconds,
+    counts = new
+    {
+        source_files = sourceFiles.Count,
+        test_files = testFiles.Count,
+        untested_files = untested.Count,
+        paired_files = sourceFiles.Count - untested.Count,
+    },
+    untested = untestedReport,
+    source_to_tests = pairedReport,
+};
+
+var opts = new JsonSerializerOptions
+{
+    WriteIndented = true,
+    TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
+};
+Console.WriteLine(JsonSerializer.Serialize(result, opts));
+Log($"Total time: {swTotal.ElapsedMilliseconds} ms");
+return 0;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+static IEnumerable<string> EnumerateCsFiles(string root)
+{
+    var stack = new Stack<string>();
+    stack.Push(root);
+    while (stack.Count > 0)
+    {
+        var dir = stack.Pop();
+        IEnumerable<string> subdirs;
+        try { subdirs = Directory.EnumerateDirectories(dir); }
+        catch { continue; }
+        foreach (var sub in subdirs)
+        {
+            var name = Path.GetFileName(sub);
+            if (name.Length == 0)
+            {
+                continue;
+            }
+            if (string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "obj", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "node_modules", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, ".git", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, ".vs", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "packages", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith(".", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            stack.Push(sub);
+        }
+        IEnumerable<string> files;
+        try { files = Directory.EnumerateFiles(dir, "*.cs"); }
+        catch { continue; }
+        foreach (var f in files)
+        {
+            if (IsSkippedFile(f))
+            {
+                continue;
+            }
+            yield return f;
+        }
+    }
+}
+
+static bool IsSkippedFile(string path)
+{
+    if (path.EndsWith(".g.cs", StringComparison.Ordinal))
+    {
+        return true;
+    }
+    if (path.EndsWith(".Designer.cs", StringComparison.Ordinal))
+    {
+        return true;
+    }
+    if (path.EndsWith(".AssemblyInfo.cs", StringComparison.Ordinal))
+    {
+        return true;
+    }
+    if (path.EndsWith(".AssemblyAttributes.cs", StringComparison.Ordinal))
+    {
+        return true;
+    }
+    if (path.EndsWith(".GlobalUsings.g.cs", StringComparison.Ordinal))
+    {
+        return true;
+    }
+    return false;
+}
+
+static bool ClassifyProjectAsTest(string csproj)
+{
+    var name = Path.GetFileNameWithoutExtension(csproj);
+    string[] testSuffixes = { ".Tests", ".Test", ".UnitTests", ".IntegrationTests", ".E2E", ".EndToEnd", ".Spec", ".Specs" };
+    foreach (var suf in testSuffixes)
+    {
+        if (name.EndsWith(suf, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+    }
+    try
+    {
+        var content = File.ReadAllText(csproj);
+        if (content.Contains("Microsoft.NET.Test.Sdk", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("MSTest.Sdk", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("Microsoft.Testing.Platform", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("<IsTestProject>true</IsTestProject>", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("xunit", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("NUnit", StringComparison.OrdinalIgnoreCase)) { return true; }
+        if (content.Contains("TUnit", StringComparison.OrdinalIgnoreCase)) { return true; }
+    }
+    catch
+    {
+    }
+    return false;
+}
+
+static string GetNamespaceFor(SyntaxNode node)
+{
+    var ns = node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
+    return ns?.Name.ToString() ?? "";
+}
+
+static bool IsUsingPrefix(HashSet<string> usings, string ns)
+{
+    if (ns.Length == 0)
+    {
+        return false;
+    }
+    foreach (var u in usings)
+    {
+        if (ns.StartsWith(u + ".", StringComparison.Ordinal))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static Dictionary<string, string> BuildProductionToTestProjectMap(string root)
+{
+    var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    var allCsproj = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories).ToList();
+    foreach (var testProj in allCsproj)
+    {
+        if (!ClassifyProjectAsTest(testProj))
+        {
+            continue;
+        }
+        string content;
+        try { content = File.ReadAllText(testProj); }
+        catch { continue; }
+        var testDir = Path.GetDirectoryName(testProj)!;
+        var matches = System.Text.RegularExpressions.Regex.Matches(content,
+            @"<ProjectReference\s+Include=""([^""]+)""");
+        foreach (System.Text.RegularExpressions.Match m in matches)
+        {
+            var rel = m.Groups[1].Value.Replace('\\', Path.DirectorySeparatorChar);
+            var abs = Path.GetFullPath(Path.Combine(testDir, rel));
+            if (File.Exists(abs) && !map.ContainsKey(abs))
+            {
+                map[abs] = testProj;
+            }
+        }
+    }
+    return map;
+}
+
+static string ToRel(string root, string path)
+{
+    try { return Path.GetRelativePath(root, path).Replace('\\', '/'); }
+    catch { return path; }
+}
+
+static void Log(string msg) => Console.Error.WriteLine($"[find-untested-sources] {msg}");
+
+internal readonly record struct Decl(string ShortName, string Namespace, string File);

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/Find-UntestedSources.cs
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/Find-UntestedSources.cs
@@ -86,10 +86,15 @@ string? ProjectFor(string filePath)
         var cur = d;
         while (cur is not null && cur.Length >= root.Length)
         {
-            var csproj = Directory.EnumerateFiles(cur, "*.csproj").FirstOrDefault();
-            if (csproj is not null)
+            string[] csprojs;
+            try { csprojs = Directory.GetFiles(cur, "*.csproj"); }
+            catch { csprojs = Array.Empty<string>(); }
+            if (csprojs.Length > 0)
             {
-                return csproj;
+                // Sort to keep selection deterministic when multiple .csproj
+                // files coexist in the same directory.
+                Array.Sort(csprojs, StringComparer.Ordinal);
+                return csprojs[0];
             }
             cur = Path.GetDirectoryName(cur);
         }
@@ -208,11 +213,12 @@ Parallel.ForEach(testFiles, file =>
         List<Decl>? preferred = null;
         foreach (var d in decls)
         {
-            if (d.Namespace.Length == 0)
-            {
-                continue;
-            }
-            if (usings.Contains(d.Namespace)
+            // Declarations in the global namespace are visible without a
+            // using directive, so accept them unconditionally. (Skipping
+            // them previously meant types declared without a namespace were
+            // never attributed to any test file.)
+            if (d.Namespace.Length == 0
+                || usings.Contains(d.Namespace)
                 || d.Namespace == localNs
                 || (localNs.Length > 0 && localNs.StartsWith(d.Namespace + ".", StringComparison.Ordinal))
                 || IsUsingPrefix(usings, d.Namespace))
@@ -370,25 +376,20 @@ static IEnumerable<string> EnumerateCsFiles(string root)
 
 static bool IsSkippedFile(string path)
 {
-    if (path.EndsWith(".g.cs", StringComparison.Ordinal))
+    string[] skippedSuffixes =
     {
-        return true;
-    }
-    if (path.EndsWith(".Designer.cs", StringComparison.Ordinal))
+        ".g.cs",
+        ".Designer.cs",
+        ".AssemblyInfo.cs",
+        ".AssemblyAttributes.cs",
+        ".GlobalUsings.g.cs",
+    };
+    foreach (var suffix in skippedSuffixes)
     {
-        return true;
-    }
-    if (path.EndsWith(".AssemblyInfo.cs", StringComparison.Ordinal))
-    {
-        return true;
-    }
-    if (path.EndsWith(".AssemblyAttributes.cs", StringComparison.Ordinal))
-    {
-        return true;
-    }
-    if (path.EndsWith(".GlobalUsings.g.cs", StringComparison.Ordinal))
-    {
-        return true;
+        if (path.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
     }
     return false;
 }
@@ -423,8 +424,20 @@ static bool ClassifyProjectAsTest(string csproj)
 
 static string GetNamespaceFor(SyntaxNode node)
 {
-    var ns = node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
-    return ns?.Name.ToString() ?? "";
+    // Walk all enclosing namespace declarations and join from outermost to
+    // innermost so nested blocks (namespace A { namespace B { ... } }) yield
+    // "A.B" rather than just "B".
+    List<string>? parts = null;
+    foreach (var ns in node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>())
+    {
+        (parts ??= new List<string>()).Add(ns.Name.ToString());
+    }
+    if (parts is null)
+    {
+        return "";
+    }
+    parts.Reverse();
+    return string.Join(".", parts);
 }
 
 static bool IsUsingPrefix(HashSet<string> usings, string ns)
@@ -446,7 +459,19 @@ static bool IsUsingPrefix(HashSet<string> usings, string ns)
 static Dictionary<string, string> BuildProductionToTestProjectMap(string root)
 {
     var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-    var allCsproj = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories).ToList();
+    List<string> allCsproj;
+    try
+    {
+        allCsproj = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories).ToList();
+    }
+    catch
+    {
+        return map;
+    }
+    // Sort so the deterministic "first write wins" rule below selects the
+    // same test project across runs/machines regardless of filesystem
+    // enumeration order.
+    allCsproj.Sort(StringComparer.Ordinal);
     foreach (var testProj in allCsproj)
     {
         if (!ClassifyProjectAsTest(testProj))


### PR DESCRIPTION
## Summary

Adds `find-untested-sources`, a parse-only Roslyn static analyzer that maps C# source files to the test files referencing their declared types, and lists production sources with no referring test.

No `Compilation`, no `MetadataReferences`, no binding — runs in **~9 s on a 3,900-file repo** (measured locally on `AITestAgent` + msbench fixtures).

## What it produces

A deterministic JSON report:

```jsonc
{
  "counts": { "source_files": 3036, "test_files": 867, "untested_files": 1852, "paired_files": 1184 },
  "untested": [
    { "source": "src/Foo/Bar.cs", "decl_count": 8, "suggested_test_path": "tests/Foo.Tests/Bar/BarTests.cs" }
  ],
  "source_to_tests": { "src/Foo/Baz.cs": ["tests/Foo.Tests/BazTests.cs"] }
}
```

- `untested` ordered by API surface (`decl_count`) descending → drop-in worklist for any test-generation agent.
- `suggested_test_path` derived from real `<ProjectReference>` edges → lands in a project that already compiles against the source.

## How it works

1. Walk repo for `.cs`, prune `bin/obj/.git/node_modules/.vs/packages/` and generated files.
2. Classify each `.csproj` as test/source by name suffix (`.Tests`, `.UnitTests`, …) or SDK reference (`Microsoft.NET.Test.Sdk`, `MSTest.Sdk`, `xunit`, `NUnit`, `TUnit`, `Microsoft.Testing.Platform`).
3. Parallel parse → record `(ShortName, EnclosingNamespace, FilePath)` per type declaration.
4. Parallel scan of test files → match identifier tokens against the index, **disambiguating strictly** by namespace using each test file's `using` directives + enclosing namespace (avoids the false-positive explosion that naive identifier matching causes on common names like `Settings` or `Context`).
5. Suggest a test path by mirroring the source under whichever test project already `<ProjectReference>`s the source's project.

## Honest limitations

Static parse-only → known gaps documented in `SKILL.md`: reflection-driven tests, DI-resolved interface types not named in source, extension-method calls as instance methods, `var`/target-typed `new()`/pattern matching. For these, the skill points users at `coverage-analysis`.

## Measurement context — honest restatement

This skill was prototyped in response to a benchmark observation: test-generation agents spend significant tokens manually pairing source ↔ test files via repeated `find`/`grep`/`glob` calls before writing any tests. A 5×136-instance internal experiment compared a baseline (skill installed, no doc pointer) against an arm with a pointer to the helper added to `code-testing-agent`'s SKILL.md (the doc edit is proposed separately in **#734**).

After re-doing the analysis correctly (per-task mean rather than volume-weighted aggregate, with a non-.NET control bucket):

| Bucket | n tasks | Per-task mean Δ input tokens |
|---|---|---|
| **.NET tasks** | 35 | **−8.73 %** (median −6.98 %) |
| **non-.NET control** | 101 | **−0.13 %** (median −1.43 %) |

Differential ≈ 8.6 pp, Welch's t ≈ −2.02 (right at p ≈ 0.05). Pass rate neutral within noise.

### Caveats you should know about

- **The helper was invoked 0/679 times in the experiment.** The Copilot CLI router did not auto-load it as a sibling skill, so any token savings come from the model reading the documentation text in the loaded `code-testing-agent` SKILL.md, not from the helper executing. **The runtime value of this skill (i.e. what happens when it actually runs) is still unmeasured.**
- The volume-weighted aggregate I originally cited (−15 %) was misleading — it was dominated by a handful of very-high-token .NET tasks.
- Per-task variance is ~21 %; 5 runs per task is not enough to nail down per-task effects precisely. The across-task pattern (control bucket flat, .NET bucket shifted) is the clean part of the signal.

**This PR ships the skill alone.** The doc integration is in PR #734.

## Test plan

- `dotnet run scripts/Find-UntestedSources.cs -- <repo-root>` produces well-formed JSON on multiple .NET repos (AITestAgent, ocelot, eShop).
- Output schema verified to match `SKILL.md` documentation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>