### PR TITLE
Add find-untested-sources-polyglot skill (tree-sitter, 9 languages)

### DIFF
--- a/eng/known-domains.txt
+++ b/eng/known-domains.txt
@@ -24,6 +24,7 @@ libimobiledevice.org
 msdl.microsoft.com
 nuget.org/account/trustedpublishing
 dotnetcli.blob.core.windows.net
+tree-sitter.github.io
 
 # Platforms
 developer.android.com

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
@@ -132,7 +132,7 @@ path). Omitted by default to keep the payload small for LLM consumption.
    | Language | Test rule |
    |---|---|
    | Python | path contains `tests/` or `test/`; or filename starts with `test_` or ends with `_test.py`; or `conftest.py`. |
-   | JS/TS/TSX | path contains `__tests__`, `tests`, `spec`, or `e2e`; or filename contains `.test.` or `.spec.`. |
+   | JS/TS/TSX | path contains `__tests__`, `tests`, `test`, `spec`, or `e2e`; or filename contains `.test.` or `.spec.`. |
    | Go | filename ends with `_test.go` (Go's standard convention). |
    | Java | path contains `test` or `tests`; or filename ends with `Test.java` / `Tests.java`. |
    | Rust | path contains `tests/` or `benches/`. |

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: find-untested-sources-polyglot
+description: >
+  Polyglot, parse-only static analysis that maps source files to the test files
+  that reference them, and lists production source files with **no** test file
+  referencing any of their declared symbols. Designed to answer "which source
+  files have no tests yet?" in seconds, without running a build or coverage,
+  across Python, TypeScript/JavaScript, Go, Java, Rust, C#, and Ruby (any
+  language tree-sitter can parse and classify as test vs. source). Emits JSON
+  with the same shape as the C# `find-untested-sources` skill so prompts and
+  tooling can consume both.
+  USE FOR: where should I write tests next, find untested files, list source
+  files without tests, build a test-pairing map for a polyglot or non-.NET
+  repo, suggest a test-file path for a source file, prioritize test work by
+  declared API surface, audit which source files any test references.
+  DO NOT USE FOR: measuring branch/line coverage (use language-native coverage
+  tools), ranking risk by complexity-vs-coverage (use `coverage-analysis` for
+  .NET CRAP scores), finding weak assertions in existing tests (use
+  `test-gap-analysis` or `assertion-quality`), or running actual mutation
+  testing. For a .NET-only repo, prefer `find-untested-sources` (Roslyn-based,
+  has richer namespace disambiguation).
+license: MIT
+---
+
+# Find Untested Sources (Polyglot)
+
+## Purpose
+
+Coverage tools answer "which lines were executed?" — they require a green build
+and a passing test run, which is minutes-to-tens-of-minutes on a real repo.
+The question this skill answers is different and much cheaper:
+
+> _Which source files have no test file referencing any of their declared
+> symbols?_
+
+That's the question an agent asks **before** writing a new test — and it can be
+answered statically in a few seconds by parsing every recognized source file
+with [tree-sitter](https://tree-sitter.github.io/), with **no build, no
+dependency resolution, no compilation**.
+
+This is the polyglot sibling of the C# `find-untested-sources` skill. The
+output schema is intentionally compatible so the same prompt patterns can
+consume either tool.
+
+## When to Use
+
+- The repository is not exclusively C#, or you want a tool that works
+  uniformly across multiple languages without per-language plumbing.
+- User asks "where should I add tests?", "which files have no tests?", "find
+  untested code", "give me a test gap list", "what's the next file to test".
+- Before invoking a test-generation agent, to produce a prioritized worklist.
+- After generating tests, to verify each new test file pairs to a source file.
+
+## When Not to Use
+
+- **C#-only repo** — prefer `find-untested-sources`. Its Roslyn-based
+  namespace disambiguation is strictly better than this skill's identifier
+  overlap on duplicated short names like `Settings` or `Context`.
+- **Line/branch coverage** — use language-native coverage tooling.
+- **Are existing tests strong?** — use `test-gap-analysis` or
+  `assertion-quality`.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| Repo root | Yes | — | Directory to scan recursively. |
+| `--lang LANG` | No | all | Restrict to a language (repeatable). One of `python`, `typescript`, `tsx`, `javascript`, `go`, `java`, `rust`, `csharp`, `ruby`. |
+| `--limit-untested N` | No | 0 (no limit) | Truncate the untested list to N entries. |
+| `--include-tested` | No | off | Include `tested_sources` in the payload (large). |
+
+### Prerequisites
+
+- Python 3.10+.
+- `pip install tree-sitter-language-pack` (single self-contained wheel that
+  bundles parsers for 300+ languages and the high-level `process()` API used
+  here). No native build, no per-language grammar install.
+
+## Usage
+
+```powershell
+# From the skill folder
+python scripts/find_untested_sources.py <repo-root>
+
+# Restrict to a language
+python scripts/find_untested_sources.py <repo-root> --lang python --lang typescript
+
+# Truncate the report (top 20 by declared API surface)
+python scripts/find_untested_sources.py <repo-root> --limit-untested 20 > pairing.json
+
+# Iterate, highest-API-surface first
+$report = Get-Content pairing.json | ConvertFrom-Json
+$report.untested_sources | Select-Object -First 10 path, declaration_count, suggested_test_path
+```
+
+Diagnostics go to stderr; JSON goes to stdout.
+
+## Output Schema
+
+```jsonc
+{
+  "repo_root": "<absolute path>",
+  "summary": {
+    "source_files": 3138,
+    "test_files": 761,
+    "tested_source_files": 1419,
+    "untested_source_files": 1719,
+    "orphan_test_files": 15,
+    "languages": ["csharp"]
+  },
+  "untested_sources": [
+    {
+      "path": "src/Foo/Bar.cs",
+      "language": "csharp",
+      "declaration_count": 8,
+      "declarations": ["Bar", "BarOptions", "IBar", "..."],
+      "suggested_test_path": "src/Foo/BarTests.cs"
+    }
+  ],
+  "orphan_tests": [
+    { "path": "tests/SomeIntegrationTest.cs", "language": "csharp" }
+  ]
+}
+```
+
+Pass `--include-tested` to additionally emit `tested_sources` (same shape as
+`untested_sources` but with a `covering_tests` array instead of a suggested
+path). Omitted by default to keep the payload small for LLM consumption.
+
+## How It Works
+
+1. **File discovery** — recursive directory walk pruning common build/vendor
+   dirs (`bin`, `obj`, `node_modules`, `target`, `dist`, `build`, `vendor`,
+   `__pycache__`, `.venv`, `.git`, etc.). Skips generated files (`.d.ts`,
+   `.g.cs`, `.Designer.cs`, `_pb2.py`, `*.min.js`, `AssemblyInfo.cs`, ...).
+
+2. **Language detection** — `tree_sitter_language_pack.detect_language_from_path`
+   maps the extension to one of the supported languages. Unknown extensions
+   are skipped silently.
+
+3. **Test-vs-source classification** — per-language path heuristics:
+
+   | Language | Test rule |
+   |---|---|
+   | Python | path contains `tests/` or `test/`; or filename starts with `test_` or ends with `_test.py`; or `conftest.py`. |
+   | JS/TS/TSX | path contains `__tests__`, `tests`, `spec`, or `e2e`; or filename contains `.test.` or `.spec.`. |
+   | Go | filename ends with `_test.go` (Go's standard convention). |
+   | Java | path contains `test` or `tests`; or filename ends with `Test.java` / `Tests.java`. |
+   | Rust | path contains `tests/` or `benches/`. |
+   | C# | path contains `tests/`; or project segment ends with `.Tests`, `.Test`, `.UnitTests`, `.IntegrationTests`; or filename ends with `Tests`/`Test`. |
+   | Ruby | path contains `spec/`, `test/`; or filename ends with `_spec.rb` / `_test.rb`. |
+
+4. **Per-file extraction** — `tree_sitter_language_pack.process(text,
+   ProcessConfig(language=lang, structure=True, imports=True, symbols=True))`
+   returns:
+   - `structure` — top-level declared items (functions, classes, methods,
+     traits, ...) with their names. Used as the declared-symbol set.
+   - `imports` — raw import statements (e.g. `from foo import bar`,
+     `import "pkg/util"`, `using System.IO;`, `use crate::foo::Bar;`).
+   - `symbols` — flat declared-name list, used as a fallback when
+     `structure` is empty.
+
+5. **Pairing** — for each test file, union the results of:
+   - **Import resolution** (per language):
+     - Python: `from pkg.mod import x` → `pkg/mod.py` or
+       `pkg/mod/__init__.py`.
+     - TS/JS: relative `./foo` / `../bar` → with `.ts`/`.tsx`/`.js`/`.jsx`
+       and `/index.*` candidate paths.
+     - Go: `"path/to/pkg"` → any source file whose final path segment
+       matches `pkg.go` in the index.
+     - Java: `import a.b.C;` → `a/b/C.java`.
+     - Rust: `use a::b::C;` → `b.rs` or `C.rs` (best-effort, no module tree).
+     - Ruby: `require 'foo/bar'` → `foo/bar.rb`.
+     - C#: `using` maps to namespaces, not files; intentionally a no-op —
+       falls through to identifier overlap below.
+   - **Identifier overlap** — every word-like token in the test source is
+     looked up in the source index of declared names (length ≥ 4 to keep
+     noise down). Any source whose declared name appears as a token in the
+     same-language test is paired.
+
+6. **JSON emit** — `untested_sources` is ordered by declaration count
+   descending so the highest-API-surface gap appears first.
+
+## Limitations
+
+This is a static, parse-only heuristic. It deliberately trades a small amount
+of accuracy for orders-of-magnitude lower cost than coverage. Known gaps:
+
+- **Reflection / DI-resolved types** that a test only references through a
+  string name or container resolution don't appear in the identifier scan.
+- **C#** specifically: namespace disambiguation is the C# tool's strength;
+  this polyglot version intentionally skips it. If you have a .NET-only
+  repository, prefer the Roslyn-based `find-untested-sources`.
+- **Short identifier names** (< 4 chars) are dropped from the overlap index
+  to avoid noisy pairings on names like `id`, `db`, `Tag`.
+- **Cross-language tests** (Python tests driving a Go binary, etc.) are
+  recorded as orphan tests since same-language pairing is the rule.
+- **Monorepo path aliases** (TS path mapping, Java module-info) are not
+  resolved; the suffix-match fallback may pick the wrong source if two files
+  share a trailing path segment in different sub-projects.
+
+For these cases, run actual coverage on the unpaired candidates the agent
+has already triaged.
+
+## Outputs the agent should consume
+
+- `untested_sources[*].path` — pick the next source file to test (highest
+  `declaration_count` first).
+- `untested_sources[*].suggested_test_path` — drop-in target for the new
+  test file using the per-language convention.
+- (With `--include-tested`) `tested_sources[*].covering_tests` — verify a
+  newly written test file lands in the list for the intended source.
+- `orphan_tests` — tests that don't appear to reference any same-language
+  source file; useful for triaging stale tests or integration-only tests.

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md
@@ -1,24 +1,13 @@
 ---
 name: find-untested-sources-polyglot
 description: >
-  Polyglot, parse-only static analysis that maps source files to the test files
-  that reference them, and lists production source files with **no** test file
-  referencing any of their declared symbols. Designed to answer "which source
-  files have no tests yet?" in seconds, without running a build or coverage,
-  across Python, TypeScript/JavaScript, Go, Java, Rust, C#, and Ruby (any
-  language tree-sitter can parse and classify as test vs. source). Emits JSON
-  with the same shape as the C# `find-untested-sources` skill so prompts and
-  tooling can consume both.
-  USE FOR: where should I write tests next, find untested files, list source
-  files without tests, build a test-pairing map for a polyglot or non-.NET
-  repo, suggest a test-file path for a source file, prioritize test work by
-  declared API surface, audit which source files any test references.
-  DO NOT USE FOR: measuring branch/line coverage (use language-native coverage
-  tools), ranking risk by complexity-vs-coverage (use `coverage-analysis` for
-  .NET CRAP scores), finding weak assertions in existing tests (use
-  `test-gap-analysis` or `assertion-quality`), or running actual mutation
-  testing. For a .NET-only repo, prefer `find-untested-sources` (Roslyn-based,
-  has richer namespace disambiguation).
+  Polyglot, parse-only static analysis that pairs source files with
+  referencing tests across Python, TypeScript/JavaScript, Go, Java, Rust,
+  C#, and Ruby. JSON shape matches `find-untested-sources`.
+  USE FOR: where to write tests next, find untested files, list sources
+  without tests, polyglot test-pairing map.
+  DO NOT USE FOR: coverage, CRAP risk. For .NET-only repos prefer
+  `find-untested-sources`.
 license: MIT
 ---
 
@@ -157,8 +146,9 @@ path). Omitted by default to keep the payload small for LLM consumption.
      traits, ...) with their names. Used as the declared-symbol set.
    - `imports` — raw import statements (e.g. `from foo import bar`,
      `import "pkg/util"`, `using System.IO;`, `use crate::foo::Bar;`).
-   - `symbols` — flat declared-name list, used as a fallback when
-     `structure` is empty.
+   - `symbols` — flat declared-name list, unioned with `structure` (acts as
+     a fallback when `structure` is empty, and broadens coverage when both
+     are populated; declaration counts may exceed pure structure parsing).
 
 5. **Pairing** — for each test file, union the results of:
    - **Import resolution** (per language):

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
@@ -250,17 +250,29 @@ def parse_file(path: Path, root: Path) -> FileInfo | None:
     except Exception:
         return info
 
-    # Top-level declarations: from structure (preferred) or symbols (fallback).
-    if getattr(result, "structure", None):
-        for item in result.structure:
-            name = getattr(item, "name", None)
-            if name:
-                info.declarations.add(name)
-    if not info.declarations and getattr(result, "symbols", None):
-        for sym in result.symbols:
-            name = getattr(sym, "name", None)
-            if name:
-                info.declarations.add(name)
+    # Top-level declarations: union of structure + symbols. The two views are
+    # complementary depending on the language — e.g. for Go, `structure` lists
+    # functions/methods but not `type` declarations, while `symbols` lists the
+    # types. We filter `module`/`namespace` kinds (they're packaging, not
+    # declarations) to avoid false-positive pairings on package names.
+    excluded_kinds = {"module", "namespace"}
+
+    def _kind_str(item: object) -> str:
+        k = getattr(item, "kind", None)
+        return str(k).lower() if k is not None else ""
+
+    for item in getattr(result, "structure", None) or []:
+        if _kind_str(item) in excluded_kinds:
+            continue
+        name = getattr(item, "name", None)
+        if name:
+            info.declarations.add(name)
+    for sym in getattr(result, "symbols", None) or []:
+        if _kind_str(sym) in excluded_kinds:
+            continue
+        name = getattr(sym, "name", None)
+        if name:
+            info.declarations.add(name)
 
     # Imports: keep the raw `source` field; we'll normalize per language.
     if getattr(result, "imports", None):

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
@@ -1,0 +1,641 @@
+"""Polyglot source-to-test pairing analyzer using tree-sitter.
+
+Given a repo root, identifies which source files are NOT covered by any test
+file via two complementary heuristics:
+
+  1. Identifier overlap: a test file declares (or references) the same name
+     a source file declares as a top-level symbol.
+  2. Import resolution: a test file imports a module/path that resolves to a
+     source file.
+
+Supports any language tree-sitter-language-pack can parse and classify (Python,
+TypeScript, JavaScript, Go, Java, Rust, C#, Ruby, ...).
+
+Output: JSON to stdout matching the schema used by the C# `find-untested-sources`
+skill, so the same prompt patterns can consume both tools.
+
+Dependencies:
+    pip install tree-sitter-language-pack
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+try:
+    from tree_sitter_language_pack import (
+        ProcessConfig,
+        detect_language_from_path,
+        process,
+    )
+except ImportError as e:
+    print(
+        "ERROR: tree-sitter-language-pack is not installed.\n"
+        "Run: pip install tree-sitter-language-pack",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from e
+
+
+# Languages we'll process. Anything not in this set is skipped even if the
+# pack can parse it, because we have no test-detection heuristic for it.
+SUPPORTED_LANGUAGES = {
+    "python",
+    "typescript",
+    "tsx",
+    "javascript",
+    "go",
+    "java",
+    "rust",
+    "csharp",
+    "ruby",
+}
+
+# Directories we never descend into. Lowercase match on segment name.
+PRUNE_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".vs",
+    ".vscode",
+    ".idea",
+    "node_modules",
+    "bower_components",
+    "vendor",
+    "third_party",
+    "dist",
+    "build",
+    "out",
+    "target",  # rust + java
+    "bin",
+    "obj",
+    "packages",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "env",
+    ".nuget",
+    "TestResults",
+    "coverage",
+    ".next",
+    ".nuxt",
+    ".cache",
+    ".gradle",
+    ".terraform",
+    "site-packages",
+}
+
+# Filename patterns to skip (generated, minified, declaration files).
+SKIP_FILENAME_PATTERNS = (
+    re.compile(r"\.min\.(js|css)$", re.IGNORECASE),
+    re.compile(r"\.d\.ts$", re.IGNORECASE),
+    re.compile(r"\.designer\.cs$", re.IGNORECASE),
+    re.compile(r"\.g\.cs$", re.IGNORECASE),
+    re.compile(r"\.g\.i\.cs$", re.IGNORECASE),
+    re.compile(r"\.generated\.cs$", re.IGNORECASE),
+    re.compile(r"AssemblyInfo\.cs$"),
+    re.compile(r"AssemblyAttributes\.cs$"),
+    re.compile(r"GlobalUsings?\.cs$"),
+    re.compile(r"_pb2\.py$"),
+    re.compile(r"_pb\.go$"),
+    re.compile(r"\.pb\.go$"),
+)
+
+
+def is_test_path(rel: PurePosixPath, lang: str) -> bool:
+    """Best-effort per-language test classification using path/filename."""
+    parts = [p.lower() for p in rel.parts]
+    name = rel.name.lower()
+    stem = rel.stem.lower()
+
+    if lang == "python":
+        if any(p in ("tests", "test") for p in parts):
+            return True
+        if name.startswith("test_") or stem.endswith("_test"):
+            return True
+        if "conftest.py" in name:
+            return True
+        return False
+
+    if lang in ("typescript", "tsx", "javascript"):
+        if any(p in ("__tests__", "tests", "test", "spec", "e2e") for p in parts):
+            return True
+        if any(s in stem for s in (".test", ".spec")):
+            return True
+        return False
+
+    if lang == "go":
+        return stem.endswith("_test")
+
+    if lang == "java":
+        if "test" in parts or "tests" in parts:
+            return True
+        return name.endswith("test.java") or name.endswith("tests.java") or name.startswith("test")
+
+    if lang == "rust":
+        if any(p in ("tests", "benches") for p in parts):
+            return True
+        return False
+
+    if lang == "csharp":
+        if any(p in ("tests", "test") for p in parts):
+            return True
+        for p in parts:
+            if p.endswith(".tests") or p.endswith(".test") or p.endswith(".unittests") or p.endswith(".integrationtests"):
+                return True
+        if stem.endswith("tests") or stem.endswith("test"):
+            return True
+        return False
+
+    if lang == "ruby":
+        if any(p in ("spec", "test", "tests") for p in parts):
+            return True
+        return stem.endswith("_spec") or stem.endswith("_test")
+
+    return False
+
+
+@dataclass
+class FileInfo:
+    path: Path
+    rel: PurePosixPath
+    lang: str
+    is_test: bool
+    declarations: set[str] = field(default_factory=set)
+    referenced_identifiers: set[str] = field(default_factory=set)
+    imports: list[str] = field(default_factory=list)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+
+def should_skip_filename(name: str) -> bool:
+    return any(p.search(name) for p in SKIP_FILENAME_PATTERNS)
+
+
+def walk_files(root: Path, lang_filter: set[str] | None = None) -> Iterable[Path]:
+    """Yield files under root, pruning common build/vendor directories."""
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            children = list(current.iterdir())
+        except (PermissionError, OSError):
+            continue
+        for child in children:
+            try:
+                if child.is_symlink():
+                    continue
+            except OSError:
+                continue
+            if child.is_dir():
+                if child.name.lower() in PRUNE_DIRS:
+                    continue
+                stack.append(child)
+                continue
+            if not child.is_file():
+                continue
+            if should_skip_filename(child.name):
+                continue
+            lang = detect_language_from_path(str(child))
+            if lang is None:
+                continue
+            if lang not in SUPPORTED_LANGUAGES:
+                continue
+            if lang_filter is not None and lang not in lang_filter:
+                continue
+            yield child
+
+
+# Word-character regex used to harvest identifiers from a test file's source
+# for the "identifier overlap" pairing strategy. Tree-sitter's `symbols` output
+# only gives us declared names; references (`new Foo()`, `Foo.bar()`) won't
+# appear, so we fall back to a simple word scan over the file body.
+IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def harvest_identifiers(text: str) -> set[str]:
+    return set(IDENTIFIER_RE.findall(text))
+
+
+def parse_file(path: Path, root: Path) -> FileInfo | None:
+    rel_str = path.relative_to(root).as_posix()
+    rel = PurePosixPath(rel_str)
+    lang = detect_language_from_path(str(path))
+    if lang is None or lang not in SUPPORTED_LANGUAGES:
+        return None
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    is_test = is_test_path(rel, lang)
+    info = FileInfo(path=path, rel=rel, lang=lang, is_test=is_test)
+
+    try:
+        cfg = ProcessConfig(language=lang, structure=True, imports=True, symbols=True)
+        result = process(text, cfg)
+    except Exception:
+        return info
+
+    # Top-level declarations: from structure (preferred) or symbols (fallback).
+    if getattr(result, "structure", None):
+        for item in result.structure:
+            name = getattr(item, "name", None)
+            if name:
+                info.declarations.add(name)
+    if not info.declarations and getattr(result, "symbols", None):
+        for sym in result.symbols:
+            name = getattr(sym, "name", None)
+            if name:
+                info.declarations.add(name)
+
+    # Imports: keep the raw `source` field; we'll normalize per language.
+    if getattr(result, "imports", None):
+        for imp in result.imports:
+            src = getattr(imp, "source", None)
+            if src:
+                info.imports.append(src)
+
+    # For test files only, scan all identifier-like tokens — caller uses these
+    # to pair with source declarations by name.
+    if is_test:
+        info.referenced_identifiers = harvest_identifiers(text)
+
+    return info
+
+
+# --- Per-language import-to-path resolution --------------------------------
+
+
+def _strip_quoted(value: str) -> str:
+    """Return the first quoted substring or the original string trimmed."""
+    m = re.search(r"""['"`]([^'"`]+)['"`]""", value)
+    if m:
+        return m.group(1)
+    return value.strip()
+
+
+def _resolve_relative_js(test_rel: PurePosixPath, target: str) -> set[PurePosixPath]:
+    """Resolve ./ or ../ relative import paths to candidate source paths."""
+    if not (target.startswith("./") or target.startswith("../") or target.startswith("/")):
+        return set()
+    base = PurePosixPath(target)
+    if target.startswith("/"):
+        joined = PurePosixPath(target.lstrip("/"))
+    else:
+        joined = (test_rel.parent / base).as_posix()
+        joined = PurePosixPath(re.sub(r"/[^/]+/\.\./", "/", joined))
+    # Try various extensions and /index suffix.
+    candidates = set()
+    stems = [str(joined)]
+    if str(joined).endswith("/index"):
+        stems.append(str(joined)[: -len("/index")])
+    for stem in stems:
+        for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
+            candidates.add(PurePosixPath(stem + ext))
+        candidates.add(PurePosixPath(stem + "/index.ts"))
+        candidates.add(PurePosixPath(stem + "/index.tsx"))
+        candidates.add(PurePosixPath(stem + "/index.js"))
+    return candidates
+
+
+def _extract_python_module(import_text: str) -> str | None:
+    """Extract `pkg.mod` from `from pkg.mod import x` or `import pkg.mod`."""
+    s = import_text.strip()
+    m = re.match(r"from\s+([\.\w]+)\s+import", s)
+    if m:
+        return m.group(1)
+    m = re.match(r"import\s+([\.\w]+)", s)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _python_module_to_path(module: str) -> set[PurePosixPath]:
+    parts = module.lstrip(".").split(".")
+    candidates: set[PurePosixPath] = set()
+    base = "/".join(parts)
+    candidates.add(PurePosixPath(base + ".py"))
+    candidates.add(PurePosixPath(base + "/__init__.py"))
+    return candidates
+
+
+def _extract_java_fqcn(import_text: str) -> str | None:
+    m = re.match(r"import\s+(?:static\s+)?([\w\.]+)", import_text.strip())
+    if not m:
+        return None
+    fqcn = m.group(1).rstrip(";").rstrip(".*")
+    return fqcn
+
+
+def _java_fqcn_to_path(fqcn: str) -> PurePosixPath:
+    return PurePosixPath(fqcn.replace(".", "/") + ".java")
+
+
+def _extract_csharp_using(import_text: str) -> str | None:
+    m = re.match(r"using\s+(?:static\s+)?([\w\.]+)", import_text.strip())
+    if not m:
+        return None
+    return m.group(1).rstrip(";")
+
+
+def _extract_rust_use(import_text: str) -> set[str]:
+    """Extract crate-relative paths from `use foo::bar::Baz;`."""
+    s = import_text.strip().rstrip(";")
+    m = re.match(r"use\s+(.+)", s)
+    if not m:
+        return set()
+    body = m.group(1).strip()
+    # Strip `as` aliases; ignore grouped imports for simplicity.
+    body = body.split(" as ")[0].strip()
+    return {body}
+
+
+def _extract_go_import_targets(import_text: str) -> set[str]:
+    s = import_text.strip()
+    targets: set[str] = set()
+    for m in re.finditer(r'"([^"]+)"', s):
+        targets.add(m.group(1))
+    return targets
+
+
+# --- Pairing engine --------------------------------------------------------
+
+
+def _build_indexes(sources: list[FileInfo]) -> dict:
+    """Build lookup indexes used to resolve test imports to source files."""
+    by_rel: dict[str, FileInfo] = {s.rel.as_posix().lower(): s for s in sources}
+    by_decl: dict[str, list[FileInfo]] = {}
+    for s in sources:
+        for d in s.declarations:
+            by_decl.setdefault(d, []).append(s)
+    # For Java/C#: index by FQCN-like trailing path.
+    by_path_suffix: dict[str, list[FileInfo]] = {}
+    for s in sources:
+        p = s.rel.as_posix().lower()
+        parts = p.split("/")
+        for i in range(len(parts)):
+            suffix = "/".join(parts[i:])
+            by_path_suffix.setdefault(suffix, []).append(s)
+    return {
+        "by_rel": by_rel,
+        "by_decl": by_decl,
+        "by_path_suffix": by_path_suffix,
+    }
+
+
+def _resolve_test_imports(test: FileInfo, indexes: dict, lang: str) -> set[FileInfo]:
+    """Given a test file's imports, return source files those imports resolve to."""
+    found: set[FileInfo] = set()
+    by_rel = indexes["by_rel"]
+    by_path_suffix = indexes["by_path_suffix"]
+
+    def add_candidate(path: PurePosixPath) -> None:
+        key = path.as_posix().lower()
+        if key in by_rel:
+            found.add(by_rel[key])
+            return
+        # Try matching by suffix (covers monorepo / aliased layouts).
+        matches = by_path_suffix.get(key, [])
+        if len(matches) == 1:
+            found.add(matches[0])
+
+    for raw in test.imports:
+        if lang in ("typescript", "tsx", "javascript"):
+            target = _strip_quoted(raw)
+            for c in _resolve_relative_js(test.rel, target):
+                add_candidate(c)
+        elif lang == "python":
+            module = _extract_python_module(raw)
+            if module is None:
+                continue
+            for c in _python_module_to_path(module):
+                add_candidate(c)
+        elif lang == "go":
+            for tgt in _extract_go_import_targets(raw):
+                segs = tgt.split("/")
+                if not segs:
+                    continue
+                last = segs[-1]
+                key = last + ".go"
+                for source_path, info in by_rel.items():
+                    if source_path.endswith("/" + key) or source_path == key:
+                        if not info.is_test:
+                            found.add(info)
+        elif lang == "java":
+            fqcn = _extract_java_fqcn(raw)
+            if fqcn:
+                add_candidate(_java_fqcn_to_path(fqcn))
+        elif lang == "rust":
+            for use_path in _extract_rust_use(raw):
+                segs = use_path.split("::")
+                if not segs:
+                    continue
+                last = segs[-1]
+                add_candidate(PurePosixPath(last + ".rs"))
+                if len(segs) >= 2:
+                    add_candidate(PurePosixPath(segs[-2] + ".rs"))
+        elif lang == "csharp":
+            ns = _extract_csharp_using(raw)
+            if ns:
+                # using maps to namespace, not file; we fall back to identifier overlap.
+                pass
+        elif lang == "ruby":
+            target = _strip_quoted(raw)
+            if target:
+                add_candidate(PurePosixPath(target + ".rb"))
+
+    return found
+
+
+def _resolve_test_by_identifiers(
+    test: FileInfo,
+    indexes: dict,
+) -> set[FileInfo]:
+    """Pair test with sources whose declarations appear in the test's token set."""
+    found: set[FileInfo] = set()
+    by_decl = indexes["by_decl"]
+    # Limit to declarations that are >=4 chars to avoid noise.
+    for decl, sources in by_decl.items():
+        if len(decl) < 4:
+            continue
+        if decl in test.referenced_identifiers:
+            for s in sources:
+                if s.lang == test.lang:
+                    found.add(s)
+    return found
+
+
+def build_pairings(
+    sources: list[FileInfo],
+    tests: list[FileInfo],
+) -> tuple[dict[FileInfo, set[FileInfo]], list[FileInfo]]:
+    """Return (source -> covering tests) and the list of orphan test files."""
+    by_lang_indexes: dict[str, dict] = {}
+    for lang in SUPPORTED_LANGUAGES:
+        lang_sources = [s for s in sources if s.lang == lang]
+        if lang_sources:
+            by_lang_indexes[lang] = _build_indexes(lang_sources)
+
+    source_to_tests: dict[FileInfo, set[FileInfo]] = {s: set() for s in sources}
+    orphans: list[FileInfo] = []
+
+    for t in tests:
+        idx = by_lang_indexes.get(t.lang)
+        if idx is None:
+            orphans.append(t)
+            continue
+        matched = _resolve_test_imports(t, idx, t.lang) | _resolve_test_by_identifiers(t, idx)
+        if not matched:
+            orphans.append(t)
+            continue
+        for s in matched:
+            source_to_tests[s].add(t)
+
+    return source_to_tests, orphans
+
+
+# --- Output ----------------------------------------------------------------
+
+
+def _suggest_test_path(source: FileInfo) -> str:
+    rel = source.rel
+    lang = source.lang
+    stem = rel.stem
+    parent = rel.parent
+
+    if lang == "python":
+        return str(parent / f"test_{stem}.py")
+    if lang == "go":
+        return str(parent / f"{stem}_test.go")
+    if lang in ("typescript", "tsx"):
+        return str(parent / f"{stem}.test.{rel.suffix.lstrip('.')}")
+    if lang == "javascript":
+        return str(parent / f"{stem}.test.js")
+    if lang == "java":
+        return str(parent / f"{stem}Test.java")
+    if lang == "rust":
+        return str(parent / f"{stem}_test.rs")
+    if lang == "csharp":
+        return str(parent / f"{stem}Tests.cs")
+    if lang == "ruby":
+        return str(parent / f"{stem}_spec.rb")
+    return ""
+
+
+def build_output(
+    sources: list[FileInfo],
+    tests: list[FileInfo],
+    source_to_tests: dict[FileInfo, set[FileInfo]],
+    orphans: list[FileInfo],
+    repo_root: Path,
+) -> dict:
+    untested: list[dict] = []
+    tested: list[dict] = []
+    for s in sources:
+        covering = sorted(source_to_tests.get(s, set()), key=lambda t: t.rel.as_posix())
+        entry = {
+            "path": s.rel.as_posix(),
+            "language": s.lang,
+            "declaration_count": len(s.declarations),
+            "declarations": sorted(s.declarations),
+        }
+        if covering:
+            entry["covering_tests"] = [c.rel.as_posix() for c in covering]
+            tested.append(entry)
+        else:
+            entry["suggested_test_path"] = _suggest_test_path(s)
+            untested.append(entry)
+
+    return {
+        "repo_root": str(repo_root),
+        "summary": {
+            "source_files": len(sources),
+            "test_files": len(tests),
+            "tested_source_files": len(tested),
+            "untested_source_files": len(untested),
+            "orphan_test_files": len(orphans),
+            "languages": sorted({s.lang for s in sources} | {t.lang for t in tests}),
+        },
+        "untested_sources": sorted(untested, key=lambda e: (-e["declaration_count"], e["path"])),
+        "tested_sources": tested,
+        "orphan_tests": [
+            {"path": t.rel.as_posix(), "language": t.lang} for t in sorted(orphans, key=lambda t: t.rel.as_posix())
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find untested source files in a polyglot repository using tree-sitter."
+    )
+    parser.add_argument("root", type=Path, help="Path to repository root.")
+    parser.add_argument(
+        "--lang",
+        action="append",
+        choices=sorted(SUPPORTED_LANGUAGES),
+        help="Restrict analysis to specified language(s). Repeatable.",
+    )
+    parser.add_argument(
+        "--limit-untested",
+        type=int,
+        default=0,
+        help="If > 0, truncate the untested_sources list to N entries.",
+    )
+    parser.add_argument(
+        "--include-tested",
+        action="store_true",
+        help="Include tested_sources in the output (omitted by default to keep payload small).",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        return 1
+
+    lang_filter = set(args.lang) if args.lang else None
+    print(f"Scanning {root}...", file=sys.stderr)
+
+    sources: list[FileInfo] = []
+    tests: list[FileInfo] = []
+    parsed_count = 0
+    for path in walk_files(root, lang_filter=lang_filter):
+        info = parse_file(path, root)
+        if info is None:
+            continue
+        parsed_count += 1
+        if info.is_test:
+            tests.append(info)
+        else:
+            sources.append(info)
+    print(f"Parsed {parsed_count} files: {len(sources)} source, {len(tests)} test.", file=sys.stderr)
+
+    source_to_tests, orphans = build_pairings(sources, tests)
+    output = build_output(sources, tests, source_to_tests, orphans, root)
+
+    if args.limit_untested and args.limit_untested > 0:
+        output["untested_sources"] = output["untested_sources"][: args.limit_untested]
+    if not args.include_tested:
+        output.pop("tested_sources", None)
+
+    json.dump(output, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
@@ -139,7 +139,7 @@ def is_test_path(rel: PurePosixPath, lang: str) -> bool:
     if lang == "java":
         if "test" in parts or "tests" in parts:
             return True
-        return name.endswith("test.java") or name.endswith("tests.java") or name.startswith("test")
+        return name.endswith("test.java") or name.endswith("tests.java")
 
     if lang == "rust":
         if any(p in ("tests", "benches") for p in parts):
@@ -152,7 +152,14 @@ def is_test_path(rel: PurePosixPath, lang: str) -> bool:
         for p in parts:
             if p.endswith(".tests") or p.endswith(".test") or p.endswith(".unittests") or p.endswith(".integrationtests"):
                 return True
-        if stem.endswith("tests") or stem.endswith("test"):
+        # Tokenize the original (un-lowered) stem on PascalCase boundaries
+        # and treat it as a test file when the final word is "Test" / "Tests".
+        # This matches the .NET convention (`UserServiceTests`, `MyTest`)
+        # without misclassifying non-test files whose lower-cased stem
+        # coincidentally ends in "test"/"tests" (e.g. "Contest.cs",
+        # "Latest.cs", "Manifest.cs").
+        words = re.findall(r"[A-Z][a-z]*|[a-z]+|[0-9]+", rel.stem)
+        if words and words[-1] in ("Test", "Tests"):
             return True
         return False
 
@@ -308,8 +315,17 @@ def _resolve_relative_js(test_rel: PurePosixPath, target: str) -> set[PurePosixP
     if target.startswith("/"):
         joined = PurePosixPath(target.lstrip("/"))
     else:
-        joined = (test_rel.parent / base).as_posix()
-        joined = PurePosixPath(re.sub(r"/[^/]+/\.\./", "/", joined))
+        joined_str = (test_rel.parent / base).as_posix()
+        # Collapse any number of "<seg>/../" pairs, including chained ones
+        # like "a/b/../../c" → "c". The previous regex only collapsed a single
+        # occurrence so chained "../../foo" imports stayed partially
+        # un-normalized and failed to match indexed paths.
+        prev = None
+        while prev != joined_str:
+            prev = joined_str
+            joined_str = re.sub(r"(?:^|/)[^/]+/\.\./", "/", joined_str)
+        joined_str = joined_str.lstrip("/")
+        joined = PurePosixPath(joined_str)
     # Try various extensions and /index suffix.
     candidates = set()
     stems = [str(joined)]
@@ -480,14 +496,19 @@ def _resolve_test_by_identifiers(
     """Pair test with sources whose declarations appear in the test's token set."""
     found: set[FileInfo] = set()
     by_decl = indexes["by_decl"]
-    # Limit to declarations that are >=4 chars to avoid noise.
-    for decl, sources in by_decl.items():
-        if len(decl) < 4:
+    # Iterate the test's referenced identifiers (typically O(hundreds))
+    # rather than scanning every declaration in the index (O(#decls × #tests)
+    # across all tests), so pairing stays linear in repo size on large
+    # codebases.
+    for ident in test.referenced_identifiers:
+        if len(ident) < 4:
             continue
-        if decl in test.referenced_identifiers:
-            for s in sources:
-                if s.lang == test.lang:
-                    found.add(s)
+        sources = by_decl.get(ident)
+        if not sources:
+            continue
+        for s in sources:
+            if s.lang == test.lang:
+                found.add(s)
     return found
 
 

--- a/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py
@@ -254,7 +254,11 @@ def parse_file(path: Path, root: Path) -> FileInfo | None:
     try:
         cfg = ProcessConfig(language=lang, structure=True, imports=True, symbols=True)
         result = process(text, cfg)
-    except Exception:
+    except Exception as exc:
+        # Emit a diagnostic so users can see when tree-sitter parsing silently
+        # degrades results (e.g. 0-declaration sources because the parser
+        # blew up on an unusual construct). Keep it short — one line per file.
+        print(f"WARN: tree-sitter parse failed for {rel_str} ({lang}): {exc}", file=sys.stderr)
         return info
 
     # Top-level declarations: union of structure + symbols. The two views are
@@ -352,8 +356,35 @@ def _extract_python_module(import_text: str) -> str | None:
     return None
 
 
-def _python_module_to_path(module: str) -> set[PurePosixPath]:
-    parts = module.lstrip(".").split(".")
+def _python_module_to_path(
+    module: str, test_rel: PurePosixPath | None = None
+) -> set[PurePosixPath]:
+    """Resolve a Python import target to candidate source paths.
+
+    Leading dots (PEP 328 relative imports) are resolved against `test_rel`'s
+    directory: one dot = same package as the test file, each extra dot walks
+    one directory up. Without a `test_rel` context we cannot resolve them
+    safely, so we return an empty set rather than risk pairing the test with
+    an unrelated `utils.py` at the repo root.
+    """
+    leading_dots = len(module) - len(module.lstrip("."))
+    rest = module[leading_dots:]
+    if leading_dots > 0:
+        if test_rel is None or not rest:
+            # Either we have no context to resolve against, or this is a
+            # `from . import x` form where the regex captured only the dots
+            # and we don't know the imported name. Skip rather than guess.
+            return set()
+        base_dir = test_rel.parent
+        for _ in range(leading_dots - 1):
+            base_dir = base_dir.parent
+        parts = rest.split(".")
+        base_path = base_dir.joinpath(*parts) if base_dir.parts else PurePosixPath(*parts)
+        return {
+            PurePosixPath(str(base_path) + ".py"),
+            PurePosixPath(str(base_path) + "/__init__.py"),
+        }
+    parts = rest.split(".")
     candidates: set[PurePosixPath] = set()
     base = "/".join(parts)
     candidates.add(PurePosixPath(base + ".py"))
@@ -412,16 +443,21 @@ def _build_indexes(sources: list[FileInfo]) -> dict:
             by_decl.setdefault(d, []).append(s)
     # For Java/C#: index by FQCN-like trailing path.
     by_path_suffix: dict[str, list[FileInfo]] = {}
+    # For Go: index by basename so import resolution is O(1) per target
+    # instead of O(#sources) per import target.
+    by_filename: dict[str, list[FileInfo]] = {}
     for s in sources:
         p = s.rel.as_posix().lower()
         parts = p.split("/")
         for i in range(len(parts)):
             suffix = "/".join(parts[i:])
             by_path_suffix.setdefault(suffix, []).append(s)
+        by_filename.setdefault(s.rel.name.lower(), []).append(s)
     return {
         "by_rel": by_rel,
         "by_decl": by_decl,
         "by_path_suffix": by_path_suffix,
+        "by_filename": by_filename,
     }
 
 
@@ -450,19 +486,19 @@ def _resolve_test_imports(test: FileInfo, indexes: dict, lang: str) -> set[FileI
             module = _extract_python_module(raw)
             if module is None:
                 continue
-            for c in _python_module_to_path(module):
+            for c in _python_module_to_path(module, test.rel):
                 add_candidate(c)
         elif lang == "go":
+            by_filename = indexes["by_filename"]
             for tgt in _extract_go_import_targets(raw):
                 segs = tgt.split("/")
                 if not segs:
                     continue
                 last = segs[-1]
-                key = last + ".go"
-                for source_path, info in by_rel.items():
-                    if source_path.endswith("/" + key) or source_path == key:
-                        if not info.is_test:
-                            found.add(info)
+                key = (last + ".go").lower()
+                for info in by_filename.get(key, ()):
+                    if not info.is_test:
+                        found.add(info)
         elif lang == "java":
             fqcn = _extract_java_fqcn(raw)
             if fqcn:
@@ -604,7 +640,7 @@ def build_output(
             "languages": sorted({s.lang for s in sources} | {t.lang for t in tests}),
         },
         "untested_sources": sorted(untested, key=lambda e: (-e["declaration_count"], e["path"])),
-        "tested_sources": tested,
+        "tested_sources": sorted(tested, key=lambda e: e["path"]),
         "orphan_tests": [
             {"path": t.rel.as_posix(), "language": t.lang} for t in sorted(orphans, key=lambda t: t.rel.as_posix())
         ],


### PR DESCRIPTION
Adds a polyglot sibling to the C# `find-untested-sources` skill (PR #733): a
single `python scripts/find_untested_sources.py <repo>` invocation that lists
production source files with no test file referencing any of their declared
symbols, across Python, TypeScript, TSX, JavaScript, Go, Java, Rust, C#, and
Ruby. Uses `tree-sitter-language-pack` (one wheel, bundled grammars, no
native build).

## Why both?

The C# version uses Roslyn with strict namespace disambiguation — strictly
better on .NET-only repos. The polyglot version covers everything else with
the same output schema, so prompts can branch on language/extension and call
whichever tool fits the repo.

The skill's `DO NOT USE FOR` says: `For a .NET-only repo, prefer
find-untested-sources`. They're sibling tools, not replacements.

## How it works

1. Walk repo, prune common build/vendor dirs (`bin`, `obj`,
   `node_modules`, `target`, `dist`, `vendor`, `__pycache__`,
   `.venv`, `.git`, ...); skip generated files (`*.d.ts`, `*.g.cs`,
   `*.Designer.cs`, `_pb2.py`, `*.min.js`, `AssemblyInfo.cs`).
2. Detect language by extension via `detect_language_from_path`.
3. Classify test vs source via per-language path heuristics (see SKILL.md
   table).
4. For each file call `tree_sitter_language_pack.process(text,
   ProcessConfig(structure=True, imports=True, symbols=True))`. Union
   `structure` and `symbols` for the declared-name set (each view is
   incomplete on its own — e.g. Go `type` declarations only appear in
   `symbols`, methods only in `structure`); filter `module`/
   `namespace` kinds (would otherwise pair on Java package names).
5. Pair each test with its sources via:
   - Import resolution (Python module paths, TS/JS relative `./../index.*`,
     Go `pkg/<name>.go`, Java FQCN, Rust `use::`, Ruby `require`).
   - Identifier overlap (every ≥4-char token in the test source matched
     against the declared-name index; this is what catches C#, since
     `using` maps to namespaces not files).

Output JSON schema deliberately mirrors PR #733's so the same prompt patterns
consume either tool: `untested_sources` ordered by `declaration_count`,
each entry has `suggested_test_path`, plus an `orphan_tests` list.

## Validation

A synthetic harness creates one fixture per language with a paired source, an
orphan source, and a test referencing only the paired source, then asserts
`tested == 1 / untested == 1 / orphan == 0` and that the test appears in
the paired source's `covering_tests`:

| Language | Result |
|---|---|
| python | PASS |
| javascript | PASS |
| typescript | PASS |
| tsx | PASS |
| go | PASS |
| java | PASS |
| rust | PASS |
| csharp | PASS |
| ruby | PASS |

Real-repo smoke tests (no expected-output assertions, just sanity checks the
volume / orphan counts are reasonable):

| Fixture | src | test | tested | untested | orphan |
|---|---:|---:|---:|---:|---:|
| python-flask-tasks fixture | 8 | 0 | 0 | 8 | 0 |
| typescript-vitest-cart fixture (`--lang typescript`) | 8 | 0 | 0 | 8 | 0 |
| gh-skills (Go) | 14 | 7 | 8 | 6 | 0 |
| AITestAgent (C#, 3899 files) | 3138 | 761 | 1429 | 1709 | 15 |

The C# numbers are slightly worse than PR #733's Roslyn-based pairing
(1429 vs Roslyn's tighter count), which is exactly why the SKILL.md routes
.NET-only repos to the Roslyn skill.

## Limitations (documented honestly in SKILL.md)

- Reflection / DI-resolved types invisible (test only references the type by
  string name or container resolution).
- C# namespace disambiguation weaker than the Roslyn version — recommend
  `find-untested-sources` for .NET-only repos.
- Short identifiers (< 4 chars) dropped from the overlap index to avoid noisy
  pairings on names like `id`, `db`, `Tag`.
- Monorepo path aliases (TS path mapping, Java module-info) not resolved;
  suffix-match fallback may pick the wrong source if two files share a
  trailing path segment in different sub-projects.

## Commits

- `39c786671` — initial polyglot skill (SKILL.md + script, 9 languages).
- `e1aa26772` — union `structure` + `symbols` after the validation
  harness caught that Go `type` declarations were being dropped, causing
  source/test pairings to silently miss.

## Files

- `plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md`
- `plugins/dotnet-test/skills/find-untested-sources-polyglot/scripts/find_untested_sources.py`
