### PR TITLE
migrate-xunit-to-mstest: forbid CancellationToken.None replacement explicitly

### DIFF
--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -342,7 +342,7 @@ public TestContext TestContext { get; set; } = null!;
 - `TestContext.Current.AddAttachment(name, path)` -> `_testContext.AddResultFile(path)`
 - `TestContext.Current.TestOutputHelper.WriteLine(...)` -> `_testContext.WriteLine(...)`
 
-> **REQUIRED for CancellationToken:** Add the constructor injection from above even if the class only uses `TestContext.Current.CancellationToken` (no `ITestOutputHelper`). Do **NOT** replace `TestContext.Current.CancellationToken` with a new `CancellationTokenSource` -- that loses the test-host's cancellation linkage and changes behavior under timeouts.
+> **REQUIRED for CancellationToken:** Add the constructor injection from above even if the class only uses `TestContext.Current.CancellationToken` (no `ITestOutputHelper`). Do **NOT** replace `TestContext.Current.CancellationToken` with `CancellationToken.None` or a freshly-constructed `CancellationTokenSource` -- both lose the test-host's cancellation linkage and change behavior under timeouts.
 
 ```csharp
 // xUnit v3

--- a/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md
@@ -342,7 +342,7 @@ public TestContext TestContext { get; set; } = null!;
 - `TestContext.Current.AddAttachment(name, path)` -> `_testContext.AddResultFile(path)`
 - `TestContext.Current.TestOutputHelper.WriteLine(...)` -> `_testContext.WriteLine(...)`
 
-> **REQUIRED for CancellationToken:** Add the constructor injection from above even if the class only uses `TestContext.Current.CancellationToken` (no `ITestOutputHelper`). Do **NOT** replace `TestContext.Current.CancellationToken` with `CancellationToken.None` or a freshly-constructed `CancellationTokenSource` -- both lose the test-host's cancellation linkage and change behavior under timeouts.
+> **REQUIRED for CancellationToken:** Add the constructor injection from above (or property injection if pinned to MSTest < 3.6) even if the class only uses `TestContext.Current.CancellationToken` (no `ITestOutputHelper`). Do **NOT** replace `TestContext.Current.CancellationToken` with `CancellationToken.None` or a freshly-constructed `CancellationTokenSource` -- both lose the test-host's cancellation linkage and change behavior under timeouts.
 
 ```csharp
 // xUnit v3


### PR DESCRIPTION
## Why

The `TestContext.Current.CancellationToken` guidance in `migrate-xunit-to-mstest` already forbids replacing it with a freshly-constructed `CancellationTokenSource`, but real-world agent migrations have been observed substituting `CancellationToken.None` instead, which silently drops the test host's cancellation linkage in the same way.

## What

Update the **REQUIRED for CancellationToken** callout to call out both shortcuts explicitly:

> Do **NOT** replace `TestContext.Current.CancellationToken` with `CancellationToken.None` or a freshly-constructed `CancellationTokenSource` -- both lose the test-host's cancellation linkage and change behavior under timeouts.

## Source

Observed during the dotnet/sdk xUnit→MSTest migration: see e.g. dotnet/sdk#54725 (BrowserRefresh.Tests) and dotnet/sdk#54731 (HotReload.Client.Tests), where the migration agent rewrote `TestContext.Current.CancellationToken` as `CancellationToken.None` in every `WriteAsync`/`FlushAsync` call. Restoring the original behavior required adding `public TestContext TestContext { get; set; }` to the test class and using `TestContext.CancellationToken`.