### PR TITLE
Add anti-pattern for forking a project instance via <MSBuild> with path-neutral global properties

### DIFF
--- a/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
@@ -316,6 +316,50 @@ This is particularly wasteful for projects where the extra property has no effec
 2. **Use `RemoveGlobalProperties` metadata** - On `ProjectReference` items, use `RemoveGlobalProperties="PublishReadyToRun"` to strip the property before building the referenced project
 3. **Condition the property** - Only set the property on projects that actually use it (e.g., only for executable projects, not class libraries)
 
+### Explicit `<MSBuild>` Build/Publish with extra global properties (self or cross-project)
+
+**Problem:** A target uses the `<MSBuild>` task to build or publish a project with an extra global property, most commonly a "publish-on-build" target. The offending call can be in the target project itself **or in another project** that consumes it (e.g. a test or layout project publishing a tool):
+
+```xml
+<!-- (a) same project (publish-on-build) -->
+<Target Name="PublishOnBuild" AfterTargets="Build">
+  <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="_IsPublishing=true" />
+</Target>
+
+<!-- (b) project A publishes project B that it consumes -->
+<MSBuild Projects="..\tool\tool.csproj" Targets="Publish" Properties="_IsPublishing=true" />
+```
+
+Either way this forks a distinct instance of the target project (`path` + `{_IsPublishing=true}`) that shares the same `OutputPath`/`IntermediateOutputPath` as the instance the solution/graph already builds. Both write the same files — for NativeAOT this includes the `*.sourcelink` intermediate, which produces `SourceLinkWriter` / "file in use" failures under parallel builds.
+
+**How to detect:** Follow the Primary workflow above — the `evaluations` and `evaluation_global_properties` tools surface two evaluations of the target project that share the same `OutputPath`/`IntermediateOutputPath` but differ only by a path-neutral publish flag such as `_IsPublishing`, and the `double_writes` tool flags the resulting shared-file writes directly. To tell case (a) from (b), see which project the extra `{_IsPublishing=true}` evaluation runs *under* in the build tree (from the overview/projects tools): the target project itself for (a), or a consumer project that invoked the `<MSBuild>` task for (b).
+
+**Fix:** Depends on where the call lives:
+
+- **Same project (a):** you can't strip the property with `RemoveGlobalProperties` (the project injects it on itself). Set the flag as a **static** (non-global) property and run the target in the **same** instance via `DependsOnTargets`/`CallTarget`, with a guard against a target cycle when publish is the entry point:
+
+```xml
+<PropertyGroup>
+  <_PublishWasInvokedDirectly Condition="'$(_IsPublishing)' == 'true'">true</_PublishWasInvokedDirectly>
+  <_IsPublishing>true</_IsPublishing>
+</PropertyGroup>
+<Target Name="PublishOnBuild"
+        AfterTargets="Build"
+        DependsOnTargets="Publish"
+        Condition="'$(_PublishWasInvokedDirectly)' != 'true'" />
+```
+
+- **Cross-project (b):** the consumer must not fork the producer with path-neutral global properties. Make the producer publish as part of its own build (the (a) fix in *its* project), then have the consumer **sequence** it and read its output instead of re-publishing it:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="..\tool\tool.csproj" ReferenceOutputAssembly="false" />
+</ItemGroup>
+<!-- consumer reads tool's publish dir; it does NOT invoke Publish on tool -->
+```
+
+See the `msbuild-antipatterns` skill (AP-22) for the authoring-time smell and rationale.
+
 ## Example Workflow
 
 ```bash
@@ -369,6 +413,7 @@ When multiple evaluations share an output path, compare these global properties 
 | `BuildProjectReferences` | No | `false` = P2P query, not a real build - ignore these |
 | `MSBuildRestoreSessionId` | No | Present = restore phase evaluation |
 | `PublishReadyToRun` | No | Publish setting, doesn't change build output path but creates distinct project instances |
+| `_IsPublishing` | No | Publish flag; an `<MSBuild>` Build/Publish call with this set (in this project or another that consumes it) forks a publish instance sharing the build output path (see "Explicit `<MSBuild>` Build/Publish with extra global properties") |
 
 ## Testing Fixes
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -404,4 +404,4 @@ MSBuild's evaluator normalizes `\` → `/` on Unix-like systems before resolving
 
 ---
 
-For additional anti-patterns (AP-16 through AP-21) and a quick-reference checklist, see [additional-antipatterns.md](references/additional-antipatterns.md).
+For additional anti-patterns (AP-16 through AP-22) and a quick-reference checklist, see [additional-antipatterns.md](references/additional-antipatterns.md).

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
@@ -171,6 +171,62 @@ For a detailed explanation of MSBuild's evaluation and execution phases, see [Bu
 
 ---
 
+## AP-22: Forking a Project Instance via `<MSBuild>` with Path-Neutral Global Properties
+
+**Smell**: A target uses the `<MSBuild>` task to build or publish a project, passing extra `Properties` that don't change that project's output path. Two common shapes:
+
+```xml
+<!-- (a) the SAME project re-invokes itself (publish-on-build) -->
+<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="_IsPublishing=true" />
+
+<!-- (b) project A invokes Build/Publish on ANOTHER project B it consumes
+        (e.g. a test or layout project publishing a tool) -->
+<MSBuild Projects="..\tool\tool.csproj" Targets="Publish" Properties="_IsPublishing=true" />
+```
+
+**Why it's bad**: An MSBuild project instance is identified by its path **plus its global properties**. Passing an extra global property creates a *distinct* instance of the target project — `(project, {_IsPublishing=true})` — that still resolves to the same `OutputPath`/`IntermediateOutputPath` as the instance the solution/graph already builds, `(project, {})`. That project is then built twice, and in a parallel/graph build the two instances can write the same files concurrently (PDBs, `*.sourcelink` and other NativeAOT intermediates, `project.assets.json`), producing `The process cannot access the file because it is being used by another process` or intermittent file-lock failures. This applies whether the offending `<MSBuild>` call is in the target project itself or in some other project in the same build. Use the `check-bin-obj-clash` skill to confirm two evaluations of that project differ only by a path-neutral property while sharing an output path.
+
+```xml
+<!-- BAD (a): forks a second instance (path + {_IsPublishing=true}) that shares this project's bin/obj -->
+<Target Name="PublishOnBuild" AfterTargets="Build">
+  <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="_IsPublishing=true" />
+</Target>
+```
+
+```xml
+<!-- GOOD (a): set the flag as a normal (non-global) property and run the target in the SAME instance -->
+<PropertyGroup>
+  <!-- Capture whether the entry point already invoked publish (it sets _IsPublishing as a global prop). -->
+  <_PublishWasInvokedDirectly Condition="'$(_IsPublishing)' == 'true'">true</_PublishWasInvokedDirectly>
+  <_IsPublishing>true</_IsPublishing>
+</PropertyGroup>
+
+<Target Name="PublishOnBuild"
+        AfterTargets="Build"
+        DependsOnTargets="Publish"
+        Condition="'$(_PublishWasInvokedDirectly)' != 'true'" />
+```
+
+For (a), the static property keeps everything in one instance (one output path, nothing to race); running `Publish` via `DependsOnTargets` (or `CallTarget`) reuses that instance instead of forking. The `_PublishWasInvokedDirectly` guard breaks the target cycle when publish is the entry point (e.g. `dotnet publish`, which sets `_IsPublishing=true` as a global property and would otherwise re-trigger `PublishOnBuild`).
+
+```xml
+<!-- BAD (b): A forks a publish instance of B that races B's own build in the graph -->
+<MSBuild Projects="..\tool\tool.csproj" Targets="Publish" Properties="_IsPublishing=true" />
+
+<!-- GOOD (b): make B publish as part of its OWN build (the (a) fix in tool.csproj), then have A
+     just sequence B and consume B's already-produced publish output — never re-publish it. -->
+<ItemGroup>
+  <ProjectReference Include="..\tool\tool.csproj" ReferenceOutputAssembly="false" />
+</ItemGroup>
+<!-- A then reads tool's publish dir; it does not invoke Publish on tool. -->
+```
+
+For (b), the consumer must not fork the producer with path-neutral global properties. Let the producer publish itself (one instance), reference it only to sequence the build, and read its output.
+
+**When extra global properties ARE fine**: only when the output path encodes the discriminator (`RuntimeIdentifier`, `TargetFramework`, `Configuration`, `Platform`) so each instance writes to a distinct directory. If you must invoke a project with a path-neutral property, give that build its own `BaseIntermediateOutputPath`/output path so it can't collide.
+
+---
+
 ## Quick-Reference Checklist
 
 When reviewing an MSBuild file, scan for these in order:
@@ -180,6 +236,7 @@ When reviewing an MSBuild file, scan for these in order:
 | AP-02 | Unquoted conditions | 🔴 Error-prone |
 | AP-19 | Side effects in evaluation | 🔴 Dangerous |
 | AP-21 | Property conditioned on TargetFramework in .props | 🔴 Silent failure |
+| AP-22 | Forking a project instance via `<MSBuild>` with path-neutral global properties (self or cross-project) | 🔴 Race/duplicate build |
 | AP-03 | Hardcoded absolute paths | 🔴 Broken on other machines |
 | AP-06 | `<Reference>` with HintPath for NuGet | 🟡 Legacy |
 | AP-07 | Missing `PrivateAssets="all"` on tools | 🟡 Leaks to consumers |

--- a/tests/dotnet-msbuild/msbuild-antipatterns/LibA/LibA.csproj
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/LibA/LibA.csproj
@@ -32,4 +32,15 @@
   <Target Name="PrintVersion" BeforeTargets="Build">
     <Exec Command="echo Building version 1.0.0" />
   </Target>
+
+  <!-- BUG (AP-22): publish-on-build re-invokes this same project through the <MSBuild>
+       task with a path-neutral global property (_IsPublishing). That forks a second
+       project instance (path + {_IsPublishing=true}) which still resolves to this
+       project's OutputPath/IntermediateOutputPath, so the project builds twice and the
+       two instances can race writing the same files. Should set _IsPublishing as a
+       static property and run Publish via DependsOnTargets in the SAME instance, with a
+       cycle guard. -->
+  <Target Name="PublishOnBuild" AfterTargets="Build">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="_IsPublishing=true" />
+  </Target>
 </Project>

--- a/tests/dotnet-msbuild/msbuild-antipatterns/eval.vally.yaml
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/eval.vally.yaml
@@ -29,6 +29,9 @@ stimuli:
       - Identified DefineConstants overwrites existing constants instead of appending
       - Identified analyzer PackageReference missing PrivateAssets, unquoted MSBuild condition, mixed Include/Update in
         same ItemGroup, or Exec instead of Message task
+      - Identified LibA's publish-on-build target that re-invokes the project via the <MSBuild> task with a path-neutral
+        global property (_IsPublishing), forking a duplicate project instance that shares the output path and can race on
+        writes
 
   - name: Add a module to an F# project
     prompt: |

--- a/tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml
@@ -15,6 +15,7 @@ scenarios:
       - "Identified TargetFramework condition in .props that silently fails because TFM is empty during .props evaluation"
       - "Identified DefineConstants overwrites existing constants instead of appending"
       - "Identified analyzer PackageReference missing PrivateAssets, unquoted MSBuild condition, mixed Include/Update in same ItemGroup, or Exec instead of Message task"
+      - "Identified LibA's publish-on-build target that re-invokes the project via the <MSBuild> task with a path-neutral global property (_IsPublishing), forking a duplicate project instance that shares the output path and can race on writes"
     timeout: 160
 
   - name: "Add a module to an F# project"


### PR DESCRIPTION
## Summary

Adds a new MSBuild anti-pattern (**AP-22**) plus guidance for using the `<MSBuild>` task to build/publish a project with an extra **global** property that doesn't change the output path.  This is a common cause of MSBuild issues.  We've hit it recently in .NET several times when switching projects to NativeAOT and trying to consume their outputs from other projects.

Because a project instance's identity is *path + global properties*, setting global properties on a build of a project that's already being built forks a second instance that still resolves to the same `OutputPath`/`IntermediateOutputPath` as the instance the graph already builds — so the project builds twice and the two instances can race writing the same files (PDBs, `*.sourcelink`/NativeAOT intermediates, `project.assets.json`).

This error case is somewhat covered in the check-bin-obj-clash skill (which this PR also updates), but that skill requires investigating a binlog for the build, while this anti-pattern tries to recognize the issue just from looking at the project file.

Most recently we had to revert a change in dotnet/dotnet#7124 because of this.  Other related PRs where we hit this or were working out the pattern to apply:

- https://github.com/dotnet/dotnet/pull/6590
- https://github.com/dotnet/dotnet/pull/6576
- https://github.com/dotnet/sdk/pull/54222

## What changed

- **`dotnet-msbuild/skills/msbuild-antipatterns`**
  - New **AP-22** in `references/additional-antipatterns.md` covering both shapes — (a) a project re-invoking itself (publish-on-build), and (b) project A publishing another project B it consumes — each with a BAD→GOOD transform. GOOD fixes: (a) static `_IsPublishing` + `DependsOnTargets` with a cycle guard; (b) let the producer publish in its own build and have the consumer **sequence** it via a non-output `ProjectReference` instead of re-publishing it.
  - Updated the `SKILL.md` pointer (AP-16 through AP-22) and the quick-reference checklist.
- **`dotnet-msbuild/skills/check-bin-obj-clash`**
  - Added the matching cause (self or cross-project `<MSBuild>` Build/Publish with a path-neutral global property), with **binlog-based** detection using the skill's documented MCP tools (`evaluations` / `evaluation_global_properties` / `double_writes`, plus the project tree to tell self vs cross-project), both fixes, and an `_IsPublishing` row in the global-properties table.
- **Tests**
  - Added a publish-on-build smell to the `msbuild-antipatterns` review fixture (`LibA.csproj`) and a matching rubric line in `eval.yaml` and `eval.vally.yaml`.

Two tightly-coupled skills are touched intentionally: AP-22 catches the smell at authoring/review time, `check-bin-obj-clash` catches the runtime symptom from a binlog. They cross-reference each other.
