### PR TITLE
Make vanilla series distinguishable on overlapping dashboard charts

### DIFF
--- a/eng/dashboard/dashboard.js
+++ b/eng/dashboard/dashboard.js
@@ -542,6 +542,7 @@
             pointRadius: 5,
             pointHoverRadius: 7,
             tension: 0.3,
+            borderDash: [8, 6],
             fill: false,
             yAxisID: 'y'
           });

--- a/eng/dashboard/dashboard.js
+++ b/eng/dashboard/dashboard.js
@@ -533,8 +533,14 @@
             data: vanTimeData,
             borderColor: '#8b949e',
             borderWidth: 2,
-            pointRadius: 4,
-            pointHoverRadius: 6,
+            // Hollow diamond markers keep vanilla visible when it overlaps the
+            // isolated/plugin lines. Vanilla is pushed last, so it draws on top.
+            pointStyle: 'rectRot',
+            pointBackgroundColor: 'transparent',
+            pointBorderColor: '#8b949e',
+            pointBorderWidth: 1.5,
+            pointRadius: 5,
+            pointHoverRadius: 7,
             tension: 0.3,
             fill: false,
             yAxisID: 'y'
@@ -544,10 +550,14 @@
             data: vanTokenData,
             borderColor: '#8b949e',
             borderWidth: 2,
-            pointRadius: 4,
-            pointHoverRadius: 6,
+            pointStyle: 'rectRot',
+            pointBackgroundColor: 'transparent',
+            pointBorderColor: '#8b949e',
+            pointBorderWidth: 1.5,
+            pointRadius: 5,
+            pointHoverRadius: 7,
             tension: 0.3,
-            borderDash: [5, 5],
+            borderDash: [8, 6],
             fill: false,
             yAxisID: 'y1'
           });
@@ -712,10 +722,18 @@
             borderColor: colorC,
             backgroundColor: colorC + '20',
             borderWidth: 2,
-            pointRadius: 4,
-            pointHoverRadius: 6,
+            // Hollow diamond markers (slightly larger than the round markers of
+            // the other series) so the vanilla series stays visible even when its
+            // value coincides exactly with another line. Vanilla is the last
+            // dataset, so it is drawn on top of the others.
+            pointStyle: 'rectRot',
+            pointBackgroundColor: 'transparent',
+            pointBorderColor: colorC,
+            pointBorderWidth: 1.5,
+            pointRadius: 5,
+            pointHoverRadius: 7,
             tension: 0.3,
-            borderDash: [5, 5],
+            borderDash: [8, 6],
             fill: false
           }
         ]
@@ -837,10 +855,18 @@
             borderColor: colorB,
             backgroundColor: colorB + '20',
             borderWidth: 2,
-            pointRadius: 4,
-            pointHoverRadius: 6,
+            // Hollow diamond markers (slightly larger than the round markers of
+            // the other series) so the vanilla series stays visible even when its
+            // value coincides exactly with the other line. Vanilla is the last
+            // dataset, so it is drawn on top.
+            pointStyle: 'rectRot',
+            pointBackgroundColor: 'transparent',
+            pointBorderColor: colorB,
+            pointBorderWidth: 1.5,
+            pointRadius: 5,
+            pointHoverRadius: 7,
             tension: 0.3,
-            borderDash: [5, 5],
+            borderDash: [8, 6],
             fill: false
           }
         ]


### PR DESCRIPTION
## What

Improve the skills evaluation dashboard so the **Vanilla** series stays distinguishable when its values overlap the Isolated/Plugin lines.

Previously, when a vanilla data point sat at the same value as another series, the thin gray dashed line was hidden behind the solid colored line and was easy to miss (see example below).

## Changes (`eng/dashboard/dashboard.js`)

Applied to every vanilla series — quality triple chart, quality paired chart, and the efficiency time/tokens chart:

- **Hollow diamond markers** (`pointStyle: 'rectRot'`, transparent fill, gray outline, `pointRadius: 5`) — slightly larger than the round markers of the other series. At coincident points the gray outline pokes out and the underlying line shows through the hollow center, so both series are visible.
- **More prominent dash** (`[8, 6]` instead of `[5, 5]`) so the gray dashed line reads clearly over a solid colored line.

Vanilla remains the last/top-drawn dataset (kept array draw order rather than the ambiguous Chart.js `order` property), and the legend still renders clean colored circles via the existing `legendLabelsWithCircle` helper.

## Notes

Presentation-only change; no data generation or schema touched. Verified with `node --check`.
