### PR TITLE
Add eval coverage for dotnet-test/run-tests

### DIFF
--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -17,8 +17,7 @@ scenarios:
       - type: "exit_success"
     rubric:
       - "Identifies the project as a VSTest project (Microsoft.NET.Test.Sdk + MSTest.TestAdapter)"
-      - "Uses the correct `dotnet test` invocation for the detected platform and SDK version (plain VSTest invocation, no MTP arguments or '--' separator)"
-      - "Uses 'dotnet test' without MTP-specific arguments or '--' separator"
+      - "Uses the correct `dotnet test` invocation for the detected platform and SDK version — a plain VSTest invocation with no MTP-specific arguments or '--' separator"
       - "Does not suggest MTP-style arguments like --report-trx or --treenode-filter"
     expect_tools: ["bash"]
     timeout: 180

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -17,6 +17,7 @@ scenarios:
       - type: "exit_success"
     rubric:
       - "Identifies the project as a VSTest project (Microsoft.NET.Test.Sdk + MSTest.TestAdapter)"
+      - "Uses the correct `dotnet test` invocation for the detected platform and SDK version (plain VSTest invocation, no MTP arguments or '--' separator)"
       - "Uses 'dotnet test' without MTP-specific arguments or '--' separator"
       - "Does not suggest MTP-style arguments like --report-trx or --treenode-filter"
     expect_tools: ["bash"]


### PR DESCRIPTION
Extends `tests/dotnet-test/run-tests/eval.yaml` to cover a previously-uncovered Validation teaching point in `plugins/dotnet-test/skills/run-tests/SKILL.md`:

- **Now covered:** "Correct `dotnet test` invocation was used for the detected platform and SDK version" (SKILL.md ~L251)

Enriched the existing "Run tests in a VSTest MSTest project" scenario with an outcome-focused rubric item asserting the agent used the correct `dotnet test` invocation for the detected platform and SDK version (plain VSTest invocation, no MTP args or `--` separator). The scenario already has a deterministic `output_matches: dotnet test` assertion.

**Verification:**
- `Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName run-tests` → Validation 100% (was 83.3%), overall 100%, `uncovered: []`, no regressions.
- `SkillValidator check --plugin ./plugins/dotnet-test` → all checks passed.

Only `eval.yaml` was changed.