### PR TITLE
Fix hashtable .Keys/.Values collision in skill coverage tool

### DIFF
--- a/eng/skill-coverage/Measure-SkillCoverage.ps1
+++ b/eng/skill-coverage/Measure-SkillCoverage.ps1
@@ -216,7 +216,7 @@ function Get-CodePatterns([string]$content) {
         if ($inCode) { $block += "$line`n" }
     }
 
-    $seen.Values | ForEach-Object {
+    $seen.get_Values() | ForEach-Object {
         [PSCustomObject]@{
             Category    = 'CodePattern'
             Description = $_[0]
@@ -257,7 +257,7 @@ function Get-BlockPatterns([string]$code) {
         if ($code -match $_.Value) { $found[$_.Key.ToLower()] = $_.Key }
     }
 
-    $found.Values
+    $found.get_Values()
 }
 
 function Get-SignificantTerms([string]$text) {
@@ -283,7 +283,10 @@ function Get-SignificantTerms([string]$text) {
         }
     }
 
-    [string[]]$terms.Keys
+    # Use get_Keys() rather than .Keys: if a significant term is literally
+    # "keys", PowerShell's hashtable member access returns that entry's value
+    # instead of the key collection, collapsing the keyword set.
+    [string[]]$terms.get_Keys()
 }
 
 # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

`Get-SignificantTerms` in `eng/skill-coverage/Measure-SkillCoverage.ps1` returned `$terms.Keys`. When a teaching point's text contains the word **"keys"**, PowerShell's hashtable member access resolves `.Keys` to *that entry's value* (`$true`) instead of the key collection — so the keyword set collapses to `{True}` and the point can never meet the ≥2-hit match rule.

This made `dotnet-test/test-tagging` **Step 3 "Classify each test method"** permanently uncoverable, regardless of eval content.

## Fix

Use the method form (`get_Keys()` / `get_Values()`), which bypasses key-name shadowing. Applied to the confirmed `.Keys` return and the two same-class `.Values` returns for robustness.

## Verification

```
$h=@{}; $h['keys']=$true; @($h.Keys)        # -> True   (bug)
$h=@{}; $h['keys']=$true; @($h.get_Keys())  # -> keys   (fixed)
```

After the fix, `test-tagging` coverage goes 24→25/28 (Step 3 now credited) with **no regressions** across the rest of the `dotnet-test` plugin. Complements #830, whose author surfaced this bug.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>