### PR TITLE
migrate-xunit-to-mstest: switch file-state graders from output to file (no false negatives)

### DIFF
--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml
@@ -18,27 +18,36 @@ stimuli:
         - src: ./fixtures/migrate-basic-xunit-v2-project-to-mstest-v4-preserving-vstest/CalculatorTests.cs
           dest: CalculatorTests.cs
     graders:
-      - type: output-matches
+      # File-state graders: assert against the migrated source/project files so
+      # the grader is not tripped by agent prose that quotes the same tokens.
+      - type: file-contains
         config:
-          pattern: Microsoft\.VisualStudio\.TestTools\.UnitTesting
-      - type: output-matches
+          path: '**/*.cs'
+          value: Microsoft.VisualStudio.TestTools.UnitTesting
+      - type: file-contains
         config:
-          pattern: \[TestClass\]
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[TestClass]'
+      - type: file-contains
         config:
-          pattern: \[TestMethod\]
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[TestMethod]'
+      - type: file-contains
         config:
-          pattern: Assert\.AreEqual
-      - type: output-matches
+          path: '**/*.cs'
+          value: Assert.AreEqual
+      - type: file-contains
         config:
-          pattern: Assert\.IsTrue
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: Assert.IsTrue
+      - type: file-not-contains
         config:
-          pattern: PackageReference Include="xunit
-      - type: output-not-matches
+          path: '**/*.csproj'
+          value: PackageReference Include="xunit
+      - type: file-not-contains
         config:
-          pattern: using Xunit;
+          path: '**/*.cs'
+          value: using Xunit;
       - type: run-command
         config:
           command: dotnet test
@@ -68,18 +77,22 @@ stimuli:
         - src: ./fixtures/migrate-basic-xunit-v3-project-to-mstest-v4-preserving-vstest/OrderTests.cs
           dest: OrderTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: Microsoft\.VisualStudio\.TestTools\.UnitTesting
-      - type: output-matches
+          path: '**/*.cs'
+          value: Microsoft.VisualStudio.TestTools.UnitTesting
+      - type: file-contains
         config:
-          pattern: \[DataRow\(
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: '[DataRow('
+      - type: file-not-contains
         config:
-          pattern: xunit\.v3
-      - type: output-not-matches
+          path: '**/*.csproj'
+          value: xunit.v3
+      - type: file-not-contains
         config:
-          pattern: InlineData
+          path: '**/*.cs'
+          value: InlineData
       - type: run-command
         config:
           command: dotnet test
@@ -125,15 +138,18 @@ stimuli:
         - src: ./fixtures/convert-iclassfixture-to-classinitialize/OrderTests.cs
           dest: OrderTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: \[ClassInitialize\]
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[ClassInitialize]'
+      - type: file-contains
         config:
-          pattern: \[ClassCleanup\]
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: '[ClassCleanup]'
+      - type: file-not-contains
         config:
-          pattern: IClassFixture
+          path: '**/*.cs'
+          value: IClassFixture
       - type: run-command
         config:
           command: dotnet test
@@ -164,9 +180,12 @@ stimuli:
         - src: ./fixtures/handle-icollectionfixture-explicitly-do-not-silently-widen-scope/CustomersTests.cs
           dest: CustomersTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: \[DoNotParallelize\]
+          path: '**/*.cs'
+          value: '[DoNotParallelize]'
+      # Agent prose grader: the rubric requires an explicit scope-decision
+      # explanation, so this stays on the response (not the file).
       - type: output-matches
         config:
           pattern: (scope|sharing|parallelization|preserve|collection)
@@ -194,18 +213,22 @@ stimuli:
         - src: ./fixtures/convert-itestoutputhelper-to-testcontext/LoggingTests.cs
           dest: LoggingTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: TestContext
-      - type: output-matches
+          path: '**/*.cs'
+          value: TestContext
+      - type: file-contains
         config:
-          pattern: WriteLine
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: WriteLine
+      - type: file-not-contains
         config:
-          pattern: ITestOutputHelper
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: ITestOutputHelper
+      - type: file-not-contains
         config:
-          pattern: Xunit\.Abstractions
+          path: '**/*.cs'
+          value: Xunit.Abstractions
       - type: run-command
         config:
           command: dotnet test
@@ -230,15 +253,18 @@ stimuli:
         - src: ./fixtures/map-exception-assertions-correctly-xunit-throws-mstest-throwsexactly/ExceptionTests.cs
           dest: ExceptionTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: Assert\.ThrowsExactly<InvalidOperationException>
-      - type: output-matches
+          path: '**/*.cs'
+          value: Assert.ThrowsExactly<InvalidOperationException>
+      - type: file-contains
         config:
-          pattern: Assert\.Throws<Exception>
-      - type: output-matches
+          path: '**/*.cs'
+          value: Assert.Throws<Exception>
+      - type: file-contains
         config:
-          pattern: Assert\.ThrowsExactlyAsync<InvalidOperationException>
+          path: '**/*.cs'
+          value: Assert.ThrowsExactlyAsync<InvalidOperationException>
       - type: run-command
         config:
           command: dotnet test
@@ -263,15 +289,18 @@ stimuli:
         - src: ./fixtures/convert-memberdata-and-theorydata-to-dynamicdata/DiscountTests.cs
           dest: DiscountTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: \[DynamicData\(
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: '[DynamicData('
+      - type: file-not-contains
         config:
-          pattern: \[MemberData\(
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: '[MemberData('
+      - type: file-not-contains
         config:
-          pattern: \[Theory\]
+          path: '**/*.cs'
+          value: '[Theory]'
       - type: run-command
         config:
           command: dotnet test
@@ -296,21 +325,26 @@ stimuli:
         - src: ./fixtures/convert-skip-trait-and-timeout/AnnotatedTests.cs
           dest: AnnotatedTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: \[Ignore\("broken"\)\]
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[Ignore("broken")]'
+      - type: file-contains
         config:
-          pattern: \[TestCategory\("Unit"\)\]
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[TestCategory("Unit")]'
+      - type: file-contains
         config:
-          pattern: \[TestProperty\("Owner"
-      - type: output-matches
+          path: '**/*.cs'
+          value: '[TestProperty("Owner"'
+      - type: file-contains
         config:
-          pattern: \[Timeout\(5000\)\]
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: '[Timeout(5000)]'
+      - type: file-not-contains
         config:
-          pattern: Trait\(
+          path: '**/*.cs'
+          value: 'Trait('
       - type: run-command
         config:
           command: dotnet test
@@ -339,15 +373,18 @@ stimuli:
         - src: ./fixtures/preserve-xunit-parallelization-default-with-assembly-parallelize/BetaTests.cs
           dest: BetaTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: assembly:\s*Parallelize
-      - type: output-matches
+          path: '**/*.cs'
+          value: 'assembly: Parallelize'
+      - type: file-contains
         config:
-          pattern: ExecutionScope\.ClassLevel
-      - type: output-not-matches
+          path: '**/*.cs'
+          value: ExecutionScope.ClassLevel
+      - type: file-not-contains
         config:
-          pattern: ExecutionScope\.MethodLevel
+          path: '**/*.cs'
+          value: ExecutionScope.MethodLevel
       - type: run-command
         config:
           command: dotnet test
@@ -373,12 +410,17 @@ stimuli:
         - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/CancellationTests.cs
           dest: CancellationTests.cs
     graders:
+      # Positive grader stays on prose because it uses regex alternation
+      # (TestContext.CancellationToken or _testContext.CancellationToken);
+      # file-contains is literal-only and cannot express OR. The file is
+      # still checked indirectly via the build/test run-command below.
       - type: output-matches
         config:
           pattern: TestContext\.CancellationToken|_testContext\.CancellationToken
-      - type: output-not-matches
+      - type: file-not-contains
         config:
-          pattern: TestContext\.Current\.CancellationToken
+          path: '**/*.cs'
+          value: TestContext.Current.CancellationToken
       - type: run-command
         config:
           command: dotnet test
@@ -400,12 +442,15 @@ stimuli:
         - src: ./fixtures/recognize-project-already-on-mstest/ExistingTests.cs
           dest: ExistingTests.cs
     graders:
+      # Positive grader stays on prose: rubric requires the agent to TELL
+      # the user no migration is needed.
       - type: output-matches
         config:
           pattern: (already|no.{0,30}migration|not.{0,20}need|already.{0,20}MSTest)
-      - type: output-not-matches
+      - type: file-not-contains
         config:
-          pattern: PackageReference Include="xunit
+          path: '**/*.csproj'
+          value: PackageReference Include="xunit
       - type: prompt
       - type: pairwise
     rubric:

--- a/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml
@@ -53,20 +53,29 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "Microsoft\\.VisualStudio\\.TestTools\\.UnitTesting"
-      - type: "output_matches"
-        pattern: "\\[TestClass\\]"
-      - type: "output_matches"
-        pattern: "\\[TestMethod\\]"
-      - type: "output_matches"
-        pattern: "Assert\\.AreEqual"
-      - type: "output_matches"
-        pattern: "Assert\\.IsTrue"
-      - type: "output_not_matches"
-        pattern: "PackageReference Include=\"xunit"
-      - type: "output_not_matches"
-        pattern: "using Xunit;"
+      # File-state assertions: assert against the migrated source/project files
+      # so the assertion is not tripped by agent prose that quotes the same tokens.
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Microsoft.VisualStudio.TestTools.UnitTesting"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[TestClass]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[TestMethod]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Assert.AreEqual"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Assert.IsTrue"
+      - type: "file_not_contains"
+        path: "**/*.csproj"
+        value: "PackageReference Include=\"xunit"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "using Xunit;"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -143,14 +152,18 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "Microsoft\\.VisualStudio\\.TestTools\\.UnitTesting"
-      - type: "output_matches"
-        pattern: "\\[DataRow\\("
-      - type: "output_not_matches"
-        pattern: "xunit\\.v3"
-      - type: "output_not_matches"
-        pattern: "InlineData"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Microsoft.VisualStudio.TestTools.UnitTesting"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[DataRow("
+      - type: "file_not_contains"
+        path: "**/*.csproj"
+        value: "xunit.v3"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "InlineData"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -259,12 +272,15 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "\\[ClassInitialize\\]"
-      - type: "output_matches"
-        pattern: "\\[ClassCleanup\\]"
-      - type: "output_not_matches"
-        pattern: "IClassFixture"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[ClassInitialize]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[ClassCleanup]"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "IClassFixture"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -351,8 +367,11 @@ scenarios:
                 public void Connects() => Assert.NotNull(_fixture.Connection);
             }
     assertions:
-      - type: "output_matches"
-        pattern: "\\[DoNotParallelize\\]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[DoNotParallelize]"
+      # Agent prose assertion: the rubric requires an explicit scope-decision
+      # explanation, so this stays on the response (not the file).
       - type: "output_matches"
         pattern: "(scope|sharing|parallelization|preserve|collection)"
       - type: run_command_and_assert
@@ -417,14 +436,18 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "TestContext"
-      - type: "output_matches"
-        pattern: "WriteLine"
-      - type: "output_not_matches"
-        pattern: "ITestOutputHelper"
-      - type: "output_not_matches"
-        pattern: "Xunit\\.Abstractions"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "TestContext"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "WriteLine"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "ITestOutputHelper"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "Xunit.Abstractions"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -497,12 +520,15 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "Assert\\.ThrowsExactly<InvalidOperationException>"
-      - type: "output_matches"
-        pattern: "Assert\\.Throws<Exception>"
-      - type: "output_matches"
-        pattern: "Assert\\.ThrowsExactlyAsync<InvalidOperationException>"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Assert.ThrowsExactly<InvalidOperationException>"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Assert.Throws<Exception>"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "Assert.ThrowsExactlyAsync<InvalidOperationException>"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -570,12 +596,15 @@ scenarios:
                 }
             }
     assertions:
-      - type: "output_matches"
-        pattern: "\\[DynamicData\\("
-      - type: "output_not_matches"
-        pattern: "\\[MemberData\\("
-      - type: "output_not_matches"
-        pattern: "\\[Theory\\]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[DynamicData("
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "[MemberData("
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "[Theory]"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -634,16 +663,21 @@ scenarios:
                 public void Slow() => Assert.True(true);
             }
     assertions:
-      - type: "output_matches"
-        pattern: "\\[Ignore\\(\"broken\"\\)\\]"
-      - type: "output_matches"
-        pattern: "\\[TestCategory\\(\"Unit\"\\)\\]"
-      - type: "output_matches"
-        pattern: "\\[TestProperty\\(\"Owner\""
-      - type: "output_matches"
-        pattern: "\\[Timeout\\(5000\\)\\]"
-      - type: "output_not_matches"
-        pattern: "Trait\\("
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[Ignore(\"broken\")]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[TestCategory(\"Unit\")]"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[TestProperty(\"Owner\""
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "[Timeout(5000)]"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "Trait("
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -699,12 +733,15 @@ scenarios:
             namespace MyApp.Tests;
             public class BetaTests { [Fact] public void T() => Assert.True(true); }
     assertions:
-      - type: "output_matches"
-        pattern: "assembly:\\s*Parallelize"
-      - type: "output_matches"
-        pattern: "ExecutionScope\\.ClassLevel"
-      - type: "output_not_matches"
-        pattern: "ExecutionScope\\.MethodLevel"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "assembly: Parallelize"
+      - type: "file_contains"
+        path: "**/*.cs"
+        value: "ExecutionScope.ClassLevel"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "ExecutionScope.MethodLevel"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -773,10 +810,15 @@ scenarios:
                 }
             }
     assertions:
+      # Positive assertion stays on prose because it uses regex alternation
+      # (TestContext.CancellationToken or _testContext.CancellationToken);
+      # file_contains is literal-only and cannot express OR. The file shape
+      # is still checked indirectly via the build/test run-command below.
       - type: "output_matches"
         pattern: "TestContext\\.CancellationToken|_testContext\\.CancellationToken"
-      - type: "output_not_matches"
-        pattern: "TestContext\\.Current\\.CancellationToken"
+      - type: "file_not_contains"
+        path: "**/*.cs"
+        value: "TestContext.Current.CancellationToken"
       - type: run_command_and_assert
         command_to_run: "dotnet"
         command_arguments: "test"
@@ -821,10 +863,13 @@ scenarios:
                 public void Works() => Assert.IsTrue(true);
             }
     assertions:
+      # Positive assertion stays on prose: rubric requires the agent to TELL
+      # the user no migration is needed.
       - type: "output_matches"
         pattern: "(already|no.{0,30}migration|not.{0,20}need|already.{0,20}MSTest)"
-      - type: "output_not_matches"
-        pattern: "PackageReference Include=\"xunit"
+      - type: "file_not_contains"
+        path: "**/*.csproj"
+        value: "PackageReference Include=\"xunit"
     rubric:
       - "Recognizes the project already references MSTest packages -- no xUnit present"
       - "Does NOT make changes (no destructive 'migration' of MSTest tests)"


### PR DESCRIPTION
## Problem

The eval was tripping false-negative graders: the skill activates and the agent EXPLAINS what it converted (e.g., "I removed `using Xunit;`", "Converting `[Theory]` to `[TestMethod]`"), so `output-not-matches` on patterns like `using Xunit;`, `[Theory]`, `Trait(`, `IClassFixture`, `TestContext.Current.CancellationToken`, etc. fired on the agent's prose even when the migrated file was correct. Conversely `output-matches` on `Microsoft.VisualStudio.TestTools.UnitTesting`, `[TestClass]`, `[DataRow(`, etc. could match the agent's explanation without verifying the file.

This dragged down the per-scenario assertion score AND propagated into the run-command / judge scores. Latest eval regressions traceable to this:

- Migrate basic xUnit v2: 4.0/5 → 3.7/5
- Migrate basic xUnit v3: 5.0/5 → 3.3/5
- Convert IClassFixture: 4.0/5 → 3.3/5
- Convert Skip/Trait/Timeout: 3.7/5 → 3.0/5
- Preserve Parallelize: 3.0/5 → 2.7/5

## Change

Convert every grader that is really checking FILE state into `file-contains` / `file-not-contains` (with the relevant glob: `**/*.cs` or `**/*.csproj`). Keep the prose-checking graders where the rubric genuinely wants the agent to talk about something:

- **Unsupported-TFM** scenario: the rubric requires the agent to *identify* and *explain* — kept on prose.
- **ICollectionFixture** scope decision: the rubric requires explicit narrative — the `[DoNotParallelize]` check moves to file-state but the scope/sharing/parallelization prose check stays.
- **Already-on-MSTest**: the rubric requires the agent to TELL the user no migration is needed — kept on prose.

The two CancellationToken positive graders stay on prose because they use regex alternation (`TestContext.CancellationToken|_testContext.CancellationToken`) that `file-contains` (literal only) can't express; the file shape is still indirectly checked by the `dotnet test` `run-command`.

Skill content (`SKILL.md`, `mapping-cheatsheet.md`) is left unchanged — those are tightened only if the grader fix alone isn't enough.

## Files

- `tests/dotnet-test/migrate-xunit-to-mstest/eval.vally.yaml` — vally runner.
- `tests/dotnet-test/migrate-xunit-to-mstest/eval.yaml` — skill-validator runner.

## Validation

- `dotnet run --project eng/skill-validator/src -- check --plugin ./plugins/dotnet-test` passes.
- YAML parses cleanly with all 12 scenarios preserved on both files.

## Note on triggering /evaluate

The `evaluation.yml` workflow on main is currently broken — the `run-name` expression contains an unescaped `#` which YAML parses as a comment, causing the `${{` block to be unclosed. That is being fixed by #759 — once #759 merges, `/evaluate` on this PR will trigger a fresh eval comparing before/after this change.
