### PR TITLE
Add eval coverage for dotnet-test/test-tagging

### DIFF
--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -252,10 +252,15 @@ scenarios:
         path: "TaskManager.Tests/TaskServiceTests.cs"
         value: "[Category("
       - type: output_matches
+        pattern: "\\[Category\\b"
+      - type: output_matches
         pattern: "(positive|negative)"
       - type: output_matches
         pattern: "(distribution|summary|trait|count)"
     rubric:
+      - "Did not guess each test's traits from its method name — read the test body's assertions and setup before classifying"
+      - "Classified each test method into the correct category based on analysis of its body rather than its name"
+      - "Applied the NUnit `[Category]` attribute to every classified test method"
       - "Classified DeleteTask_Success as negative (and/or security) because the body asserts UnauthorizedAccessException, despite the name suggesting success"
       - "Classified CreateTask_Fails_WhenFieldsPresent as positive because the body verifies successful creation, despite the name containing 'Fails'"
       - "Classified GetByAssignee_Error_NoTasks as positive (and/or boundary) because the body asserts an empty result for a valid query, despite the name containing 'Error'"
@@ -301,3 +306,36 @@ scenarios:
       - "Used only valid trait values from the taxonomy — no invented category names that would cause logical errors"
       - "Every test method received at least one positive or negative tag"
     timeout: 600
+
+  # ==========================================================================
+  # Scenario 9: Report-only framework (Go standard testing) — no source edits
+  # ==========================================================================
+
+  - name: "Report traits for a Go test suite without modifying source"
+    prompt: >-
+      I have a small Go module under calculator/ with a handful of tests in
+      calculator_test.go using the standard testing package. Can you analyze
+      each test and tell me what category it falls into — positive, negative,
+      boundary, and so on — and give me a summary of the distribution?
+    setup:
+      files:
+        - path: "calculator/go.mod"
+          source: "fixtures/go-report-only/calculator/go.mod"
+        - path: "calculator/calculator.go"
+          source: "fixtures/go-report-only/calculator/calculator.go"
+        - path: "calculator/calculator_test.go"
+          source: "fixtures/go-report-only/calculator/calculator_test.go"
+    assertions:
+      - type: output_matches
+        pattern: "(positive|negative)"
+      - type: output_matches
+        pattern: "(report|table|distribution|summary)"
+      - type: file_not_contains
+        path: "calculator/calculator_test.go"
+        value: "//go:build"
+    rubric:
+      - "For report-only frameworks like Go standard testing, left all source files unmodified and emitted a report instead of editing them"
+      - "Produced a Markdown report or table mapping each Go test function to its suggested traits rather than inserting attributes"
+      - "Classified TestDivide_ByZero_ReturnsError as negative and the valid Add/Divide tests as positive by reading each test body"
+      - "Recommended a project-wide convention (such as build tags or file-name suffixes) the team could adopt for tagging"
+    timeout: 300

--- a/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/calculator.go
+++ b/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/calculator.go
@@ -1,0 +1,19 @@
+package calculator
+
+import "errors"
+
+// ErrDivideByZero is returned when a division by zero is attempted.
+var ErrDivideByZero = errors.New("divide by zero")
+
+// Add returns the sum of two integers.
+func Add(a, b int) int {
+	return a + b
+}
+
+// Divide returns the quotient of a and b, or ErrDivideByZero when b is zero.
+func Divide(a, b int) (int, error) {
+	if b == 0 {
+		return 0, ErrDivideByZero
+	}
+	return a / b, nil
+}

--- a/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/calculator_test.go
+++ b/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/calculator_test.go
@@ -1,0 +1,31 @@
+package calculator
+
+import "testing"
+
+func TestAdd_ValidInputs_ReturnsSum(t *testing.T) {
+	if got := Add(2, 3); got != 5 {
+		t.Fatalf("expected 5, got %d", got)
+	}
+}
+
+func TestDivide_ValidInputs_ReturnsQuotient(t *testing.T) {
+	got, err := Divide(10, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("expected 5, got %d", got)
+	}
+}
+
+func TestDivide_ByZero_ReturnsError(t *testing.T) {
+	if _, err := Divide(1, 0); err == nil {
+		t.Fatal("expected an error when dividing by zero")
+	}
+}
+
+func TestAdd_ZeroOperands_ReturnsZero(t *testing.T) {
+	if got := Add(0, 0); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}

--- a/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/go.mod
+++ b/tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/go.mod
@@ -1,0 +1,3 @@
+module calculator
+
+go 1.21


### PR DESCRIPTION
## Summary

Extends `tests/dotnet-test/test-tagging/eval.yaml` to raise SKILL.md teaching-point coverage from **85.7% → 96.4%** (24/28 → 27/28 points), measured by `eng/skill-coverage/Measure-SkillCoverage.ps1`.

### Now-covered target points
- **[Validation] "For `report-only` frameworks, no source files were modified"** (SKILL.md ~L243) — added a new Go standard-`testing` scenario (a report-only framework) with a fixture, plus an outcome-focused rubric item about leaving source files unmodified and producing a report only. Also asserts the test file is not given `//go:build` tags (`file_not_contains`).
- **[Pitfall] "Guessing traits without reading the test body"** (~L250) — added a rubric item to the NUnit misleading-names scenario about reading each test body's assertions/setup before classifying rather than guessing from the method name.
- **[CodePattern] `[Category]`** (~L135) — added a deterministic `output_matches: "\[Category\b"` assertion in the NUnit scenario (whose output genuinely emits the NUnit `[Category]` attribute), plus a rubric item referencing the `[Category]` attribute.

### Changes
- `tests/dotnet-test/test-tagging/eval.yaml` — enriched Scenario 7 (NUnit misleading names); added Scenario 9 (Go report-only).
- `tests/dotnet-test/test-tagging/fixtures/go-report-only/calculator/` — new Go module fixture (`go.mod`, `calculator.go`, `calculator_test.go`).

### Verification
- `Measure-SkillCoverage.ps1 -PluginName dotnet-test -SkillName test-tagging`: 27/28 (96.4%), no regressions.
- `SkillValidator check --plugin ./plugins/dotnet-test`: ✅ all checks passed (only pre-existing token-count warnings).

## Known blocker — Step 3 remains uncovered (measurement-tool bug, not eval.yaml)

The 4th target, **[WorkflowStep] "Step 3: Classify each test method"** (~L92), **cannot** be covered by editing `eval.yaml`. Root cause is a bug in `eng/skill-coverage/Measure-SkillCoverage.ps1`:

`Get-SignificantTerms` returns `[string[]]$terms.Keys`, where `$terms` is a hashtable of extracted keywords. SKILL.md line 108 (inside the Step 3 body) contains the word **"keys"** ("...tests missing **keys**..."), so `$terms` gains an entry named `keys`. PowerShell member access `$terms.Keys` then returns that **entry's value** (`$true`) instead of the key collection — so Step 3's keyword set collapses to the single token `True`. The matcher requires ≥2 keyword hits (or 1 distinctive code term), so no eval evidence can ever match this point.

Suggested one-line fix (separate PR, broader impact across all skills): use `$terms.get_Keys()` (or `([System.Collections.IDictionary]$terms).Keys`) instead of `$terms.Keys`. This generally affects any step whose body contains a hashtable member name (`keys`, `values`, `count`, `item`, ...). The eval.yaml in this PR already includes outcome-focused rubric items for classifying each test method, so Step 3 will be credited automatically once the tool bug is fixed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>