### PR TITLE
Fix skill activation for 5 more MSTest v3-to-v4 eval scenarios

### DIFF
--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
@@ -341,9 +341,8 @@ stimuli:
     prompt: |
       I upgraded my test project to MSTest v4 and it no longer compiles. I use
       [TestMethod("display name")] and [TestMethodAttribute("display name")] to set custom
-      display names, and those constructors now break because of the CallerInfo constructor
-      changes on TestMethodAttribute. Help me fix this MSTest v4 breaking change -- how
-      should I update them?
+      display names, and those constructors now break. Help me fix this MSTest v4 breaking
+      change -- the CallerInfo constructor on TestMethodAttribute. How should I update them?
     environment:
       files:
         - src: fixtures/v3-testmethod-displayname/TestProject.csproj
@@ -370,8 +369,8 @@ stimuli:
       I upgraded my test project to MSTest v4 and my tests that use Assert.IsInstanceOfType
       with an out parameter no longer compile. I get errors like:
       - CS1615: Argument 2 should not be passed with the 'out' keyword
-      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter
-      removal. How do I update these assertions?
+      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter removal.
+      How do I update these assertions?
     environment:
       files:
         - src: fixtures/v3-instanceoftype/TestProject.csproj

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.vally.yaml
@@ -6,9 +6,10 @@ config:
 stimuli:
   - name: Migrate custom TestMethodAttribute from Execute to ExecuteAsync
     prompt: |
-      I have a custom RetryTestMethodAttribute that overrides Execute.
-      After upgrading to MSTest v4, I get an error that Execute is not virtual or doesn't exist.
-      How do I fix this?
+      I upgraded my test project to MSTest v4 and now it won't compile. I have a custom
+      RetryTestMethodAttribute that overrides Execute, and I get an error that Execute is
+      not virtual or doesn't exist. Help me fix this MSTest v4 breaking change -- how do I
+      migrate my custom TestMethodAttribute from Execute to ExecuteAsync?
     environment:
       files:
         - src: fixtures/v3-custom-testmethod/TestProject.csproj
@@ -31,8 +32,9 @@ stimuli:
       - Mentions that this change fixes deadlock bugs from the v3 synchronous API
   - name: Replace ExpectedExceptionAttribute with Assert.ThrowsExactly
     prompt: |
-      My MSTest v3 project uses [ExpectedException] on several test methods.
-      After upgrading to MSTest v4, these no longer compile. What's the replacement?
+      I upgraded my test project to MSTest v4 and several test methods that use
+      [ExpectedException] no longer compile. Help me fix this MSTest v4 breaking change:
+      what's the replacement after the ExpectedExceptionAttribute removal?
     environment:
       files:
         - src: fixtures/v3-expected-exception/TestProject.csproj
@@ -55,9 +57,9 @@ stimuli:
       - Mentions that the MSTEST0006 analyzer in MSTest 3.2+ could have caught this earlier
   - name: "Fix multiple v4 breaking changes: Assert, ClassCleanup, TestContext, Timeout"
     prompt: |
-      I upgraded from MSTest 3.8 to MSTest 4.0 and my test project has compilation errors.
-      The errors mention ThrowsException, ClassCleanupBehavior, and TestTimeout.
-      Can you review my code and fix the breaking changes?
+      I upgraded my test project to MSTest v4 (from 3.8 to 4.0) and now it won't compile.
+      The errors mention ThrowsException, ClassCleanupBehavior, and TestTimeout. Help me
+      fix these MSTest v4 breaking changes -- can you review my code and fix them?
     environment:
       files:
         - src: fixtures/v3-assert-changes/TestProject.csproj
@@ -337,10 +339,11 @@ stimuli:
 
   - name: Fix TestMethodAttribute and TestMethod display name constructor
     prompt: |
-      My MSTest v3 project uses [TestMethod("display name")] and
-      [TestMethodAttribute("display name")] to set custom display names on tests.
-      After upgrading to MSTest v4, these constructors no longer work because of
-      CallerInfo parameter changes. How should I update them?
+      I upgraded my test project to MSTest v4 and it no longer compiles. I use
+      [TestMethod("display name")] and [TestMethodAttribute("display name")] to set custom
+      display names, and those constructors now break because of the CallerInfo constructor
+      changes on TestMethodAttribute. Help me fix this MSTest v4 breaking change -- how
+      should I update them?
     environment:
       files:
         - src: fixtures/v3-testmethod-displayname/TestProject.csproj
@@ -364,10 +367,11 @@ stimuli:
 
   - name: Fix Assert.IsInstanceOfType out parameter removal
     prompt: |
-      After upgrading to MSTest 4.x, my tests that use Assert.IsInstanceOfType with
-      an out parameter no longer compile. I get errors like:
+      I upgraded my test project to MSTest v4 and my tests that use Assert.IsInstanceOfType
+      with an out parameter no longer compile. I get errors like:
       - CS1615: Argument 2 should not be passed with the 'out' keyword
-      How do I update these assertions?
+      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter
+      removal. How do I update these assertions?
     environment:
       files:
         - src: fixtures/v3-instanceoftype/TestProject.csproj

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -479,9 +479,8 @@ scenarios:
     prompt: |
       I upgraded my test project to MSTest v4 and it no longer compiles. I use
       [TestMethod("display name")] and [TestMethodAttribute("display name")] to set custom
-      display names, and those constructors now break because of the CallerInfo constructor
-      changes on TestMethodAttribute. Help me fix this MSTest v4 breaking change -- how
-      should I update them?
+      display names, and those constructors now break. Help me fix this MSTest v4 breaking
+      change -- the CallerInfo constructor on TestMethodAttribute. How should I update them?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -509,8 +508,8 @@ scenarios:
       I upgraded my test project to MSTest v4 and my tests that use Assert.IsInstanceOfType
       with an out parameter no longer compile. I get errors like:
       - CS1615: Argument 2 should not be passed with the 'out' keyword
-      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter
-      removal. How do I update these assertions?
+      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter removal.
+      How do I update these assertions?
     setup:
       files:
         - path: "TestProject.csproj"

--- a/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test/migrate-mstest-v3-to-v4/eval.yaml
@@ -5,9 +5,10 @@ scenarios:
 
   - name: "Migrate custom TestMethodAttribute from Execute to ExecuteAsync"
     prompt: |
-      I have a custom RetryTestMethodAttribute that overrides Execute.
-      After upgrading to MSTest v4, I get an error that Execute is not virtual or doesn't exist.
-      How do I fix this?
+      I upgraded my test project to MSTest v4 and now it won't compile. I have a custom
+      RetryTestMethodAttribute that overrides Execute, and I get an error that Execute is
+      not virtual or doesn't exist. Help me fix this MSTest v4 breaking change -- how do I
+      migrate my custom TestMethodAttribute from Execute to ExecuteAsync?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -32,8 +33,9 @@ scenarios:
 
   - name: "Replace ExpectedExceptionAttribute with Assert.ThrowsExactly"
     prompt: |
-      My MSTest v3 project uses [ExpectedException] on several test methods.
-      After upgrading to MSTest v4, these no longer compile. What's the replacement?
+      I upgraded my test project to MSTest v4 and several test methods that use
+      [ExpectedException] no longer compile. Help me fix this MSTest v4 breaking change:
+      what's the replacement after the ExpectedExceptionAttribute removal?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -58,9 +60,9 @@ scenarios:
 
   - name: "Fix multiple v4 breaking changes: Assert, ClassCleanup, TestContext, Timeout"
     prompt: |
-      I upgraded from MSTest 3.8 to MSTest 4.0 and my test project has compilation errors.
-      The errors mention ThrowsException, ClassCleanupBehavior, and TestTimeout.
-      Can you review my code and fix the breaking changes?
+      I upgraded my test project to MSTest v4 (from 3.8 to 4.0) and now it won't compile.
+      The errors mention ThrowsException, ClassCleanupBehavior, and TestTimeout. Help me
+      fix these MSTest v4 breaking changes -- can you review my code and fix them?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -475,10 +477,11 @@ scenarios:
 
   - name: "Fix TestMethodAttribute and TestMethod display name constructor"
     prompt: |
-      My MSTest v3 project uses [TestMethod("display name")] and
-      [TestMethodAttribute("display name")] to set custom display names on tests.
-      After upgrading to MSTest v4, these constructors no longer work because of
-      CallerInfo parameter changes. How should I update them?
+      I upgraded my test project to MSTest v4 and it no longer compiles. I use
+      [TestMethod("display name")] and [TestMethodAttribute("display name")] to set custom
+      display names, and those constructors now break because of the CallerInfo constructor
+      changes on TestMethodAttribute. Help me fix this MSTest v4 breaking change -- how
+      should I update them?
     setup:
       files:
         - path: "TestProject.csproj"
@@ -503,10 +506,11 @@ scenarios:
 
   - name: "Fix Assert.IsInstanceOfType out parameter removal"
     prompt: |
-      After upgrading to MSTest 4.x, my tests that use Assert.IsInstanceOfType with
-      an out parameter no longer compile. I get errors like:
+      I upgraded my test project to MSTest v4 and my tests that use Assert.IsInstanceOfType
+      with an out parameter no longer compile. I get errors like:
       - CS1615: Argument 2 should not be passed with the 'out' keyword
-      How do I update these assertions?
+      Help me fix this MSTest v4 breaking change -- the Assert.IsInstanceOfType out parameter
+      removal. How do I update these assertions?
     setup:
       files:
         - path: "TestProject.csproj"


### PR DESCRIPTION
## Problem

Following the activation fix in #782, five more `migrate-mstest-v3-to-v4` eval scenarios still show **NOT ACTIVATED** — the runtime answers from general model knowledge without loading the skill:

- Migrate custom TestMethodAttribute from Execute to ExecuteAsync
- Replace ExpectedExceptionAttribute with Assert.ThrowsExactly
- Fix multiple v4 breaking changes: Assert, ClassCleanup, TestContext, Timeout
- Fix TestMethodAttribute and TestMethod display name constructor
- Fix Assert.IsInstanceOfType out parameter removal

Each prompt lacked an explicit fix request and the exact trigger phrases from the SKILL.md `description`.

## Fix

Reworded each prompt in both `eval.yaml` and `eval.vally.yaml` into an explicit *"I upgraded my test project to MSTest v4"* fix request embedding the exact trigger phrase **"Help me fix this MSTest v4 breaking change"** plus the matching `USE FOR` entry:

- *migrate my custom TestMethodAttribute from Execute to ExecuteAsync*
- *the ExpectedExceptionAttribute removal*
- *the CallerInfo constructor changes on TestMethodAttribute*
- *the Assert.IsInstanceOfType out parameter removal*

The scenarios still require the skill's specific knowledge — graders and rubrics are unchanged, and both YAML files parse cleanly.