### PR TITLE
Fix evaluation.yml run-name: quote expression so '#' isn't a YAML comment

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -31,7 +31,7 @@ name: evaluation
 # head_sha is the default branch — not the PR head — so the run name is how the
 # worker recognises that an evaluation has already been dispatched for this head.
 # For all other events the expression yields '' and GitHub uses the default name.
-run-name: ${{ inputs.pr_number != '' && format('Evaluate PR #{0} @ {1}', inputs.pr_number, inputs.head_sha) || '' }}
+run-name: "${{ inputs.pr_number != '' && format('Evaluate PR #{0} @ {1}', inputs.pr_number, inputs.head_sha) || '' }}"
 
 on:
   # Manual trigger for one-off deploys (e.g., AGENTVIZ SPA update) and


### PR DESCRIPTION
## Problem

Every `evaluation.yml` run on `main` has failed since #746 merged (13:50), with GitHub reporting **"This run likely failed because of a workflow file issue"** and no jobs starting. This is **not** caused by #754 (baseline reuse) — that feature's eval run succeeded at 13:17; the first failure is the #746 merge commit.

## Root cause

#746 added a `run-name` as an **unquoted** plain YAML scalar:

```yaml
run-name: ${{ inputs.pr_number != '' && format('Evaluate PR #{0} @ {1}', inputs.pr_number, inputs.head_sha) || '' }}
```

In YAML, a space followed by `#` begins a comment. So ` #{0} @ {1}', inputs.pr_number, inputs.head_sha) || '' }}` is stripped as a comment, leaving an **unterminated `${{` expression**. The file still parses as valid YAML (which is why `yaml.safe_load` and a casual review pass), but the GitHub Actions workflow parser rejects the broken expression and refuses to start any run.

## Fix

Wrap the value in double quotes so the `#` stays inside the scalar:

```yaml
run-name: "${{ inputs.pr_number != '' && format('Evaluate PR #{0} @ {1}', inputs.pr_number, inputs.head_sha) || '' }}"
```

The inner expression only uses single quotes, so double-quoting is safe.

## Verification

- `actionlint` on the fixed file: **0 errors** (previously: `got unexpected EOF while lexing end of string literal` at line 34).
- One-line change; no behavioral change to the run name itself.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
