### PR TITLE
Fix dotnet-msbuild Codex plugin install by externalizing mcpServers

### DIFF
--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -161,13 +161,18 @@ public static partial class ExternalDependencyChecker
 
             if (doc.TryGetProperty("mcpServers", out var serversEl))
             {
-                System.Text.Json.JsonElement? mcpObject = serversEl.ValueKind switch
+                System.Text.Json.JsonElement? mcpObject = null;
+                if (serversEl.ValueKind == System.Text.Json.JsonValueKind.Object)
                 {
-                    System.Text.Json.JsonValueKind.Object => serversEl,
-                    System.Text.Json.JsonValueKind.String => ResolveMcpFileSync(
-                        Path.Combine(Path.GetDirectoryName(pluginJsonPath)!, serversEl.GetString()!)),
-                    _ => null
-                };
+                    mcpObject = serversEl;
+                }
+                else if (serversEl.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    var refPath = serversEl.GetString()!;
+                    if (!Path.IsPathRooted(refPath) && !refPath.Contains(".."))
+                        mcpObject = ResolveMcpFileSync(
+                            Path.Combine(Path.GetDirectoryName(pluginJsonPath)!, refPath));
+                }
 
                 if (mcpObject is { } obj)
                 {

--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -159,14 +159,24 @@ public static partial class ExternalDependencyChecker
             var doc = System.Text.Json.JsonSerializer.Deserialize(
                 json, SkillValidatorJsonContext.Default.JsonElement);
 
-            if (doc.TryGetProperty("mcpServers", out var serversEl)
-                && serversEl.ValueKind == System.Text.Json.JsonValueKind.Object)
+            if (doc.TryGetProperty("mcpServers", out var serversEl))
             {
-                foreach (var prop in serversEl.EnumerateObject())
+                System.Text.Json.JsonElement? mcpObject = serversEl.ValueKind switch
                 {
-                    var key = $"mcp-server:{plugin.Name}:{prop.Name}";
-                    if (allowed?.Contains(key) != true)
-                        findings.Add($"MCP server '{prop.Name}' — review needed: verify this MCP server dependency is intentional and necessary. (allow: {key})");
+                    System.Text.Json.JsonValueKind.Object => serversEl,
+                    System.Text.Json.JsonValueKind.String => ResolveMcpFileSync(
+                        Path.Combine(Path.GetDirectoryName(pluginJsonPath)!, serversEl.GetString()!)),
+                    _ => null
+                };
+
+                if (mcpObject is { } obj)
+                {
+                    foreach (var prop in obj.EnumerateObject())
+                    {
+                        var key = $"mcp-server:{plugin.Name}:{prop.Name}";
+                        if (allowed?.Contains(key) != true)
+                            findings.Add($"MCP server '{prop.Name}' — review needed: verify this MCP server dependency is intentional and necessary. (allow: {key})");
+                    }
                 }
             }
         }
@@ -176,6 +186,19 @@ public static partial class ExternalDependencyChecker
         }
 
         return findings;
+    }
+
+    private static System.Text.Json.JsonElement? ResolveMcpFileSync(string mcpPath)
+    {
+        if (!File.Exists(mcpPath)) return null;
+        try
+        {
+            var doc = System.Text.Json.JsonSerializer.Deserialize(
+                File.ReadAllText(mcpPath), SkillValidatorJsonContext.Default.JsonElement);
+            return doc.TryGetProperty("mcpServers", out var obj)
+                && obj.ValueKind == System.Text.Json.JsonValueKind.Object ? obj : null;
+        }
+        catch { return null; }
     }
 
     // Matches "INVOKES" followed by a script-like filename (word.ext)

--- a/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
@@ -1724,9 +1724,17 @@ public static class EvaluateCommand
                         SkillValidatorJsonContext.Default.JsonElement);
                     if (raw.TryGetProperty("mcpServers", out var serversEl))
                     {
-                        var mcpObject = serversEl.ValueKind == JsonValueKind.String
-                            ? await ResolveMcpFile(Path.Combine(dir, serversEl.GetString()!))
-                            : serversEl.ValueKind == JsonValueKind.Object ? serversEl : (JsonElement?)null;
+                        JsonElement? mcpObject = null;
+                        if (serversEl.ValueKind == JsonValueKind.String)
+                        {
+                            var refPath = serversEl.GetString()!;
+                            if (!Path.IsPathRooted(refPath) && !refPath.Contains(".."))
+                                mcpObject = await ResolveMcpFile(Path.Combine(dir, refPath));
+                        }
+                        else if (serversEl.ValueKind == JsonValueKind.Object)
+                        {
+                            mcpObject = serversEl;
+                        }
 
                         if (mcpObject is { } obj)
                         {
@@ -1772,7 +1780,11 @@ public static class EvaluateCommand
             return doc.TryGetProperty("mcpServers", out var obj) && obj.ValueKind == JsonValueKind.Object
                 ? obj : null;
         }
-        catch { return null; }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to parse .mcp.json at {mcpPath}: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>

--- a/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/EvaluateCommand.cs
@@ -1722,19 +1722,25 @@ public static class EvaluateCommand
                     var raw = JsonSerializer.Deserialize(
                         await File.ReadAllTextAsync(candidate),
                         SkillValidatorJsonContext.Default.JsonElement);
-                    if (raw.TryGetProperty("mcpServers", out var serversEl)
-                        && serversEl.ValueKind == JsonValueKind.Object)
+                    if (raw.TryGetProperty("mcpServers", out var serversEl))
                     {
-                        var result = new Dictionary<string, MCPServerDef>();
-                        foreach (var prop in serversEl.EnumerateObject())
+                        var mcpObject = serversEl.ValueKind == JsonValueKind.String
+                            ? await ResolveMcpFile(Path.Combine(dir, serversEl.GetString()!))
+                            : serversEl.ValueKind == JsonValueKind.Object ? serversEl : (JsonElement?)null;
+
+                        if (mcpObject is { } obj)
                         {
-                            var def = JsonSerializer.Deserialize(
-                                prop.Value.GetRawText(),
-                                SkillValidatorJsonContext.Default.MCPServerDef);
-                            if (def is not null)
-                                result[prop.Name] = def;
+                            var result = new Dictionary<string, MCPServerDef>();
+                            foreach (var prop in obj.EnumerateObject())
+                            {
+                                var def = JsonSerializer.Deserialize(
+                                    prop.Value.GetRawText(),
+                                    SkillValidatorJsonContext.Default.MCPServerDef);
+                                if (def is not null)
+                                    result[prop.Name] = def;
+                            }
+                            return result.Count > 0 ? result : null;
                         }
-                        return result.Count > 0 ? result : null;
                     }
                 }
                 catch (Exception ex)
@@ -1749,6 +1755,24 @@ public static class EvaluateCommand
             dir = parent;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Resolve a .mcp.json file path and return the mcpServers object element, or null.
+    /// Codex plugins use a string path in plugin.json to reference an external .mcp.json file.
+    /// </summary>
+    private static async Task<JsonElement?> ResolveMcpFile(string mcpPath)
+    {
+        if (!File.Exists(mcpPath)) return null;
+        try
+        {
+            var doc = JsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(mcpPath),
+                SkillValidatorJsonContext.Default.JsonElement);
+            return doc.TryGetProperty("mcpServers", out var obj) && obj.ValueKind == JsonValueKind.Object
+                ? obj : null;
+        }
+        catch { return null; }
     }
 
     /// <summary>

--- a/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "binlog": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "Microsoft.AITools.BinlogMcp",
+        "--yes",
+        "--prerelease",
+        "--add-source",
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+      ],
+      "tools": ["*"]
+    }
+  }
+}

--- a/plugins/dotnet-msbuild/.codex-plugin/plugin.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/plugin.json
@@ -8,19 +8,5 @@
       "./agents/msbuild-code-review.agent.md",
       "./agents/msbuild.agent.md"
   ],
-  "mcpServers": {
-    "binlog": {
-      "type": "stdio",
-      "command": "dotnet",
-      "args": [
-        "dnx",
-        "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--prerelease",
-        "--add-source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
-      ],
-      "tools": ["*"]
-    }
-  }
+  "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
## Summary

Fixes #738 — thanks @grevgeny for filing this with a clear repro and root cause analysis!

The `dotnet-msbuild` Codex plugin fails to install because the `mcpServers` configuration is embedded inline in `plugin.json` as an object. Per the [Codex plugin spec](https://github.com/openai/codex/blob/main/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md), `mcpServers` should be a **string path** pointing to an external `.mcp.json` file.

## Changes

1. Created `plugins/dotnet-msbuild/.codex-plugin/.mcp.json` containing the MCP server configuration
2. Updated `plugins/dotnet-msbuild/.codex-plugin/plugin.json` to reference `./.mcp.json` instead of embedding the config inline
3. Root `plugins/dotnet-msbuild/plugin.json` retains inline `mcpServers` for the skill-validator
4. Updated the skill-validator (`FindPluginMcpServers` and `ExternalDependencyChecker.CheckPlugin`) to also handle the Codex string path format for forward compatibility

## Verification

This matches the fix verified locally by the issue reporter, and aligns with the Codex plugin-json-spec which states:
> `apps` and `mcpServers` should appear in `plugin.json` only when `.app.json` and `.mcp.json` actually exist.