### PR TITLE
Add eval coverage for dotnet-test/migrate-static-to-wrapper

### DIFF
--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -106,6 +106,7 @@ scenarios:
         - path: "BillingApp.Tests/InvoiceServiceTests.cs"
           content: |
             using Xunit;
+            using BillingApp;
 
             namespace BillingApp.Tests;
 
@@ -177,6 +178,7 @@ scenarios:
     prompt: |
       Replace all File.ReadAllText calls in my project with IFileSystem. Just do
       the bulk replacement across all files.
+    expect_activation: false
     setup:
       files:
         - path: "MyProject/MyProject.csproj"

--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -18,7 +18,10 @@ scenarios:
       - "Replaced all DateTime.UtcNow calls in CouponService.cs with TimeProvider calls"
       - "Added TimeProvider as a constructor parameter to CouponService"
       - "Stored TimeProvider in a readonly field following the class's existing naming convention"
-      - "Did not change the behavior of any method — only the time source changed"
+      - "Added any required `using` directives so the migrated file still compiles"
+      - "Left the project in a state where the build still succeeds after the migration"
+      - "Introduced no behavioral changes — the migrated code delegates directly to the injected TimeProvider in place of the static DateTime.UtcNow"
+      - "Did not break the original static class or alter it in a way that breaks existing callers"
       - "Did not modify Program.cs DI registration since TimeProvider was already registered"
     timeout: 180
 
@@ -40,15 +43,140 @@ scenarios:
     rubric:
       - "Migrated DateTime.UtcNow to TimeProvider in CouponService.cs"
       - "Left AuditLogger.cs completely untouched with DateTime.UtcNow calls still present"
+      - "Migrated incrementally rather than too much at once, keeping the change to the single file the user scoped"
       - "Respected the scope boundary the user specified"
       - "Reported what was migrated and what remains to be done"
+    timeout: 180
+
+  - name: "Update test doubles when migrating a service to TimeProvider"
+    prompt: |
+      Please migrate DateTime.UtcNow to TimeProvider in my InvoiceService, and
+      update the unit tests so they use a controllable time source and stay
+      deterministic. TimeProvider is already registered in my DI container.
+    setup:
+      files:
+        - path: "BillingApp/BillingApp.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+            </Project>
+        - path: "BillingApp/InvoiceService.cs"
+          content: |
+            namespace BillingApp;
+
+            public class InvoiceService
+            {
+                public Invoice Create(decimal amount)
+                {
+                    return new Invoice
+                    {
+                        Amount = amount,
+                        IssuedAt = DateTime.UtcNow
+                    };
+                }
+            }
+
+            public class Invoice
+            {
+                public decimal Amount { get; set; }
+                public DateTimeOffset IssuedAt { get; set; }
+            }
+        - path: "BillingApp.Tests/BillingApp.Tests.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+                <PackageReference Include="xunit" Version="2.9.2" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+                <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
+              </ItemGroup>
+              <ItemGroup>
+                <ProjectReference Include="..\BillingApp\BillingApp.csproj" />
+              </ItemGroup>
+            </Project>
+        - path: "BillingApp.Tests/InvoiceServiceTests.cs"
+          content: |
+            using Xunit;
+
+            namespace BillingApp.Tests;
+
+            public class InvoiceServiceTests
+            {
+                [Fact]
+                public void Create_SetsIssuedAt()
+                {
+                    var service = new InvoiceService();
+
+                    var invoice = service.Create(100m);
+
+                    Assert.True(invoice.IssuedAt <= DateTimeOffset.UtcNow);
+                }
+            }
+    assertions:
+      - type: "file_contains"
+        path: "**/InvoiceService.cs"
+        value: "TimeProvider"
+      - type: "file_not_contains"
+        path: "**/InvoiceService.cs"
+        value: "DateTime.UtcNow"
+      - type: "file_contains"
+        path: "**/InvoiceServiceTests.cs"
+        value: "TimeProvider"
+      - type: "exit_success"
+    rubric:
+      - "Updated the affected test files with an appropriate test double for the time source (such as FakeTimeProvider) instead of relying on the real clock"
+      - "Kept the migrated production code free of behavioral changes — it delegates directly to the injected TimeProvider rather than the static DateTime.UtcNow"
+      - "Left both the production and test projects in a state where the build still succeeds after the migration"
+      - "Added any required `using` directives to the files it changed"
+    timeout: 240
+
+  - name: "Handle a genuinely static class that cannot take constructor injection"
+    prompt: |
+      I want to migrate DateTime.UtcNow to TimeProvider in my TimestampFormatter
+      helper. It's a static class with only static members. TimeProvider is
+      registered in DI. How should I do this?
+    setup:
+      files:
+        - path: "Utils/Utils.csproj"
+          content: |
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+            </Project>
+        - path: "Utils/TimestampFormatter.cs"
+          content: |
+            namespace Utils;
+
+            public static class TimestampFormatter
+            {
+                public static string Now() => DateTime.UtcNow.ToString("O");
+            }
+    assertions:
+      - type: "output_matches"
+        pattern: "(static class|ambient|constructor|TimeProvider)"
+      - type: "exit_success"
+    rubric:
+      - "Recognized that the static class cannot receive constructor injection without breaking it"
+      - "Used an ambient context approach for the time source instead of adding a constructor to the static class"
+      - "Did not produce code that fails to compile by adding instance constructors or fields to a static class"
     timeout: 180
 
   - name: "Decline migration when wrapper does not exist yet"
     prompt: |
       Replace all File.ReadAllText calls in my project with IFileSystem. Just do
       the bulk replacement across all files.
-    expect_activation: false
     setup:
       files:
         - path: "MyProject/MyProject.csproj"


### PR DESCRIPTION
## Summary

Extends `tests/dotnet-test/migrate-static-to-wrapper/eval.yaml` to close the remaining skill-coverage gaps for the `migrate-static-to-wrapper` skill. Coverage is now **21/21 points (100%)**, up from 15/21.

### Newly covered points
- **[Validation]** Required `using` directives added
- **[Validation]** Build succeeds after migration
- **[Validation]** Test files updated with appropriate test doubles
- **[Validation]** No behavioral changes introduced (wrapper delegates directly to the static)
- **[Pitfall]** Breaking static classes
- **[Pitfall]** Migrating too much at once

### Changes
- Enriched the existing **service-class** and **scoped-migration** scenarios with outcome-focused rubric items (using directives, build still succeeds, no behavioral changes, incremental migration, not breaking the static class/callers).
- Added a **test-doubles** scenario (inline fixtures: production + xUnit test project) verifying the agent updates tests to use a controllable time source and keeps both projects building.
- Added a **genuinely-static-class** scenario verifying the agent recognizes a static class can't take constructor injection and uses an ambient-context approach instead of breaking it.

All prompts are natural developer requests; rubric items test outcomes and are independently evaluable.

### Verification
- `eng/skill-coverage/Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName migrate-static-to-wrapper` → `uncovered count: 0`, 21/21 covered (100%).
- `SkillValidator check --plugin ./plugins/dotnet-test` → ✅ All checks passed.

Only `eval.yaml` is modified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>