### PR TITLE
code-testing-implementer: add mandatory harness-discovery check

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -37,10 +37,13 @@ For each file in your phase:
 - **Trace the logic** for each code path you plan to test — understand what the function actually does, not what you think it should do
 - Note dependencies and how to mock them
 - **Validate project references**: Read the test project file and verify it references the source project(s) you'll test. Add missing references before creating test files
+- **Capture the baseline test count**: run the harness-equivalent discovery command from the repo root (see the "Harness Discovery Check" section of your language extension) and record the count. You will compare against this in Step 7.
 
 ### 3. Register Test Project with Build System
 
 If the test project is new, register it with the project's build system so the test command can discover it. Call the `code-testing-extensions` skill and read the relevant language extension (e.g., `dotnet.md` for .NET solution registration).
+
+> **Reminder**: If Step 4 below creates a *new* test project (`dotnet new`, scaffolded gem, new module), come back here before Step 5 — a new project that is not registered will pass your scoped build/test but will be invisible to the harness, every CI pipeline, and the final solution-level test command.
 
 ### 4. Write Test Files
 
@@ -82,17 +85,30 @@ If tests fail:
 - Never mark a test `[Ignore]`, `[Skip]`, or `[Inconclusive]`
 - Retry the fix-test cycle up to 5 times
 
-### 7. Format Code (Optional)
+### 7. Verify Harness Discovery (MANDATORY)
+
+Tests that pass via your *scoped* build/test command but are invisible to a generic CI/benchmark harness count as 0 generated tests. Every "Harness Discovery Check" section in the language extension exists because we have seen this fail in production:
+
+- A new C# test project that was never `dotnet sln add`ed: passes locally, invisible to the solution-level harness.
+- A Pester test file placed under a custom directory (`pester/`, `tst/`): passes when you pass `-Path` explicitly, invisible to the default `Invoke-Pester` the harness runs.
+- An RSpec spec placed in a sub-gem's `spec/` dir of a monorepo: passes via `bundle exec rspec <subdir>/spec`, invisible to `bundle exec rspec` from the repo root.
+
+Read the **"Harness Discovery Check"** section in your language's extension file and run the command it specifies *from the repo root* (not from the test project / sub-gem directory). Compute the delta against the initial test count you captured in Step 2. If the delta does not match what you generated, fix the root cause — registration, placement, or harness configuration — and re-run. **Do not proceed to Step 8 until the harness-equivalent command sees your new tests.**
+
+If your language extension has no "Harness Discovery Check" section, use the canonical default-discovery command for the test framework (`pytest --collect-only -q | tail -n 1`, `npx vitest --reporter=verbose --run 2>&1 | grep -E '^\s*[√×]'` from repo root, `go test -list '.*' ./...`, `mvn test -DskipTests=false -Dtest.failure.ignore=true`, etc.) and apply the same delta logic.
+
+### 8. Format Code (Optional)
 
 If a lint command is available, call the `code-testing-linter` sub-agent.
 
-### 8. Report Results
+### 9. Report Results
 
 ```text
 PHASE: [N]
 STATUS: SUCCESS | PARTIAL | FAILED
 TESTS_CREATED: [count]
 TESTS_PASSING: [count]
+HARNESS_DISCOVERY: [count delta from Step 7]
 FILES:
 - path/to/TestFile.ext (N tests)
 ISSUES:

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -88,6 +88,11 @@ Search for commands in:
 - `README.md` instructions
 - Project files
 
+Identify **two** test commands and record both in `.testagent/research.md`:
+
+1. **Scoped test command** — what the implementer should run during fix cycles (e.g., `dotnet test <test.csproj>`, `bundle exec rspec spec/foo_spec.rb`, `Invoke-Pester -Path ./Tests/Foo.Tests.ps1`). Optimized for speed and locality.
+2. **Harness-equivalent discovery command** — what a generic CI/benchmark verifier would run from the repo root with no args (e.g., `dotnet test <solution> --list-tests`, `bundle exec rspec --dry-run`, `Invoke-Pester` with default config, `pytest --collect-only -q`). This is the command the implementer's "Verify Harness Discovery" step uses to confirm new tests are visible to outside tooling. Call the `code-testing-extensions` skill and consult the "Harness Discovery Check" section of the relevant language extension.
+
 ### 7. Discover Preexisting Tests
 
 Locate all existing test files and analyze what they cover:
@@ -119,7 +124,8 @@ Create `.testagent/research.md` with this structure:
 
 ## Build & Test Commands
 - **Build**: `[command]`
-- **Test**: `[command]`
+- **Test (scoped — fix cycles)**: `[command run on the specific test project/file]`
+- **Test (harness-equivalent — discovery check)**: `[command run from repo root that mirrors what a CI/benchmark verifier sees]`
 - **Lint**: `[command]` (if available)
 
 ## Project Structure

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
@@ -63,7 +63,7 @@ This prevents CS0234 ("namespace not found") and CS0246 ("type not found") error
 
 ### Registering a new test project (MANDATORY when `dotnet new` was used)
 
-A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` run from the repo root, and to any CI/benchmark harness until it is added to the solution. Run `dotnet sln add` *immediately* after creating the project — do not defer it to "Step 8 cleanup".
+A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` run from the repo root, and to any CI/benchmark harness until it is added to the solution. Run `dotnet sln add` *immediately* after creating the project as part of Step 3 ("Register Test Project with Build System") — do not defer it to a later step.
 
 1. Use the exact solution or solution-filter target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
 2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
@@ -71,13 +71,13 @@ A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` r
 4. Skip this if the project is already included in the solution or solution filter used for testing.
 5. Prefer the researched test command. If you need to run the solution directly, use `dotnet test --solution <solution>` only for repos on .NET SDK 10+ with MTP-style syntax; otherwise use the standard positional form `dotnet test <solution>`.
 
-## Harness Discovery Check
+### Harness Discovery Check
 
 Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the test count went up by at least the number of tests you generated. The harness (CI, msbench, coverage tools) does not know which `.csproj` you targeted — it runs the solution-level command, so a test that passes via `dotnet test MyProject.Tests.csproj` is still worthless if `dotnet test <solution> --list-tests` doesn't enumerate it.
 
 ```bash
 # From repo root, against the solution identified in .testagent/research.md
-dotnet test <solution> --list-tests --no-build 2>&1 | grep -c '^\s\{4\}[A-Za-z]'
+dotnet test <solution> --list-tests --no-build 2>&1 | grep -c '^    [A-Za-z]'
 ```
 
 If the delta is `0`, the new project isn't in the solution. Run `dotnet sln <solution> add <test-project.csproj>` and re-run the check. Do **not** report success until the harness command sees your new tests.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
@@ -61,15 +61,26 @@ This prevents CS0234 ("namespace not found") and CS0246 ("type not found") error
 - For the final validation, build the full `.sln` with `--no-incremental`
 - Full-solution builds catch cross-project reference errors invisible in scoped builds
 
-### Registering a new test project
+### Registering a new test project (MANDATORY when `dotnet new` was used)
 
-If a new test project was created, register it with the solution so `dotnet test` can discover it:
+A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` run from the repo root, and to any CI/benchmark harness until it is added to the solution. Run `dotnet sln add` *immediately* after creating the project — do not defer it to "Step 8 cleanup".
 
 1. Use the exact solution or solution-filter target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
 2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
 3. If the target is a `.slnf` (solution filter), also ensure the new project is included in the filter; adding only to the underlying `.sln` may not be enough for test discovery.
 4. Skip this if the project is already included in the solution or solution filter used for testing.
 5. Prefer the researched test command. If you need to run the solution directly, use `dotnet test --solution <solution>` only for repos on .NET SDK 10+ with MTP-style syntax; otherwise use the standard positional form `dotnet test <solution>`.
+
+## Harness Discovery Check
+
+Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the test count went up by at least the number of tests you generated. The harness (CI, msbench, coverage tools) does not know which `.csproj` you targeted — it runs the solution-level command, so a test that passes via `dotnet test MyProject.Tests.csproj` is still worthless if `dotnet test <solution> --list-tests` doesn't enumerate it.
+
+```bash
+# From repo root, against the solution identified in .testagent/research.md
+dotnet test <solution> --list-tests --no-build 2>&1 | grep -c '^\s\{4\}[A-Za-z]'
+```
+
+If the delta is `0`, the new project isn't in the solution. Run `dotnet sln <solution> add <test-project.csproj>` and re-run the check. Do **not** report success until the harness command sees your new tests.
 
 ## Test Framework Detection
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell.md
@@ -46,6 +46,18 @@ After writing the **first** `*.Tests.ps1` file — before writing any others:
 
 This catches placement and discovery mistakes on turn 1 instead of after dozens of failed-test iterations.
 
+### Harness Discovery Check
+
+Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the test count went up by at least the number of tests you generated. CI/msbench/coverage harnesses do not know which directory you targeted with `-Path`; they invoke Pester from the repo root with default discovery, so a test that passes via `Invoke-Pester -Path ./tools/Foo.Tests.ps1` is still worthless if `Invoke-Pester` from the repo root does not enumerate it.
+
+```powershell
+# From repo root — mirrors what a generic harness sees
+$result = Invoke-Pester -Configuration @{ Run = @{ PassThru = $true; SkipRun = $true } }
+"$($result.TotalCount) tests discovered"
+```
+
+If the count did not increase, your `*.Tests.ps1` file is outside the harness discovery root. Move it to the convention the repo's existing tests use (or, if there are no existing tests, prefer the repo root's `tests/`, `Tests/`, `tst/`, `test/`, or co-locate next to the source). Do **not** report success until the harness-equivalent command sees your new tests.
+
 ## Rule #1: Investigate the Repo First
 
 Before writing any test or running any command, read:

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
@@ -63,7 +63,7 @@ Before reporting success, run the **harness-equivalent** discovery command from 
 bundle exec rspec --dry-run 2>&1 | grep -E '^[0-9]+ example'
 
 # Minitest (Rails)
-bundle exec rake test 2>/dev/null --dry-run || bin/rails test --list-tests | wc -l
+{ bundle exec rake test --dry-run 2>/dev/null || bin/rails test --list-tests; } | wc -l
 
 # Custom runner (Homebrew, ruby/ruby, etc.)
 # Use the repo's own runner — `./bin/brew tests --list`, `make test-all`, etc.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby.md
@@ -37,6 +37,13 @@ RSpec only discovers specs under `spec/` by default, and verification harnesses 
 
 A spec placed anywhere outside `spec/` (e.g. next to the source under `lib/`) will be invisible to `bundle exec rspec` and to the harness. The same applies to Minitest: place tests under `test/` and use `*_test.rb` naming.
 
+**Gem-monorepo trap (fastlane, ruby/ruby, large gems with sub-gems):** if the repo contains multiple `*/spec/` directories (each sub-gem with its own specs), `bundle exec rspec` from the repo root only loads `./spec/` by default — sub-gem specs are invisible to the harness. Either:
+
+- place the new spec inside the **root** `./spec/` (with a `require_relative` to the sub-gem's `lib/`), or
+- run the sub-gem's `bundle exec rspec` from the sub-gem dir AND verify in the Harness Discovery Check below that the root command also enumerates it (often it won't — you'll need to extend `.rspec` with `--default-path` or the root `Rakefile`'s test task).
+
+For interpreter-build repos (ruby/ruby itself) the test runner requires `make test-all` after `make miniruby` — `ruby test/foo_test.rb` alone is not what the harness runs.
+
 ### First-Test Sanity Loop
 
 After writing the **first** spec — before writing any others:
@@ -46,6 +53,24 @@ After writing the **first** spec — before writing any others:
 3. Only then expand to cover the remaining methods.
 
 This catches placement and load-path mistakes on turn 1 instead of after dozens of failed-test iterations.
+
+### Harness Discovery Check
+
+Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the example count went up by at least the number of tests you generated. CI/msbench/coverage harnesses do not know which file or sub-gem dir you targeted; they run the framework's default discovery from the repo root, so a spec that passes via `bundle exec rspec fastlane_core/spec/foo_spec.rb` is still worthless if `bundle exec rspec --dry-run` from the repo root doesn't enumerate it.
+
+```bash
+# RSpec — from repo root
+bundle exec rspec --dry-run 2>&1 | grep -E '^[0-9]+ example'
+
+# Minitest (Rails)
+bundle exec rake test 2>/dev/null --dry-run || bin/rails test --list-tests | wc -l
+
+# Custom runner (Homebrew, ruby/ruby, etc.)
+# Use the repo's own runner — `./bin/brew tests --list`, `make test-all`, etc.
+# If no `--list`/`--dry-run` mode exists, run a single matching test by name and confirm exit 0.
+```
+
+If the count did not increase, your spec is invisible to the harness. Move it into `./spec/`, extend `.rspec`/`Rakefile` so the harness picks up the sub-gem dir, or switch to a `require_relative` strategy from a root-level spec. Do **not** report success until the harness-equivalent command sees your new tests.
 
 ## Rule #1: Investigate the Repo First
 


### PR DESCRIPTION
Generic CI/benchmark verifiers run the framework's default discovery from the repo root. Tests that pass via a scoped command (e.g. `dotnet test MyProject.Tests.csproj`, `bundle exec rspec subgem/spec`, `Invoke-Pester -Path ./tools`) but are invisible to the harness count as **0 generated tests** to anyone running the suite from outside.

## Why

Observed across multiple msbench cta-nightly runs of github-copilot-cli + claude-opus-4.6 on swe-test-bench. In every case the agent wrote, built and ran tests successfully via a scoped command, called `task_complete` reporting full success, and got graded `Resolved=False` because the rubric's harness saw 0 new tests:

- **ocelot** — new `xunit` csproj created with `dotnet new`, `dotnet add reference` run, but `dotnet sln add` skipped. Scoped `dotnet test` passes; `dotnet test <sln>` doesn't see the project.
- **homebrew, ruby/ruby** — Pester tests placed under `pester/`, `Tests/`, `tst/` (matches one repo's convention but not the harness's default discovery root).
- **fastlane** — RSpec spec placed in `fastlane_core/spec/` (sub-gem). `bundle exec rspec` from the repo root only loads `./spec/` by default.

The dotnet-test implementer agent had the *registration* rules in `dotnet.md` already, but no enforcement loop, and the polyglot `powershell.md` / `ruby.md` extensions had no harness-discovery check at all.

## Changes

- **`code-testing-implementer.agent.md`** — capture baseline test count in Step 2, new **Step 7 'Verify Harness Discovery (MANDATORY)'** with the three concrete failure modes above, `HARNESS_DISCOVERY:` line in the report template, and a reminder after Step 3 to revisit registration if Step 4 creates a new project.
- **`code-testing-researcher.agent.md`** — record **both** the scoped test command and the harness-equivalent discovery command in `.testagent/research.md` so the implementer has the right command to run in Step 7.
- **`extensions/dotnet.md`** — strengthen the 'Registering a new test project' heading to **MANDATORY when `dotnet new` was used**; add a 'Harness Discovery Check' section with `dotnet test <solution> --list-tests --no-build` from the repo root.
- **`extensions/powershell.md`** — new 'Harness Discovery Check' section with default-config `Invoke-Pester` from the repo root.
- **`extensions/ruby.md`** — new 'Gem-monorepo trap' paragraph in the Test Placement Contract covering fastlane / ruby/ruby; new 'Harness Discovery Check' section with `bundle exec rspec --dry-run` from the repo root.

## Out of scope

- Other language extensions (`go.md`, `java.md`, `python.md`, `rust.md`, `typescript.md`, `kotlin.md`, `swift.md`, `cpp.md`) don't yet have a 'Harness Discovery Check' section. Step 7 of the implementer has a fallback (canonical default-discovery command per framework) for those, but follow-up PRs should add explicit sections.
- The two `-fix-` task grader-rubric mismatches and the scope-explosion case observed in the same run are separate msbench/grader issues, not skill issues.