### PR TITLE
Add eval coverage for dotnet-test/generate-testability-wrappers

### DIFF
--- a/tests/dotnet-test/generate-testability-wrappers/eval.yaml
+++ b/tests/dotnet-test/generate-testability-wrappers/eval.yaml
@@ -13,6 +13,8 @@ scenarios:
         pattern: "(FakeTimeProvider|fake.*time|mock.*time|test.*time)"
       - type: "output_matches"
         pattern: "(AddSingleton|Register|services\\.Add)"
+      - type: "output_matches"
+        pattern: "Assert\\.True"
       - type: "exit_success"
     rubric:
       - "Recommended TimeProvider as the built-in abstraction since the project targets .NET 10"
@@ -34,11 +36,14 @@ scenarios:
         pattern: "(interface|IEnvironment)"
       - type: "output_matches"
         pattern: "(GetEnvironmentVariable|MachineName)"
+      - type: "output_matches"
+        pattern: "\\bsealed\\b"
       - type: "exit_success"
     rubric:
       - "Generated an interface with methods for GetEnvironmentVariable and MachineName"
       - "Generated a default implementation that delegates to the real Environment static class"
       - "Provided DI registration code for the wrapper"
+      - "Registered the stateless wrapper with AddSingleton rather than AddTransient, noting that transient suits stateful wrappers"
       - "Only wrapped the two members actually used in the code, not every Environment member"
     timeout: 240
 
@@ -53,6 +58,8 @@ scenarios:
         pattern: "(System\\.IO\\.Abstractions|IFileSystem)"
       - type: "output_matches"
         pattern: "(MockFileSystem|mock.*file)"
+      - type: "output_matches"
+        pattern: "Assert\\.Equal"
       - type: "exit_success"
     rubric:
       - "Recommended System.IO.Abstractions NuGet package instead of writing a custom wrapper"
@@ -84,3 +91,35 @@ scenarios:
       - "Did not generate a redundant wrapper interface"
       - "May have suggested other improvements but did not create duplicate abstractions"
     timeout: 120
+
+  - name: "Provide ambient context alternative when DI is unavailable"
+    prompt: |
+      I have a small class library with no dependency injection container and I
+      don't want to add one. A few classes read DateTimeOffset.UtcNow directly,
+      which makes my tests flaky and order-dependent. How can I make the current
+      time controllable in tests without introducing DI?
+    setup:
+      files:
+        - path: "InvoiceLib/InvoiceCalculator.cs"
+          content: |
+            namespace InvoiceLib;
+            public class InvoiceCalculator
+            {
+                public bool IsOverdue(DateTimeOffset dueDate)
+                    => DateTimeOffset.UtcNow > dueDate;
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "AsyncLocal"
+      - type: "output_matches"
+        pattern: "\\breadonly\\b"
+      - type: "output_matches"
+        pattern: "(IDisposable|Dispose)"
+      - type: "exit_success"
+    rubric:
+      - "Offered an ambient context alternative because the codebase does not use dependency injection"
+      - "Implemented the ambient context using AsyncLocal so that parallel tests do not interfere with each other"
+      - "Provided scoped disposal that resets the ambient override when the scope is disposed"
+      - "Explained the trade-offs of the ambient context approach, such as the per-call null check cost in production"
+      - "Used AsyncLocal rather than ThreadStatic so the ambient context survives across async and await boundaries"
+    timeout: 240

--- a/tests/dotnet-test/generate-testability-wrappers/eval.yaml
+++ b/tests/dotnet-test/generate-testability-wrappers/eval.yaml
@@ -94,10 +94,10 @@ scenarios:
 
   - name: "Provide ambient context alternative when DI is unavailable"
     prompt: |
-      I have a small class library with no dependency injection container and I
-      don't want to add one. A few classes read DateTimeOffset.UtcNow directly,
-      which makes my tests flaky and order-dependent. How can I make the current
-      time controllable in tests without introducing DI?
+      I maintain a small class library. A few classes read DateTimeOffset.UtcNow
+      directly, which makes my tests flaky and order-dependent. The library has no
+      dependency injection set up. What's the lightest way to make the current
+      time controllable in my tests?
     setup:
       files:
         - path: "InvoiceLib/InvoiceCalculator.cs"


### PR DESCRIPTION
Extends `tests/dotnet-test/generate-testability-wrappers/eval.yaml` to cover previously-uncovered teaching points in the `generate-testability-wrappers` SKILL.md. Skill coverage is now **22/22 points (100%)**, up from 14/22 (63.6%).

## Now-covered points
- **[Validation]** DI registration uses `AddSingleton` for stateless wrappers, `AddTransient` for stateful ones
- **[Validation]** Ambient context pattern includes `AsyncLocal<T>`, scoped disposal, and trade-off explanation
- **[Pitfall]** Ambient context without `AsyncLocal`
- **[WorkflowStep]** Step 5: Generate ambient context alternative (when DI is not available)
- **[CodePattern]** `Assert.Equal`
- **[CodePattern]** `Assert.True`
- **[CodePattern]** `sealed`
- **[CodePattern]** `readonly`

## Changes
- Added a new scenario "Provide ambient context alternative when DI is unavailable" with a natural prompt (a DI-free class library needing controllable time), outcome-focused rubric items, and deterministic `output_matches` assertions for `AsyncLocal` and `\breadonly\b`.
- Enriched existing scenarios with an `AddSingleton` vs `AddTransient` rubric item and `output_matches` assertions for `Assert\.True`, `Assert\.Equal`, and `\bsealed\b`, placed in scenarios whose generated code genuinely contains them.

## Verification
- `Measure-SkillCoverage.ps1` → `uncovered count: 0`, 22/22 covered (100%); no other point regressed.
- `SkillValidator -- check --plugin ./plugins/dotnet-test` → ✅ All checks passed.

Only `eval.yaml` was modified; SKILL.md and other skills are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>