### PR TITLE
Resolve Microsoft.AITools.BinlogMcp from nuget.org

### DIFF
--- a/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
@@ -6,10 +6,7 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--prerelease",
-        "--add-source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+        "--yes"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/plugin.json
+++ b/plugins/dotnet-msbuild/plugin.json
@@ -15,10 +15,7 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--prerelease",
-        "--add-source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+        "--yes"
       ],
       "tools": ["*"]
     }


### PR DESCRIPTION
The `Microsoft.AITools.BinlogMcp` package is now published on [nuget.org](https://www.nuget.org/packages/Microsoft.AITools.BinlogMcp) as stable `1.0.0`, so the `binlog` MCP server no longer needs the dnceng AzDO `dotnet-tools` feed or the `--prerelease` flag.

## Changes
- **plugins/dotnet-msbuild/plugin.json** — removed `--prerelease` and `--add-source <azdo feed>` from the `binlog` server args (nuget.org is the default source).
- **plugins/dotnet-msbuild/.codex-plugin/.mcp.json** — same change in the Codex plugin mirror.