### PR TITLE
Add eval coverage for dotnet-test/test-anti-patterns

### DIFF
--- a/tests/dotnet-test/test-anti-patterns/eval.yaml
+++ b/tests/dotnet-test/test-anti-patterns/eval.yaml
@@ -38,6 +38,8 @@ scenarios:
       - "Identified that AddUser_NullUser uses broad Assert.ThrowsException<Exception> instead of the specific ArgumentNullException"
       - "Identified that the static HttpClient field is never disposed and appears unused"
       - "Provided concrete fixes for the critical and high severity findings"
+      - "Every reported finding cites a specific location — the file, the test method name, or a line — rather than a vague general warning"
+      - "Recommendations are prioritized by severity, ordering the critical fixes ahead of lower-severity ones"
     reject_tools: ["bash", "edit", "create"]
     timeout: 180
 


### PR DESCRIPTION
Extends the existing eval scenario for the `dotnet-test/test-anti-patterns` skill with two outcome-focused rubric items to close coverage gaps in the **Validation** category.

## Now-covered points
- **[Validation]** "Every finding includes a specific location (not just a general warning)" (SKILL.md ~L155)
- **[Validation]** "Recommendations are prioritized by severity" (SKILL.md ~L159)

Both rubric items were added to the existing *"Detect mixed severity anti-patterns in repository service tests"* scenario and test outcomes independently.

## Verification
- `Measure-SkillCoverage.ps1` → **100%** (21/21 points covered), `uncovered` list now empty, no regressions.
- `SkillValidator check --plugin ./plugins/dotnet-test` → ✅ All checks passed.

Only `tests/dotnet-test/test-anti-patterns/eval.yaml` was modified.