### PR TITLE
Add worked example files for C++, PowerShell, Ruby, Rust, Kotlin

### DIFF
--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
@@ -204,7 +204,7 @@ TEST_CASE("InvoiceService calculates totals", "[invoice-service]") {
         Invoice invoice = make_invoice();
         invoice.line_items.clear();
 
-        REQUIRE_THROWS_MATCHES(sut.calculate_total(invoice), std::invalid_argument, ContainsSubstring("no line items"));
+        REQUIRE_THROWS_WITH(sut.calculate_total(invoice), ContainsSubstring("no line items"));
     }
 }
 
@@ -219,7 +219,7 @@ TEST_CASE("InvoiceService uses the repository", "[invoice-service]") {
     }
 
     SECTION("get_by_id throws when missing") {
-        REQUIRE_THROWS_MATCHES(sut.get_by_id(999), std::out_of_range, ContainsSubstring("not found"));
+        REQUIRE_THROWS_WITH(sut.get_by_id(999), ContainsSubstring("not found"));
     }
 
     SECTION("mark_as_paid updates status, date, and repository") {
@@ -237,7 +237,7 @@ TEST_CASE("InvoiceService uses the repository", "[invoice-service]") {
         invoice.status = InvoiceStatus::paid;
         repository.invoices.emplace(2, invoice);
 
-        REQUIRE_THROWS_MATCHES(sut.mark_as_paid(2), std::logic_error, ContainsSubstring("already paid"));
+        REQUIRE_THROWS_WITH(sut.mark_as_paid(2), ContainsSubstring("already paid"));
     }
 }
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
@@ -1,0 +1,292 @@
+# C++ Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a C++ codebase using CMake + Catch2. These show what each pipeline phase produces for a small library project.
+
+> GoogleTest follows the same shape. Replace `TEST_CASE` / `SECTION` / `REQUIRE` with `TEST` / `EXPECT_*` and link the test executable to `GTest::gtest_main` instead of `Catch2::Catch2WithMain`.
+
+## Source Under Test
+
+A simple `InvoiceService` in a CMake project:
+
+```text
+CMakeLists.txt
+include/contoso/billing/
+  invoice.hpp
+  invoice_repository.hpp
+  invoice_service.hpp
+src/invoice_service.cpp
+tests/CMakeLists.txt        (links Catch2::Catch2WithMain)
+```
+
+```cpp
+// src/invoice_service.cpp
+#include "contoso/billing/invoice_service.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace contoso::billing {
+
+InvoiceService::InvoiceService(InvoiceRepository& repository, Clock clock)
+    : repository_(repository), clock_(std::move(clock)) {}
+
+double InvoiceService::calculate_total(const Invoice& invoice) const {
+    if (invoice.line_items.empty()) {
+        throw std::invalid_argument("invoice has no line items");
+    }
+
+    double subtotal = 0.0;
+    for (const LineItem& item : invoice.line_items) {
+        subtotal += static_cast<double>(item.quantity) * item.unit_price;
+    }
+
+    return std::round((subtotal + subtotal * invoice.tax_rate) * 100.0) / 100.0;
+}
+
+Invoice InvoiceService::get_by_id(int id) const {
+    auto invoice = repository_.find(id);
+    if (!invoice.has_value()) {
+        throw std::out_of_range("invoice not found");
+    }
+
+    return *invoice;
+}
+
+void InvoiceService::mark_as_paid(int id) {
+    auto invoice = repository_.find(id);
+    if (!invoice.has_value()) {
+        throw std::out_of_range("invoice not found");
+    }
+    if (invoice->status == InvoiceStatus::paid) {
+        throw std::logic_error("invoice is already paid");
+    }
+
+    invoice->status = InvoiceStatus::paid;
+    invoice->paid_at = clock_();
+    repository_.update(*invoice);
+}
+
+} // namespace contoso::billing
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: C++20
+- **Build System**: CMake (preset `ninja-debug` present)
+- **Test Framework**: Catch2 v3 (detected via `find_package(Catch2 3 REQUIRED)`)
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Configure**: `cmake --preset ninja-debug`
+- **Build tests**: `cmake --build --preset ninja-debug --target invoice_service_tests`
+- **Test**: `ctest --preset ninja-debug --output-on-failure`
+- **Coverage (if configured)**: rebuild with `--coverage`, then use `gcov` or `llvm-cov`
+
+## Files to Test
+
+### High Priority
+| File | Classes/Functions | Testability | Notes |
+|------|-------------------|-------------|-------|
+| src/invoice_service.cpp | InvoiceService: calculate_total, get_by_id, mark_as_paid | High | Repository is an interface; clock dependency is injectable |
+
+## Testing Patterns
+- No existing patterns; recommend Catch2 `TEST_CASE` blocks, `SECTION` cases, `Approx` for floating-point assertions, and a hand-written fake repository.
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate Catch2 tests for InvoiceService covering pure calculation logic,
+repository lookup behavior, and the paid-state transition.
+
+## Commands
+- **Build**: `cmake --build --preset ninja-debug --target invoice_service_tests`
+- **Test**: `ctest --preset ninja-debug --output-on-failure`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+- **Source**: `src/invoice_service.cpp`
+- **Test File**: `tests/invoice_service_tests.cpp`
+
+**Methods to Test**:
+1. `calculate_total` — tax, zero tax, rounding, empty line items
+2. `get_by_id` — existing invoice and missing invoice
+3. `mark_as_paid` — success with fixed clock, already-paid, missing
+```
+
+## Sample Generated Test File
+
+```cpp
+// tests/invoice_service_tests.cpp
+#include "contoso/billing/invoice_service.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <chrono>
+#include <optional>
+#include <stdexcept>
+#include <unordered_map>
+
+using Catch::Matchers::ContainsSubstring;
+
+namespace contoso::billing {
+namespace {
+
+class FakeRepository final : public InvoiceRepository {
+public:
+    std::optional<Invoice> find(int id) override {
+        auto it = invoices.find(id);
+        return it == invoices.end() ? std::nullopt : std::optional<Invoice>{it->second};
+    }
+
+    void update(const Invoice& invoice) override {
+        updated = invoice;
+        invoices[invoice.id] = invoice;
+    }
+
+    std::unordered_map<int, Invoice> invoices;
+    std::optional<Invoice> updated;
+};
+
+Invoice make_invoice(int id = 1) {
+    return Invoice{
+        .id = id,
+        .status = InvoiceStatus::pending,
+        .tax_rate = 0.10,
+        .line_items = {LineItem{.quantity = 1, .unit_price = 100.0}},
+    };
+}
+
+} // namespace
+
+TEST_CASE("InvoiceService calculates totals", "[invoice-service]") {
+    FakeRepository repository;
+    InvoiceService sut(repository, [] { return std::chrono::system_clock::time_point{}; });
+
+    SECTION("single item with tax") {
+        REQUIRE(sut.calculate_total(make_invoice()) == Catch::Approx(110.0));
+    }
+
+    SECTION("multi quantity with zero tax") {
+        Invoice invoice = make_invoice();
+        invoice.tax_rate = 0.0;
+        invoice.line_items = {LineItem{.quantity = 3, .unit_price = 25.0}};
+
+        REQUIRE(sut.calculate_total(invoice) == Catch::Approx(75.0));
+    }
+
+    SECTION("rounds to two decimals") {
+        Invoice invoice = make_invoice();
+        invoice.tax_rate = 0.07;
+        invoice.line_items = {LineItem{.quantity = 2, .unit_price = 9.99}};
+
+        REQUIRE(sut.calculate_total(invoice) == Catch::Approx(21.38).epsilon(0.001));
+    }
+
+    SECTION("empty line items throw") {
+        Invoice invoice = make_invoice();
+        invoice.line_items.clear();
+
+        REQUIRE_THROWS_MATCHES(sut.calculate_total(invoice), std::invalid_argument, ContainsSubstring("no line items"));
+    }
+}
+
+TEST_CASE("InvoiceService uses the repository", "[invoice-service]") {
+    const auto fixed_time = std::chrono::system_clock::time_point{std::chrono::seconds{123}};
+    FakeRepository repository;
+    repository.invoices.emplace(42, make_invoice(42));
+    InvoiceService sut(repository, [fixed_time] { return fixed_time; });
+
+    SECTION("get_by_id returns an existing invoice") {
+        REQUIRE(sut.get_by_id(42).id == 42);
+    }
+
+    SECTION("get_by_id throws when missing") {
+        REQUIRE_THROWS_MATCHES(sut.get_by_id(999), std::out_of_range, ContainsSubstring("not found"));
+    }
+
+    SECTION("mark_as_paid updates status, date, and repository") {
+        repository.invoices.emplace(1, make_invoice(1));
+
+        sut.mark_as_paid(1);
+
+        REQUIRE(repository.updated.has_value());
+        REQUIRE(repository.updated->status == InvoiceStatus::paid);
+        REQUIRE(repository.updated->paid_at == fixed_time);
+    }
+
+    SECTION("mark_as_paid rejects an already-paid invoice") {
+        Invoice invoice = make_invoice(2);
+        invoice.status = InvoiceStatus::paid;
+        repository.invoices.emplace(2, invoice);
+
+        REQUIRE_THROWS_MATCHES(sut.mark_as_paid(2), std::logic_error, ContainsSubstring("already paid"));
+    }
+}
+
+} // namespace contoso::billing
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a compile or runner issue, the fixer agent diagnoses and resolves it.
+
+**Build output:**
+
+```text
+error: cannot declare variable 'repository' to be of abstract type 'FakeRepository'
+note: missing pure virtual method 'InvoiceRepository::update'
+```
+
+**Fixer diagnosis:** The fake repository implemented `find` but not the full `InvoiceRepository` interface.
+
+**Fix applied:** Add `void update(const Invoice& invoice) override` to `FakeRepository` and record the updated invoice for assertions.
+
+**Rebuild + rerun:** `cmake --build --preset ninja-debug --target invoice_service_tests && ctest --preset ninja-debug --output-on-failure` → SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (C++ / CMake)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 9     |
+| Tests passing  | 9     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `tests/invoice_service_tests.cpp` (2 Catch2 test cases, 9 sections)
+
+### Coverage
+- InvoiceService.calculate_total — tax, zero tax, rounding, empty input
+- InvoiceService.get_by_id — found and missing branches
+- InvoiceService.mark_as_paid — success and already-paid branches
+
+### Build / Test Validation
+- Configure: ✅ `cmake --preset ninja-debug`
+- Build: ✅ `cmake --build --preset ninja-debug --target invoice_service_tests`
+- Test: ✅ `ctest --preset ninja-debug --output-on-failure`
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin-examples.md
@@ -1,0 +1,300 @@
+# Kotlin Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Kotlin JVM codebase using Gradle + JUnit 5. These show what each pipeline phase produces for a small project.
+
+> `kotlin.test` follows the same shape for multiplatform projects. Replace JUnit Jupiter parameterization with `@Test` methods or the repo's established KMP data pattern, and place tests under `src/commonTest/kotlin` or the matching target source set.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Gradle Kotlin JVM project:
+
+```text
+settings.gradle.kts
+build.gradle.kts
+src/main/kotlin/com/contoso/billing/
+  Invoice.kt
+  InvoiceRepository.kt
+  InvoiceService.kt
+src/test/kotlin/com/contoso/billing/   (exists, empty)
+```
+
+```kotlin
+// src/main/kotlin/com/contoso/billing/InvoiceService.kt
+package com.contoso.billing
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Clock
+import java.time.LocalDateTime
+
+class InvoiceService(
+    private val repository: InvoiceRepository,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    fun calculateTotal(invoice: Invoice): BigDecimal {
+        require(invoice.lineItems.isNotEmpty()) { "Invoice has no line items." }
+
+        val subtotal = invoice.lineItems
+            .map { it.unitPrice.multiply(BigDecimal.valueOf(it.quantity.toLong())) }
+            .fold(BigDecimal.ZERO, BigDecimal::add)
+        val tax = subtotal.multiply(invoice.taxRate)
+        return subtotal.add(tax).setScale(2, RoundingMode.HALF_UP)
+    }
+
+    fun getById(id: Int): Invoice = repository.find(id)
+        ?: throw NoSuchElementException("Invoice $id not found.")
+
+    fun markAsPaid(id: Int) {
+        val invoice = getById(id)
+        check(invoice.status != InvoiceStatus.PAID) { "Invoice is already paid." }
+
+        invoice.status = InvoiceStatus.PAID
+        invoice.paidAt = LocalDateTime.now(clock)
+        repository.update(invoice)
+    }
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: Kotlin 2.0 JVM
+- **Build Tool**: Gradle wrapper present (`./gradlew`)
+- **Test Framework**: JUnit 5 + kotlin.test assertions (`useJUnitPlatform()` and `junit-jupiter-params` detected)
+- **Mocking**: MockK is not present; repository is an interface and can be faked directly
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Compile tests**: `./gradlew compileTestKotlin --console=plain`
+- **Single class**: `./gradlew test --tests "com.contoso.billing.InvoiceServiceTest" --console=plain`
+- **All tests**: `./gradlew test --console=plain`
+
+## Files to Test
+
+### High Priority
+| File | Classes/Methods | Testability | Notes |
+|------|-----------------|-------------|-------|
+| src/main/kotlin/com/contoso/billing/InvoiceService.kt | calculateTotal, getById, markAsPaid | High | Repository interface is fakeable; Clock is injectable |
+
+## Testing Patterns
+- No existing patterns; recommend JUnit 5 `@Test`, `@ParameterizedTest` + `@CsvSource`, backticked test names, `kotlin.test` assertions, and a hand-written fake repository.
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate JUnit 5 tests for InvoiceService covering calculation, lookup, and
+paid-state transition behavior.
+
+## Commands
+- **Compile tests**: `./gradlew compileTestKotlin --console=plain`
+- **Test**: `./gradlew test --tests "com.contoso.billing.InvoiceServiceTest" --console=plain`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+- **Source**: `src/main/kotlin/com/contoso/billing/InvoiceService.kt`
+- **Test File**: `src/test/kotlin/com/contoso/billing/InvoiceServiceTest.kt`
+
+**Methods to Test**:
+1. `calculateTotal` — parameterized tax, zero tax, rounding, empty-line-items error
+2. `getById` — existing invoice and missing invoice
+3. `markAsPaid` — success with fixed clock, already-paid, missing
+```
+
+## Sample Generated Test File
+
+```kotlin
+// src/test/kotlin/com/contoso/billing/InvoiceServiceTest.kt
+package com.contoso.billing
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class InvoiceServiceTest {
+
+    private class FakeRepository : InvoiceRepository {
+        val invoices = mutableMapOf<Int, Invoice>()
+        var updated: Invoice? = null
+
+        override fun find(id: Int): Invoice? = invoices[id]
+
+        override fun update(invoice: Invoice) {
+            updated = invoice
+            invoices[invoice.id] = invoice
+        }
+    }
+
+    @ParameterizedTest(name = "qty={0}, unitPrice={1}, taxRate={2} -> {3}")
+    @CsvSource(
+        "1, 100.00, 0.10, 110.00",
+        "3, 25.00, 0.00, 75.00",
+        "2, 9.99, 0.07, 21.38",
+    )
+    fun `calculateTotal returns expected total for valid line items`(
+        quantity: Int,
+        unitPrice: BigDecimal,
+        taxRate: BigDecimal,
+        expected: BigDecimal,
+    ) {
+        val service = InvoiceService(FakeRepository())
+        val invoice = invoice(
+            taxRate = taxRate,
+            lineItems = mutableListOf(LineItem(quantity = quantity, unitPrice = unitPrice)),
+        )
+
+        val total = service.calculateTotal(invoice)
+
+        assertEquals(0, total.compareTo(expected), "expected $expected but got $total")
+    }
+
+    @Test
+    fun `calculateTotal throws for empty line items`() {
+        val service = InvoiceService(FakeRepository())
+        val invoice = invoice(lineItems = mutableListOf())
+
+        val exception = assertThrows<IllegalArgumentException> { service.calculateTotal(invoice) }
+
+        assertTrue(exception.message!!.contains("no line items", ignoreCase = true))
+    }
+
+    @Test
+    fun `getById returns existing invoice`() {
+        val repository = FakeRepository()
+        val expected = invoice(id = 42)
+        repository.invoices[42] = expected
+        val service = InvoiceService(repository)
+
+        val result = service.getById(42)
+
+        assertSame(expected, result)
+    }
+
+    @Test
+    fun `getById throws for missing invoice`() {
+        val service = InvoiceService(FakeRepository())
+
+        val exception = assertThrows<NoSuchElementException> { service.getById(999) }
+
+        assertTrue(exception.message!!.contains("999"))
+    }
+
+    @Test
+    fun `markAsPaid updates status date and repository`() {
+        val repository = FakeRepository()
+        val invoice = invoice(id = 1)
+        repository.invoices[1] = invoice
+        val fixedClock = Clock.fixed(Instant.parse("2025-01-01T12:00:00Z"), ZoneOffset.UTC)
+        val service = InvoiceService(repository, fixedClock)
+
+        service.markAsPaid(1)
+
+        assertEquals(InvoiceStatus.PAID, invoice.status)
+        assertEquals(LocalDateTime.ofInstant(fixedClock.instant(), ZoneOffset.UTC), invoice.paidAt)
+        assertSame(invoice, repository.updated)
+    }
+
+    @Test
+    fun `markAsPaid throws and does not update already paid invoice`() {
+        val repository = FakeRepository()
+        repository.invoices[1] = invoice(id = 1, status = InvoiceStatus.PAID)
+        val service = InvoiceService(repository)
+
+        val exception = assertThrows<IllegalStateException> { service.markAsPaid(1) }
+
+        assertTrue(exception.message!!.contains("already paid", ignoreCase = true))
+        assertEquals(null, repository.updated)
+    }
+
+    private fun invoice(
+        id: Int = 1,
+        status: InvoiceStatus = InvoiceStatus.PENDING,
+        taxRate: BigDecimal = BigDecimal("0.10"),
+        lineItems: MutableList<LineItem> = mutableListOf(LineItem(quantity = 1, unitPrice = BigDecimal("100.00"))),
+    ): Invoice = Invoice(id = id, status = status, taxRate = taxRate, lineItems = lineItems, paidAt = null)
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a Gradle or Kotlin compile issue, the fixer agent diagnoses and resolves it.
+
+**Build output:**
+
+```text
+No tests found for given includes: [com.contoso.billing.InvoiceServiceTest]
+```
+
+**Fixer diagnosis:** The test file was created under `src/test/java` with Kotlin source, so the Kotlin JVM source set did not compile it into the expected package.
+
+**Fix applied:** Move the file to `src/test/kotlin/com/contoso/billing/InvoiceServiceTest.kt` and keep `package com.contoso.billing` at the top.
+
+**Rebuild + rerun:** `./gradlew test --tests "com.contoso.billing.InvoiceServiceTest" --console=plain` → SUCCESS
+
+---
+
+**Another common cycle — JUnit Platform not enabled:**
+
+**Test output:**
+
+```text
+0 tests completed
+```
+
+**Fixer diagnosis:** The project has JUnit Jupiter dependencies but the Gradle `test` task is not configured with `useJUnitPlatform()`.
+
+**Fix applied:** Match the repo's build convention and add `tasks.test { useJUnitPlatform() }` if it is missing.
+
+**Rerun:** SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (Kotlin / Gradle)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 8     |
+| Tests passing  | 8     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `src/test/kotlin/com/contoso/billing/InvoiceServiceTest.kt` (8 JUnit 5 tests, 3 parameterized cases)
+
+### Coverage
+- InvoiceService.calculateTotal — 3 happy path, 1 error case
+- InvoiceService.getById — found and missing branches
+- InvoiceService.markAsPaid — success and already-paid branches
+
+### Build / Test Validation
+- Compile tests: ✅ `./gradlew compileTestKotlin --console=plain`
+- Test run: ✅ `./gradlew test --tests "com.contoso.billing.InvoiceServiceTest" --console=plain`
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
@@ -22,7 +22,7 @@ enum InvoiceStatus {
 
 function Get-InvoiceTotal {
     [CmdletBinding()]
-    param([Parameter(Mandatory)][hashtable]$Invoice)
+    param([Parameter(Mandatory)][pscustomobject]$Invoice)
 
     if (-not $Invoice.LineItems -or $Invoice.LineItems.Count -eq 0) {
         throw 'Invoice has no line items.'
@@ -204,7 +204,7 @@ Describe 'Contoso.Billing invoice functions' {
 
             $invoice.Status | Should -Be ([InvoiceStatus]::Paid)
             $invoice.PaidDate | Should -Be $fixedNow
-            $updatedInvoice | Should -BeSame $invoice
+            $script:updatedInvoice | Should -BeSame $invoice
         }
 
         It 'throws and does not update an already-paid invoice' {
@@ -214,7 +214,7 @@ Describe 'Contoso.Billing invoice functions' {
             $updateInvoice = { param($Invoice) $script:updatedInvoice = $Invoice }
 
             { Set-InvoicePaid -Id 1 -FindInvoice $findInvoice -UpdateInvoice $updateInvoice } | Should -Throw '*already paid*'
-            $updatedInvoice | Should -BeNullOrEmpty
+            $script:updatedInvoice | Should -BeNullOrEmpty
         }
     }
 }

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
@@ -1,0 +1,267 @@
+# PowerShell Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a PowerShell module using Pester v5. These show what each pipeline phase produces for a small module.
+
+## Source Under Test
+
+A simple `InvoiceService` module:
+
+```text
+src/
+  Contoso.Billing.psd1
+  Contoso.Billing.psm1
+Tests/                      (empty)
+```
+
+```powershell
+# src/Contoso.Billing.psm1
+enum InvoiceStatus {
+    Pending
+    Paid
+}
+
+function Get-InvoiceTotal {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][hashtable]$Invoice)
+
+    if (-not $Invoice.LineItems -or $Invoice.LineItems.Count -eq 0) {
+        throw 'Invoice has no line items.'
+    }
+
+    $subtotal = 0
+    foreach ($lineItem in $Invoice.LineItems) {
+        $subtotal += $lineItem.Quantity * $lineItem.UnitPrice
+    }
+
+    [math]::Round($subtotal + ($subtotal * $Invoice.TaxRate), 2)
+}
+
+function Get-InvoiceById {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][int]$Id, [Parameter(Mandatory)][scriptblock]$FindInvoice)
+
+    $invoice = & $FindInvoice $Id
+    if ($null -eq $invoice) {
+        throw "Invoice $Id not found."
+    }
+
+    $invoice
+}
+
+function Set-InvoicePaid {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$Id,
+        [Parameter(Mandatory)][scriptblock]$FindInvoice,
+        [Parameter(Mandatory)][scriptblock]$UpdateInvoice,
+        [scriptblock]$GetNow = { Get-Date }
+    )
+
+    $invoice = Get-InvoiceById -Id $Id -FindInvoice $FindInvoice
+    if ($invoice.Status -eq [InvoiceStatus]::Paid) {
+        throw 'Invoice is already paid.'
+    }
+
+    $invoice.Status = [InvoiceStatus]::Paid
+    $invoice.PaidDate = & $GetNow
+    & $UpdateInvoice $invoice
+}
+
+Export-ModuleMember -Function Get-InvoiceTotal, Get-InvoiceById, Set-InvoicePaid
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: C:\work\contoso-billing
+- **Language**: PowerShell 7.4
+- **Module**: `src/Contoso.Billing.psd1` imports `Contoso.Billing.psm1`
+- **Test Framework**: Pester v5
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Module load**: `Import-Module ./src/Contoso.Billing.psd1 -Force -ErrorAction Stop`
+- **Discovery**: `Invoke-Pester -Configuration @{ Run = @{ Path = './Tests'; PassThru = $true; SkipRun = $true } }`
+- **Test**: `Invoke-Pester -Path ./Tests -Output Detailed`
+
+## Files to Test
+
+### High Priority
+| File | Functions | Testability | Notes |
+|------|-----------|-------------|-------|
+| src/Contoso.Billing.psm1 | Get-InvoiceTotal, Get-InvoiceById, Set-InvoicePaid | High | Dependencies are scriptblocks, easy to fake; clock is injectable |
+
+## Testing Patterns
+- No existing patterns; recommend Pester v5 `Describe` / `Context` / `It`, `BeforeAll` module import, `-TestCases` for total calculations, and scriptblock fakes for repository operations.
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate Pester v5 tests for total calculation, repository lookup, and the
+paid-state transition. Single phase since there is one module file.
+
+## Commands
+- **Import**: `Import-Module ./src/Contoso.Billing.psd1 -Force -ErrorAction Stop`
+- **Test**: `Invoke-Pester -Path ./Tests/Contoso.Billing.Tests.ps1 -Output Detailed`
+
+## Phase 1: Contoso.Billing
+
+### Files to Test
+- **Source**: `src/Contoso.Billing.psm1`
+- **Test File**: `Tests/Contoso.Billing.Tests.ps1`
+
+**Functions to Test**:
+1. `Get-InvoiceTotal` — table-driven happy paths and empty-line-items error
+2. `Get-InvoiceById` — existing invoice and missing invoice
+3. `Set-InvoicePaid` — status/date update and persistence; already-paid error; missing invoice error
+```
+
+## Sample Generated Test File
+
+```powershell
+# Tests/Contoso.Billing.Tests.ps1
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'src' 'Contoso.Billing.psd1') -Force -ErrorAction Stop
+
+    function New-TestInvoice {
+        param(
+            [int]$Id = 1,
+            [InvoiceStatus]$Status = [InvoiceStatus]::Pending,
+            [double]$TaxRate = 0.10,
+            [object[]]$LineItems = @(@{ Quantity = 1; UnitPrice = 100.00 })
+        )
+
+        [pscustomobject]@{
+            Id = $Id
+            Status = $Status
+            TaxRate = $TaxRate
+            LineItems = $LineItems
+            PaidDate = $null
+        }
+    }
+}
+
+Describe 'Contoso.Billing invoice functions' {
+    Context 'Get-InvoiceTotal' {
+        It 'returns <Expected> for <Name>' -TestCases @(
+            @{ Name = 'single item with tax'; LineItems = @(@{ Quantity = 1; UnitPrice = 100.00 }); TaxRate = 0.10; Expected = 110.00 }
+            @{ Name = 'multi quantity zero tax'; LineItems = @(@{ Quantity = 3; UnitPrice = 25.00 }); TaxRate = 0.00; Expected = 75.00 }
+            @{ Name = 'rounds to two decimals'; LineItems = @(@{ Quantity = 2; UnitPrice = 9.99 }); TaxRate = 0.07; Expected = 21.38 }
+        ) {
+            param($LineItems, $TaxRate, $Expected)
+
+            $invoice = New-TestInvoice -LineItems $LineItems -TaxRate $TaxRate
+
+            Get-InvoiceTotal -Invoice $invoice | Should -BeExactly $Expected
+        }
+
+        It 'throws when the invoice has no line items' {
+            $invoice = New-TestInvoice -LineItems @()
+
+            { Get-InvoiceTotal -Invoice $invoice } | Should -Throw '*no line items*'
+        }
+    }
+
+    Context 'Get-InvoiceById' {
+        It 'returns an existing invoice' {
+            $expected = New-TestInvoice -Id 42
+            $findInvoice = { param($Id) if ($Id -eq 42) { $expected } }
+
+            $result = Get-InvoiceById -Id 42 -FindInvoice $findInvoice
+
+            $result | Should -BeSame $expected
+        }
+
+        It 'throws when the invoice is missing' {
+            $findInvoice = { $null }
+
+            { Get-InvoiceById -Id 999 -FindInvoice $findInvoice } | Should -Throw '*999*'
+        }
+    }
+
+    Context 'Set-InvoicePaid' {
+        It 'marks a pending invoice as paid and persists it' {
+            $invoice = New-TestInvoice -Id 1
+            $script:updatedInvoice = $null
+            $fixedNow = [datetime]'2025-01-01T12:00:00Z'
+            $findInvoice = { param($Id) if ($Id -eq 1) { $invoice } }
+            $updateInvoice = { param($Invoice) $script:updatedInvoice = $Invoice }
+
+            Set-InvoicePaid -Id 1 -FindInvoice $findInvoice -UpdateInvoice $updateInvoice -GetNow { $fixedNow }
+
+            $invoice.Status | Should -Be ([InvoiceStatus]::Paid)
+            $invoice.PaidDate | Should -Be $fixedNow
+            $updatedInvoice | Should -BeSame $invoice
+        }
+
+        It 'throws and does not update an already-paid invoice' {
+            $invoice = New-TestInvoice -Status ([InvoiceStatus]::Paid)
+            $script:updatedInvoice = $null
+            $findInvoice = { $invoice }
+            $updateInvoice = { param($Invoice) $script:updatedInvoice = $Invoice }
+
+            { Set-InvoicePaid -Id 1 -FindInvoice $findInvoice -UpdateInvoice $updateInvoice } | Should -Throw '*already paid*'
+            $updatedInvoice | Should -BeNullOrEmpty
+        }
+    }
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a Pester discovery or run issue, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+CommandNotFoundException: The term 'Get-InvoiceTotal' is not recognized
+```
+
+**Fixer diagnosis:** The module import was placed at script top level. Import the module in `BeforeAll` so the Pester run phase sees the exported functions.
+
+**Fix applied:** Move `Import-Module ... -Force` into `BeforeAll` (as shown above).
+
+**Rerun:** `Invoke-Pester -Path ./Tests/Contoso.Billing.Tests.ps1 -Output Detailed` → SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (PowerShell)
+**Strategy**: Direct (single module in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 8     |
+| Tests passing  | 8     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `Tests/Contoso.Billing.Tests.ps1` (8 Pester examples, 3 data-driven total cases)
+
+### Coverage
+- Get-InvoiceTotal — 3 happy path, 1 error case
+- Get-InvoiceById — found and missing branches
+- Set-InvoicePaid — success and already-paid branches
+
+### Build / Test Validation
+- Module load: ✅ `Import-Module ./src/Contoso.Billing.psd1 -Force -ErrorAction Stop`
+- Discovery: ✅ Pester found 8 tests
+- Test run: ✅ `Invoke-Pester -Path ./Tests -Output Detailed`
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby-examples.md
@@ -1,0 +1,277 @@
+# Ruby Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Ruby codebase using RSpec. These show what each pipeline phase produces for a small gem-style project.
+
+> Minitest follows the same coverage shape. Replace `RSpec.describe` / `it` / `expect` with `Minitest::Test` methods and assertions, and run through `bundle exec rake test` or the repo's established Minitest command.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Ruby gem:
+
+```text
+Gemfile
+lib/
+  contoso_billing.rb
+  contoso_billing/invoice.rb
+  contoso_billing/invoice_repository.rb
+  contoso_billing/invoice_service.rb
+spec/spec_helper.rb
+```
+
+```ruby
+# lib/contoso_billing/invoice_service.rb
+require 'bigdecimal'
+require 'time'
+
+module ContosoBilling
+  class InvoiceService
+    def initialize(repository:, clock: -> { Time.now.utc })
+      @repository = repository
+      @clock = clock
+    end
+
+    def calculate_total(invoice)
+      raise ArgumentError, 'invoice must not be nil' if invoice.nil?
+      raise ArgumentError, 'Invoice has no line items.' if invoice.line_items.empty?
+
+      subtotal = invoice.line_items.sum { |item| item.quantity * item.unit_price }
+      tax = subtotal * invoice.tax_rate
+      (subtotal + tax).round(2)
+    end
+
+    def get_by_id(id)
+      invoice = @repository.find(id)
+      raise KeyError, "Invoice #{id} not found." if invoice.nil?
+
+      invoice
+    end
+
+    def mark_as_paid(id)
+      invoice = get_by_id(id)
+      raise StandardError, 'Invoice is already paid.' if invoice.status == :paid
+
+      invoice.status = :paid
+      invoice.paid_at = @clock.call
+      @repository.update(invoice)
+    end
+  end
+end
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: Ruby 3.3 (from `.ruby-version`)
+- **Project Type**: Plain gem
+- **Test Framework**: RSpec 3.x (detected in Gemfile.lock and `spec/spec_helper.rb`)
+- **Run Prefix**: `bundle exec` required because Gemfile.lock is present
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 examples across 0 files
+
+## Build & Test Commands
+- **Syntax**: `ruby -c lib/contoso_billing/invoice_service.rb`
+- **Discovery**: `bundle exec rspec --dry-run`
+- **Single file**: `bundle exec rspec spec/contoso_billing/invoice_service_spec.rb`
+- **All specs**: `bundle exec rspec`
+
+## Files to Test
+
+### High Priority
+| File | Classes/Methods | Testability | Notes |
+|------|-----------------|-------------|-------|
+| lib/contoso_billing/invoice_service.rb | InvoiceService: calculate_total, get_by_id, mark_as_paid | High | Repository dependency and clock are injected |
+
+## Testing Patterns
+- Existing specs use `RSpec.describe`, `subject`, `let`, and `instance_double`.
+- Recommend `instance_double('InvoiceRepository')` for the repository and a fixed clock lambda for time-dependent behavior.
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate RSpec tests for ContosoBilling::InvoiceService, covering calculation,
+lookup, and paid-state transition behavior.
+
+## Commands
+- **Syntax**: `ruby -c spec/contoso_billing/invoice_service_spec.rb`
+- **Discovery**: `bundle exec rspec --dry-run`
+- **Test**: `bundle exec rspec spec/contoso_billing/invoice_service_spec.rb`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+- **Source**: `lib/contoso_billing/invoice_service.rb`
+- **Test File**: `spec/contoso_billing/invoice_service_spec.rb`
+
+**Methods to Test**:
+1. `calculate_total` — tax, zero tax, rounding, nil, and empty line items
+2. `get_by_id` — existing invoice and missing invoice
+3. `mark_as_paid` — success with fixed clock, already-paid, missing
+```
+
+## Sample Generated Test File
+
+```ruby
+# spec/contoso_billing/invoice_service_spec.rb
+require 'spec_helper'
+require 'bigdecimal'
+require 'ostruct'
+require 'time'
+require 'contoso_billing/invoice_service'
+
+RSpec.describe ContosoBilling::InvoiceService do
+  subject(:service) { described_class.new(repository: repository, clock: clock) }
+
+  let(:repository) { instance_double('InvoiceRepository') }
+  let(:fixed_time) { Time.utc(2025, 1, 1, 12, 0, 0) }
+  let(:clock) { -> { fixed_time } }
+
+  def build_invoice(id: 1, status: :pending, tax_rate: BigDecimal('0.10'), line_items: [OpenStruct.new(quantity: 1, unit_price: BigDecimal('100.00'))])
+    OpenStruct.new(id: id, status: status, tax_rate: tax_rate, line_items: line_items, paid_at: nil)
+  end
+
+  describe '#calculate_total' do
+    it 'returns the total for a single item with tax' do
+      expect(service.calculate_total(build_invoice)).to eq(BigDecimal('110.00'))
+    end
+
+    it 'returns the subtotal when tax is zero' do
+      invoice = build_invoice(
+        tax_rate: BigDecimal('0'),
+        line_items: [OpenStruct.new(quantity: 3, unit_price: BigDecimal('25.00'))]
+      )
+
+      expect(service.calculate_total(invoice)).to eq(BigDecimal('75.00'))
+    end
+
+    it 'rounds to two decimals' do
+      invoice = build_invoice(
+        tax_rate: BigDecimal('0.07'),
+        line_items: [OpenStruct.new(quantity: 2, unit_price: BigDecimal('9.99'))]
+      )
+
+      expect(service.calculate_total(invoice)).to eq(BigDecimal('21.38'))
+    end
+
+    it 'raises for a nil invoice' do
+      expect { service.calculate_total(nil) }.to raise_error(ArgumentError, /must not be nil/)
+    end
+
+    it 'raises when there are no line items' do
+      expect { service.calculate_total(build_invoice(line_items: [])) }.to raise_error(ArgumentError, /no line items/)
+    end
+  end
+
+  describe '#get_by_id' do
+    it 'returns an existing invoice' do
+      invoice = build_invoice(id: 42)
+      allow(repository).to receive(:find).with(42).and_return(invoice)
+
+      expect(service.get_by_id(42)).to be(invoice)
+    end
+
+    it 'raises KeyError for a missing invoice' do
+      allow(repository).to receive(:find).with(999).and_return(nil)
+
+      expect { service.get_by_id(999) }.to raise_error(KeyError, /999/)
+    end
+  end
+
+  describe '#mark_as_paid' do
+    it 'marks a pending invoice as paid and persists it' do
+      invoice = build_invoice(id: 1)
+      allow(repository).to receive(:find).with(1).and_return(invoice)
+      allow(repository).to receive(:update)
+
+      service.mark_as_paid(1)
+
+      expect(invoice.status).to eq(:paid)
+      expect(invoice.paid_at).to eq(fixed_time)
+      expect(repository).to have_received(:update).with(invoice)
+    end
+
+    it 'raises and does not update an already-paid invoice' do
+      invoice = build_invoice(id: 1, status: :paid)
+      allow(repository).to receive(:find).with(1).and_return(invoice)
+      allow(repository).to receive(:update)
+
+      expect { service.mark_as_paid(1) }.to raise_error(StandardError, /already paid/)
+      expect(repository).not_to have_received(:update)
+    end
+  end
+end
+```
+
+## Sample Fix Cycle
+
+When the implementer encounters a load or mock issue, the fixer agent diagnoses and resolves it.
+
+**Test output:**
+
+```text
+LoadError: cannot load such file -- contoso_billing/invoice_service
+```
+
+**Fixer diagnosis:** The generated spec omitted `require 'spec_helper'`, so the gem's load-path setup did not run.
+
+**Fix applied:** Add `require 'spec_helper'` as the first require and keep source requires consistent with existing specs.
+
+**Rerun:** `bundle exec rspec spec/contoso_billing/invoice_service_spec.rb` → SUCCESS
+
+---
+
+**Another common cycle — verifying double mismatch:**
+
+**Test output:**
+
+```text
+The InvoiceRepository class does not implement the instance method: find_by_id
+```
+
+**Fixer diagnosis:** `instance_double` caught a typo in the test setup. The production code calls `repository.find`, not `find_by_id`.
+
+**Fix applied:** Stub `find` with the expected id instead of `find_by_id`.
+
+**Rerun:** SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (Ruby)
+**Strategy**: Direct (single source file in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 9     |
+| Tests passing  | 9     |
+| Tests failing  | 0     |
+| Files created  | 1     |
+
+### Files Created
+- `spec/contoso_billing/invoice_service_spec.rb` (9 RSpec examples)
+
+### Coverage
+- InvoiceService#calculate_total — 3 happy path, 2 error cases
+- InvoiceService#get_by_id — found and missing branches
+- InvoiceService#mark_as_paid — success and already-paid branches
+
+### Build / Test Validation
+- Syntax: ✅ `ruby -c spec/contoso_billing/invoice_service_spec.rb`
+- Discovery: ✅ `bundle exec rspec --dry-run` found the new examples
+- Test run: ✅ `bundle exec rspec spec/contoso_billing/invoice_service_spec.rb`
+```

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
@@ -178,7 +178,7 @@ mod tests {
         }
     }
 
-    fn service_with(repository: FakeRepository) -> InvoiceService<FakeRepository, impl Fn() -> std::time::SystemTime> {
+    fn service_with(repository: FakeRepository) -> InvoiceService<FakeRepository, fn() -> std::time::SystemTime> {
         InvoiceService::new(repository, || UNIX_EPOCH + Duration::from_secs(123))
     }
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
@@ -1,0 +1,327 @@
+# Rust Pipeline Examples
+
+Concrete input→output examples for the test generation pipeline targeting a Rust crate using the built-in test harness. These show what each pipeline phase produces for a small library crate.
+
+## Source Under Test
+
+A simple `InvoiceService` in a Rust crate:
+
+```text
+Cargo.toml
+src/
+  lib.rs
+  invoice.rs
+  invoice_repository.rs
+  invoice_service.rs
+```
+
+```rust
+// src/invoice_service.rs
+use crate::invoice::{Invoice, InvoiceStatus};
+use crate::invoice_repository::InvoiceRepository;
+use std::time::SystemTime;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InvoiceError {
+    EmptyLineItems,
+    NotFound(i32),
+    AlreadyPaid,
+    Repository(String),
+}
+
+pub struct InvoiceService<R, C>
+where
+    R: InvoiceRepository,
+    C: Fn() -> SystemTime,
+{
+    repository: R,
+    clock: C,
+}
+
+impl<R, C> InvoiceService<R, C>
+where
+    R: InvoiceRepository,
+    C: Fn() -> SystemTime,
+{
+    pub fn new(repository: R, clock: C) -> Self {
+        Self { repository, clock }
+    }
+
+    pub fn calculate_total(&self, invoice: &Invoice) -> Result<f64, InvoiceError> {
+        if invoice.line_items.is_empty() {
+            return Err(InvoiceError::EmptyLineItems);
+        }
+
+        let subtotal: f64 = invoice.line_items.iter().map(|item| item.quantity as f64 * item.unit_price).sum();
+        Ok(((subtotal + subtotal * invoice.tax_rate) * 100.0).round() / 100.0)
+    }
+
+    pub fn get_by_id(&self, id: i32) -> Result<Invoice, InvoiceError> {
+        self.repository.find(id).map_err(InvoiceError::Repository)?.ok_or(InvoiceError::NotFound(id))
+    }
+
+    pub fn mark_as_paid(&mut self, id: i32) -> Result<(), InvoiceError> {
+        let mut invoice = self.get_by_id(id)?;
+        if invoice.status == InvoiceStatus::Paid {
+            return Err(InvoiceError::AlreadyPaid);
+        }
+
+        invoice.status = InvoiceStatus::Paid;
+        invoice.paid_at = Some((self.clock)());
+        self.repository.update(invoice).map_err(InvoiceError::Repository)
+    }
+}
+```
+
+## Sample Research Output
+
+What `code-testing-researcher` produces in `.testagent/research.md`:
+
+```markdown
+# Test Generation Research
+
+## Project Overview
+- **Path**: /work/contoso-billing
+- **Language**: Rust 1.78 (edition 2021, from Cargo.toml)
+- **Crate Type**: library
+- **Test Framework**: built-in Rust test harness (`#[test]`), no `mockall`/`rstest` dev-dependencies detected
+
+## Coverage Baseline
+- **Initial Line Coverage**: unknown
+- **Strategy**: broad
+- **Existing Test Count**: 0 tests across 0 files
+
+## Build & Test Commands
+- **Check**: `cargo check --all-targets`
+- **Compile tests**: `cargo test --no-run`
+- **Test**: `cargo test`
+- **Single module**: `cargo test invoice_service::tests`
+
+## Files to Test
+
+### High Priority
+| File | Types/Methods | Testability | Notes |
+|------|---------------|-------------|-------|
+| src/invoice_service.rs | InvoiceService: calculate_total, get_by_id, mark_as_paid | High | Generic repository trait is easy to fake; clock closure is injectable |
+
+## Testing Patterns
+- No existing patterns; recommend unit tests in `#[cfg(test)] mod tests` at the bottom of `invoice_service.rs` and a hand-written fake repository.
+```
+
+## Sample Plan Output
+
+```markdown
+# Test Implementation Plan
+
+## Overview
+Generate built-in Rust unit tests for InvoiceService covering calculation,
+lookup, and paid-state transition behavior.
+
+## Commands
+- **Check**: `cargo check --all-targets`
+- **Compile tests**: `cargo test --no-run`
+- **Test**: `cargo test invoice_service::tests`
+
+## Phase 1: InvoiceService
+
+### Files to Test
+- **Source**: `src/invoice_service.rs`
+- **Test Location**: `#[cfg(test)] mod tests` appended to `src/invoice_service.rs`
+
+**Methods to Test**:
+1. `calculate_total` — tax, zero tax, rounding, empty-line-items error
+2. `get_by_id` — existing invoice, missing invoice, repository error
+3. `mark_as_paid` — success, already-paid, missing invoice
+```
+
+## Sample Generated Test File
+
+```rust
+// Appended to src/invoice_service.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::invoice::{Invoice, InvoiceStatus, LineItem};
+    use std::collections::HashMap;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[derive(Default)]
+    struct FakeRepository {
+        invoices: HashMap<i32, Invoice>,
+        updated: Option<Invoice>,
+        find_error: Option<String>,
+    }
+
+    impl InvoiceRepository for FakeRepository {
+        fn find(&self, id: i32) -> Result<Option<Invoice>, String> {
+            if let Some(error) = &self.find_error {
+                return Err(error.clone());
+            }
+
+            Ok(self.invoices.get(&id).cloned())
+        }
+
+        fn update(&mut self, invoice: Invoice) -> Result<(), String> {
+            self.updated = Some(invoice.clone());
+            self.invoices.insert(invoice.id, invoice);
+            Ok(())
+        }
+    }
+
+    fn make_invoice(id: i32) -> Invoice {
+        Invoice {
+            id,
+            status: InvoiceStatus::Pending,
+            tax_rate: 0.10,
+            line_items: vec![LineItem { quantity: 1, unit_price: 100.0 }],
+            paid_at: None,
+        }
+    }
+
+    fn service_with(repository: FakeRepository) -> InvoiceService<FakeRepository, impl Fn() -> std::time::SystemTime> {
+        InvoiceService::new(repository, || UNIX_EPOCH + Duration::from_secs(123))
+    }
+
+    #[test]
+    fn calculate_total_valid_line_items_returns_expected_total() {
+        let cases = [
+            ("single item with tax", vec![LineItem { quantity: 1, unit_price: 100.0 }], 0.10, 110.0),
+            ("multi quantity zero tax", vec![LineItem { quantity: 3, unit_price: 25.0 }], 0.0, 75.0),
+            ("rounds to two decimals", vec![LineItem { quantity: 2, unit_price: 9.99 }], 0.07, 21.38),
+        ];
+        let service = service_with(FakeRepository::default());
+
+        for (name, line_items, tax_rate, expected) in cases {
+            let mut invoice = make_invoice(1);
+            invoice.line_items = line_items;
+            invoice.tax_rate = tax_rate;
+
+            let total = service.calculate_total(&invoice).unwrap_or_else(|err| panic!("{name}: unexpected error: {err:?}"));
+
+            assert!((total - expected).abs() < 0.001, "{name}: got {total}, expected {expected}");
+        }
+    }
+
+    #[test]
+    fn calculate_total_empty_line_items_returns_error() {
+        let service = service_with(FakeRepository::default());
+        let mut invoice = make_invoice(1);
+        invoice.line_items.clear();
+
+        assert_eq!(Err(InvoiceError::EmptyLineItems), service.calculate_total(&invoice));
+    }
+
+    #[test]
+    fn get_by_id_existing_invoice_returns_invoice() {
+        let mut repository = FakeRepository::default();
+        repository.invoices.insert(42, make_invoice(42));
+        let service = service_with(repository);
+
+        let invoice = service.get_by_id(42).expect("invoice should exist");
+
+        assert_eq!(42, invoice.id);
+    }
+
+    #[test]
+    fn get_by_id_missing_invoice_returns_not_found() {
+        let service = service_with(FakeRepository::default());
+
+        assert_eq!(Err(InvoiceError::NotFound(999)), service.get_by_id(999));
+    }
+
+    #[test]
+    fn get_by_id_repository_error_is_preserved() {
+        let repository = FakeRepository { find_error: Some("boom".to_owned()), ..FakeRepository::default() };
+        let service = service_with(repository);
+
+        assert_eq!(Err(InvoiceError::Repository("boom".to_owned())), service.get_by_id(1));
+    }
+
+    #[test]
+    fn mark_as_paid_pending_invoice_updates_status_date_and_repository() {
+        let mut repository = FakeRepository::default();
+        repository.invoices.insert(1, make_invoice(1));
+        let mut service = service_with(repository);
+
+        service.mark_as_paid(1).expect("mark_as_paid should succeed");
+
+        let updated = service.repository.updated.as_ref().expect("repository should be updated");
+        assert_eq!(InvoiceStatus::Paid, updated.status);
+        assert_eq!(Some(UNIX_EPOCH + Duration::from_secs(123)), updated.paid_at);
+    }
+
+    #[test]
+    fn mark_as_paid_already_paid_returns_error_without_update() {
+        let mut invoice = make_invoice(1);
+        invoice.status = InvoiceStatus::Paid;
+        let mut repository = FakeRepository::default();
+        repository.invoices.insert(1, invoice);
+        let mut service = service_with(repository);
+
+        assert_eq!(Err(InvoiceError::AlreadyPaid), service.mark_as_paid(1));
+        assert!(service.repository.updated.is_none());
+    }
+}
+```
+
+## Sample Fix Cycle
+
+When the implementer hits a compiler or test-runner issue, the fixer agent diagnoses and resolves it.
+
+**Build output:**
+
+```text
+error[E0596]: cannot borrow `self.repository` as mutable, as it is behind a `&` reference
+```
+
+**Fixer diagnosis:** `mark_as_paid` calls `repository.update(...)`, which requires mutable repository access. The production method must take `&mut self`, and tests must bind the service as `let mut service`.
+
+**Fix applied:** Change the method receiver to `&mut self` and update tests to use mutable bindings for `mark_as_paid` cases.
+
+**Rebuild + rerun:** `cargo test --no-run && cargo test invoice_service::tests` → SUCCESS
+
+---
+
+**Another common cycle — integration test imports:**
+
+**Build output:**
+
+```text
+error[E0432]: unresolved import `crate::invoice_service`
+```
+
+**Fixer diagnosis:** The test was created under `tests/invoice_service.rs`, which is an integration test crate. Integration tests import the library by crate name, not `crate::`.
+
+**Fix applied:** Move the tests into `#[cfg(test)] mod tests` in `src/invoice_service.rs` and use `use super::*;`.
+
+**Rerun:** SUCCESS
+
+## Sample Final Report
+
+```markdown
+## Test Generation Report
+
+**Project**: contoso-billing (Rust)
+**Strategy**: Direct (single module in scope)
+
+### Results
+| Metric         | Value |
+|----------------|-------|
+| Tests created  | 7     |
+| Tests passing  | 7     |
+| Tests failing  | 0     |
+| Files created  | 0 (tests appended to source module) |
+
+### Files Modified
+- `src/invoice_service.rs` (7 unit tests in `#[cfg(test)] mod tests`)
+
+### Coverage
+- InvoiceService::calculate_total — 3 happy path, 1 error case
+- InvoiceService::get_by_id — found, missing, repository error
+- InvoiceService::mark_as_paid — success and already-paid branches
+
+### Build / Test Validation
+- Check: ✅ `cargo check --all-targets`
+- Compile tests: ✅ `cargo test --no-run`
+- Test run: ✅ `cargo test invoice_service::tests`
+```


### PR DESCRIPTION
These languages had a <lang>.md extension but no companion <lang>-examples.md. This adds worked, compilable example tests modeled on the existing go/python/typescript examples, using each language's idiomatic framework (Catch2/GoogleTest, Pester, RSpec, cargo test, JUnit5).