### PR TITLE
Fix skill activation for MSTest.Sdk/MTP v4 migration eval scenario

### DIFF
--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
@@ -158,9 +158,10 @@ stimuli:
       - Mentions TreatDiscoveryWarningsAsErrors now defaults to true as another potential behavioral change
   - name: Handle MSTest.Sdk and MTP changes in v4
     prompt: |
-      I'm using MSTest.Sdk/3.8.0 with Microsoft.Testing.Platform. After upgrading to
-      MSTest.Sdk/4.1.0, my CI pipeline that uses vstest.console no longer discovers tests.
-      What changed?
+      I upgraded my test project to MSTest v4 -- it uses MSTest.Sdk/4.1.0 (previously
+      MSTest.Sdk/3.8.0) with Microsoft.Testing.Platform. Now my CI pipeline that runs
+      vstest.console no longer discovers any tests. Help me fix this MSTest v4 breaking
+      change: what changed in MSTest.Sdk v4 and how do I restore test discovery?
     environment:
       files:
         - src: ./fixtures/handle-mstest-sdk-and-mtp-changes-in-v4/TestProject.csproj

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -240,9 +240,10 @@ scenarios:
 
   - name: "Handle MSTest.Sdk and MTP changes in v4"
     prompt: |
-      I'm using MSTest.Sdk/3.8.0 with Microsoft.Testing.Platform. After upgrading to
-      MSTest.Sdk/4.1.0, my CI pipeline that uses vstest.console no longer discovers tests.
-      What changed?
+      I upgraded my test project to MSTest v4 -- it uses MSTest.Sdk/4.1.0 (previously
+      MSTest.Sdk/3.8.0) with Microsoft.Testing.Platform. Now my CI pipeline that runs
+      vstest.console no longer discovers any tests. Help me fix this MSTest v4 breaking
+      change: what changed in MSTest.Sdk v4 and how do I restore test discovery?
     setup:
       files:
         - path: "TestProject.csproj"


### PR DESCRIPTION
## Problem

The `migrate-mstest-v3-to-v4` / **Handle MSTest.Sdk and MTP changes in v4** eval scenario uses a passive diagnostic prompt ending in *"What changed?"*:

> I'm using MSTest.Sdk/3.8.0 with Microsoft.Testing.Platform. After upgrading to MSTest.Sdk/4.1.0, my CI pipeline that uses vstest.console no longer discovers tests. What changed?

This is answerable from general model knowledge and lacks an exact trigger phrase from the SKILL.md `description`, so the runtime often answers without loading the skill (NOT ACTIVATED pattern).

## Fix

Reworded the prompt in both `eval.yaml` and `eval.vally.yaml` into an explicit fix request embedding exact trigger phrases:

- *upgraded my test project to MSTest v4*
- *Help me fix this MSTest v4 breaking change*
- *what changed in MSTest.Sdk v4* (matches the `MSTest.Sdk MTP changes` USE FOR entry)

The scenario still requires the skill's specific knowledge — that MSTest.Sdk v4 no longer references `Microsoft.NET.Test.Sdk` under MTP, breaking `vstest.console` discovery — without giving away the answer. Graders and rubrics are unchanged; both YAML files parse cleanly.