### PR TITLE
Cover MSTESTxxxx analyzer diagnostics in writing-mstest-tests skill

### DIFF
--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -2,8 +2,7 @@
 name: code-testing-agent
 description: >-
   Generates and writes new unit tests for any programming language —
-  scaffolds .NET test projects, pytest suites, Vitest/Jest suites,
-  Go test files, and JUnit suites, and configures coverage tooling
+  scaffolds test projects and configures coverage tooling
   (coverlet, pytest-cov, @vitest/coverage-v8) as part of test
   generation. Use when asked to generate tests, generate pytest
   tests, generate Vitest tests, write unit tests, add tests, improve
@@ -16,7 +15,8 @@ description: >-
   planning, and implementation pipeline so tests compile and pass.
   DO NOT USE FOR: running existing tests (use run-tests); analyzing
   existing coverage reports (use coverage-analysis or crap-score);
-  MSTest modernization (use writing-mstest-tests).
+  writing, fixing, or modernizing MSTest-specific tests, assertions,
+  attributes, or lifecycle (use writing-mstest-tests).
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -3,7 +3,7 @@ name: writing-mstest-tests
 description: >
   Write new MSTest unit tests and fix existing MSTest code using MSTest 3.x/4.x
   modern APIs and best practices.
-  USE FOR: write or create MSTest unit tests, fix or modernize MSTest assertions,
+  USE FOR: write, create, or modernize comprehensive MSTest unit tests, fix MSTest assertions,
   better MSTest assertion than Assert.IsTrue, replace hard cast with MSTest type assertion,
   MSTest assertion APIs (IsInstanceOfType, Contains, ContainsSingle, HasCount,
   IsEmpty, IsNotEmpty, DoesNotContain, IsNull),

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -371,7 +371,7 @@ public sealed class DatabaseIntegrationTests { }
 
 The `MSTest.Analyzers` package reports `MSTESTxxxx` diagnostics during build and in the IDE. The analyzers come in automatically with the modern `MSTest` metapackage and `MSTest.Sdk` (and are bundled with `MSTest.TestFramework` 3.7+); for other setups, reference `MSTest.Analyzers` explicitly. Most rules have an automated code fix (light bulb) in Visual Studio. When fixing one by hand, apply the idiomatic change below rather than suppressing the rule.
 
-When asked to "fix MSTESTxxxx", look up the rule in the table, apply the fix, and rebuild to confirm the diagnostic is gone. Full reference: <https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview>.
+When asked to "fix MSTESTxxxx", look it up in the table of common diagnostics below, apply the fix, and rebuild to confirm the diagnostic is gone. The table is not exhaustive — for any rule it does not list, consult the full reference and apply the documented guidance: <https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview>.
 
 #### Common diagnostics and their fixes
 

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: writing-mstest-tests
 description: >
-  Write new MSTest unit tests and fix existing MSTest code using MSTest 3.x/4.x
-  modern APIs and best practices.
-  USE FOR: write, create, or modernize comprehensive MSTest unit tests, fix MSTest assertions,
-  better MSTest assertion than Assert.IsTrue, replace hard cast with MSTest type assertion,
-  MSTest assertion APIs (IsInstanceOfType, Contains, ContainsSingle, HasCount,
-  IsEmpty, IsNotEmpty, DoesNotContain, IsNull),
-  fix swapped Assert.AreEqual arguments, replace ExpectedException with Assert.Throws,
-  data-driven tests (DataRow, DynamicData, ValueTuples),
-  test lifecycle (sealed classes, TestInitialize, TestCleanup),
-  async tests and cancellation tokens, test parallelization (Parallelize / DoNotParallelize),
-  MSTest.Sdk project setup, fix MSTEST analyzer diagnostics (MSTESTxxxx rules).
-  DO NOT USE FOR: broad test quality audits (use test-anti-patterns),
-  running tests (use run-tests), MSTest version migration (use migrate-mstest-v1v2-to-v3
-  or migrate-mstest-v3-to-v4), xUnit/NUnit/TUnit, or non-.NET languages.
+  Write, create, modernize, or fix comprehensive MSTest unit tests with MSTest 3.x/4.x APIs.
+  USE FOR: write or create MSTest unit tests, fix/modernize MSTest assertions,
+  better MSTest assertion than Assert.IsTrue, replace hard cast with type check (IsInstanceOfType),
+  MSTest assertion APIs (Contains, ContainsSingle, HasCount, IsEmpty, IsNotEmpty, DoesNotContain,
+  AreSame, IsNull, StartsWith, EndsWith, MatchesRegex, IsGreaterThan, IsLessThan, IsInRange),
+  swapped Assert.AreEqual args, replace ExpectedException with Assert.Throws,
+  data-driven (DataRow, DynamicData, ValueTuples),
+  lifecycle (TestInitialize, TestCleanup, TestContext),
+  async tests and cancellation tokens, conditional execution/retry/cleanup (OSCondition, Retry),
+  parallelization (Parallelize/DoNotParallelize), MSTest.Sdk setup, MSTESTxxxx analyzer fixes.
+  DO NOT USE FOR: test quality audits (use test-anti-patterns),
+  running tests (use run-tests), MSTest version migration (use the migrate-mstest skills),
+  xUnit/NUnit/TUnit, or non-.NET languages.
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -369,7 +369,7 @@ public sealed class DatabaseIntegrationTests { }
 
 ### Step 8: Fix MSTest analyzer diagnostics (MSTESTxxxx)
 
-Starting with MSTest.TestFramework 3.7, the `MSTest.Analyzers` package ships with the framework and reports `MSTESTxxxx` diagnostics during build and in the IDE. Most rules have an automated code fix (light bulb) in Visual Studio. When fixing one by hand, apply the idiomatic change below rather than suppressing the rule.
+The `MSTest.Analyzers` package reports `MSTESTxxxx` diagnostics during build and in the IDE. The analyzers come in automatically with the modern `MSTest` metapackage and `MSTest.Sdk` (and are bundled with `MSTest.TestFramework` 3.7+); for other setups, reference `MSTest.Analyzers` explicitly. Most rules have an automated code fix (light bulb) in Visual Studio. When fixing one by hand, apply the idiomatic change below rather than suppressing the rule.
 
 When asked to "fix MSTESTxxxx", look up the rule in the table, apply the fix, and rebuild to confirm the diagnostic is gone. Full reference: <https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview>.
 
@@ -393,7 +393,7 @@ When asked to "fix MSTESTxxxx", look up the rule in the table, apply the fix, an
 | MSTEST0045 / MSTEST0049 / MSTEST0054 | Timeout/token not cooperative | Flow `TestContext.CancellationToken` into the awaited call (Step 6) |
 | MSTEST0036 | Member shadows a base test member | Rename or use `override` instead of `new` |
 | MSTEST0061 | Runtime OS check inside a test | Use `[OSCondition(...)]` (Step 7) |
-| MSTEST0002 / MSTEST0003 / MSTEST0005 / MSTEST0007–0014 | Invalid test class / method / fixture / `TestContext` / data-source layout | Fix the signature (public, correct return type, parameters, `static` where required) the rule names |
+| MSTEST0002 / MSTEST0003 / MSTEST0005 / MSTEST0007–0014 | Invalid test class / method / fixture / `TestContext` / data-source layout | Correct the signature named by the rule (e.g. make it public, fix the return type and parameters, add `static` where required) |
 
 #### Tuning which rules are enforced
 

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -6,13 +6,12 @@ description: >
   USE FOR: write or create MSTest unit tests, fix or modernize MSTest assertions,
   better MSTest assertion than Assert.IsTrue, replace hard cast with MSTest type assertion,
   MSTest assertion APIs (IsInstanceOfType, Contains, ContainsSingle, HasCount,
-  IsEmpty, IsNotEmpty, DoesNotContain, StartsWith, EndsWith, MatchesRegex,
-  IsGreaterThan, IsInRange, IsNull),
+  IsEmpty, IsNotEmpty, DoesNotContain, IsNull),
   fix swapped Assert.AreEqual arguments, replace ExpectedException with Assert.Throws,
   data-driven tests (DataRow, DynamicData, ValueTuples),
   test lifecycle (sealed classes, TestInitialize, TestCleanup),
   async tests and cancellation tokens, test parallelization (Parallelize / DoNotParallelize),
-  MSTest.Sdk project setup.
+  MSTest.Sdk project setup, fix MSTEST analyzer diagnostics (MSTESTxxxx rules).
   DO NOT USE FOR: broad test quality audits (use test-anti-patterns),
   running tests (use run-tests), MSTest version migration (use migrate-mstest-v1v2-to-v3
   or migrate-mstest-v3-to-v4), xUnit/NUnit/TUnit, or non-.NET languages.
@@ -33,6 +32,7 @@ Help users write effective, modern unit tests with MSTest 3.x/4.x using current 
 - User needs help fixing a specific MSTest test bug or failing assertion
 - User asks to fix swapped `Assert.AreEqual` argument order (expected first, actual second)
 - User asks to convert `DynamicData` from `IEnumerable<object[]>` to ValueTuple-based data
+- User asks to fix or understand an MSTest analyzer diagnostic (an `MSTESTxxxx` warning/error)
 
 ## When Not to Use
 
@@ -366,3 +366,47 @@ public void LocalOnly_InteractiveTest() { }
 [DoNotParallelize]  // Opt out specific classes
 public sealed class DatabaseIntegrationTests { }
 ```
+
+### Step 8: Fix MSTest analyzer diagnostics (MSTESTxxxx)
+
+Starting with MSTest.TestFramework 3.7, the `MSTest.Analyzers` package ships with the framework and reports `MSTESTxxxx` diagnostics during build and in the IDE. Most rules have an automated code fix (light bulb) in Visual Studio. When fixing one by hand, apply the idiomatic change below rather than suppressing the rule.
+
+When asked to "fix MSTESTxxxx", look up the rule in the table, apply the fix, and rebuild to confirm the diagnostic is gone. Full reference: <https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview>.
+
+#### Common diagnostics and their fixes
+
+| Rule | Problem | Fix |
+|---|---|---|
+| MSTEST0006 | `[ExpectedException]` used | Replace with `Assert.Throws<T>` / `Assert.ThrowsExactly<T>` (Step 3) |
+| MSTEST0017 | `Assert.AreEqual` args swapped | Put `expected` first, `actual` second |
+| MSTEST0023 | Negated boolean assertion (`Assert.IsTrue(!x)`) | Use `Assert.IsFalse(x)` |
+| MSTEST0025 | Always-false condition asserted | Use `Assert.Fail("reason")` |
+| MSTEST0032 | Always-true assert condition | Remove or correct the assertion |
+| MSTEST0037 | Sub-optimal assert (`IsTrue(x == null)`) | Use the specific assert (`Assert.IsNull`, `HasCount`, etc.) (Step 3) |
+| MSTEST0038 | `Assert.AreSame` on value types | Use `Assert.AreEqual` (value types box to distinct references) |
+| MSTEST0039 | Legacy `Assert.ThrowsException` | Use `Assert.Throws` / `Assert.ThrowsExactly` (+ `Async` variants) |
+| MSTEST0044 | `[DataTestMethod]` used | Replace with `[TestMethod]` (it now supports data rows) |
+| MSTEST0046 | `StringAssert` used | Use the equivalent `Assert` method (`Assert.Contains`, `StartsWith`, ...) |
+| MSTEST0052 | Explicit `DynamicDataSourceType` | Drop it — the source type is inferred |
+| MSTEST0042 / MSTEST0060 | Duplicate `[DataRow]` / `[TestMethod]` | Remove the duplicate attribute |
+| MSTEST0024 | Static `TestContext` field | Make it an instance member (Step 5) |
+| MSTEST0045 / MSTEST0049 / MSTEST0054 | Timeout/token not cooperative | Flow `TestContext.CancellationToken` into the awaited call (Step 6) |
+| MSTEST0036 | Member shadows a base test member | Rename or use `override` instead of `new` |
+| MSTEST0061 | Runtime OS check inside a test | Use `[OSCondition(...)]` (Step 7) |
+| MSTEST0002 / MSTEST0003 / MSTEST0005 / MSTEST0007–0014 | Invalid test class / method / fixture / `TestContext` / data-source layout | Fix the signature (public, correct return type, parameters, `static` where required) the rule names |
+
+#### Tuning which rules are enforced
+
+Use the `MSTestAnalysisMode` MSBuild property (MSTest 3.8+) to control the rule set globally:
+
+```xml
+<PropertyGroup>
+  <!-- None | Default | Recommended | All -->
+  <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
+</PropertyGroup>
+```
+
+- `Recommended` escalates info-level rules to warnings and is the mode most projects should adopt.
+- A handful of rules are completely opt-in (e.g. MSTEST0015, MSTEST0019–0022); enable them per project via `.editorconfig` when you want their convention enforced.
+- Prefer fixing the underlying code over suppressing a diagnostic. Suppress only with a documented justification.
+

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -409,4 +409,3 @@ Use the `MSTestAnalysisMode` MSBuild property (MSTest 3.8+) to control the rule 
 - `Recommended` escalates info-level rules to warnings and is the mode most projects should adopt.
 - A handful of rules are completely opt-in (e.g. MSTEST0015, MSTEST0019–0022); enable them per project via `.editorconfig` when you want their convention enforced.
 - Prefer fixing the underlying code over suppressing a diagnostic. Suppress only with a documented justification.
-


### PR DESCRIPTION
## What

Extends the existing `writing-mstest-tests` skill to cover the MSTest analyzer rules (`MSTESTxxxx`) instead of adding a new skill per rule.

## Why

There are 63 `MSTESTxxxx` rules. They are Roslyn analyzers that already self-surface during build and in the IDE (with messages and, in most cases, automated code fixes). What an agent needs is the *idiomatic fix + rationale*, which is content — not 63 separate, overlapping, activation-gated skills that would cannibalize each other''s activation and require a web of "DO NOT USE" redirects. The existing skill already teaches the correct patterns these analyzers enforce, so this consolidates the remaining gaps in one place.

## Changes

- New **"Step 8: Fix MSTest analyzer diagnostics (MSTESTxxxx)"** section with a `rule → problem → fix` table covering the high-value rules not previously called out (MSTEST0023, 0025, 0032, 0038, 0044, 0052, 0024, 0036, 0061, the 0042/0060 duplicates, the 0002–0014 layout family), cross-linked to existing steps for the rules already covered (0006/0017/0037/0039/0046/0045-0049-0054).
- `MSTestAnalysisMode` (`None`/`Default`/`Recommended`/`All`) guidance and the opt-in rules note.
- Link to the official [MSTest code analysis overview](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview).
- Added a **USE FOR** keyword (`fix MSTEST analyzer diagnostics (MSTESTxxxx rules)`) and a When-to-Use trigger; trimmed the verbose assertion-API list to keep the description at 1000 chars (under the 1024 cap).

## Validation

`skill-validator check --plugin ./plugins/dotnet-test` → all checks pass (27 skills, 11 agents). Only a soft "approaching comprehensive token range" warning on the skill size.
