### PR TITLE
Add eval coverage for dotnet-test/dotnet-test-frameworks

### DIFF
--- a/tests/dotnet-test/dotnet-test-frameworks/eval.yaml
+++ b/tests/dotnet-test/dotnet-test-frameworks/eval.yaml
@@ -157,7 +157,7 @@ scenarios:
       - type: "output_matches"
         pattern: "\\[TestMethod\\].*Assert\\.Throws(Exactly)?<|Assert\\.Throws(Exactly)?<.*AreEqual"
       - type: "output_matches"
-        pattern: "Assert\\.AreEqual"
+        pattern: "Assert\\.AreEqual\\([^)]*\\.Message"
       - type: "output_matches"
         pattern: "\\[Fact\\].*Assert\\.Throws<|Assert\\.Throws<.*Assert\\.Equal"
       - type: "output_matches"
@@ -167,7 +167,7 @@ scenarios:
       - "Replaced the MSTest try/catch with Assert.ThrowsExactly<T> or Assert.Throws<T>"
       - "Replaced the xUnit try/catch with Assert.Throws<T>"
       - "Replaced the NUnit try/catch with the constraint-model pattern or Assert.Throws<T>"
-      - "Preserved exception message verification in all three refactored versions"
+      - "Preserved exception message verification in all three refactored versions (e.g. `Assert.AreEqual(\"...\", ex.Message)` for MSTest)"
     reject_tools: ["bash", "edit", "create"]
     timeout: 120
 

--- a/tests/dotnet-test/dotnet-test-frameworks/eval.yaml
+++ b/tests/dotnet-test/dotnet-test-frameworks/eval.yaml
@@ -157,6 +157,8 @@ scenarios:
       - type: "output_matches"
         pattern: "\\[TestMethod\\].*Assert\\.Throws(Exactly)?<|Assert\\.Throws(Exactly)?<.*AreEqual"
       - type: "output_matches"
+        pattern: "Assert\\.AreEqual"
+      - type: "output_matches"
         pattern: "\\[Fact\\].*Assert\\.Throws<|Assert\\.Throws<.*Assert\\.Equal"
       - type: "output_matches"
         pattern: "Throws\\.TypeOf<InvalidOperationException>|Assert\\.That\\(.*Throws"


### PR DESCRIPTION
## Summary

Adds eval-test coverage for the previously-uncovered MSTest assertion CodePattern `Assert.AreEqual` in the `dotnet-test/dotnet-test-frameworks` skill.

## Change

In the "Replace try-catch with framework-native exception assertions" scenario, the MSTest refactor genuinely preserves the message check `Assert.AreEqual("...", ex.Message);`. Added a deterministic `output_matches` assertion with pattern `Assert\.AreEqual` where that output is naturally expected.

## Verification

- `Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName dotnet-test-frameworks`: coverage is now **5/5 (100%)**, `uncovered: []` — `Assert.AreEqual` is covered, no other point regressed.
- `SkillValidator check --plugin ./plugins/dotnet-test`: ✅ all checks passed (only pre-existing, unrelated warnings).

Only `tests/dotnet-test/dotnet-test-frameworks/eval.yaml` was modified.