### PR TITLE
Add eval coverage for dotnet-test/assertion-quality

### DIFF
--- a/tests/dotnet-test/assertion-quality/eval.yaml
+++ b/tests/dotnet-test/assertion-quality/eval.yaml
@@ -29,6 +29,7 @@ scenarios:
       - "Noted that no tests verify collection contents in GetTransactionHistory — only the count is checked"
       - "Recommended specific additional assertion types that would improve coverage (exception, collection, structural)"
       - "Provided concrete examples of assertions that could be added to specific test methods"
+      - "Reported assertion metrics that are computed correctly — the per-category counts add up and are internally consistent with the total number of assertions"
     timeout: 120
 
   # ==========================================================================
@@ -89,6 +90,7 @@ scenarios:
       - "Acknowledged the negative assertions (Assert.IsNull for non-existent user, Assert.IsFalse for failed delete, Assert.AreNotEqual for role change)"
       - "Acknowledged the exception assertions with specific exception types and parameter name verification"
       - "If any gaps were identified, they were presented as minor enhancement opportunities rather than problems"
+      - "Because the suite already has good diversity, the report explicitly acknowledges this strength instead of inventing problems"
     timeout: 300
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Extends `tests/dotnet-test/assertion-quality/eval.yaml` with two outcome-focused rubric items so that two previously-uncovered `## Validation` teaching points from `SKILL.md` are now covered. No existing scenarios were removed and no other teaching points lost coverage.

## Now-covered teaching points (both Validation)

- **"Metrics are computed correctly (counts add up)"** — added a rubric item to the low-diversity scenario asserting the reported per-category counts add up and are internally consistent with the total.
- **"If the suite has good diversity, the report acknowledges this"** — added a rubric item to the good-diversity scenario asserting the report explicitly acknowledges the suite's existing diversity instead of inventing problems.

Both rubric items test outcomes (not techniques/vocabulary) and are independently evaluable. Prompts were left unchanged and natural.

## Verification

`pwsh eng/skill-coverage/Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName assertion-quality`:
- Before: 20/22 points covered (90.9%), `uncovered` = the two Validation points above.
- After: **22/22 points covered (100%)**, `uncovered: []`.

`dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-test`: ✅ All checks passed (only pre-existing, unrelated warnings).