### PR TITLE
Raise per-plugin aggregate description cap to 22,000 (unblock dotnet-test)

### DIFF
--- a/eng/skill-validator/src/Check/SkillProfiler.cs
+++ b/eng/skill-validator/src/Check/SkillProfiler.cs
@@ -47,7 +47,13 @@ public static partial class SkillProfiler
     // actually degrade selection accuracy or just cost more tokens up-front.
     // Until then, keep the cap aligned with current enforcement as a hard
     // validation failure, while leaving enough headroom for reasonable plugin growth.
-    internal const int MaxAggregateDescriptionLength = 20_000;
+    //
+    // Raised 20,000 -> 22,000: the dotnet-test plugin (the largest and most
+    // active) reached ~20,400 aggregate chars after adding the
+    // find-untested-sources-polyglot skill, legitimate growth that exceeded the
+    // previous cap. Bumped to restore ~1.6k headroom rather than degrade the
+    // routing keywords of existing skills. Prior precedent: 15,000 -> 20,000.
+    internal const int MaxAggregateDescriptionLength = 22_000;
     private const int MaxNameLength = 64;
     internal const int MinDescriptionLength = 10;
     private const int MaxCompatibilityLength = 500;


### PR DESCRIPTION
## Problem

The skill-validator `check` job is failing on PRs #767 and #768 (and on `main` itself):

```
❌ [plugin:dotnet-test] Plugin 'dotnet-test' aggregate description size is 20,397 characters — maximum is 20,000.
```

Root cause: the `find-untested-sources-polyglot` skill merged in #735 added a ~396-char description, pushing the **dotnet-test** plugin's aggregate skill-description size from ~20,000 to **20,397**, over the per-plugin cap.

## Fix

Raise `SkillProfiler.MaxAggregateDescriptionLength` from 20,000 to **22,000**.

Rationale:
- This is legitimate plugin growth (a useful cross-language skill), not metadata bloat. dotnet-test is the largest and most active plugin.
- The cap's own comment documents it as an *unvalidated local heuristic* meant to `leave enough headroom for reasonable plugin growth`, with precedent for raising it as plugins grow (15,000 → 20,000).
- The arithmetic forces a choice: the overage (397) is larger than the polyglot description itself (396), so it cannot be resolved by trimming only the offending skill — any trim-based fix would have to degrade the routing-keyword lists of *other* dotnet-test skills (owned by @dotnet/dotnet-testing). A 5% cap bump avoids degrading routing quality.

Tests reference the constant dynamically, so no test changes are needed.

## Alternative considered

Trimming descriptions to fit under 20,000. Rejected because it would require cutting other owners' carefully-tuned USE FOR / DO NOT USE FOR routing keywords. If maintainers prefer that route (or a smaller bump), happy to adjust.

Unblocks #767 and #768.