### PR TITLE
Add eval coverage for dotnet-test/test-smell-detection

### DIFF
--- a/tests/dotnet-test/test-smell-detection/eval.yaml
+++ b/tests/dotnet-test/test-smell-detection/eval.yaml
@@ -210,7 +210,7 @@ scenarios:
           source: "fixtures/skip-and-magic/Inventory.Tests/InventoryServiceTests.cs"
     assertions:
       - type: "output_matches"
-        pattern: "(Sleep|Thread\\.Sleep|sleepy|delay)"
+        pattern: "(Thread\\.Sleep|sleepy test|sleepy)"
       - type: "output_matches"
         pattern: "(no assert|assertion.free|without.*assert|verifies nothing)"
       - type: "output_matches"
@@ -224,6 +224,6 @@ scenarios:
       - "Justified each severity level with a concrete rationale tied to the risk, rather than assigning severity arbitrarily"
       - "For every finding, included a concrete fix example showing the corrected code, not just a vague 'fix this' instruction"
       - "Flagged the Thread.Sleep(3000) in Replenish_AsyncJob_Completes as a Sleepy Test and Audit_RunsWithoutError as Assertion-Free"
-    reject_tools: ["edit", "create"]
+    reject_tools: ["bash", "edit", "create"]
     timeout: 180
 

--- a/tests/dotnet-test/test-smell-detection/eval.yaml
+++ b/tests/dotnet-test/test-smell-detection/eval.yaml
@@ -188,3 +188,42 @@ scenarios:
     reject_tools: ["bash", "edit", "create"]
     timeout: 180
 
+  # ==========================================================================
+  # Scenario: Skip calibration, magic-number context, fix examples & severity
+  # ==========================================================================
+
+  - name: "Distinguish reasoned skips, spare obvious numbers, justify severity"
+    prompt: |
+      Please review the xUnit tests in
+      Inventory.Tests/InventoryServiceTests.cs for quality problems.
+
+      For every problem you find, give it a severity (high/medium/low) and
+      tell me WHY that severity — I don't want a number pulled out of thin
+      air. And for each one, show me the corrected code, not just "go fix
+      it". A couple of these tests are disabled; let me know how worried I
+      should actually be about each. This is a read-only review.
+    setup:
+      files:
+        - path: "Inventory.Tests/Inventory.Tests.csproj"
+          source: "fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj"
+        - path: "Inventory.Tests/InventoryServiceTests.cs"
+          source: "fixtures/skip-and-magic/Inventory.Tests/InventoryServiceTests.cs"
+    assertions:
+      - type: "output_matches"
+        pattern: "(Sleep|Thread\\.Sleep|sleepy|delay)"
+      - type: "output_matches"
+        pattern: "(no assert|assertion.free|without.*assert|verifies nothing)"
+      - type: "output_matches"
+        pattern: "(skip|disabled|ignored|#1487)"
+      - type: "output_matches"
+        pattern: "(severity|high|medium|low)"
+      - type: "exit_success"
+    rubric:
+      - "Treated the reasoned skip annotation on Reserve_AcrossWarehouses_BalancesStock (Skip with the #1487 tracking reason) as less concerning than the bare skip on Restock_FromSupplier_UpdatesQuantities, which gives no reason — did not lump the two skips together as equally bad"
+      - "Did not flag the contextually obvious numbers (count is 3 after three adds, 1 after removing one of two items) as magic numbers, because their meaning is self-evident from the surrounding test"
+      - "Justified each severity level with a concrete rationale tied to the risk, rather than assigning severity arbitrarily"
+      - "For every finding, included a concrete fix example showing the corrected code, not just a vague 'fix this' instruction"
+      - "Flagged the Thread.Sleep(3000) in Replenish_AsyncJob_Completes as a Sleepy Test and Audit_RunsWithoutError as Assertion-Free"
+    reject_tools: ["edit", "create"]
+    timeout: 180
+

--- a/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj
+++ b/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/InventoryServiceTests.cs
+++ b/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/InventoryServiceTests.cs
@@ -1,0 +1,82 @@
+using Xunit;
+
+namespace Inventory.Tests;
+
+public sealed class InventoryServiceTests
+{
+    // Contextually obvious numbers: we add exactly three items, then assert
+    // the count is three. The literals are self-documenting and should NOT be
+    // flagged as Magic Number Test.
+    [Fact]
+    public void AddItems_ThreeAdded_CountIsThree()
+    {
+        var service = new InventoryService();
+
+        service.Add("SKU-1", 1);
+        service.Add("SKU-2", 1);
+        service.Add("SKU-3", 1);
+
+        Assert.Equal(3, service.ItemCount);
+    }
+
+    // Contextually obvious number: removing one of two items leaves one.
+    [Fact]
+    public void RemoveItem_FromTwo_LeavesOne()
+    {
+        var service = new InventoryService();
+        service.Add("SKU-1", 1);
+        service.Add("SKU-2", 1);
+
+        service.Remove("SKU-1");
+
+        Assert.Equal(1, service.ItemCount);
+    }
+
+    // Reasoned skip: the annotation documents WHY it is skipped and links a
+    // tracking issue. This is less concerning than an unexplained skip.
+    [Fact(Skip = "Tracked by #1487 - blocked on the warehouse API redesign")]
+    public void Reserve_AcrossWarehouses_BalancesStock()
+    {
+        var service = new InventoryService();
+        service.Add("SKU-1", 10);
+
+        var reserved = service.Reserve("SKU-1", 4);
+
+        Assert.True(reserved);
+    }
+
+    // Bare skip: no reason given at all. The reader has no idea why it is
+    // disabled or whether the underlying issue is tracked anywhere.
+    [Fact(Skip = "skip")]
+    public void Restock_FromSupplier_UpdatesQuantities()
+    {
+        var service = new InventoryService();
+
+        service.Restock("SKU-9", 50);
+
+        Assert.Equal(50, service.QuantityOf("SKU-9"));
+    }
+
+    // Sleepy Test: real smell with a clear high-confidence severity rationale.
+    [Fact]
+    public void Replenish_AsyncJob_Completes()
+    {
+        var service = new InventoryService();
+        service.Add("SKU-1", 1);
+
+        service.ReplenishAsync("SKU-1");
+        Thread.Sleep(3000);
+
+        Assert.True(service.WasReplenished("SKU-1"));
+    }
+
+    // Assertion-Free Test: real smell, exercises code but verifies nothing.
+    [Fact]
+    public void Audit_RunsWithoutError()
+    {
+        var service = new InventoryService();
+        service.Add("SKU-1", 1);
+
+        service.Audit();
+    }
+}


### PR DESCRIPTION
Extends the `test-smell-detection` eval suite to close four previously-uncovered teaching points from `SKILL.md`.

## What changed
- New scenario **"Distinguish reasoned skips, spare obvious numbers, justify severity"** with outcome-focused rubric items.
- New xUnit fixture under `fixtures/skip-and-magic/Inventory.Tests/` containing a reasoned skip (`Skip = "Tracked by #1487 ..."`), a bare skip (`Skip = "skip"`), contextually-obvious count assertions, plus a Sleepy Test and an Assertion-Free Test so findings need severity rationale and fix examples.

## Now-covered points
- **[Validation]** Every finding includes a concrete fix example (not just "fix this")
- **[Validation]** Contextually obvious numbers are not flagged as magic numbers
- **[Validation]** Severity levels are justified, not arbitrary
- **[Pitfall]** Treating skip annotations with reasons same as bare skips

## Verification
- `Measure-SkillCoverage.ps1` → **100% (26/26 points covered, `uncovered: []`)**, up from 84.6%; no regressions.
- `SkillValidator … check --plugin ./plugins/dotnet-test` → ✅ All checks passed.

Only `eval.yaml` and new fixture files are touched; no SKILL.md or other skills changed.