### PR TITLE
Fix broken pipeline: pin SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (CVE-2025-6965)

### DIFF
--- a/eng/skill-validator/src/SkillValidator.csproj
+++ b/eng/skill-validator/src/SkillValidator.csproj
@@ -60,6 +60,16 @@
       the v2 line as of 2.5.301.  Drop this once the upstream chain bumps past it.
     -->
     <PackageReference Include="MessagePack" Version="2.5.301" />
+
+    <!--
+      Transitive pin: Microsoft.Data.Sqlite 10.0.7 -> SQLitePCLRaw.bundle_e_sqlite3
+      drags in the native SQLitePCLRaw.lib.e_sqlite3 2.1.11, which bundles a
+      SQLite older than 3.50.2 and carries a known high-severity vulnerability
+      (GHSA-2m69-gcr7-jv3q / CVE-2025-6965). 3.50.3 ships the patched SQLite
+      native library and is API-compatible with the 2.1.x managed provider.
+      Drop this once Microsoft.Data.Sqlite bumps past it.
+    -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

The build/check pipeline is failing **repo-wide** with `NU1903` (NuGet audit, warnings-as-errors):

```
error NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity
vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
```

`Microsoft.Data.Sqlite` 10.0.7 transitively pulls `SQLitePCLRaw.lib.e_sqlite3` **2.1.11**, whose bundled SQLite is older than 3.50.2 and is affected by **GHSA-2m69-gcr7-jv3q / CVE-2025-6965**. A NuGet advisory-database update started flagging it, so every `build`/`check` job started failing (not caused by any code change).

## Fix

Pin the native lib to **`SQLitePCLRaw.lib.e_sqlite3` 3.50.3** (patched SQLite 3.50.3), following the existing transitive-pin pattern already used in this project for `Nerdbank.MessagePack` and `MessagePack`. The 3.50.x native package is ABI-compatible with the 2.1.x managed provider (`SQLitePCLRaw.provider.e_sqlite3`), so no managed/API changes are needed.

## Verification (local)

- `dotnet restore` — clean, no `NU1903` / no `NU1605` downgrade.
- `dotnet build SkillValidator.slnx` — succeeds, **0 warnings / 0 errors**.
- `dotnet test SkillValidator.slnx` — **586 passed, 0 failed** (confirms the swapped native SQLite library works at runtime, including the SQLite-backed session store).
