### PR TITLE
Fix code-testing-agent activation for the Flask pytest scenario

### DIFF
--- a/tests/dotnet-test/code-testing-agent/eval.vally.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.vally.yaml
@@ -64,35 +64,22 @@ stimuli:
   - name: Generate pytest tests for the Flask tasks API (Python polyglot)
     prompt: |
       I have a Python Flask web application under fixtures/python-flask-tasks/
-      — a tasks REST API with a TaskService layer (with an injected clock and
-      configurable max title length), a TaskRepository Protocol with two
-      backends (InMemoryTaskRepository, SqliteTaskRepository), a separate
-      queries module (TaskQuery / TaskPage / apply_query) for
-      filter/sort/pagination, and a Flask blueprint exposing /tasks CRUD,
-      tag endpoints, and listing with status / tag / q / overdue / sort /
-      order / limit / offset query parameters (see
-      fixtures/python-flask-tasks/README.md for the layout). There are no
-      test files yet — the tests/ directory contains only a .gitkeep
-      marker. This is a project-wide, multi-file test generation task
-      across the service layer, the query layer, both repositories, and
-      the Flask blueprint.
+      — a tasks REST API with a service layer, a repository abstraction with
+      in-memory and SQLite backends, a query/filter/pagination module, and a
+      Flask blueprint exposing the /tasks CRUD, tag, and listing endpoints
+      (see fixtures/python-flask-tasks/README.md for the layout). This is a
+      project-wide, multi-file test generation task. There are no tests yet —
+      the tests/ directory contains only a .gitkeep marker.
 
       Please scaffold a comprehensive pytest test suite under
-      fixtures/python-flask-tasks/tests/, then write comprehensive unit
-      and integration tests across the tasks_api package — covering
-      TaskService (with the repository mocked and the clock injected),
-      the queries.apply_query function over fixed Task lists,
-      InMemoryTaskRepository, SqliteTaskRepository against an in-memory
-      connection, and the Flask blueprint via Flask's test_client.
-
-      Coverage tooling (pytest-cov) is pre-configured in pyproject.toml
-      with a hard floor of 80% line + branch coverage on the tasks_api
-      package. The generated tests should pass with: `python -m pip
-      install -e ".[test]"` then `python -m pytest` from the
-      fixtures/python-flask-tasks/ directory — the run fails (and the
-      coverage XML report under fixtures/python-flask-tasks/coverage.xml
-      is not produced) if your tests do not clear the 80% floor across
-      every module.
+      fixtures/python-flask-tasks/tests/ and write thorough unit and
+      integration tests across the tasks_api package. Achieve high coverage:
+      pytest-cov is pre-configured in pyproject.toml with a hard floor of 80%
+      line + branch coverage on the tasks_api package. The generated tests
+      should pass with `python -m pip install -e ".[test]"` then
+      `python -m pytest` from the fixtures/python-flask-tasks/ directory,
+      producing the coverage XML report under
+      fixtures/python-flask-tasks/coverage.xml.
     environment:
       files:
         - src: .

--- a/tests/dotnet-test/code-testing-agent/eval.vally.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.vally.yaml
@@ -76,8 +76,8 @@ stimuli:
       integration tests across the tasks_api package. Achieve high coverage:
       pytest-cov is pre-configured in pyproject.toml with a hard floor of 80%
       line + branch coverage on the tasks_api package. The generated tests
-      should pass with `python -m pip install -e ".[test]"` then
-      `python -m pytest` from the fixtures/python-flask-tasks/ directory,
+      should pass with `python3 -m pip install -e ".[test]"` then
+      `python3 -m pytest` from the fixtures/python-flask-tasks/ directory,
       producing the coverage XML report under
       fixtures/python-flask-tasks/coverage.xml.
     environment:

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -59,35 +59,22 @@ scenarios:
   - name: "Generate pytest tests for the Flask tasks API (Python polyglot)"
     prompt: |
       I have a Python Flask web application under fixtures/python-flask-tasks/
-      — a tasks REST API with a TaskService layer (with an injected clock and
-      configurable max title length), a TaskRepository Protocol with two
-      backends (InMemoryTaskRepository, SqliteTaskRepository), a separate
-      queries module (TaskQuery / TaskPage / apply_query) for
-      filter/sort/pagination, and a Flask blueprint exposing /tasks CRUD,
-      tag endpoints, and listing with status / tag / q / overdue / sort /
-      order / limit / offset query parameters (see
-      fixtures/python-flask-tasks/README.md for the layout). There are no
-      test files yet — the tests/ directory contains only a .gitkeep
-      marker. This is a project-wide, multi-file test generation task
-      across the service layer, the query layer, both repositories, and
-      the Flask blueprint.
+      — a tasks REST API with a service layer, a repository abstraction with
+      in-memory and SQLite backends, a query/filter/pagination module, and a
+      Flask blueprint exposing the /tasks CRUD, tag, and listing endpoints
+      (see fixtures/python-flask-tasks/README.md for the layout). This is a
+      project-wide, multi-file test generation task. There are no tests yet —
+      the tests/ directory contains only a .gitkeep marker.
 
       Please scaffold a comprehensive pytest test suite under
-      fixtures/python-flask-tasks/tests/, then write comprehensive unit
-      and integration tests across the tasks_api package — covering
-      TaskService (with the repository mocked and the clock injected),
-      the queries.apply_query function over fixed Task lists,
-      InMemoryTaskRepository, SqliteTaskRepository against an in-memory
-      connection, and the Flask blueprint via Flask's test_client.
-
-      Coverage tooling (pytest-cov) is pre-configured in pyproject.toml
-      with a hard floor of 80% line + branch coverage on the tasks_api
-      package. The generated tests should pass with: `python -m pip
-      install -e ".[test]"` then `python -m pytest` from the
-      fixtures/python-flask-tasks/ directory — the run fails (and the
-      coverage XML report under fixtures/python-flask-tasks/coverage.xml
-      is not produced) if your tests do not clear the 80% floor across
-      every module.
+      fixtures/python-flask-tasks/tests/ and write thorough unit and
+      integration tests across the tasks_api package. Achieve high coverage:
+      pytest-cov is pre-configured in pyproject.toml with a hard floor of 80%
+      line + branch coverage on the tasks_api package. The generated tests
+      should pass with `python -m pip install -e ".[test]"` then
+      `python -m pytest` from the fixtures/python-flask-tasks/ directory,
+      producing the coverage XML report under
+      fixtures/python-flask-tasks/coverage.xml.
     setup:
       copy_test_files: true
     assertions:

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -71,8 +71,8 @@ scenarios:
       integration tests across the tasks_api package. Achieve high coverage:
       pytest-cov is pre-configured in pyproject.toml with a hard floor of 80%
       line + branch coverage on the tasks_api package. The generated tests
-      should pass with `python -m pip install -e ".[test]"` then
-      `python -m pytest` from the fixtures/python-flask-tasks/ directory,
+      should pass with `python3 -m pip install -e ".[test]"` then
+      `python3 -m pytest` from the fixtures/python-flask-tasks/ directory,
       producing the coverage XML report under
       fixtures/python-flask-tasks/coverage.xml.
     setup:


### PR DESCRIPTION
## What

Fixes plugin- and isolated-mode skill activation for the **code-testing-agent** scenario *"Generate pytest tests for the Flask tasks API (Python polyglot)"*.

## Root cause

The scenario prompt enumerated, layer by layer and class by class, exactly what to mock, inject, and test (`TaskService` with the repository mocked and the clock injected, `queries.apply_query` over fixed `Task` lists, both repositories, `SqliteTaskRepository` against an in-memory connection, the blueprint via `test_client`…). That level of detail acts as an **answer key**: the base agent just executed it directly with `edit` tools and never routed to the `code-testing-agent` research → plan → implement pipeline.

Reproduced locally with the skill-validator: the original prompt yielded `detected: []` in **both** isolated and plugin runs. The sibling ContosoUniversity scenario (same skill, concise high-level prompt) activates fine.

## Fix

Rewrote the prompt to a realistic, high-level ask mirroring the ContosoUniversity scenario:
- describes the app at a layer level (service / repository / query / blueprint) instead of a per-module test checklist,
- keeps the *no tests yet*, *project-wide multi-file* framing,
- keeps the 80% line+branch coverage floor and the `pip install -e ".[test]"` + `pytest` + `coverage.xml` expectations.

**Assertions, rubric, and timeout are unchanged** — the agent must still discover mocking, `test_client` usage, validation paths, etc. via the skill. Applied to both `eval.yaml` and `eval.vally.yaml`.

## Verification

Local skill-validator run after the change: `🔌 Skill activated (isolated): skills=code-testing-agent` and `🔌 Skill activated (plugin): skills=code-testing-agent`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>