### PR TITLE
Fix skill activation for dropped-TFM v3 migration eval scenario

### DIFF
--- a/tests/dotnet-test/migrate-mstest-v1v2-to-v3/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-mstest-v1v2-to-v3/eval.vally.yaml
@@ -150,8 +150,9 @@ stimuli:
       - Notes that MSTest.Sdk defaults to Microsoft.Testing.Platform
   - name: Handle dropped target framework during v3 migration
     prompt: |
-      My test project multi-targets several frameworks and currently uses MSTest v2.
-      I want to migrate to MSTest v3. Will I run into any target framework compatibility issues?
+      I want to migrate my MSTest v2 test project to MSTest v3. The project
+      multi-targets net5.0, net462, and netcoreapp3.1. Help me upgrade to MSTest v3 --
+      which of these target frameworks are no longer supported, and what do I need to change?
     environment:
       files:
         - src: ./fixtures/handle-dropped-target-framework-during-v3-migration/TestProject.csproj

--- a/tests/dotnet-test/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -306,8 +306,9 @@ scenarios:
 
   - name: "Handle dropped target framework during v3 migration"
     prompt: |
-      My test project multi-targets several frameworks and currently uses MSTest v2.
-      I want to migrate to MSTest v3. Will I run into any compatibility issues?
+      I want to migrate my MSTest v2 test project to MSTest v3. The project
+      multi-targets net5.0, net462, and netcoreapp3.1. Help me upgrade to MSTest v3 --
+      which of these target frameworks are no longer supported, and what do I need to change?
     setup:
       files:
         - path: "TestProject.csproj"


### PR DESCRIPTION
## Problem

The `migrate-mstest-v1v2-to-v3` / **Handle dropped target framework during v3 migration** eval scenario suffers from the documented NOT ACTIVATED failure pattern. The prompt was a passive yes/no diagnostic question:

> My test project multi-targets several frameworks and currently uses MSTest v2. I want to migrate to MSTest v3. Will I run into any compatibility issues?

This is answerable from general model knowledge, so the runtime often answers without ever loading the skill. This scenario has required activation fixes before (#589, #641).

## Fix

Reworded the prompt in both `eval.yaml` and `eval.vally.yaml` into an explicit migration request that embeds exact trigger phrases from the SKILL.md `description`:

- *migrate my MSTest v2 test project to MSTest v3*
- *Help me upgrade to MSTest v3*
- *which of these target frameworks are no longer supported*

It now names the concrete TFMs from the fixture (`net5.0; net462; netcoreapp3.1`) but deliberately does **not** reveal which one is dropped — strengthening description-to-prompt matching without gaming the rubric.

Graders and rubrics are unchanged; both YAML files parse cleanly.