### PR TITLE
fix(devops-health): resilient dashboard issue discovery

### DIFF
--- a/.github/aw/shared/devops-health.lock.md
+++ b/.github/aw/shared/devops-health.lock.md
@@ -231,6 +231,7 @@ If no previous fingerprints exist in `cache-memory`:
 |-----|----------|---------|
 | `health-check-fingerprints` | Map of fingerprint → finding (with occurrences, first_seen) | Every run |
 | `health-check-history` | Array of daily summaries (date, counts by diff type and severity) | Appended each run |
+| `health-dashboard-issue` | Issue number of the canonical health dashboard issue. Used to update the dashboard **by number** so it stays stable even when GitHub's label search/list index drops the issue (which otherwise causes a duplicate dashboard to be created). | Every run |
 | `known-noise` | Array of fingerprint patterns to demote to Info | Manual edit |
 
 ### 7.4 Graceful Degradation

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -323,14 +323,45 @@ Using the classified findings, generate:
 
 ## Step 4: Output
 
-### 4.1 Find or Create the Pinned Issue
+### 4.1 Find or Create the Dashboard Issue
 
-Search for open issues with label `devops-health`:
-- If exactly one exists → update it
-- If none exist → create one with title `🏥 Repository Health Dashboard` and label `devops-health`
-- If multiple exist → update the most recently created one, close the others
+The dashboard MUST be the **same issue on every run**. GitHub's label search and
+issue-list APIs occasionally drop an open, correctly-labeled issue from their
+index — when that happens to the dashboard, searching by label alone returns
+nothing and a **duplicate dashboard gets created**, abandoning the real (often
+pinned) one. To be resilient, resolve the dashboard issue in this priority order:
 
-Before creating/updating, ensure the `devops-health` label exists. If not, create it with color `#0E8A16` and description `Daily automated health check report`.
+1. **Cached issue number (authoritative).** Load the `health-dashboard-issue`
+   key from `cache-memory`. If it holds a number, fetch that issue **directly by
+   number** (`GET /repos/{owner}/{repo}/issues/{number}`). Fetching and updating
+   an issue by number works **even when it is missing from label search/list
+   results**. If that issue is open, it IS the dashboard — use it.
+2. **Label search + pinned issues.** If there is no cached number (first run or
+   cache loss) or the cached issue is closed, build the candidate set two ways
+   and union them: (a) search open issues with the `devops-health` label; and
+   (b) if the GitHub tools expose pinned issues, include any open pinned issue
+   titled `🏥 Repository Health Dashboard`. Pinned-issue lookup does not use the
+   label index, so it finds dashboards that label search misses.
+3. **Create.** Only if no dashboard issue is found by any method above, create
+   one titled `🏥 Repository Health Dashboard` with the `devops-health` label.
+
+**Never leave two open dashboards.** If more than one distinct open dashboard is
+found, choose a single canonical issue — prefer the cached number, else the
+pinned one, else the oldest — update only that one, and close each other with a
+one-line comment: `Superseded by #{canonical} — duplicate health dashboard.`
+
+**Persist every run.** After resolving, always save the canonical dashboard's
+number back to `cache-memory` under `health-dashboard-issue`, so future runs
+update it directly by number and never create a duplicate — even if the label
+index drops it again.
+
+> This workflow cannot pin issues itself. If the canonical dashboard is **not**
+> currently pinned, add a single line at the very top of the issue body asking a
+> maintainer to pin it (and to unpin/close any stale duplicate). Keep exactly
+> one dashboard pinned.
+
+Before creating/updating, ensure the `devops-health` label exists. If not, create
+it with color `#0E8A16` and description `Daily automated health check report`.
 
 ### 4.2 Issue Body Format
 
@@ -487,6 +518,7 @@ Before finishing, verify:
 - **Be data-driven**: Include specific numbers, durations, percentages, and links.
 - **Be precise with fingerprints**: Use the exact fingerprint formulas from the knowledge file. Consistency is critical — the same finding MUST produce the same fingerprint across runs.
 - **First run handling**: If `cache-memory` has no previous state, note: "⚠️ This is the first health check run. All findings appear as new. Diff will resume from next run."
+- **Stable dashboard (don't duplicate)**: Always reuse the existing dashboard issue and update it **by number** (see §4.1). Persist its number in `cache-memory` (`health-dashboard-issue`) every run. Never create a second dashboard just because a label search came back empty — the issue may simply be missing from GitHub's search index.
 - **Graceful degradation**: If an API call fails, skip that check category and note the skip in the output. Don't fail the entire workflow.
 - **Noise awareness**: Demote known-noise findings (matching patterns in `cache-memory` `known-noise` list) to 🔵 Info severity, but still show them in the output for audit.
 - **Issue body limit**: Keep under 60k characters. Truncate EXISTING section if needed.

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -331,14 +331,22 @@ index — when that happens to the dashboard, searching by label alone returns
 nothing and a **duplicate dashboard gets created**, abandoning the real (often
 pinned) one. To be resilient, resolve the dashboard issue in this priority order:
 
-1. **Cached issue number (authoritative).** Load the `health-dashboard-issue`
+1. **Cached issue number (validated).** Load the `health-dashboard-issue`
    key from `cache-memory`. If it holds a number, fetch that issue **directly by
-   number** (`GET /repos/{owner}/{repo}/issues/{number}`). Fetching and updating
-   an issue by number works **even when it is missing from label search/list
-   results**. If that issue is open, it IS the dashboard — use it.
+   number** (`GET /repos/{owner}/{repo}/issues/{number}`) — this works **even
+   when the issue is missing from label search/list results**. Accept it as the
+   dashboard ONLY if it passes every check below:
+   - the fetch succeeds (treat `404`/`410` as a **cache miss**),
+   - the issue is **open**, and
+   - it still looks like the dashboard — it carries the `devops-health` label
+     **or** its title is `🏥 Repository Health Dashboard`.
+   If any check fails (the number was deleted, closed, or now points at an
+   unrelated issue), discard the cached number, treat it as a **cache miss**, and
+   fall through to discovery (step 2). This prevents a stale or corrupted cache
+   from silently overwriting an unrelated open issue on every run.
 2. **Label search + pinned issues.** If there is no cached number (first run or
-   cache loss) or the cached issue is closed, build the candidate set two ways
-   and union them: (a) search open issues with the `devops-health` label; and
+   cache loss) or the cached number failed validation above, build the candidate
+   set two ways and union them: (a) search open issues with the `devops-health` label; and
    (b) if the GitHub tools expose pinned issues, include any open pinned issue
    titled `🏥 Repository Health Dashboard`. Pinned-issue lookup does not use the
    label index, so it finds dashboards that label search misses.
@@ -356,9 +364,9 @@ update it directly by number and never create a duplicate — even if the label
 index drops it again.
 
 > This workflow cannot pin issues itself. If the canonical dashboard is **not**
-> currently pinned, add a single line at the very top of the issue body asking a
-> maintainer to pin it (and to unpin/close any stale duplicate). Keep exactly
-> one dashboard pinned.
+> currently pinned, surface a one-line pin request **inside** the body template
+> (immediately below the Status / Since-yesterday block — see §4.2), never above
+> the `# 🏥 Daily Health Check — {date}` header. Keep exactly one dashboard pinned.
 
 Before creating/updating, ensure the `devops-health` label exists. If not, create
 it with color `#0E8A16` and description `Daily automated health check report`.
@@ -372,6 +380,9 @@ Replace the entire issue body with the following structure:
 
 **Status:** 🔴 {critical_count} critical · 🟡 {warning_count} warnings · 🔵 {info_count} info
 **Since yesterday:** 🆕 {new_count} new · ✅ {resolved_count} resolved · 📌 {existing_count} unchanged
+
+{Pin request — include this line ONLY when the dashboard issue is not currently pinned; omit it entirely when already pinned:}
+> 📌 **Maintainer action needed:** please pin this issue as the canonical health dashboard and unpin/close any stale duplicate.
 
 ---
 


### PR DESCRIPTION
The health check found its dashboard issue only via the `devops-health` label search. When GitHub silently dropped the pinned dashboard (#288) from its search/list index, the workflow couldn't find it, created a duplicate (#695), and abandoned the pinned issue — leaving it stale for days.

Step 4.1 now resolves the dashboard by a cached issue number first (updating it directly by number, which works even when the issue is missing from search), persists that number every run, falls back to label + pinned-issue lookup, and consolidates duplicates.

Lock file unchanged — the prompt is runtime-imported from these `.md` files.

Live cleanup already applied: #695 pinned, #288 closed as duplicate.