### PR TITLE
Add eval coverage for dotnet-test/writing-mstest-tests

### DIFF
--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -407,7 +407,7 @@ scenarios:
   # ============================================================================
 
   - name: "Write tests with collection, null, and reference assertions"
-    prompt: "Write MSTest tests for my ServiceRegistry class using the most appropriate assertion for each check. I need tests that verify registration, resolution returning the same instance, null for unregistered services, clearing all services, and removal."
+    prompt: "Write MSTest tests for my ServiceRegistry class using the most appropriate assertion for each check. I need tests that verify: registering a service and resolving it returns the exact same instance; resolving an unregistered service returns null; the GetAll list contains a registered service and does not contain it after removal; and GetAll is empty before any registration but not empty afterwards."
     setup:
       files:
         - path: "src/ServiceRegistry.cs"
@@ -462,11 +462,29 @@ scenarios:
       - type: file_contains
         path: "tests/*.cs"
         value: "[TestClass]"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.AreSame"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.IsNull"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.Contains"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.DoesNotContain"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.IsEmpty"
+      - type: file_contains
+        path: "tests/*.cs"
+        value: "Assert.IsNotEmpty"
     rubric:
-      - "Verifies reference identity (same object instance, not just value equality) when testing that resolving a registered service returns the exact object that was registered"
-      - "Checks that resolving an unregistered service type returns null, using a null-specific assertion rather than a boolean check"
-      - "Asserts the collection is empty after calling Clear, using a dedicated empty-collection assertion rather than checking count manually"
-      - "Verifies that a removed service is no longer resolvable after calling Remove (e.g., returns null or is absent from the collection)"
+      - "Verifies reference identity (same object instance, not just value equality) using Assert.AreSame when testing that resolving a registered service returns the exact object that was registered"
+      - "Checks that resolving an unregistered service type returns null, using Assert.IsNull rather than a boolean check"
+      - "Uses Assert.Contains to verify the GetAll collection includes a registered service, and Assert.DoesNotContain to verify it is absent after Remove"
+      - "Asserts the collection is empty with Assert.IsEmpty before registration and not empty with Assert.IsNotEmpty afterwards, rather than checking count manually"
       - "The written tests reference correct class and method names from the provided source code"
     timeout: 180
 

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -480,6 +480,22 @@ scenarios:
       - type: file_contains
         path: "tests/*.cs"
         value: "Assert.IsNotEmpty"
+      # Guard the substring-based file_contains checks above against the legacy
+      # CollectionAssert/StringAssert helpers (e.g. "CollectionAssert.Contains"
+      # also contains the substring "Assert.Contains"). Rejecting them keeps the
+      # scenario a deterministic check for the modern Assert.* API.
+      - type: file_not_contains
+        path: "tests/*.cs"
+        value: "CollectionAssert.Contains"
+      - type: file_not_contains
+        path: "tests/*.cs"
+        value: "CollectionAssert.DoesNotContain"
+      - type: file_not_contains
+        path: "tests/*.cs"
+        value: "StringAssert.Contains"
+      - type: file_not_contains
+        path: "tests/*.cs"
+        value: "StringAssert.DoesNotContain"
     rubric:
       - "Verifies reference identity (same object instance, not just value equality) using Assert.AreSame when testing that resolving a registered service returns the exact object that was registered"
       - "Checks that resolving an unregistered service type returns null, using Assert.IsNull rather than a boolean check"


### PR DESCRIPTION
## Summary

Adds eval-test coverage for six previously-uncovered modern MSTest assertion APIs taught in `plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md`.

The existing "Write tests with collection, null, and reference assertions" scenario (Goal 7) already ships the ideal `ServiceRegistry` fixture — a class whose members naturally elicit each assertion — but lacked deterministic assertions tying the generated test code to these tokens. This PR enriches that scenario's prompt, adds deterministic `file_contains` assertions, and sharpens the rubric.

### Now-covered CodePattern points

- `Assert.IsNull` (SKILL.md ~L154) — resolving an unregistered service returns null
- `Assert.AreSame` (~L154) — resolving a registered service returns the same instance
- `Assert.Contains` (~L178) — `GetAll()` includes a registered service
- `Assert.DoesNotContain` (~L178) — service absent after `Remove`
- `Assert.IsEmpty` (~L178) — `GetAll()` empty before registration
- `Assert.IsNotEmpty` (~L178) — `GetAll()` not empty after registration

### Verification

- `eng/skill-coverage/Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName writing-mstest-tests -Format Json` → `"uncovered": []` (all six targets covered, no regressions).
- `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-test` → ✅ All checks passed (only pre-existing token-budget warnings).

Only `eval.yaml` changed; no SKILL.md or other skills touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>