### PR TITLE
code-testing-agent: pin down behavior in generated tests

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -65,15 +65,7 @@ These rules apply to every language and override any pattern an existing test fi
 
 #### Test depth (cross-language invariants)
 
-Coverage is necessary but not sufficient — a test that exercises code without verifying its behavior gives false confidence. Every test you write must *pin down behavior* so it would fail under a plausible bug. Apply the principles in the `code-testing-agent` skill's `unit-test-generation.prompt.md` → "Write Tests That Pin Down Behavior" section:
-
-- **Mutation thinking** — each assertion would fail under at least one plausible code mutation (`>` flipped to `>=`, a `null`/`None`/`nil` check removed, an `&&` swapped for `||`, an off-by-one boundary). If the test would still pass under such a mutation, the assertion is too weak — replace `IsNotNull`/`toBeDefined` with a concrete expected value or add a follow-up assertion that pins the contract.
-- **Property intersections** — when the code under test handles multiple independent properties (quoted vs. unquoted, ASCII vs. escaped, present vs. absent), add at least one test that exercises **several properties together**, not only one test per property. Bugs live at intersections.
-- **Behavior radius** — assert on at least one *secondary* observable per test (related state, log output, neighboring fields, history buffer, retry counter, event subscription), not only the primary return value. Bugs where the return looks right but a side-effect contract is broken require this.
-- **Fixture realism** — never set the parameter under test to a degenerate value: don't test scroll with `scrollback=0`, eviction with `capacity=1`, retries with `maxRetries=0`, or iteration ordering with a single-element collection.
-- **Avoid tautological assertions** — never assert that a value you just wrote can be read back unchanged on an identity/round-trip operation; that proves only that storage works, not that the code under test produces the right value. Assert on the *transformation* the code is supposed to perform.
-
-These rules apply to every language and framework. They are not a substitute for the existing rules above (happy/edge/error paths, mock external dependencies) — they are a depth requirement that sits on top of them.
+Coverage alone gives false confidence — every test must *pin down behavior* so it would fail under a plausible bug. Apply the `code-testing-agent` skill's `unit-test-generation.prompt.md` → "Write Tests That Pin Down Behavior" section: mutation thinking (each assertion fails under a plausible mutation), no tautological round-trip assertions, property intersections, at least one secondary observable per test, and realistic (non-degenerate) fixtures. This is a depth requirement on top of the happy/edge/error-path and mocking rules above, and applies to every language.
 
 ### 5. Verify with Build
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -63,6 +63,18 @@ These rules apply to every language and override any pattern an existing test fi
 - **Prefer new test files over edits to existing ones** when both options are equally valid (e.g., a new feature, a separate concern, or any case where the existing file isn't strictly required). A new file is always purely additive.
 - **One exception**: build-system manifests (`.csproj`/`.sln`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited when registering a new test project or adding a missing test dependency. Keep these edits minimal and limited to the registration/dependency change.
 
+#### Test depth (cross-language invariants)
+
+Coverage is necessary but not sufficient — a test that exercises code without verifying its behavior gives false confidence. Every test you write must *pin down behavior* so it would fail under a plausible bug. Apply the principles in the `code-testing-agent` skill's `unit-test-generation.prompt.md` → "Write Tests That Pin Down Behavior" section:
+
+- **Mutation thinking** — each assertion would fail under at least one plausible code mutation (`>` flipped to `>=`, a `null`/`None`/`nil` check removed, an `&&` swapped for `||`, an off-by-one boundary). If the test would still pass under such a mutation, the assertion is too weak — replace `IsNotNull`/`toBeDefined` with a concrete expected value or add a follow-up assertion that pins the contract.
+- **Property intersections** — when the code under test handles multiple independent properties (quoted vs. unquoted, ASCII vs. escaped, present vs. absent), add at least one test that exercises **several properties together**, not only one test per property. Bugs live at intersections.
+- **Behavior radius** — assert on at least one *secondary* observable per test (related state, log output, neighboring fields, history buffer, retry counter, event subscription), not only the primary return value. Bugs where the return looks right but a side-effect contract is broken require this.
+- **Fixture realism** — never set the parameter under test to a degenerate value: don't test scroll with `scrollback=0`, eviction with `capacity=1`, retries with `maxRetries=0`, or iteration ordering with a single-element collection.
+- **Avoid tautological assertions** — never assert that a value you just wrote can be read back unchanged on an identity/round-trip operation; that proves only that storage works, not that the code under test produces the right value. Assert on the *transformation* the code is supposed to perform.
+
+These rules apply to every language and framework. They are not a substitute for the existing rules above (happy/edge/error paths, mock external dependencies) — they are a depth requirement that sits on top of them.
+
 ### 5. Verify with Build
 
 Call the `code-testing-builder` sub-agent to compile. Build only the specific test project, not the full solution.

--- a/plugins/dotnet-test/skills/code-testing-agent/unit-test-generation.prompt.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/unit-test-generation.prompt.md
@@ -52,44 +52,15 @@ When the task specifies particular test scenarios or behaviors to cover:
 
 ## Write Tests That Pin Down Behavior
 
-A test that passes coincidentally is worse than no test — it gives a false signal of correctness. Apply these principles to every test you write. They are language-agnostic and apply equally to MSTest, xUnit, NUnit, TUnit, pytest, Jest, Vitest, Go's `testing` package, JUnit, RSpec, GoogleTest, etc.
+A test that passes coincidentally gives a false signal. Beyond covering code, every test must *pin down behavior* — it should fail under a plausible bug. These principles are language-agnostic (MSTest, xUnit, NUnit, pytest, Jest, Go `testing`, JUnit, RSpec, ...):
 
-### 1. Mutation thinking — would the test fail if the code had a plausible bug?
+- **Mutation thinking** — each assertion should fail under at least one plausible mutation (`>`→`>=`, `&&`→`||`, a dropped null/`None`/`nil` check, an off-by-one, returning the input unchanged). If it survives every mutation, replace weak checks (`IsNotNull`/`toBeDefined`) with a concrete expected value.
+- **No tautologies** — never assert that a value you just wrote reads back unchanged; assert on the *transformation* the code performs, not that storage works.
+- **Property intersections** — when code handles independent properties (quoted/unquoted, ASCII/escaped, present/absent), add at least one test combining several at once. Bugs live at intersections, not on single axes.
+- **Behavior radius** — assert on at least one *secondary* observable (related state, log output, neighboring field, retry counter, event), not only the return value.
+- **Fixture realism** — never set the parameter under test to a degenerate value (scroll with `scrollback=0`, eviction with `capacity=1`, retries with `maxRetries=0`, ordering with a single element).
 
-For each assertion, mentally apply a small mutation to the code under test — flip a `>` to `>=`, swap `&&` for `||`, drop a null/`None`/`nil` check, off-by-one a boundary, return the input unchanged instead of transforming it. If the test would still pass under any plausible mutation, the assertion is too weak. Strengthen it with a concrete expected value, or add a second assertion that pins down the contract.
-
-Watch out for **tautological assertions** — asserting that a value you just wrote can be read back unchanged proves only that storage works, not that the code under test produces the right value. Assert on the *transformation* the code is supposed to perform.
-
-### 2. Property intersections, not just coordinate axes
-
-When the code under test handles multiple independent properties (e.g., quoted vs. unquoted input, ASCII vs. escaped characters, present vs. absent fields), write at least one test that exercises **several properties together**, not only one test per property.
-
-Real bugs live at intersections. Three orthogonal tests covering one property each will not catch a bug that only fires when two properties combine. If the parser handles quoting, escaping, and embedded spaces, add a test with a quoted-and-escaped value containing spaces — not only one test per dimension.
-
-### 3. Behavior radius — assert on secondary observables, not only the primary one
-
-For each test, ask: *"what else changes when this operation runs?"* The returned value is the primary observable, but most operations also touch secondary state: history/scrollback buffers, log output, telemetry, related collections, neighboring fields, cursor position, event subscriptions, retry counters, etc. Pick at least one secondary observable per test and assert on it. This catches bugs where the primary output looks right but the side-effect contract is broken.
-
-### 4. Fixture realism
-
-Configure fixtures to match how the code is realistically used, not the bare minimum that makes the test parse. Common anti-patterns to avoid:
-
-- Setting `scrollback=0` when testing scroll behavior (it disables the very thing being exercised)
-- A cache with capacity 1 when testing eviction
-- A single-element collection when testing iteration ordering
-- A 1×1 grid when testing region boundaries
-- A retry policy with `maxRetries=0` when testing retry behavior
-
-If a parameter is what the test is about, **never set it to a degenerate value**.
-
-### 5. Quick self-review before you stop writing the test
-
-Before declaring a test method done, re-read it and check:
-
-- Would deleting the function body cause this test to fail? (If not, assertions are too weak.)
-- Does any assertion check a value that came from the input itself, unchanged? (Tautological assertion — strengthen or remove.)
-- Do similar tests in the same file assert on more dimensions than this one? (If so, match their depth.)
-- Did you assert on at least one secondary observable? (If not, add one.)
+Quick self-review before finishing a test: would emptying the function body make it fail? If not, the assertions are too weak.
 
 ## Parameterization
 

--- a/plugins/dotnet-test/skills/code-testing-agent/unit-test-generation.prompt.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/unit-test-generation.prompt.md
@@ -50,6 +50,47 @@ When the task specifies particular test scenarios or behaviors to cover:
 3. **Fewer focused tests beat many shallow ones** — 5 tests that thoroughly exercise the function are better than 20 that only check surface behavior
 4. **Every test must pass** — run tests after writing them; fix immediately if they fail
 
+## Write Tests That Pin Down Behavior
+
+A test that passes coincidentally is worse than no test — it gives a false signal of correctness. Apply these principles to every test you write. They are language-agnostic and apply equally to MSTest, xUnit, NUnit, TUnit, pytest, Jest, Vitest, Go's `testing` package, JUnit, RSpec, GoogleTest, etc.
+
+### 1. Mutation thinking — would the test fail if the code had a plausible bug?
+
+For each assertion, mentally apply a small mutation to the code under test — flip a `>` to `>=`, swap `&&` for `||`, drop a null/`None`/`nil` check, off-by-one a boundary, return the input unchanged instead of transforming it. If the test would still pass under any plausible mutation, the assertion is too weak. Strengthen it with a concrete expected value, or add a second assertion that pins down the contract.
+
+Watch out for **tautological assertions** — asserting that a value you just wrote can be read back unchanged proves only that storage works, not that the code under test produces the right value. Assert on the *transformation* the code is supposed to perform.
+
+### 2. Property intersections, not just coordinate axes
+
+When the code under test handles multiple independent properties (e.g., quoted vs. unquoted input, ASCII vs. escaped characters, present vs. absent fields), write at least one test that exercises **several properties together**, not only one test per property.
+
+Real bugs live at intersections. Three orthogonal tests covering one property each will not catch a bug that only fires when two properties combine. If the parser handles quoting, escaping, and embedded spaces, add a test with a quoted-and-escaped value containing spaces — not only one test per dimension.
+
+### 3. Behavior radius — assert on secondary observables, not only the primary one
+
+For each test, ask: *"what else changes when this operation runs?"* The returned value is the primary observable, but most operations also touch secondary state: history/scrollback buffers, log output, telemetry, related collections, neighboring fields, cursor position, event subscriptions, retry counters, etc. Pick at least one secondary observable per test and assert on it. This catches bugs where the primary output looks right but the side-effect contract is broken.
+
+### 4. Fixture realism
+
+Configure fixtures to match how the code is realistically used, not the bare minimum that makes the test parse. Common anti-patterns to avoid:
+
+- Setting `scrollback=0` when testing scroll behavior (it disables the very thing being exercised)
+- A cache with capacity 1 when testing eviction
+- A single-element collection when testing iteration ordering
+- A 1×1 grid when testing region boundaries
+- A retry policy with `maxRetries=0` when testing retry behavior
+
+If a parameter is what the test is about, **never set it to a degenerate value**.
+
+### 5. Quick self-review before you stop writing the test
+
+Before declaring a test method done, re-read it and check:
+
+- Would deleting the function body cause this test to fail? (If not, assertions are too weak.)
+- Does any assertion check a value that came from the input itself, unchanged? (Tautological assertion — strengthen or remove.)
+- Do similar tests in the same file assert on more dimensions than this one? (If so, match their depth.)
+- Did you assert on at least one secondary observable? (If not, add one.)
+
 ## Parameterization
 
 - Prefer parameterized tests (e.g., `[DataRow]`, `[Theory]`, `@pytest.mark.parametrize`) over multiple similar methods

--- a/tests/dotnet-test/code-testing-agent/eval.vally.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.vally.yaml
@@ -49,6 +49,12 @@ stimuli:
         `.testagent/research.md` cites the helper's `source_to_tests` / `untested` JSON output, or the skill's bundled
         `Find-UntestedSources.cs` helper script was executed) instead of building the source-to-test pairing map
         purely through manual `find` / `grep` / `glob` walks
+      - Tests pin down behavior with concrete expected values — minimal use of `Assert.IsNotNull`-only assertions;
+        primary observables (return values, output collections) are checked with `Assert.AreEqual` / specific-content
+        assertions rather than truthy/existence-only checks
+      - At least one test per controller asserts on a secondary observable in addition to the primary return — e.g.,
+        for Create/Edit actions, the test inspects the underlying `SchoolContext` to confirm the entity was persisted
+        (or not, for invalid input) rather than only checking the action's `IActionResult` type
 
   - name: Generate pytest tests for the Flask tasks API (Python polyglot)
     prompt: |
@@ -118,6 +124,12 @@ stimuli:
         due_at), the overdue filter, and pagination boundaries (offset, limit, has_more)
       - Exercises SqliteTaskRepository against an in-memory connection (SqliteTaskRepository.in_memory() or a
         sqlite3.connect(':memory:') fixture), covering at least add/get, update of tags, and delete
+      - Tests pin down behavior with concrete expected values — minimal use of `assert x is not None`-only assertions;
+        tests assert on actual returned `Task` fields (id, title, status, due_at, priority) rather than
+        truthy/existence-only checks
+      - At least one TaskService validation test exercises a *combination* of properties (e.g., over-length title AND
+        invalid priority, or tag normalization on a Task with naive due_at) rather than only single-property tests,
+        exercising property intersections
 
   - name: Generate Vitest tests for the shopping-cart library (TypeScript polyglot)
     prompt: |
@@ -199,3 +211,9 @@ stimuli:
         RegionalTaxCalculator, and WeightBasedShippingCalculator (rejects empty bracket list, out-of-range / negative
         inputs)
       - No real network or filesystem dependencies in the generated tests
+      - Tests pin down behavior with concrete expected values — minimal use of `toBeDefined`/`toBeTruthy`-only
+        assertions; primary observables (totalCents, line item counts, calculated tax, computed shipping) are
+        checked with `toBe(specificNumber)` rather than truthy/existence-only checks
+      - At least one Cart test exercises the *intersection* of multiple pricing dimensions (e.g., a
+        CompositeDiscountPolicy combined with a RegionalTaxCalculator and a WeightBasedShippingCalculator above the
+        threshold) rather than only one dimension at a time, exercising property intersections

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -39,6 +39,8 @@ scenarios:
       - "Generated tests that cover multiple controllers (Students, Courses, Departments, Instructors)"
       - "Set up the EF Core SchoolContext correctly for testing without a real SQL Server (e.g., InMemory provider or SQLite)"
       - "When the `find-untested-sources` skill is available in the workspace, the research phase leveraged it (e.g., `.testagent/research.md` cites the helper's `source_to_tests` / `untested` JSON output, or the skill's bundled `Find-UntestedSources.cs` helper script was executed) instead of building the source-to-test pairing map purely through manual `find` / `grep` / `glob` walks"
+      - "Tests pin down behavior with concrete expected values — minimal use of `Assert.IsNotNull`-only assertions; primary observables (return values, output collections) are checked with `Assert.AreEqual` / specific-content assertions rather than truthy/existence-only checks"
+      - "At least one test per controller asserts on a secondary observable in addition to the primary return — e.g., for Create/Edit actions, the test inspects the underlying `SchoolContext` to confirm the entity was persisted (or not, for invalid input) rather than only checking the action's `IActionResult` type"
     timeout: 3600
 
   # ============================================================================
@@ -108,6 +110,8 @@ scenarios:
       - "Covers TaskService validation paths: empty / over-length title, naive (timezone-unaware) due_at rejection, invalid priority, tag normalization & deduplication, and 'already done' / 'already pending' state transition errors"
       - "Covers queries.apply_query directly against fixed Task lists, including at least one sort option (priority or due_at), the overdue filter, and pagination boundaries (offset, limit, has_more)"
       - "Exercises SqliteTaskRepository against an in-memory connection (SqliteTaskRepository.in_memory() or a sqlite3.connect(':memory:') fixture), covering at least add/get, update of tags, and delete"
+      - "Tests pin down behavior with concrete expected values — minimal use of `assert x is not None`-only assertions; tests assert on actual returned `Task` fields (id, title, status, due_at, priority) rather than truthy/existence-only checks"
+      - "At least one TaskService validation test exercises a *combination* of properties (e.g., over-length title AND invalid priority, or tag normalization on a Task with naive due_at) rather than only single-property tests, exercising property intersections"
     timeout: 1800
 
   # ============================================================================
@@ -186,4 +190,6 @@ scenarios:
       - "Exercises async Cart.checkout() with vi.fn().mockResolvedValue / mockRejectedValue for PriceFetcher (price refresh), InventoryChecker (denial via available=false and via availableQuantity < requested), and AsyncTaxRateProvider, including asserting the InventoryError shape (productId / requested / available)"
       - "Includes constructor boundary tests for PercentageDiscountPolicy, FixedAmountDiscountPolicy, RegionalTaxCalculator, and WeightBasedShippingCalculator (rejects empty bracket list, out-of-range / negative inputs)"
       - "No real network or filesystem dependencies in the generated tests"
+      - "Tests pin down behavior with concrete expected values — minimal use of `toBeDefined`/`toBeTruthy`-only assertions; primary observables (totalCents, line item counts, calculated tax, computed shipping) are checked with `toBe(specificNumber)` rather than truthy/existence-only checks"
+      - "At least one Cart test exercises the *intersection* of multiple pricing dimensions (e.g., a CompositeDiscountPolicy combined with a RegionalTaxCalculator and a WeightBasedShippingCalculator above the threshold) rather than only one dimension at a time, exercising property intersections"
     timeout: 1800


### PR DESCRIPTION
## Summary

Adds explicit guidance for producing tests that **pin down behavior**, not just exercise code paths. Coverage is necessary but not sufficient — a passing test that does not actually verify the contract gives false confidence. This PR teaches the `code-testing-agent` skill and `code-testing-implementer` agent to write tests that would fail under a plausible code mutation, with eval rubrics that check it.

## Motivation

Comparing two recent runs of a polyglot test-generation benchmark (44 instances across Python, Go, JS, Ruby, C), the `code-testing-generator` agent matched the stock generic agent on whether tests *compiled and passed* (mutation_pass) but underperformed on whether tests actually verified the spec (rubrics_pass). Inspection of the produced tests revealed three recurring failure modes — all language-agnostic and well-known in testing literature:

1. **Orthogonal decomposition.** When a function handled quoting, escaping, and spaces, the agent wrote one test per property and never one test combining them. The bugs lived in the intersection.
2. **Degenerate fixtures.** The agent set the parameter *under test* to a no-op value (e.g. `scrollback=0` while testing scroll history, `capacity=1` while testing eviction), then asserted on the resulting noop. Tests passed but proved nothing about the feature being tested.
3. **Trivial assertions.** `Assert.IsNotNull(result)`, `expect(x).toBeDefined()`, `assert result is not None` — only the existence of a return value was checked. Side-effects, related state, and the actual transformation went unasserted.

These are universal anti-patterns documented in mutation-testing literature (Offutt et al.), the observability/behavior-radius literature (Binder, *Testing OO Systems*, 1999), and combinatorial-testing literature (Kuhn et al.). They affect any test-generation workflow in any language.

## Changes

### Skill prompt (the conventions doc loaded by every code-testing-agent invocation)

`plugins/dotnet-test/skills/code-testing-agent/unit-test-generation.prompt.md` — new section `Write Tests That Pin Down Behavior` between `Quality over Quantity` and `Parameterization`. Five named principles, ~40 lines, no language-specific assertion APIs:

* **Mutation thinking** — would the test fail if the code had a plausible bug?
* **Property intersections** — exercise combinations, not only coordinate axes
* **Behavior radius** — assert on at least one secondary observable per test
* **Fixture realism** — never set the parameter under test to a degenerate value
* **Quick self-review** before declaring a test method done

### Implementer agent (the sub-agent that actually writes test files)

`plugins/dotnet-test/agents/code-testing-implementer.agent.md` — new `Test depth (cross-language invariants)` subsection appended to Step 4, mirroring the same five principles at the point in the workflow where test files are produced. Cross-references the prompt file for the full discussion.

### Eval rubrics (so we can detect regressions)

`tests/dotnet-test/code-testing-agent/eval.yaml` and `tests/dotnet-test/code-testing-agent/eval.vally.yaml` — adds depth-oriented rubric items to each of the three existing scenarios:

* **ContosoUniversity (.NET)** — minimal `IsNotNull`-only assertions; per-controller secondary-observable check on the underlying `SchoolContext`
* **python-flask-tasks (Python)** — minimal `is not None`-only assertions; at least one combined-property TaskService validation test
* **typescript-vitest-cart (TypeScript)** — minimal `toBeDefined`/`toBeTruthy`-only assertions; at least one intersection test combining discount + tax + shipping

The rubric additions are LLM-judged, consistent with the rest of the scenario rubrics, and require no new fixtures.

## Non-goals

* Not benchmark-specific — every change is framed in universal test-craft principles. No mention of any specific eval, prompt, or rubric vocabulary outside of the eval files themselves.
* Not a new skill — leverages files that already exist in every code-testing-agent execution path.
* Not changing the existing rules (happy/edge/error paths, mock externals) — depth is *additive* on top of them.
* Not modifying `code-testing-generator.agent.md` — that file gets a *separate* PR for the pre-completion self-review gate (test-gap-analysis + assertion-quality), which is a different concern.

## Validation

* `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin plugins/dotnet-test` — passes; the SKILL.md token count for code-testing-agent is unchanged (the new content lives in a separate file in the skill bundle).
