### PR TITLE
Require environment input to pat_pool shared workflow.

### DIFF
--- a/.github/workflows/close-stale-prs.agent.lock.yml
+++ b/.github/workflows/close-stale-prs.agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"c8214e9af2530588ef924a58df3bc8fae6fa76943f7effeace54386211e91c29","body_hash":"4cfe51387f079a2efaadcf0bca4afb2c5ef2d5bfcf44f5c4ba975abcd4aeb5f1","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"5354f6c550d77638a89c91435e043c1e0e56e1fd00c63cdfc743a03d78751113","body_hash":"9caea2d16810798c5cdf63dbeb5d3a5866e81a594bfcc608d362984b94d7620f","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -30,14 +30,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -60,8 +62,7 @@
 
 name: "Close Stale Pull Requests"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   schedule:
   - cron: "6 22 * * 1"
     # Friendly format: weekly on monday (scattered)
@@ -102,7 +103,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -167,11 +167,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -364,6 +359,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     concurrency:
@@ -816,7 +812,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -879,15 +888,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1015,6 +1026,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1174,7 +1186,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "close-stale-prs.agent"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1212,6 +1223,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1369,7 +1381,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1443,7 +1468,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1460,11 +1487,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1478,7 +1505,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1496,28 +1523,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: (!(github.event_name == 'schedule' && github.event.repository.fork))
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1557,6 +1586,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write

--- a/.github/workflows/close-stale-prs.agent.md
+++ b/.github/workflows/close-stale-prs.agent.md
@@ -2,33 +2,14 @@
 name: "Close Stale Pull Requests"
 description: "Automatically warn about and close pull requests that have been open for more than 30 days with no recent activity."
 on:
+  permissions: {}
   schedule: weekly on monday
   workflow_dispatch: # Allow manual triggering
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
 
 # Don't run scheduled triggers on forked repositories — forks lack the
 # secrets and context required, and scheduled runs would consume the
 # fork owner's minutes.
 if: ${{ (!(github.event_name == 'schedule' && github.event.repository.fork)) }}
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
-
 safe-outputs:
   close-pull-request:
     max: 25
@@ -36,6 +17,38 @@ safe-outputs:
     max: 30
   noop:
     report-as-issue: false
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # Close Stale Pull Requests

--- a/.github/workflows/devops-health-check.lock.yml
+++ b/.github/workflows/devops-health-check.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"64e9bb0733cf667ee1384b3b25e37f7cd4f3424dcae85302903dd7686f7add74","body_hash":"d94682994971d9413d0e0c17af21f510012d043d3d611196d47eeb369f4fdd39","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"503fbb853987151f3897cf8d22b18246df52c1ec425f177db4cdd3e042f334ef","body_hash":"be2dfd908e83e5975be61ce948c14848605abfed9013cf89f2c106cb31dcfada","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -31,14 +31,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -63,8 +65,7 @@
 
 name: "DevOps Daily Health Check"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   schedule:
   - cron: "0 3 * * *"
   workflow_dispatch:
@@ -104,7 +105,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -169,11 +169,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -374,6 +369,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       actions: read
       contents: read
@@ -993,7 +989,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -1056,15 +1065,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1211,6 +1222,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       actions: write
       contents: read
@@ -1371,7 +1383,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "devops-health-check"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1410,6 +1421,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1567,7 +1579,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1641,7 +1666,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1658,11 +1685,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1676,7 +1703,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1694,28 +1721,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: (!(github.event_name == 'schedule' && github.event.repository.fork))
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1755,6 +1784,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/devops-health-check.md
+++ b/.github/workflows/devops-health-check.md
@@ -10,39 +10,20 @@ description: >
   PR review status.
 
 on:
+  permissions: {}
   schedule:
     - cron: "0 3 * * *"  # 03:00 UTC daily
   workflow_dispatch:
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
 
 # Don't run scheduled triggers on forked repositories — forks lack the
 # secrets and context required, and scheduled runs would consume the
 # fork owner's minutes.
 if: ${{ (!(github.event_name == 'schedule' && github.event.repository.fork)) }}
 
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
-
 permissions:
   contents: read
   actions: read
   issues: read
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-  - ../aw/shared/devops-health.lock.md
 
 tools:
   github:
@@ -72,6 +53,39 @@ network:
     - defaults
 
 timeout-minutes: 60
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+  - ../aw/shared/devops-health.lock.md
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # DevOps Daily Health Check — Orchestrator

--- a/.github/workflows/devops-health-groom.lock.yml
+++ b/.github/workflows/devops-health-groom.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"bbbea0ebd573002e1a5febfab0606cce2d5918a8546663e6de8b2fb32b4de6f2","body_hash":"a705abb034b85b397a4ad86f39d60e3e88cdd5e98bd134f3aaa63deca849b577","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a43fc2612655bc80e627c91a99340b33991ac16cc0b0a3b684c37db620d00cda","body_hash":"a27131174a96d7671809822b4cfb5fefbfe8279caeb694037028d93461b73de2","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -31,14 +31,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -60,8 +62,7 @@
 
 name: "DevOps Health — Groom Dashboard"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   schedule:
   - cron: "0 6 * * *"
   workflow_dispatch:
@@ -101,7 +102,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -166,11 +166,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -364,6 +359,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       actions: read
       contents: read
@@ -872,7 +868,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -935,15 +944,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1073,6 +1084,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1231,7 +1243,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "devops-health-groom"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1269,6 +1280,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1426,7 +1438,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1500,7 +1525,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1517,11 +1544,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1535,7 +1562,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1553,28 +1580,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: (!(github.event_name == 'schedule' && github.event.repository.fork))
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1614,6 +1643,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write

--- a/.github/workflows/devops-health-groom.md
+++ b/.github/workflows/devops-health-groom.md
@@ -6,39 +6,20 @@ description: >
   prunes stale comments older than 7 days, and marks resolved findings.
 
 on:
+  permissions: {}
   schedule:
     - cron: "0 6 * * *"  # 06:00 UTC daily (3h after health check)
   workflow_dispatch:
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
 
 # Don't run scheduled triggers on forked repositories — forks lack the
 # secrets and context required, and scheduled runs would consume the
 # fork owner's minutes.
 if: ${{ (!(github.event_name == 'schedule' && github.event.repository.fork)) }}
 
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
-
 permissions:
   contents: read
   actions: read
   issues: read
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-  - ../aw/shared/devops-health.lock.md
 
 tools:
   github:
@@ -62,6 +43,39 @@ network:
     - defaults
 
 timeout-minutes: 60
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+  - ../aw/shared/devops-health.lock.md
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # DevOps Health — Groom Dashboard

--- a/.github/workflows/devops-health-investigate.lock.yml
+++ b/.github/workflows/devops-health-investigate.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"4fda3bb0d660353cadb6f2dc3f9d968f7599eb4ec2220cbe1d654017129800c4","body_hash":"8a0ee37353425842ad0e7226a6f87139333b3c5d9d78b2ba027424c90487bc55","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"307240611409e35727a3bd4f3e06b41bd20c3fba3f2a18fd31033e02e0f0855c","body_hash":"73a044497f0e054bc45cac64ecbe2e3cdfeb85425ac6ab7de1cfdda007e14fbd","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -31,14 +31,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -61,8 +63,7 @@
 
 name: "DevOps Health — Deep Investigation"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -120,7 +121,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -185,11 +185,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -411,6 +406,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       actions: read
       contents: read
@@ -864,7 +860,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -927,15 +936,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1063,6 +1074,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1222,7 +1234,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "devops-health-investigate"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1260,6 +1271,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1417,7 +1429,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1491,7 +1516,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1508,11 +1535,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1526,7 +1553,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1544,27 +1571,29 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1604,6 +1633,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write

--- a/.github/workflows/devops-health-investigate.md
+++ b/.github/workflows/devops-health-investigate.md
@@ -6,6 +6,7 @@ description: >
   Dispatched by the health check orchestrator.
 
 on:
+  permissions: {}
   workflow_dispatch:
     inputs:
       finding_id:
@@ -30,34 +31,14 @@ on:
         description: "Unique ID linking this investigation to the health check run"
         required: true
 
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
-
 concurrency:
   group: gh-aw-${{ github.workflow }}-${{ inputs.finding_id }}
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
 
 permissions:
   contents: read
   actions: read
   issues: read
   pull-requests: read
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-  - ../aw/shared/devops-investigate.lock.md
 
 tools:
   github:
@@ -75,6 +56,39 @@ network:
     - defaults
 
 timeout-minutes: 60
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+  - ../aw/shared/devops-investigate.lock.md
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # DevOps Health — Deep Investigation Worker

--- a/.github/workflows/issue-investigate.lock.yml
+++ b/.github/workflows/issue-investigate.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7209753f16bd5037fc56d7746c3c47b495e87b7d47555cf28d6b59c85ddc6fac","body_hash":"807aa54507fcc78c86e18f9bd76834876260cccafa806d15e70bb92626e21ef3","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"38a24f273dc1259c27e890ae2d8be1e8c3e18d7e33715e796f9621c2282fbe02","body_hash":"1ee23560e90292f9f579338ccf5e73faa84ea5069da6f09715501f2baaba0713","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -30,14 +30,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
@@ -64,8 +66,7 @@ on:
   issues:
     types:
     - labeled
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
 
 permissions: {}
 
@@ -96,7 +97,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -163,11 +163,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -378,6 +373,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
       issues: read
@@ -902,7 +898,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -965,15 +974,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1101,6 +1112,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: write
       discussions: write
@@ -1260,7 +1272,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "issue-investigate"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1300,6 +1311,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1457,7 +1469,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1531,7 +1556,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1548,11 +1575,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1566,7 +1593,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1584,28 +1611,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: github.event.label.name == 'auto-investigate'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1645,6 +1674,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: write
       discussions: write

--- a/.github/workflows/issue-investigate.md
+++ b/.github/workflows/issue-investigate.md
@@ -7,33 +7,15 @@ description: >
   a draft PR with the fix if the solution is clear.
 
 on:
+  permissions: {}
   issues:
     types: [labeled]
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
 
 # Only run when the 'auto-investigate' label is applied
 if: ${{ github.event.label.name == 'auto-investigate' }}
 
 concurrency:
   group: gh-aw-${{ github.workflow }}-${{ github.event.issue.number }}
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
 
 permissions:
   contents: read
@@ -59,6 +41,38 @@ network:
     - defaults
 
 timeout-minutes: 30
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # Issue Investigation

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"d869d3bcef6c1097f3cb1d5f574e6c7b3ed0870a18b13e6b8377883a4c14a534","body_hash":"b2cee3583bd0fc7804b803c7f6644b3932e96df409c120259ac6f79ea0d3b17d","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"284c09063c36bd7d9f834db9e97c3a7eb8c697675aa93b97b3c8e5cba014d889","body_hash":"46f394bf9aaf8200f676c051cbe214e9fb8055733c12d4bf9ab0f9c86229e60e","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -30,14 +30,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -63,9 +65,8 @@ on:
     types:
     - opened
     - reopened
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
   # roles: all # Roles processed as role check in pre-activation job
+  # skip-if-no-match: is:issue is:open # Skip-if-no-match processed as search check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -106,7 +107,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -173,11 +173,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -389,6 +384,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
       issues: read
@@ -912,7 +908,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -975,15 +984,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1113,6 +1124,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1272,7 +1284,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "issue-triage"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1310,6 +1321,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1467,7 +1479,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1541,7 +1566,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1558,11 +1585,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1576,7 +1603,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1594,29 +1621,31 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
-      activated: ${{ 'true' }}
+      activated: ${{ steps.check_skip_if_no_match.outputs.skip_no_match_check_ok == 'true' }}
       matched_command: ''
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
@@ -1634,6 +1663,19 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.60"
           GH_AW_INFO_AWF_VERSION: "v0.27.2"
           GH_AW_INFO_ENGINE_ID: "copilot"
+      - name: Check skip-if-no-match query
+        id: check_skip_if_no_match
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_AW_SKIP_QUERY: "is:issue is:open"
+          GH_AW_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_SKIP_MIN_MATCHES: "1"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_no_match.cjs');
+            await main();
 
   safe_outputs:
     needs:
@@ -1642,6 +1684,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -21,27 +21,13 @@ on:
   # [admin, maintainer, write] and silently skip everyone else.
   roles: all
 
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
+  # With 'roles: all', no pre_activation job will be created. But the pat_pool
+  # job depends on pre_activation. Force a pre_activation job to be created by
+  # defining a skip-if-no-match query that ensures there are open issues.
+  skip-if-no-match: "is:issue is:open"
 
 concurrency:
   group: gh-aw-${{ github.workflow }}-${{ github.event.issue.number || inputs.issue_number }}
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
 
 permissions:
   contents: read
@@ -86,6 +72,38 @@ network:
     - defaults
 
 timeout-minutes: 10
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # Issue Triage

--- a/.github/workflows/markdown-linter.lock.yml
+++ b/.github/workflows/markdown-linter.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"63c4104b50f8532b60ad91989c49a1d69f57ee5ed724d795141e71388d7548d7","body_hash":"8fbb9025178e8d4337b0bceaf6873a612cc1d4e78d5de0998e8cdd77f62dad03","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"de0fac2e4500dabe0009e67214ff5f5447ce83dd"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"},{"repo":"super-linter/super-linter","sha":"61abc07d755095a68f4987d1c2c3d1d64408f1f9","version":"61abc07d755095a68f4987d1c2c3d1d64408f1f9"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"70bbf875e5f26058a7bda9ae8ad1d23318a6a365199e2665db47fb8681edf79c","body_hash":"37558638517d0376014f13d06ca0bfe9c88f9d62959269d093c09a5c40523e0c","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"de0fac2e4500dabe0009e67214ff5f5447ce83dd"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"},{"repo":"super-linter/super-linter","sha":"61abc07d755095a68f4987d1c2c3d1d64408f1f9","version":"61abc07d755095a68f4987d1c2c3d1d64408f1f9"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -30,14 +30,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -64,8 +66,7 @@
 
 name: "Markdown Linter"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   schedule:
   - cron: "0 14 * * 1-5"
   workflow_dispatch:
@@ -105,7 +106,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -170,11 +170,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -382,6 +377,7 @@ jobs:
       - super_linter
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       actions: read
       contents: read
@@ -871,7 +867,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -934,15 +943,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1090,6 +1101,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       issues: write
@@ -1247,7 +1259,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "markdown-linter"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1286,6 +1297,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1443,7 +1455,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1517,7 +1542,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1534,11 +1561,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1552,7 +1579,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1570,28 +1597,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: (!(github.event_name == 'schedule' && github.event.repository.fork))
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1631,6 +1660,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/markdown-linter.md
+++ b/.github/workflows/markdown-linter.md
@@ -5,14 +5,10 @@ description: >
   for violations found across the repository.
 
 on:
+  permissions: {}
   workflow_dispatch:
   schedule:
     - cron: "0 14 * * 1-5" # 2 PM UTC, weekdays only
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
 
 # Don't run scheduled triggers on forked repositories — forks lack the
 # secrets and context required, and scheduled runs would consume the
@@ -66,20 +62,6 @@ jobs:
           path: super-linter.log
           retention-days: 7
 
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
-
 permissions:
   contents: read
   actions: read
@@ -121,6 +103,38 @@ steps:
     with:
       name: super-linter-log
       path: /tmp/gh-aw/
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # Markdown Quality Report

--- a/.github/workflows/pr-malicious-scan.agent.lock.yml
+++ b/.github/workflows/pr-malicious-scan.agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"991e05d5ef56fe4d642836dd993118d96162ca346927ae545e230add11d1f40c","body_hash":"53ad20adab8620af32df10e5a37760ad5fa707956fafd017d08842ba95b07465","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_GITHUB_TOKEN_2","COPILOT_GITHUB_TOKEN_3","COPILOT_GITHUB_TOKEN_4","COPILOT_GITHUB_TOKEN_5","COPILOT_GITHUB_TOKEN_6","COPILOT_GITHUB_TOKEN_7","COPILOT_GITHUB_TOKEN_8","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"8aad20d150bbac5944a9f9d289da16a4b0d87c1e","version":"v4.36.2"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9ba1a14dfb3001d98d31eb7b0659e54738713b839e50223ad91b5846b2c0bc2c","body_hash":"312ef8e5ac993af34ea4c61c6af483c2ed6a130d95b998d113214818c754ce33","compiler_version":"v0.79.8","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.60"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/codeql-action/upload-sarif","sha":"8aad20d150bbac5944a9f9d289da16a4b0d87c1e","version":"v4.36.2"},{"repo":"github/gh-aw-actions/setup","sha":"c0338fef4749d08c21f8f975fb0e37efa17dda47","version":"v0.79.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 # This file was automatically generated by gh-aw (v0.79.8). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -30,14 +30,16 @@
 #     - shared/pat_pool.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
-#   - COPILOT_GITHUB_TOKEN_2
-#   - COPILOT_GITHUB_TOKEN_3
-#   - COPILOT_GITHUB_TOKEN_4
-#   - COPILOT_GITHUB_TOKEN_5
-#   - COPILOT_GITHUB_TOKEN_6
-#   - COPILOT_GITHUB_TOKEN_7
-#   - COPILOT_GITHUB_TOKEN_8
+#   - COPILOT_PAT_0
+#   - COPILOT_PAT_1
+#   - COPILOT_PAT_2
+#   - COPILOT_PAT_3
+#   - COPILOT_PAT_4
+#   - COPILOT_PAT_5
+#   - COPILOT_PAT_6
+#   - COPILOT_PAT_7
+#   - COPILOT_PAT_8
+#   - COPILOT_PAT_9
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -60,8 +62,7 @@
 
 name: "PR Malicious Code Scan"
 on:
-  # needs: # Needs processed as dependency in pre-activation job
-  # - pat_pool # Needs processed as dependency in pre-activation job
+  # permissions: {} # Permissions applied to pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -102,7 +103,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
@@ -167,11 +167,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
             await main();
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -369,6 +364,7 @@ jobs:
       - pat_pool
     if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
       pull-requests: read
@@ -880,7 +876,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: agent
@@ -943,15 +952,17 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,COPILOT_GITHUB_TOKEN_2,COPILOT_GITHUB_TOKEN_3,COPILOT_GITHUB_TOKEN_4,COPILOT_GITHUB_TOKEN_5,COPILOT_GITHUB_TOKEN_6,COPILOT_GITHUB_TOKEN_7,COPILOT_GITHUB_TOKEN_8,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          SECRET_COPILOT_GITHUB_TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          SECRET_COPILOT_GITHUB_TOKEN_3: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          SECRET_COPILOT_GITHUB_TOKEN_4: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          SECRET_COPILOT_GITHUB_TOKEN_5: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          SECRET_COPILOT_GITHUB_TOKEN_6: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          SECRET_COPILOT_GITHUB_TOKEN_7: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          SECRET_COPILOT_GITHUB_TOKEN_8: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          GH_AW_SECRET_NAMES: 'COPILOT_PAT_0,COPILOT_PAT_1,COPILOT_PAT_2,COPILOT_PAT_3,COPILOT_PAT_4,COPILOT_PAT_5,COPILOT_PAT_6,COPILOT_PAT_7,COPILOT_PAT_8,COPILOT_PAT_9,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          SECRET_COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          SECRET_COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          SECRET_COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          SECRET_COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          SECRET_COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          SECRET_COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          SECRET_COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          SECRET_COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          SECRET_COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1082,6 +1093,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1242,7 +1254,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "pr-malicious-scan.agent"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens || '' }}
           GH_AW_AI_CREDITS_RATE_LIMIT_ERROR: ${{ needs.agent.outputs.ai_credits_rate_limit_error || 'false' }}
@@ -1280,6 +1291,7 @@ jobs:
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
+    environment: copilot-pat-pool
     permissions:
       contents: read
     outputs:
@@ -1437,7 +1449,20 @@ jobs:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
-          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
+          COPILOT_GITHUB_TOKEN: |
+            ${{ case(
+              needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+              needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+              needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+              needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+              needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+              needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+              needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+              needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+              needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+              needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+              'NO COPILOT PAT AVAILABLE')
+            }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_MAX_TURNS: ${{ vars.GH_AW_DEFAULT_MAX_TURNS || '' }}
           GH_AW_PHASE: detection
@@ -1511,7 +1536,9 @@ jobs:
             }
 
   pat_pool:
+    needs: pre_activation
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
     steps:
@@ -1528,11 +1555,11 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -1546,7 +1573,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -1564,28 +1591,30 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          COPILOT_PAT_0: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_PAT_1: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
-          COPILOT_PAT_2: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
-          COPILOT_PAT_3: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
-          COPILOT_PAT_4: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
-          COPILOT_PAT_5: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
-          COPILOT_PAT_6: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
-          COPILOT_PAT_7: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
 
   pre_activation:
-    needs: pat_pool
     if: (!github.event.repository.fork)
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1625,6 +1654,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       contents: read
       discussions: write
@@ -1735,6 +1765,7 @@ jobs:
     needs: safe_outputs
     if: needs.safe_outputs.outputs.sarif_file != ''
     runs-on: ubuntu-slim
+    environment: copilot-pat-pool
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr-malicious-scan.agent.md
+++ b/.github/workflows/pr-malicious-scan.agent.md
@@ -7,6 +7,7 @@ description: >
   code, never checks out the head with write tokens.
 
 on:
+  permissions: {}
   # Dispatched exclusively by .github/workflows/pr-triage-batch.yml.
   # The orchestrator owns dedup (one scan per head SHA via a pre-dispatch
   # marker comment), so this workflow is intentionally NOT triggered by
@@ -17,11 +18,6 @@ on:
         description: "PR number to scan"
         required: true
 
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs (which consume it in
-  # engine.env). See: shared/pat_pool.README.md.
-  needs: [pat_pool]
-
 # Skip on forks (no secrets, no point). Drafts are filtered out by the
 # orchestrator before dispatch.
 if: ${{ (!github.event.repository.fork) }}
@@ -29,20 +25,6 @@ if: ${{ (!github.event.repository.fork) }}
 concurrency:
   group: gh-aw-${{ github.workflow }}-${{ inputs.pr_number }}
   cancel-in-progress: true
-
-# ###############################################################
-# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
-# When org-level billing is available, this will be removed.
-# See `shared/pat_pool.README.md` for more information.
-# ###############################################################
-imports:
-  - shared/pat_pool.md
-
-engine:
-  id: copilot
-  env:
-    # If none of the COPILOT_GITHUB_TOKEN[_#] pool secrets were selected, the default COPILOT_GITHUB_TOKEN is used.
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8, secrets.COPILOT_GITHUB_TOKEN) }}
 
 permissions:
   contents: read
@@ -92,6 +74,38 @@ network:
     - defaults
 
 timeout-minutes: 10
+
+# ###############################################################
+# Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
+# When org-level billing is available, this will be removed.
+# See `shared/pat_pool.README.md` for more information.
+# ###############################################################
+imports:
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
+
+engine:
+  id: copilot
+  env:
+    COPILOT_GITHUB_TOKEN: |
+      ${{ case(
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
+      }}
 ---
 
 # PR Malicious Code Scan

--- a/.github/workflows/shared/pat_pool.README.md
+++ b/.github/workflows/shared/pat_pool.README.md
@@ -48,11 +48,11 @@ Team members providing PATs for workflows should set weekly recurring reminders 
 
 For a PAT pool that is specific to an environment, PATs can be added to repositories as **Environment Secrets** for the environment created above. _This requires repo admin permission_.
 
-* **Settings** >
-   * **Environments** >
-      * **copilot-pat-pool** (or other environment name) >
-         * **Add environment secret** (or edit your existing secret)
-            * Enter your secret name of `COPILOT_PAT_{0-9}` and paste in your PAT
+- **Settings** >
+   - **Environments** >
+      - **copilot-pat-pool** (or other environment name) >
+         - **Add environment secret** (or edit your existing secret)
+            - Enter your secret name of `COPILOT_PAT_{0-9}` and paste in your PAT
 
 This can also be accomplished using the `gh` CLI, specifying the repo and environment arguments.
 

--- a/.github/workflows/shared/pat_pool.README.md
+++ b/.github/workflows/shared/pat_pool.README.md
@@ -186,7 +186,7 @@ The `pat_pool` import integration requires that the workflow's compilation resul
 .github\workflows\<workflow-name>.md:1:1: error: failed to generate YAML: failed to build and validate jobs: job dependency validation failed: job 'pat_pool' depends on non-existent job 'pre_activation'
 ```
 
-To work around this, add `on.permissions: {}` to your workflow, which forces a no-op `pre_activation` job to be generated.
+To work around this, add `on.permissions: {}` (or another `on.*` setting that forces `pre_activation`, such as `skip-if-no-match`) to your workflow, which forces a no-op `pre_activation` job to be generated.
 
 ```yml
 on:

--- a/.github/workflows/shared/pat_pool.README.md
+++ b/.github/workflows/shared/pat_pool.README.md
@@ -2,7 +2,7 @@
 
 Selects a random Copilot PAT from a numbered pool of secrets. This addresses limitations that arise from having a single PAT shared across all agentic workflows, such as rate-limiting.
 
-**This is a stop-gap workaround.** As soon as organization/enterprise billing is offered for agentic workflows, this approach will be removed from our workflows.
+**This is a stop-gap workaround.** As soon as organization/enterprise billing is available to the dotnet org, this approach will be removed from our workflows.
 
 ## Repository Onboarding
 
@@ -19,9 +19,19 @@ gh extension install github/gh-aw --force
 gh aw --version
 ```
 
+### Environment
+
+Create an environment for the agentic workflows:
+  - _Configuring these settings requires repo admin permission_
+  - https://github.com/dotnet/{repo}/settings/environments
+  - Recommended Name: **copilot-pat-pool**
+  - Recommended Deployment branches and tags: **Protected branches only**
+
+This environment is used for all agentic workflows, restricting agentic workflows to the repo's protected branches and preventing the workflows from accessing secrets defined for other environments.
+
 ## PAT Management
 
-Team members provide PATs into the pool for the repository by adding them as repository secrets. In this repository the pool is backed by the `COPILOT_GITHUB_TOKEN` secret (pool slot `0`) and the numbered `COPILOT_GITHUB_TOKEN_2` through `COPILOT_GITHUB_TOKEN_8` secrets (pool slots `1` through `7`). The first slot reuses the default `COPILOT_GITHUB_TOKEN` so a single-PAT repository still works without any extra secrets.
+Team members provide PATs into the pool with secret names matching the pattern of `{pool-name}_{0-9}`, such as `COPILOT_PAT_0`.
 
 [Use this link to prefill the PAT creation form with the required settings][create-pat]:
 
@@ -32,12 +42,30 @@ Team members provide PATs into the pool for the repository by adding them as rep
 
 The **Token Name** _does not_ need to match the secret name and is only visible to the owner of the PAT. It's recommended to use a token name indicating the PAT is used for dotnet org agentic workflows. The **Description** is also only used for your own reference.
 
-Team members providing PATs for workflows should set weekly recurring reminders to regenerate and update their PATs in the repository secrets. With an 8-day expiration, renewal can be done on the same day each week.
+Team members providing PATs for workflows should set weekly recurring reminders to regenerate and update their PATs in the PAT pool. With an 8-day expiration, renewal can be done on the same day each week.
 
-PATs are added to repositories through the **Settings > Secrets and variables > Actions** UI, saved as **Repository secrets**. This can also be done using the GitHub CLI.
+## PAT Pool Secrets
+
+For a PAT pool that is specific to an environment, PATs can be added to repositories as **Environment Secrets** for the environment created above. _This requires repo admin permission_.
+
+* **Settings** >
+   * **Environments** >
+      * **copilot-pat-pool** (or other environment name) >
+         * **Add environment secret** (or edit your existing secret)
+            * Enter your secret name of `COPILOT_PAT_{0-9}` and paste in your PAT
+
+This can also be accomplished using the `gh` CLI, specifying the repo and environment arguments.
 
 ```sh
-gh aw secrets set "COPILOT_GITHUB_TOKEN_2" --value "<your-github-pat>" --repo <org>/<repo>
+# Register the PAT secret. This will prompt for you to paste the PAT.
+gh secret set "<pool_name>_<0-9>" --repo <org>/<repo> --env "copilot-pat-pool"
+```
+
+It's also helpful to record who owns each PAT within the pool. To capture which team member is associated with each PAT, a `<pool_name>_<0-9>_<username>` "sidecar secret" can be added alongside the PAT secret to make the username for the PAT pool entry visible. This sidecar secret must have a non-empty value, but it's never consumed, so any value is sufficient.
+
+```sh
+# Record a sidecar secret that presents who owns this PAT.
+gh secret set "<pool_name>_<0-9>_<username>" --body "<username>" --repo <org>/<repo> --env "copilot-pat-pool"
 ```
 
 ## Workflow Output Attribution
@@ -46,50 +74,55 @@ Team members' PATs are _only_ used for the Copilot requests from within the agen
 
 ## Usage
 
-The [`pat_pool.md`](./pat_pool.md) workflow import defines a custom job with a `pat_number` output. Consuming workflows need three additions to their frontmatter: declare `pat_pool` in `on.needs` so it runs before the activation gate, import the job, and use the PAT number to override the `COPILOT_GITHUB_TOKEN` passed to the workflow's agent job.
+The [`pat_pool.md`](./pat_pool.md) workflow import defines a custom job with a `pat_number` output. Consuming workflows need two additions to their frontmatter to import this job and use the PAT number to override the `COPILOT_GITHUB_TOKEN` passed to the workflow's agent job.
 
 ```yml
-on:
-  # ... your workflow's real triggers go here (schedule, issues, etc.) ...
-
-  # Run the imported pat_pool job before the activation gate so its pat_number
-  # output is available to the activation and agent jobs.
-  needs: [pat_pool]
-
 # ###############################################################
 # Select a PAT from the pool and override COPILOT_GITHUB_TOKEN.
+# Run agentic jobs in an isolated `copilot-pat-pool` environment.
+#
 # When org-level billing is available, this will be removed.
 # See `shared/pat_pool.README.md` for more information.
 # ###############################################################
 imports:
-  - shared/pat_pool.md
+  - uses: shared/pat_pool.md
+    with:
+      environment: copilot-pat-pool
+
+environment: copilot-pat-pool
 
 engine:
   id: copilot
   env:
     COPILOT_GITHUB_TOKEN: |
       ${{ case(
-        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_GITHUB_TOKEN,
-        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_GITHUB_TOKEN_2,
-        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_GITHUB_TOKEN_3,
-        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_GITHUB_TOKEN_4,
-        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_GITHUB_TOKEN_5,
-        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_GITHUB_TOKEN_6,
-        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_GITHUB_TOKEN_7,
-        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_GITHUB_TOKEN_8,
-        secrets.COPILOT_GITHUB_TOKEN)
+        needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0,
+        needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1,
+        needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2,
+        needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3,
+        needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4,
+        needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5,
+        needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6,
+        needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7,
+        needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8,
+        needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9,
+        'NO COPILOT PAT AVAILABLE')
       }}
 ```
 
-The expression can be collapsed onto a single line if desired. Declaring `on.needs: [pat_pool]` wires `pat_pool` as a dependency of the built-in `pre_activation` and `activation` jobs (in addition to the agent job, which the compiler wires automatically from the `needs.pat_pool.*` references in `engine.env`). This makes `pat_pool` run first, so the selected PAT is available both to the activation job's secret validation and to the agent's Copilot requests.
+The `COPILOT_GITHUB_TOKEN` expression can be collapsed onto a single line if desired. `gh-aw compile` automatically wires `pat_pool` into the activation and agent jobs' `needs:` graph because of the `needs.pat_pool.` references within the `engine.env` property.
 
 ```sh
-gh aw compile <workflow-name>
+gh aw compile <workflow-name> --schedule-seed <org>/<repo>
 ```
+
+### Specifying the environment
+
+The `environment` must be specified both to the `pat_pool.md` import and to the containing workflow to ensure both jobs access the PAT pool from the same environment. The `copilot-pat-pool` environment name is recommended as the isolated environment for agentic workflows that use the PAT pool.
 
 ### Customizing the pool
 
-The import declares 8 optional inputs (`COPILOT_PAT_0` through `COPILOT_PAT_7`), each defaulting to the matching repository secret (`COPILOT_GITHUB_TOKEN`, then `COPILOT_GITHUB_TOKEN_2` through `COPILOT_GITHUB_TOKEN_8`). To point a workflow at a different pool of repository secrets, use the parameterized `uses`/`with` form when importing and pass the substitute secrets as the `COPILOT_PAT_#` inputs:
+The import declares 10 optional inputs (`COPILOT_PAT_0` through `COPILOT_PAT_9`), each defaulting to `secrets.COPILOT_PAT_#` of the matching number. To point a workflow at a different pool of repository secrets, use the parameterized `uses`/`with` form when importing and pass the substitute secrets as the `COPILOT_PAT_#` inputs:
 
 ```yml
 imports:
@@ -97,7 +130,7 @@ imports:
     with:
       COPILOT_PAT_0: ${{ secrets.MY_TEAM_PAT_0 }}
       COPILOT_PAT_1: ${{ secrets.MY_TEAM_PAT_1 }}
-      # Unspecified inputs default to the repository's COPILOT_GITHUB_TOKEN[_#] secrets
+      # Unspecified inputs default to `secrets.COPILOT_PAT_#` lookups
 ```
 
 The secrets passed via `with:` must match the secrets referenced in the consuming workflow's `case` expression that overrides `COPILOT_GITHUB_TOKEN`--both sides need to agree on which secret backs each `COPILOT_PAT_#` slot. Update the `case` expression accordingly:
@@ -106,7 +139,7 @@ The secrets passed via `with:` must match the secrets referenced in the consumin
 engine:
   id: copilot
   env:
-    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.MY_TEAM_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.MY_TEAM_PAT_1, ..., secrets.COPILOT_GITHUB_TOKEN) }}
+    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.MY_TEAM_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.MY_TEAM_PAT_1, ..., 'NO COPILOT PAT AVAILABLE') }}
 ```
 
 This approach aligns with GitHub's documented guidance for [passing secrets][passing-secrets] between workflows, where the `pat_pool` job returns a PAT number and the `case` statement acts as a secret store to look the PAT secret up based on the selected number.
@@ -117,38 +150,48 @@ There are several details of this implementation that keep our workflows and rep
 
 1. **Secrets adhere to existing trust boundaries.** The pool of PAT secrets is
    provided to a dedicated step within the `pat_pool` job. That job runs
-   before the activation gate and contains only the trusted token-selection
-   step--no untrusted context or input is within scope. The
-   `select-pat-number` step only references the secret values to determine
+   after `pre_activation` and contains only the trusted checkout and action
+   steps--no untrusted context or input is within scope. The
+   `select-pat-number` action only references the secret values to determine
    which are non-empty, filtering the secret numbers to those with values.
 1. **The `pat_pool` job emits only a number, never a secret.** Its sole output,
-   `pat_number`, is the 0-7 index of the selected PAT (or empty when the pool
+   `pat_number`, is the 0-9 index of the selected PAT (or empty when the pool
    is empty). The actual secret materializes only later, in the activation
    job's `engine.env` mapping, where the `case()` expression resolves the
    number to the matching secret. This follows GitHub's guidance for
    [passing secrets][passing-secrets] between jobs or workflows, with the
    `case` statement acting as a very simple secret store.
-1. **The `select-pat-number` step does not require any permissions.** It
+1. **The `select-pat-number` action does not require any permissions.** It
    reads only the `COPILOT_PAT_#` environment variables passed to it and writes
    only to `GITHUB_OUTPUT`. The job that hosts it sets `permissions:` to the
    workflow defaults (no elevated scopes).
 1. **The implementation uses supported Agentic Workflow extensibility hooks.**
    Defining a custom job inside an [imported workflow file][imports] is
-   supported by `gh aw compile`. Declaring `pat_pool` in the consuming
-   workflow's `on.needs` wires it ahead of the built-in `pre_activation` and
-   `activation` jobs. The
+   supported by `gh aw compile`. gh-aw automatically
+   wires `pat_pool` into the activation job's `needs:` graph based on the
+   `needs.pat_pool.outputs.pat_number` references in `engine.env`. The
    [secret override][secret-override] capability supplies the `COPILOT_GITHUB_TOKEN`
    value via `engine.env` rather than the default secret of the same name.
 
 Each of the references below contributed to the design and implementation to ensure a secure and reliable design.
 
-## Design Note: `on.needs` vs. `engine.env`-only wiring
+## Known Issues
 
-`gh aw compile` will attach `pat_pool` to the agent job automatically from the `needs.pat_pool.*` references in `engine.env`, but it attaches it _after_ the activation job (as `needs: activation`). That ordering is wrong for the PAT pool: the activation job's secret-validation step also reads the `engine.env` `COPILOT_GITHUB_TOKEN`, and with `pat_pool` running afterwards it would see an empty `pat_number` and validate the default token instead of the selected one.
+The `pat_pool` import integration requires that the workflow's compilation results in a `pre_activation` job. If nothing in your workflow definition produces a `pre_activation` job, a compilation error will be received.
 
-Declaring `on.needs: [pat_pool]` fixes the ordering by wiring `pat_pool` as a dependency of the built-in `pre_activation` and `activation` jobs, so `pat_pool` runs first. This also makes the integration work for workflows that use `roles: all` (which otherwise produce no `pre_activation` job at all).
+```text
+✗ Failed workflows:
+  ✗ <workflow-name>.md
 
-The `pat_pool` job intentionally declares no `needs:` of its own, so it can be pulled in front of `pre_activation` by `on.needs` without creating a dependency cycle.
+.github\workflows\<workflow-name>.md:1:1: error: failed to generate YAML: failed to build and validate jobs: job dependency validation failed: job 'pat_pool' depends on non-existent job 'pre_activation'
+```
+
+To work around this, add `on.permissions: {}` to your workflow, which forces a no-op `pre_activation` job to be generated.
+
+```yml
+on:
+  permissions: {}
+```
 
 See: [Activation 'needs' does not incorporate jobs in engine.env expressions (github/gh-aw#30790)](https://github.com/github/gh-aw/issues/30790)
 

--- a/.github/workflows/shared/pat_pool.md
+++ b/.github/workflows/shared/pat_pool.md
@@ -3,6 +3,8 @@ description: Agentic workflow import to integrate the Copilot PAT Pool
 
 jobs:
   pat_pool:
+    environment: ${{ github.aw.import-inputs.environment }}
+    needs: [pre_activation]
     runs-on: ubuntu-slim
     outputs:
       pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
@@ -18,14 +20,16 @@ jobs:
           COPILOT_PAT_5: ${{ github.aw.import-inputs.COPILOT_PAT_5 }}
           COPILOT_PAT_6: ${{ github.aw.import-inputs.COPILOT_PAT_6 }}
           COPILOT_PAT_7: ${{ github.aw.import-inputs.COPILOT_PAT_7 }}
-          RANDOM_SEED: ${{ github.aw.import-inputs.random_seed }}
+          COPILOT_PAT_8: ${{ github.aw.import-inputs.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ github.aw.import-inputs.COPILOT_PAT_9 }}
+          RANDOM_SEED:   ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_7.
+          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
           PAT_NUMBERS=()
-          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
 
-          for i in $(seq 0 7); do
+          for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
@@ -39,7 +43,7 @@ jobs:
           # using COPILOT_GITHUB_TOKEN.
           if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
-            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_7)"
+            warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
           fi
@@ -57,46 +61,57 @@ jobs:
           echo "Selected PAT number ${PAT_NUMBER} (index: ${PAT_INDEX})"
 
           # Emit a markdown table of the pool entries to the step summary
-          echo "|0|1|2|3|4|5|6|7|" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
           (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
 
           # Set the PAT number as the output
           echo "copilot_pat_number=${PAT_NUMBER}" >> "$GITHUB_OUTPUT"
 
 import-schema:
+  environment:
+    type: string
+    required: true
   COPILOT_PAT_0:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    default: ${{ secrets.COPILOT_PAT_0 }}
   COPILOT_PAT_1:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
+    default: ${{ secrets.COPILOT_PAT_1 }}
   COPILOT_PAT_2:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
+    default: ${{ secrets.COPILOT_PAT_2 }}
   COPILOT_PAT_3:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
+    default: ${{ secrets.COPILOT_PAT_3 }}
   COPILOT_PAT_4:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
+    default: ${{ secrets.COPILOT_PAT_4 }}
   COPILOT_PAT_5:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
+    default: ${{ secrets.COPILOT_PAT_5 }}
   COPILOT_PAT_6:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
+    default: ${{ secrets.COPILOT_PAT_6 }}
   COPILOT_PAT_7:
     type: string
     required: false
-    default: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+    default: ${{ secrets.COPILOT_PAT_7 }}
+  COPILOT_PAT_8:
+    type: string
+    required: false
+    default: ${{ secrets.COPILOT_PAT_8 }}
+  COPILOT_PAT_9:
+    type: string
+    required: false
+    default: ${{ secrets.COPILOT_PAT_9 }}
   random_seed:
     type: number
     required: false

--- a/.github/workflows/validate-pat-pool.yml
+++ b/.github/workflows/validate-pat-pool.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   validate:
+    environment: copilot-pat-pool
     name: Validate Copilot PAT Pool
     if: ${{ github.event_name == 'workflow_dispatch' || !github.event.repository.fork }}
     runs-on: ubuntu-latest
@@ -22,96 +23,114 @@ jobs:
         else echo "status=invalid" >> "$GITHUB_OUTPUT"; fi
     steps:
       - name: Setup gh-aw scripts
-        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
+        uses: github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
 
       - name: Install Copilot CLI
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.55
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.21
 
       # -----------------------------------------------------------
-      # Make a Copilot CLI request with each PAT in the pool.
+      # Make a Copilot CLI request with each PAT.
       # Each step sets COPILOT_GITHUB_TOKEN directly from the secret
       # via env: so the value never passes through shell variables.
-      # The pool maps slot 0 -> COPILOT_GITHUB_TOKEN and slots 1-7 ->
-      # COPILOT_GITHUB_TOKEN_2 .. COPILOT_GITHUB_TOKEN_8.
       # -----------------------------------------------------------
 
-      - name: Validate COPILOT_GITHUB_TOKEN
+      - name: Validate COPILOT_PAT_0
         id: pat0
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_2
+      - name: Validate COPILOT_PAT_1
         id: pat1
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_1 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_3
+      - name: Validate COPILOT_PAT_2
         id: pat2
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_3 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_2 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_4
+      - name: Validate COPILOT_PAT_3
         id: pat3
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_4 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_3 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_5
+      - name: Validate COPILOT_PAT_4
         id: pat4
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_5 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_4 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_6
+      - name: Validate COPILOT_PAT_5
         id: pat5
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_6 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_5 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_7
+      - name: Validate COPILOT_PAT_6
         id: pat6
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_7 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_6 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
           eval "$VALIDATE_PAT"
 
-      - name: Validate COPILOT_GITHUB_TOKEN_8
+      - name: Validate COPILOT_PAT_7
         id: pat7
         continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN_8 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_7 }}
+        shell: bash
+        run: |
+          # copilot --prompt "Say OK"
+          eval "$VALIDATE_PAT"
+
+      - name: Validate COPILOT_PAT_8
+        id: pat8
+        continue-on-error: true
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_8 }}
+        shell: bash
+        run: |
+          # copilot --prompt "Say OK"
+          eval "$VALIDATE_PAT"
+
+      - name: Validate COPILOT_PAT_9
+        id: pat9
+        continue-on-error: true
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_9 }}
         shell: bash
         run: |
           # copilot --prompt "Say OK"
@@ -132,11 +151,12 @@ jobs:
           S5: ${{ steps.pat5.outputs.status }}
           S6: ${{ steps.pat6.outputs.status }}
           S7: ${{ steps.pat7.outputs.status }}
+          S8: ${{ steps.pat8.outputs.status }}
+          S9: ${{ steps.pat9.outputs.status }}
         shell: bash
         run: |
           # Build summary
-          statuses=("$S0" "$S1" "$S2" "$S3" "$S4" "$S5" "$S6" "$S7")
-          names=("COPILOT_GITHUB_TOKEN" "COPILOT_GITHUB_TOKEN_2" "COPILOT_GITHUB_TOKEN_3" "COPILOT_GITHUB_TOKEN_4" "COPILOT_GITHUB_TOKEN_5" "COPILOT_GITHUB_TOKEN_6" "COPILOT_GITHUB_TOKEN_7" "COPILOT_GITHUB_TOKEN_8")
+          statuses=("$S0" "$S1" "$S2" "$S3" "$S4" "$S5" "$S6" "$S7" "$S8" "$S9")
 
           valid=0; empty=0; invalid=0; unknown=0
           for s in "${statuses[@]}"; do
@@ -179,14 +199,14 @@ jobs:
             echo "| PAT Secret | Status |"
             echo "|:-----------|:-------|"
 
-            for i in $(seq 0 7); do
+            for i in $(seq 0 9); do
               case "${statuses[$i]}" in
                 valid)   symbol="☑️ Valid" ;;
                 empty)   symbol="⏹️ Empty" ;;
                 invalid) symbol="❌ Invalid" ;;
                 *)       symbol="❓ Unknown" ;;
               esac
-              echo "| \`${names[$i]}\` | ${symbol} |"
+              echo "| \`COPILOT_PAT_${i}\` | ${symbol} |"
             done
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/validate-pat-pool.yml
+++ b/.github/workflows/validate-pat-pool.yml
@@ -23,12 +23,12 @@ jobs:
         else echo "status=invalid" >> "$GITHUB_OUTPUT"; fi
     steps:
       - name: Setup gh-aw scripts
-        uses: github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
 
       - name: Install Copilot CLI
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.21
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.60
 
       # -----------------------------------------------------------
       # Make a Copilot CLI request with each PAT.


### PR DESCRIPTION
- Updates the PAT pool shared workflow to latest version
- Updates the validate-pat-pool workflow to match other repos
- Updates all agentic workflows to use the updated PAT pool import with the standard secret names used across other repos
- The new version of the import does not require the 'needs' workaround but the issue-triage workflow's 'roles: all' configuration requires a different workaround to ensure the pre_activation job exists for the pat_pool job to be able to depend on it (necessary for ordering).