### PR TITLE
Port dotnet-blazor evals to Vally format

### DIFF
--- a/.vally.yaml
+++ b/.vally.yaml
@@ -28,6 +28,11 @@ suites:
     evals:
       - "tests/dotnet-aspnetcore/*/eval.vally.yaml"
 
+  dotnet-blazor:
+    description: Blazor evals
+    evals:
+      - "tests/dotnet-blazor/*/eval.vally.yaml"
+
   dotnet-data:
     description: Data/EF Core evals
     evals:

--- a/tests/dotnet-blazor/author-component/eval.vally.yaml
+++ b/tests/dotnet-blazor/author-component/eval.vally.yaml
@@ -1,0 +1,246 @@
+name: author-component
+description: Evaluates the dotnet-blazor/author-component skill
+type: capability
+config:
+  timeout: 3m
+stimuli:
+  - name: Author a data-loading search component
+    prompt: |
+      Write a Blazor component called ProductSearch that will be used on a catalog browsing page. Here are the service contracts the application already registers in DI:
+
+      ```csharp
+      public record Product(int Id, string Name, decimal Price, string ImageUrl);
+
+      public interface IProductService
+      {
+          /// <summary>
+          /// Searches products by query string. Throws on network failure.
+          /// Respects the cancellation token — callers should cancel when results are no longer needed.
+          /// </summary>
+          Task<List<Product>> SearchAsync(string query, CancellationToken ct);
+      }
+      ```
+
+      The parent page will use the component like this:
+
+      ```razor
+      <ProductSearch OnProductSelected="HandleSelection" />
+      ```
+
+      The component should:
+      - Have a search text input. When the user stops typing for 300ms, search automatically
+      - Call IProductService.SearchAsync to fetch results
+      - Display each product as a card showing Name, Price, and ImageUrl
+      - Notify the parent when a card is clicked so it can navigate to the product detail page
+      - Handle all the states the component can be in (fetching, nothing found, failure, etc.)
+      - If the user types again while a search is in flight, the old search should be abandoned
+      - Clean up properly when the component is removed from the page
+    graders:
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-contains
+        config:
+          substring: CancellationToken
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (@if|@else)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - 'Handles all visual states: loading, empty, error, and loaded — no missing branches'
+      - Uses EventCallback<Product> for product selection notification to the parent
+      - Cancels the previous CancellationTokenSource when a new search starts
+      - Implements IAsyncDisposable and cancels/disposes resources in DisposeAsync
+      - Uses a private field for mutable state — does not mutate [Parameter] properties
+      - Debounces search input with Task.Delay + CancellationTokenSource
+  - name: Author a multi-step wizard with async validation and shared state
+    prompt: |
+      Author a set of Blazor components for a checkout wizard with async validation.
+      Here are the models and service:
+
+      ```csharp
+      public class ShippingInfo
+      {
+          public string Name { get; set; } = "";
+          public string Address { get; set; } = "";
+          public string City { get; set; } = "";
+          public string ZipCode { get; set; } = "";
+      }
+
+      public class PaymentInfo
+      {
+          public string CardNumber { get; set; } = "";
+          public string ExpiryDate { get; set; } = "";
+      }
+
+      public class Order
+      {
+          public ShippingInfo Shipping { get; set; } = new();
+          public PaymentInfo Payment { get; set; } = new();
+      }
+
+      public interface IAddressValidator
+      {
+          Task<bool> ValidateAddressAsync(string address, string city, string zip, CancellationToken ct);
+      }
+      ```
+
+      Write the .razor component code for:
+      1. CheckoutWizard.razor — manages which step is active and holds the order state.
+         When "Place Order" is clicked, the parent of CheckoutWizard receives the completed order.
+      2. ShippingStep.razor — collects shipping address fields. When "Next" is clicked,
+         validates the address asynchronously using IAddressValidator. While validating,
+         show a loading indicator and disable the button. If the user goes back and
+         changes fields then clicks Next again, cancel the previous validation.
+      3. PaymentStep.razor — collects payment info, has "Back" and "Place Order" buttons.
+
+      The wizard must handle disposal correctly — if the user navigates away mid-validation,
+      the pending async operation should be cancelled cleanly.
+    graders:
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: CancellationToken
+      - type: output-matches
+        config:
+          pattern: (CheckoutWizard|ShippingStep|PaymentStep)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Parent (CheckoutWizard) owns the order state and passes data to children via [Parameter]
+      - Children communicate back to the parent through EventCallback
+      - Steps are separate component files, not inline blocks in the parent
+      - ShippingStep cancels the previous validation when a new one starts — uses CancellationTokenSource that is replaced on each attempt
+      - Implements IAsyncDisposable and cancels the CTS in DisposeAsync — pending validations are cancelled when navigating away
+      - Parameters are public auto-properties with { get; set; }
+  - name: Author a generic data table component
+    prompt: |
+      Write a generic Blazor component called DataTable that works with any item type.
+      The parent should be able to customize how headers and rows are rendered by passing
+      in their own templates. Here's an example of how a consumer would use it:
+
+      ```razor
+      <DataTable Items="@people" OnRowClick="HandleRowClick">
+          <HeaderTemplate>
+              <th>Name</th>
+              <th>Email</th>
+          </HeaderTemplate>
+          <RowTemplate>
+              <td>@context.Name</td>
+              <td>@context.Email</td>
+          </RowTemplate>
+      </DataTable>
+      ```
+
+      When there are no items, it should show a sensible default empty state, but the
+      consumer should be able to override that too.
+    graders:
+      - type: output-contains
+        config:
+          substring: '@typeparam'
+      - type: output-matches
+        config:
+          pattern: RenderFragment
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses @typeparam to make the component generic
+      - RowTemplate is RenderFragment<TItem> — not RenderFragment or a delegate
+      - HeaderTemplate and EmptyTemplate are RenderFragment (non-generic)
+      - Uses @key on repeated row elements for efficient diffing in loops
+      - Handles the empty state with a default message and an optional override template
+      - Uses EventCallback<TItem> for OnRowClick
+      - Items parameter is IReadOnlyList<TItem> or List<TItem>
+  - name: Author a real-time notification badge component
+    prompt: |
+      Write a Blazor component called NotificationBadge. Here are the service contracts:
+
+      ```csharp
+      public record Notification(int Id, string Title, DateTime ReceivedAt);
+
+      public interface INotificationService
+      {
+          event Action<Notification> OnNotificationReceived;
+          Task<int> GetUnreadCountAsync();
+      }
+      ```
+
+      The component should:
+      - Show a badge with the current unread count
+      - Update the count in real time when OnNotificationReceived fires
+      - Also poll GetUnreadCountAsync every 30 seconds as a fallback
+      - When clicked, the parent needs to know so it can open a notification panel
+      - Clean up everything when the component is removed
+    graders:
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-contains
+        config:
+          substring: DisposeAsync
+      - type: output-contains
+        config:
+          substring: InvokeAsync
+      - type: output-matches
+        config:
+          pattern: (\+=|OnNotificationReceived)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Implements IAsyncDisposable and unsubscribes from the event in DisposeAsync
+      - Subscribes to the event in OnInitialized and unsubscribes in DisposeAsync with -=
+      - Uses InvokeAsync to marshal the event callback onto the Blazor sync context before calling StateHasChanged
+      - Cancels CTS in DisposeAsync to stop polling
+      - Event handler properly dispatches exceptions to the renderer
+      - Polls using Task.Delay in a loop or PeriodicTimer
+  - name: Author a sortable list with code-behind pattern
+    prompt: |
+      Write a Blazor component called SortableList using the code-behind pattern
+      (SortableList.razor + SortableList.razor.cs). It should work with any item type.
+
+      Here's an example of how a consumer would use it:
+
+      ```razor
+      <SortableList Items="@tasks" OnOrderChanged="HandleReorder">
+          <ItemTemplate>
+              <span>@context.Title</span>
+          </ItemTemplate>
+      </SortableList>
+      ```
+
+      Each item should have "Move Up" and "Move Down" buttons. After each reorder,
+      the parent needs the updated list. The component must not modify the list
+      that was passed in — it should work on its own internal copy.
+    graders:
+      - type: output-contains
+        config:
+          substring: partial class
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (private|_items|localItems|internalItems)
+      - type: output-matches
+        config:
+          pattern: RenderFragment
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - 'Uses the code-behind pattern: .razor file for markup, .razor.cs for logic with partial class'
+      - Does NOT mutate the [Parameter] Items property — copies to a private field
+      - Copies Items to a local field in OnParametersSet
+      - Uses @key in the loop for efficient diffing
+      - Uses EventCallback to notify the parent of reorder

--- a/tests/dotnet-blazor/collect-user-input/eval.vally.yaml
+++ b/tests/dotnet-blazor/collect-user-input/eval.vally.yaml
@@ -1,0 +1,115 @@
+name: collect-user-input
+description: Evaluates the dotnet-blazor/collect-user-input skill
+type: capability
+config:
+  timeout: 15m
+stimuli:
+  - name: Event registration with custom validation
+    prompt: |
+      I have an existing Blazor Web App with Interactive Server (per-page).
+
+      I need an interactive /register page for event registration:
+      - Attendee name (required)
+      - Email (required, valid email)
+      - Number of guests (0-5)
+      - Preferred session (Morning, Afternoon, Evening)
+      - Special dietary requirements (free text, optional)
+
+      Here's the catch: after the user fills everything in and clicks Register,
+      I need to check with the server whether that email is already registered
+      for this event. If it is, show an error message on the email field saying
+      "This email is already registered" — not a generic error, but a field-specific
+      error that appears right next to the email input. The user should be able to
+      change the email and try again.
+
+      Create a RegistrationService with a stub ValidateAsync method that returns
+      field-specific errors (simulate the email already being registered for a
+      hardcoded test email like "taken@example.com").
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --no-https --force
+    graders:
+      - type: file-exists
+        config:
+          path: '**/Register.razor'
+      - type: file-contains
+        config:
+          path: '**/Register.razor'
+          value: EditForm
+      - type: file-contains
+        config:
+          path: '**/Register.razor'
+          value: ValidationMessage
+      - type: file-contains
+        config:
+          path: '**/Register.razor'
+          value: DataAnnotationsValidator
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses a custom validator component (or ValidationMessageStore directly) to display server-returned field-specific errors — the email duplicate error appears next to the email field via ValidationMessage, not as a generic message
+      - Model uses data annotation attributes for basic validation (Required, EmailAddress, Range) with DataAnnotationsValidator
+      - Submit handler calls the registration service, checks for server-returned errors, and displays them on the correct fields without losing the user's input
+      - The form lets the user correct the email and resubmit — errors clear when the field changes
+      - Uses InputText, InputNumber, InputSelect or InputRadioGroup for the respective fields
+  - name: Multi-step booking form with cross-field validation
+    prompt: |
+      I have a Blazor Web App with per-page interactivity (Server mode).
+
+      I need a /book-appointment page for scheduling medical appointments.
+      The form has two steps on the same page (not separate routes):
+
+      STEP 1 (always visible):
+      - Patient name (required)
+      - Email (required, valid format)
+      - Phone (required)
+      - Insurance provider (dropdown: Aetna, BlueCross, Cigna, UnitedHealth, None)
+
+      STEP 2 (appears after step 1 validation passes):
+      - Preferred doctor (dropdown: loaded from an AppointmentService)
+      - Date (required, must be in the future)
+      - Time slot (dropdown: available slots from AppointmentService based on doctor + date)
+      - Reason for visit (required, max 500 chars)
+
+      When the user clicks "Check Availability" between steps, call
+      AppointmentService.ValidatePatientAsync which checks server-side rules:
+      - If the email belongs to a patient with an outstanding balance, return
+        an error on the Email field: "Account has outstanding balance"
+      - If the insurance provider is "None" and the selected doctor doesn't
+        accept self-pay, return an error on the Doctor field: "Selected doctor
+        does not accept self-pay patients"
+      - If the selected time slot was just taken (race condition), return an
+        error on the TimeSlot field: "This slot is no longer available"
+
+      These server errors must appear next to the specific fields — not as
+      a generic error banner. The user should be able to correct the field
+      and try again without losing other form data.
+
+      Create stub AppointmentService that simulates these validations:
+      reject "taken@example.com" for balance, reject "None" insurance
+      with doctor "Dr. Smith", and reject timeslot "10:00 AM" as taken.
+
+      Make this page interactive with @rendermode InteractiveServer.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --no-https --force
+    graders:
+      - type: file-exists
+        config:
+          path: '**/BookAppointment.razor'
+      - type: file-contains
+        config:
+          path: '**/BookAppointment.razor'
+          value: EditForm
+      - type: file-contains
+        config:
+          path: '**/BookAppointment.razor'
+          value: ValidationMessage
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Server-returned errors appear next to the specific field via ValidationMessage — uses ValidationMessageStore or equivalent to add field-level errors from the service response, not manual conditional divs
+      - After server validation failure, the user can change the flagged field and resubmit — errors clear on the relevant field without losing other form data
+      - Uses data annotation attributes for client-side validation (Required, EmailAddress, MaxLength, custom date validator) with DataAnnotationsValidator
+      - Multi-step progression — step 2 fields only appear after step 1 validates successfully, providing progressive disclosure
+      - Time slots load dynamically based on doctor and date selection — cascading dropdown behavior within the form

--- a/tests/dotnet-blazor/configure-auth/eval.vally.yaml
+++ b/tests/dotnet-blazor/configure-auth/eval.vally.yaml
@@ -1,0 +1,107 @@
+name: configure-auth
+description: Evaluates the dotnet-blazor/configure-auth skill
+type: capability
+config:
+  timeout: 20m
+stimuli:
+  - name: Login and account management in a globally interactive app
+    prompt: |
+      I have a Blazor Web App with Interactive Server mode applied globally
+      (all pages are interactive by default).
+
+      I need to add ASP.NET Core Identity-based authentication. Here's where
+      I'm stuck:
+
+      1. I need a /account/login page with email/password that calls
+         SignInManager.PasswordSignInAsync. But when I try to use SignInManager
+         in my interactive page, I get an error about HttpContext not being
+         available. The whole app is globally interactive — how do I make
+         login work?
+
+      2. Same problem for /account/register using UserManager.CreateAsync —
+         it also needs HttpContext for cookie authentication.
+
+      3. After login, the user should be redirected to / (homepage). After
+         registration, redirect to login. Both pages need proper form
+         validation (required fields, email format).
+
+      4. I also need a /account/logout endpoint that signs out. But wait —
+         signing out also needs HttpContext... same problem again?
+
+      5. Add a "Logged in as {email} | Logout" display in the nav when
+         authenticated, and "Login | Register" links when not.
+
+      6. The rest of the app must stay fully interactive — I don't want to
+         lose global interactivity for my normal pages just because auth
+         pages have special needs.
+
+      Set up Identity services in Program.cs with an in-memory EF store.
+      I don't need user seeding — just the pages and plumbing.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --all-interactive --no-https --force
+    graders:
+      - type: file-contains
+        config:
+          path: '**/*ogin*'
+          value: ExcludeFromInteractiveRouting
+      - type: file-contains
+        config:
+          path: '**/App.razor'
+          value: AcceptsInteractiveRouting
+      - type: file-contains
+        config:
+          path: '**/*ogin*'
+          value: SignInManager
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Login and register pages use [ExcludeFromInteractiveRouting] to render as static SSR — explains that SignInManager and UserManager need HttpContext which is unavailable in interactive components
+      - App.razor conditionally applies the render mode using HttpContext.AcceptsInteractiveRouting() — returns null for excluded pages and InteractiveServer for everything else
+      - Identity services are registered in Program.cs (AddIdentity or AddIdentityCore with AddEntityFrameworkStores and AddSignInManager) and authentication middleware is added
+      - Logout is handled correctly (either a static page or a minimal API endpoint) — does not attempt HttpContext operations inside an interactive component
+      - Auth state is reflected in the UI — shows user info when logged in, login/register links when not
+  - name: Multi-tier app with WebAssembly auth
+    prompt: |
+      I have a Blazor Web App using Auto interactivity mode (per-page). Some
+      pages will run on Server, others on WebAssembly.
+
+      I need to add authentication that works across both render modes:
+
+      1. Create a custom AuthenticationStateProvider on the server that
+         simulates a logged-in user "bob@example.com" with roles "User" and
+         "Editor". No real database needed — just hardcode the claims.
+
+      2. A /profile page (interactive, any mode) that displays the authenticated
+         user's name and all their roles. It should work regardless of whether
+         it's currently running on Server or WebAssembly.
+
+      3. A /editor page (interactive, any mode) restricted to the "Editor" role.
+         Show an "Access denied" message for users without the role.
+
+      4. A /viewer page (interactive, any mode) accessible to any authenticated
+         user.
+
+      The key requirement: after the page initially loads and the WebAssembly
+      runtime takes over, the user's identity and roles must still be available.
+      I've heard that auth state can get lost when the client-side runtime
+      activates — make sure that doesn't happen.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity auto --no-https --force
+    graders:
+      - type: file-contains
+        config:
+          path: '**/Program.cs'
+          value: AddAuthenticationStateSerialization
+      - type: file-contains
+        config:
+          path: '**/*.razor'
+          value: '[Authorize'
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Server Program.cs calls AddAuthenticationStateSerialization so auth state is serialized into the prerendered HTML — without this the WebAssembly runtime starts with an anonymous user
+      - Client Program.cs calls AddAuthenticationStateDeserialization so the WASM runtime can reconstitute the auth state from the serialized data
+      - Profile page displays user name and roles that remain correct after WebAssembly takes over from prerendering — the auth state is not lost during the handoff
+      - Editor page enforces role-based access via [Authorize(Roles = ...)] or AuthorizeView with Roles — unauthorized users see a denied message, not the page content

--- a/tests/dotnet-blazor/coordinate-components/eval.vally.yaml
+++ b/tests/dotnet-blazor/coordinate-components/eval.vally.yaml
@@ -1,0 +1,118 @@
+name: coordinate-components
+description: Evaluates the dotnet-blazor/coordinate-components skill
+type: capability
+config:
+  timeout: 15m
+stimuli:
+  - name: Warehouse dashboard with site selector and live stock alerts
+    prompt: |
+      I have a Blazor Web App using per-page interactivity (InteractiveServer).
+
+      I need to coordinate shared state between components that are NOT in a
+      parent-child relationship. The scenario is a warehouse management page
+      where several unrelated components must stay synchronized through a
+      shared service — they can't pass parameters to each other directly.
+
+      1. A "current warehouse" dropdown that lives in the MainLayout. The
+         layout renders statically (no interactivity attribute). The dropdown
+         itself must be interactive so it can handle change events. Every
+         interactive component on every page should automatically know which
+         warehouse is currently selected without manually querying for it.
+         When the user switches warehouses, everything on the current page
+         should immediately update to reflect the new site.
+
+      2. A live low-stock alert count that checks for items below minimum
+         levels every 10 seconds. Create an InventoryAlertService with a
+         GetLowStockCountAsync(string warehouseId) method that simulates a
+         database query (return a random number between 0 and 15). The alert
+         count should appear as a badge in the sidebar navigation AND on the
+         main dashboard page. Polling should start when the dashboard is
+         visible and stop when the user leaves the page. The sidebar badge
+         should also refresh when new data arrives.
+
+      3. When polling detects new data, ALL components subscribed to alerts
+         should update — not just the one that triggered the poll. This means
+         you need a proper notification/event mechanism between components
+         that aren't in a parent-child relationship.
+
+      4. Multiple warehouse managers using the app simultaneously must each
+         see their own independent warehouse selection and alert counts.
+         One manager switching to "Warehouse B" must not affect another
+         manager viewing "Warehouse A".
+
+      Build the shared state service with change notification events, the
+      polling mechanism, a warehouse selector component, an alert badge
+      component, and a page that ties it all together.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --no-https --force
+    graders:
+      - type: file-contains
+        config:
+          path: '**/Program.cs'
+          value: AddScoped
+      - type: file-contains
+        config:
+          path: '**/*.razor'
+          value: InvokeAsync
+      - type: file-contains
+        config:
+          path: '**/*.razor'
+          value: IDisposable
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - The selected warehouse is available to all interactive page components without each one fetching it independently — shared state works despite the static layout boundary
+      - When the user picks a different warehouse, all subscribed components re-render with the new value without a full page reload
+      - Polling fires on a background timer, so the component marshals UI updates through InvokeAsync(StateHasChanged) — calling StateHasChanged directly from a non-Blazor thread would throw
+      - 'Each user''s state is isolated: state services use scoped lifetime (per circuit) — not singleton, which would leak one user''s selection to another'
+      - Polling is stopped and event subscriptions are removed when components are disposed — implements IDisposable or IAsyncDisposable and cleans up all resources
+      - Alert updates notify ALL subscribed components (sidebar badge AND dashboard) — multiple subscribers react to the same state change
+  - name: Multi-tenant notification hub with cross-component fan-out
+    prompt: |
+      I have a Blazor Web App with per-page Interactive Server mode (not global).
+      The MainLayout renders statically (no @rendermode attribute on it).
+
+      I need to build an app-wide theme system with these requirements:
+
+      1. A theme service that holds the current theme (Light/Dark/System) and
+         a user's preferred accent color (string). Any component on any page
+         should be able to read AND change these values.
+
+      2. When ANY component changes the theme (e.g., a toggle in the sidebar
+         on one page), all OTHER components consuming the theme must immediately
+         update — including components in the static layout area (like a theme
+         indicator in the header).
+
+      3. I also want a "user preferences" panel on a /settings page where the
+         user can change both theme and accent color. Saving here must update
+         the header theme indicator AND any themed components on any page.
+
+      4. Each user (circuit) must have independent theme state — one user
+         switching to dark mode must not affect another user.
+
+      5. When navigating between pages (enhanced nav), the theme choice must
+         persist without page reload.
+
+      What's the best pattern for sharing this state app-wide across all
+      pages and components, given the per-page interactivity setup?
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --no-https --force
+    graders:
+      - type: file-contains
+        config:
+          path: '**/Program.cs'
+          value: CascadingValue
+      - type: file-contains
+        config:
+          path: '**/Program.cs'
+          value: NotifyChangedAsync
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses CascadingValueSource<T> registered in DI (not <CascadingValue> in the layout) — explains this is required because CascadingValue in a static layout cannot reach interactive children
+      - Calls NotifyChangedAsync when the theme changes — without this call, subscribers don't re-render even though the value object was mutated
+      - Components consume the theme via [CascadingParameter] — same consumption pattern as CascadingValue but backed by DI-registered source
+      - State is isolated per user — the CascadingValueSource registration is scoped (or effectively per-circuit), not singleton
+      - Theme persists across enhanced navigations without page reload — the DI-registered source survives nav events within the same circuit

--- a/tests/dotnet-blazor/create-blazor-project/eval.vally.yaml
+++ b/tests/dotnet-blazor/create-blazor-project/eval.vally.yaml
@@ -1,0 +1,118 @@
+name: create-blazor-project
+description: Evaluates the dotnet-blazor/create-blazor-project skill
+type: capability
+config:
+  timeout: 20m
+stimuli:
+  - name: University course catalog with enrollment form
+    prompt: |
+      Create a Blazor Web App for a university course catalog.
+
+      Requirements:
+      - Browse departments and courses in a searchable, filterable list
+      - View course detail pages (description, schedule, credits, instructor bio)
+      - Students submit an enrollment request form (name, student ID, course selection) — standard HTML form, no wizards or real-time validation
+      - Homepage shows featured courses and department links
+      - No authentication — open to all students and visitors
+      - Hosted on the university intranet with fast, reliable connectivity
+    graders:
+      - type: output-contains
+        config:
+          substring: dotnet new blazor
+      - type: output-matches
+        config:
+          pattern: -int(eractivity)? None
+      - type: output-not-contains
+        config:
+          substring: blazorwasm
+      - type: output-not-contains
+        config:
+          substring: blazorserver
+      - type: output-matches
+        config:
+          pattern: (Static SSR|no.interactive|None.*interactivity)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Correct template and configuration — single-project structure (no .Client project), Program.cs calls AddRazorComponents() without any AddInteractive* chains, App.razor does NOT set @rendermode on Routes or HeadOutlet
+      - Recognizes that Static SSR uses standard HTML POST forms and enhanced navigation — no interactivity needed for a course catalog with enrollment
+      - Documents the static rendering choice — explains why the app uses no interactive render mode
+      - Plans the domain features — identifies the pages/components needed for browsing courses and submitting enrollments
+  - name: Recipe community with interactive ratings on static pages
+    prompt: |
+      Create a new Blazor Web App project for a recipe sharing community.
+      Run `dotnet new blazor` with the appropriate options, create the project structure,
+      and implement the pages.
+
+      Requirements:
+      - Browse recipes by category — read-only content pages
+      - Each recipe page has a star-rating widget (click to rate 1–5 stars)
+      - A "Submit Recipe" page with a form (title, ingredients, steps)
+      - Homepage displays recipe categories (static content)
+      - Most pages are read-only; only the rating widget and submit form need interactivity
+    graders:
+      - type: output-contains
+        config:
+          substring: dotnet new blazor
+      - type: output-matches
+        config:
+          pattern: -int(eractivity)? Server
+      - type: output-not-matches
+        config:
+          pattern: dotnet new blazor[^\n]*-ai
+      - type: output-not-contains
+        config:
+          substring: blazorwasm
+      - type: output-not-contains
+        config:
+          substring: blazorserver
+      - type: output-matches
+        config:
+          pattern: (per.page|per-page|opt.in)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Correct template and configuration — Program.cs registers AddInteractiveServerComponents() and AddInteractiveServerRenderMode(), App.razor does NOT set @rendermode on Routes so interactivity is per-page opt-in
+      - Static pages (browse, homepage, recipe content) remain SSR for performance while interactive components (rating widget, comments) opt in with @rendermode InteractiveServer
+      - Documents the per-page strategy — explains why most pages are static and only specific features opt in to interactivity
+      - Differentiates which features need interactivity (rating widget, form submission) vs which can be static (content browsing)
+  - name: Global logistics tracking for worldwide users
+    prompt: |
+      Create a Blazor Web App for a logistics company that tracks shipments.
+
+      Requirements:
+      - Dispatchers view a list of shipments with status and destination
+      - Customers check their shipment status and estimated delivery
+      - Users are worldwide — round-trip latency to a single server is noticeable
+      - The app must load fast on first visit, then feel snappy without server round-trips
+      - Every page involves interactive controls
+      - Staff and customers authenticate with individual accounts
+    graders:
+      - type: output-contains
+        config:
+          substring: dotnet new blazor
+      - type: output-matches
+        config:
+          pattern: -int(eractivity)? Auto
+      - type: output-matches
+        config:
+          pattern: (-ai|--all-interactive)
+      - type: output-not-contains
+        config:
+          substring: blazorwasm
+      - type: output-not-contains
+        config:
+          substring: blazorserver
+      - type: output-matches
+        config:
+          pattern: (-au|--auth) Individual
+      - type: output-matches
+        config:
+          pattern: (\.Client|Auto.*mode|dual.*execution)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Correct template and configuration — two-project structure with .Client project, Server Program.cs registers both AddInteractiveServerComponents() and AddInteractiveWebAssemblyComponents(), interactive components live in .Client
+      - Components cannot directly access server resources — all data through HTTP APIs, both server and client Program.cs register matching services, component code must not assume execution environment
+      - Documents the Auto mode trade-offs — explains why this rendering strategy suits the requirements
+      - Addresses the latency requirement — explains why Auto mode solves worldwide latency (Server first, then switches to WebAssembly for client-side speed)

--- a/tests/dotnet-blazor/fetch-and-send-data/eval.vally.yaml
+++ b/tests/dotnet-blazor/fetch-and-send-data/eval.vally.yaml
@@ -1,0 +1,131 @@
+name: fetch-and-send-data
+description: Evaluates the dotnet-blazor/fetch-and-send-data skill
+type: capability
+config:
+  timeout: 15m
+stimuli:
+  - name: Recipe browser with resilient data loading
+    prompt: |
+      I have a Blazor Web App with Interactive Server (per-page).
+
+      I need an interactive /recipes/{CuisineId:int} page that calls a
+      backend service to fetch and display recipe data for a given cuisine.
+      It also accepts a ?sort= query parameter (newest or popular) that only
+      controls display order.
+
+      Create a RecipeService with a GetByCuisineAsync(int cuisineId,
+      CancellationToken cancellationToken) method that simulates a slow API
+      call (Task.Delay(2000, cancellationToken)) and returns a list of
+      recipes (Id, Title, Description, PrepTimeMinutes). Seed data for 3
+      cuisines.
+
+      The data fetching should handle the full async lifecycle correctly —
+      here are the specific behaviors I need:
+
+      1. If the user picks a different cuisine while the current one is still
+         loading, stop loading the current cuisine and start loading the new one.
+         Changing only the sort parameter should not trigger a data reload.
+
+      2. The first time the page loads (no data yet), show a loading placeholder.
+         When navigating to a different cuisine after data is already on screen,
+         keep the existing recipes visible and show a small "Refreshing…" indicator.
+         When the new data arrives, swap it in and hide the indicator.
+
+      3. If something goes wrong — timeout, network error, whatever — show
+         the user a friendly message and a Retry button so they can try again.
+         If it's a timeout specifically, say so. Never show raw exception
+         details to the user — log errors properly through ILogger.
+
+      4. If the user navigates away from the page, all ongoing work should stop
+         immediately.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity server --no-https --force
+    graders:
+      - type: file-exists
+        config:
+          path: '**/Recipes.razor'
+      - type: file-contains
+        config:
+          path: '**/Recipes.razor'
+          value: CancellationTokenSource
+      - type: file-contains
+        config:
+          path: '**/Recipes.razor'
+          value: IAsyncDisposable
+      - type: file-contains
+        config:
+          path: '**/Recipes.razor'
+          value: ILogger
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses OnParametersSetAsync (not OnInitializedAsync) because the data depends on a route parameter that changes during navigation — guards with a tracked value to skip reloading when only the sort parameter changes
+      - Cancels the previous in-flight request when CuisineId changes by cancelling the existing CancellationTokenSource and creating a new one — the token is captured into a local variable BEFORE the await to avoid races with a replaced CTS
+      - On the first load (data is null), shows a loading placeholder. On subsequent loads (data already exists), keeps the existing data visible and shows an additional loading indicator — does NOT clear existing data on subsequent loads
+      - Catches external OperationCanceledException using 'when (!cancellationToken.IsCancellationRequested)' — this means a timeout or external cancellation that the component did NOT trigger. Self-initiated cancellation (parameter change, disposal) is NOT caught because ComponentBase silently swallows it
+      - Catches general Exception separately for non-cancellation errors — both catch blocks log via ILogger and set a user-facing error string that is a hardcoded generic message, NEVER exception.Message (PII risk)
+      - Shows a Retry button when an error is set, wired to the load method so the user can attempt the operation again
+      - Implements IAsyncDisposable that cancels and disposes the CancellationTokenSource — does NOT catch OperationCanceledException in DisposeAsync because ComponentBase handles self-cancellation automatically
+  - name: Real-time shipment tracker with Auto interactivity
+    prompt: |
+      I have a Blazor Web App using Auto interactivity mode (per-page). Pages
+      may run on Server first, then switch to WebAssembly.
+
+      I need an interactive /shipments/{TrackingNumber} page that tracks a
+      package.
+
+      Create a ShipmentService interface with:
+      - GetShipmentAsync(string trackingNumber, CancellationToken ct) — returns
+        shipment details (TrackingNumber, Status, Location, EstimatedDelivery,
+        and a list of StatusUpdate events with timestamps).
+
+      On the server side, implement a concrete ShipmentService that simulates a
+      slow backend (Task.Delay(1500, ct)) and returns fake data. Seed data for
+      3 tracking numbers.
+
+      Behaviors I need:
+
+      1. When the page loads, fetch the shipment details and display them. While
+         loading, show a loading placeholder with the tracking number.
+
+      2. The component should work correctly regardless of whether it's running
+         on Server or WebAssembly — the data access pattern must be the same in
+         both environments.
+
+      3. If the user navigates to a different tracking number while data is
+         loading, cancel the previous load and start fresh for the new tracking
+         number.
+
+      4. If something goes wrong — timeout, network error, anything — show the
+         user a friendly message and let them retry. If it's a timeout, say so.
+         Don't show raw exception details. Log errors through ILogger.
+
+      5. When the user leaves the page, all pending requests must stop
+         immediately.
+    environment:
+      commands:
+        - dotnet new blazor --interactivity auto --no-https --force
+    graders:
+      - type: file-exists
+        config:
+          path: '**/*.Client/**/*.razor'
+      - type: file-contains
+        config:
+          path: '**/*.Client/**/Program.cs'
+          value: HttpClient
+      - type: file-contains
+        config:
+          path: '**/*.razor'
+          value: CancellationTokenSource
+      - type: file-contains
+        config:
+          path: '**/*.razor'
+          value: IAsyncDisposable
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses OnParametersSetAsync because the route parameter changes during navigation — cancels previous in-flight requests when TrackingNumber changes
+      - Handles errors with user-facing messages and a retry mechanism — logs through ILogger and never displays exception.Message
+      - Implements IAsyncDisposable that cancels and disposes the CancellationTokenSource — stops all pending requests on disposal
+      - The data access pattern works regardless of execution environment — component depends on an abstraction, not a concrete server-only service

--- a/tests/dotnet-blazor/plan-ui-change/eval.vally.yaml
+++ b/tests/dotnet-blazor/plan-ui-change/eval.vally.yaml
@@ -1,0 +1,335 @@
+name: plan-ui-change
+description: Evaluates the dotnet-blazor/plan-ui-change skill
+type: capability
+config:
+  timeout: 40m
+stimuli:
+  - name: Project management Kanban board
+    prompt: |
+      Build a Blazor page for a project management Kanban board. This is a complex
+      multi-section layout. Here are the service contracts
+      already registered in DI:
+
+      ```csharp
+      public record TaskItem(int Id, string Title, string Assignee, string Priority, DateTime DueDate, string Status);
+
+      public interface ITaskService
+      {
+          Task<List<TaskItem>> GetAllTasksAsync();
+          Task<TaskItem> CreateTaskAsync(string title, string assignee, string priority, DateTime dueDate);
+          Task UpdateTaskStatusAsync(int taskId, string newStatus);
+      }
+      ```
+
+      The page should have:
+      - A summary stats bar at the top showing: total task count, count per column (To Do, In Progress, Done),
+        and a count of overdue tasks (DueDate < today)
+      - A search bar that filters visible tasks by title (client-side filtering)
+      - Three columns side by side: "To Do", "In Progress", "Done"
+      - Each column header shows the column name and the number of tasks in it
+      - Each column displays task cards showing: title, assignee name, a priority badge (High = red,
+        Medium = yellow, Low = green CSS class), and the due date formatted as "MMM dd"
+      - Each task card has "Move Left" and "Move Right" buttons to move the task to the adjacent column
+        (hide the button if there's no column in that direction). Moving a task calls UpdateTaskStatusAsync
+      - Each column has an "Add Task" button at the bottom. Clicking it reveals an inline form within that
+        column with inputs for title, assignee, priority (dropdown: High/Medium/Low), and due date.
+        A "Save" button calls CreateTaskAsync and a "Cancel" button hides the form
+      - The page loads all tasks on initialization and handles loading/error states
+
+      Route: `/board`
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (ITaskService|TaskItem)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - The board is organized into focused, reusable components — task cards, columns, and the stats bar are separate from the page itself
+      - State changes in child components propagate correctly to the parent and other siblings — e.g., moving a task updates the column counts
+      - Handles loading and error states with conditional rendering (@if/@else)
+  - name: E-commerce product catalog with filters and pagination
+    prompt: |
+      Build a Blazor page for browsing a product catalog. Here are the service contracts
+      already registered in DI:
+
+      ```csharp
+      public record Product(int Id, string Name, decimal Price, string Category, double Rating, bool InStock, string ImageUrl);
+      public record ProductFilter(List<string>? Categories, decimal? MinPrice, decimal? MaxPrice, bool InStockOnly);
+      public record PagedResult<T>(List<T> Items, int TotalCount, int Page, int PageSize);
+
+      public interface IProductService
+      {
+          Task<PagedResult<Product>> SearchAsync(ProductFilter filter, string sortBy, int page, int pageSize);
+          Task<List<string>> GetCategoriesAsync();
+      }
+      ```
+
+      The page layout should have:
+      - A left sidebar (about 25% width) with filter controls:
+        - Category checkboxes (loaded from GetCategoriesAsync)
+        - Min price and max price number inputs
+        - An "In Stock Only" checkbox toggle
+        - An "Apply Filters" button that triggers a new search
+        - A "Clear Filters" button that resets all filters to defaults
+      - A main content area (about 75% width) with:
+        - A toolbar row containing: a sort dropdown (options: "Price: Low to High", "Price: High to Low",
+          "Name: A-Z", "Rating: Highest"), and a "Showing X–Y of Z products" label
+        - A product grid displaying product cards, each showing: a placeholder image div with the product name
+          as alt text, the product name, the price formatted as currency, a star rating display (e.g., "★★★★☆"
+          for 4/5), an "Out of Stock" badge if not in stock, and an "Add to Cart" button (disabled when out of stock)
+        - When a product card is clicked (not the Add to Cart button), the parent should be notified via
+          EventCallback so it can navigate to a detail page
+        - Pagination controls at the bottom: "Previous" button (disabled on first page), numbered page buttons,
+          "Next" button (disabled on last page)
+      - The page loads the first page of products and the category list on initialization
+      - Handle loading, empty results, and error states
+
+      Route: `/catalog`
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (IProductService|ProductFilter|PagedResult)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - The catalog uses a multi-component architecture — product cards, filter sidebar, and pagination are separate reusable units
+      - Child components communicate changes back to the parent via defined interfaces — e.g., filter sidebar notifies the page when filters change, pagination notifies on page change
+      - Filtering, sorting, and pagination all work together — changing filters resets to page 1, changing sort re-fetches
+      - Handles loading, empty, and error states with conditional rendering
+  - name: Multi-step job application wizard
+    prompt: |
+      Build a Blazor page for a multi-step job application form. This has many
+      distinct visual sections and shared state. Here are the service contracts already registered in DI:
+
+      ```csharp
+      public record JobApplication(PersonalInfo Personal, WorkHistory Work, List<Reference> References, string CoverLetter);
+      public record PersonalInfo(string FullName, string Email, string Phone, string Address);
+      public record WorkHistory(List<WorkEntry> Entries);
+      public record WorkEntry(string Company, string Title, DateTime StartDate, DateTime? EndDate, string Description);
+      public record Reference(string Name, string Relationship, string Email, string Phone);
+
+      public interface IApplicationService
+      {
+          Task<int> SubmitApplicationAsync(JobApplication application);
+          Task<bool> ValidateEmailAsync(string email);
+      }
+      ```
+
+      The page should have:
+
+      **Step indicator bar:**
+      - Shows all steps: "Personal Info" → "Work History" → "References" → "Cover Letter" → "Review & Submit"
+      - The current step is highlighted, completed steps show a checkmark, future steps are dimmed
+      - Users can click a completed step to go back and edit it
+
+      **Step 1 — Personal Info:**
+      - Inputs for full name, email, phone, and address
+      - Email is validated via ValidateEmailAsync when the user moves to the next step
+      - A "Next" button that validates required fields before advancing
+
+      **Step 2 — Work History:**
+      - A dynamic list of work entries — start with one empty entry
+      - Each entry has: company name, job title, start date, end date (optional, checkbox for "current"), description
+      - "Add Another Position" button to add more entries
+      - "Remove" button on each entry (except if it's the only one)
+      - "Back" and "Next" buttons
+
+      **Step 3 — References:**
+      - Space for 2-3 references, each with: name, relationship, email, phone
+      - "Add Reference" button (max 3)
+      - "Back" and "Next" buttons
+
+      **Step 4 — Cover Letter:**
+      - A large textarea for the cover letter
+      - A character count display (e.g., "342 / 2000 characters")
+      - "Back" and "Next" buttons
+
+      **Step 5 — Review & Submit:**
+      - Read-only summary of all entered data organized by section
+      - An "Edit" link next to each section that jumps back to that step
+      - A "Submit Application" button that calls SubmitApplicationAsync
+      - After submission, show a confirmation with the application ID
+
+      Route: `/apply`
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (IApplicationService|JobApplication)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - The wizard is decomposed so each step lives in its own component — navigation flows between them rather than toggling visibility in one file
+      - Step data is passed down via parameters and changes flow up via callbacks — steps don't share or mutate parent state directly
+      - Navigation between steps validates before advancing — prevents skipping required fields
+      - The review step displays a read-only summary of all steps and supports going back to edit a specific step
+  - name: Application settings page with nested tab panels
+    prompt: |
+      Build a Blazor page for an application settings dashboard. This has multiple
+      nested sections. Here are the service contracts
+      already registered in DI:
+
+      ```csharp
+      public record UserProfile(string DisplayName, string Email, string AvatarUrl, string Bio);
+      public record NotificationPrefs(bool EmailNotifications, bool PushNotifications, bool WeeklyDigest, List<string> MutedChannels);
+      public record SecuritySettings(bool TwoFactorEnabled, DateTime? LastPasswordChange, List<ActiveSession> Sessions);
+      public record ActiveSession(string Id, string Device, string Location, DateTime LastActive);
+      public record AppearanceSettings(string Theme, string FontSize, string Language, bool CompactMode);
+
+      public interface ISettingsService
+      {
+          Task<UserProfile> GetProfileAsync();
+          Task SaveProfileAsync(UserProfile profile);
+          Task<NotificationPrefs> GetNotificationPrefsAsync();
+          Task SaveNotificationPrefsAsync(NotificationPrefs prefs);
+          Task<SecuritySettings> GetSecuritySettingsAsync();
+          Task ChangePasswordAsync(string currentPassword, string newPassword);
+          Task RevokeSessionAsync(string sessionId);
+          Task<AppearanceSettings> GetAppearanceAsync();
+          Task SaveAppearanceAsync(AppearanceSettings settings);
+      }
+      ```
+
+      The page should have:
+
+      **Left sidebar navigation (vertical tabs):**
+      - Four sections: "Profile", "Notifications", "Security", "Appearance"
+      - The active section is highlighted
+      - Clicking a section loads its content in the main area
+
+      **Profile section:**
+      - Editable fields: display name, email, bio (textarea)
+      - An avatar preview area with the current URL displayed
+      - A "Save Changes" button — shows a success toast/message on save
+      - A "Discard Changes" button that reverts to the last saved state
+
+      **Notifications section:**
+      - Toggle switches for: email notifications, push notifications, weekly digest
+      - A list of channels with checkboxes to mute/unmute each
+      - A "Save Preferences" button
+
+      **Security section:**
+      - A "Change Password" expandable panel with: current password, new password, confirm password fields and a "Update Password" button
+      - Two-factor authentication toggle with status indicator
+      - An "Active Sessions" table showing: device, location, last active time, and a "Revoke" button for each session (except the current one)
+      - A confirmation dialog before revoking a session
+
+      **Appearance section:**
+      - Theme selector: radio buttons for "Light", "Dark", "System"
+      - Font size selector: "Small", "Medium", "Large"
+      - Language dropdown
+      - Compact mode toggle
+      - A live preview area that shows how the selected options look
+      - A "Save" button
+
+      Route: `/settings`
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (ISettingsService|UserProfile|SecuritySettings)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Each settings section (Profile, Notifications, Security, Appearance) is its own component — not all inlined in the page
+      - Switching tabs loads the correct section content without a full page reload
+      - Handles the save/discard flow with appropriate UI feedback (success message, disabled buttons during save)
+  - name: Team chat interface with message threads
+    prompt: |
+      Build a Blazor page for a team messaging app. This is a complex multi-panel
+      layout with a sidebar, main area, and collapsible thread panel. Here are the service contracts
+      already registered in DI:
+
+      ```csharp
+      public record Channel(int Id, string Name, string Description, int UnreadCount);
+      public record Message(int Id, int ChannelId, string Author, string Content, DateTime SentAt, int? ReplyToId, List<Reaction> Reactions);
+      public record Reaction(string Emoji, List<string> Users);
+      public record ThreadSummary(int RootMessageId, int ReplyCount, DateTime LastReplyAt);
+
+      public interface IChatService
+      {
+          Task<List<Channel>> GetChannelsAsync();
+          Task<List<Message>> GetMessagesAsync(int channelId, int skip, int take);
+          Task<Message> SendMessageAsync(int channelId, string content, int? replyToId);
+          Task<List<Message>> GetThreadAsync(int rootMessageId);
+          Task AddReactionAsync(int messageId, string emoji);
+          Task MarkChannelReadAsync(int channelId);
+      }
+      ```
+
+      The page layout should have:
+
+      **Left sidebar (channel list, about 20% width):**
+      - A list of channels, each showing: channel name (with # prefix), description snippet, and an unread count badge
+      - The active channel is highlighted
+      - Clicking a channel loads its messages in the main area and marks it as read
+
+      **Main message area (about 55% width, or 80% if no thread is open):**
+      - A header showing the current channel name and description
+      - A scrollable message list showing messages for the selected channel
+      - Each message displays: author name, timestamp (relative — "2 min ago"), message content, and a row of reaction emoji badges (each showing emoji + count)
+      - Hovering a message reveals action buttons: "Reply" (opens thread panel), "React" (shows emoji picker with 5-6 common emojis)
+      - Messages that are thread starters show a "N replies" link below them
+      - A message input area at the bottom: a textarea and a "Send" button
+      - Load older messages on scroll-to-top (pagination via skip/take)
+
+      **Right panel (thread view, about 25% width, shown when a thread is open):**
+      - Header: "Thread" with the original message quoted and a close button
+      - A scrollable list of reply messages in the thread
+      - A reply input area at the bottom (textarea + "Reply" button)
+      - Closing the thread panel widens the main message area back
+
+      Route: `/chat`
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: '[Parameter]'
+      - type: output-contains
+        config:
+          substring: EventCallback
+      - type: output-matches
+        config:
+          pattern: (IChatService|Message|Channel)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - The chat interface is decomposed into focused components — channel list, message area, thread panel, and message input each have clear responsibilities
+      - The message input component is reused in both the main area and thread panel
+      - Channel selection, sending messages, and opening threads all work correctly — selecting a channel loads its messages, opening a thread shows replies

--- a/tests/dotnet-blazor/support-prerendering/eval.vally.yaml
+++ b/tests/dotnet-blazor/support-prerendering/eval.vally.yaml
@@ -1,0 +1,81 @@
+name: support-prerendering
+description: Evaluates the dotnet-blazor/support-prerendering skill
+type: capability
+config:
+  timeout: 10m
+stimuli:
+  - name: Equipment inventory loaded once
+    prompt: |
+      I have an existing Blazor Web App with Interactive Server (per-page).
+
+      I need an interactive /inventory page that shows a table of equipment items
+      (Id, Name, Location, LastInspected date). The data comes from an EquipmentService
+      you should create (just return fake data, 5-10 items).
+
+      The page should show "Loading inventory..." until data is ready, then display
+      the table. The important thing is that when the page first loads I see the HTML
+      instantly (fast initial paint), but the equipment data should NOT be fetched
+      twice — once during the initial server render and again when the page becomes
+      interactive. It should only call the service once and carry that data across.
+    graders:
+      - type: file-exists
+        config:
+          path: '**/Inventory.razor'
+      - type: file-contains
+        config:
+          path: '**/Inventory.razor'
+          value: PersistentState
+      - type: file-contains
+        config:
+          path: '**/Inventory.razor'
+          value: InteractiveServer
+      - type: file-contains
+        config:
+          path: '**/Inventory.razor'
+          value: '??='
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Data persists across the prerender-to-interactive handoff — uses state persistence ([PersistentState] or PersistentComponentState) with ??= pattern to avoid duplicate data fetches
+      - Component correctly shows loading state when data is null, then displays the equipment table when loaded
+      - Does NOT disable prerendering — preserves the fast initial HTML response while avoiding duplicate loads
+      - Creates a proper EquipmentService registered in DI, not inline data generation
+  - name: Notifications page with live polling
+    prompt: |
+      I have an existing Blazor Web App with Interactive Server (per-page).
+
+      I need an interactive /notifications page that:
+      - Loads an initial set of notifications from a NotificationService (create it with fake data)
+      - After the page becomes interactive, starts a background polling loop that
+        checks for new notifications every 5 seconds and updates the UI
+      - Shows a notification count badge and a list of notification messages
+
+      Important constraints:
+      - The initial notifications should appear in the fast server-rendered HTML
+        and NOT be fetched again when the page becomes interactive
+      - The polling loop must not run during the initial server render — only after
+        the page is live and interactive in the browser
+      - When the user navigates away, the polling should stop cleanly (no leaked tasks)
+    graders:
+      - type: file-exists
+        config:
+          path: '**/Notifications.razor'
+      - type: file-contains
+        config:
+          path: '**/Notifications.razor'
+          value: RendererInfo.IsInteractive
+      - type: file-contains
+        config:
+          path: '**/Notifications.razor'
+          value: PersistentState
+      - type: file-contains
+        config:
+          path: '**/Notifications.razor'
+          value: InteractiveServer
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Guards the polling loop so it only runs when the component is interactive — not during prerendering
+      - Persists initial notification data across the prerender-to-interactive handoff so the service is not called twice
+      - Polling uses an async loop with CancellationTokenSource, cancelled in DisposeAsync — not System.Threading.Timer
+      - Component implements IAsyncDisposable and cancels the polling token in DisposeAsync to prevent resource leaks

--- a/tests/dotnet-blazor/use-js-interop/eval.vally.yaml
+++ b/tests/dotnet-blazor/use-js-interop/eval.vally.yaml
@@ -1,0 +1,184 @@
+name: use-js-interop
+description: Evaluates the dotnet-blazor/use-js-interop skill
+type: capability
+config:
+  timeout: 10m
+stimuli:
+  - name: Auto-saving notepad that survives page reloads
+    prompt: |
+      I need a `Notepad` component for my Blazor Web App.
+
+      Requirements:
+      - A textarea where the user can type notes
+      - Content is automatically saved to the browser every 30 seconds
+      - When the user returns to the page (or reloads), their last saved content is restored
+      - A "Last saved at HH:MM:SS" label that updates after each save
+      - If the user has unsaved changes and tries to close the browser tab, show the browser's
+        built-in "Leave site?" confirmation dialog
+      - A "Clear" button that erases both the textarea and the saved data
+      - A "Save now" button for manual saves
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: OnAfterRenderAsync
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-matches
+        config:
+          pattern: (export function|export \{)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses a collocated .razor.js file with exported functions — not a global script tag or window-level globals
+      - Initializes interop in OnAfterRenderAsync(firstRender), not in OnInitializedAsync — JS is unavailable during prerendering
+      - Restores saved content on first interactive render so the user sees their previous notes immediately
+      - Batches related browser operations into single JS calls where possible — e.g., save content + timestamp together instead of separate interop calls for each
+      - Registers and removes the beforeunload listener properly — adds on setup, removes on dispose
+      - Manages the auto-save interval in JS and clears it on dispose — no dangling timers
+      - Implements IAsyncDisposable and catches JSDisconnectedException so disposal doesn't throw when the circuit is already gone
+      - Uses InvokeVoidAsync when no return value is needed
+      - Does not use fire-and-forget (unawaited ValueTask) — all JS calls are properly awaited
+      - The clear function removes stored data and resets the beforeunload guard in one operation
+      - Uses sessionStorage (or localStorage) for persistence, the beforeunload event for the unsaved-changes prompt, and setInterval/clearInterval for the auto-save timer
+  - name: User activity tracker that detects idle timeout
+    prompt: |
+      I need a `UserActivityTracker` component for my Blazor Web App.
+
+      Requirements:
+      - Monitors user activity on the page (mouse movement, key presses, clicks, scrolling)
+      - After a configurable period of inactivity, triggers an `EventCallback OnIdle` to notify the parent
+      - When the user becomes active again after being idle, triggers `EventCallback OnActive`
+      - The idle timeout duration is set via `[Parameter] int TimeoutSeconds` (default 300)
+      - Wraps child content — can be placed around any section of the app
+      - After the component is removed from the page, no leftover timers or event handlers should remain
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: OnAfterRenderAsync
+      - type: output-contains
+        config:
+          substring: DotNetObjectReference
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-matches
+        config:
+          pattern: (export function|export \{)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses a collocated .razor.js file with exported functions — not global window functions or inline scripts
+      - Registers activity event listeners (mousemove, keydown, click, scroll) in OnAfterRenderAsync(firstRender) — not during prerendering
+      - Uses DotNetObjectReference so JS can call back into .NET for idle/active transitions and disposes it in DisposeAsync
+      - Implements IAsyncDisposable and catches JSDisconnectedException in DisposeAsync
+      - Manages the idle timeout timer in JavaScript using setTimeout/clearTimeout — not via .NET Task.Delay
+      - Cleans up all event listeners and timers in the JS dispose function — no dangling handlers after component removal
+  - name: Responsive layout that adapts to screen size
+    prompt: |
+      My Blazor Web App needs to adapt its layout based on the browser viewport width. I need:
+
+      1. A `ScreenSizeProvider` component that wraps child content and detects the current
+         viewport category:
+         - `Mobile` (width < 768px)
+         - `Tablet` (768px ≤ width < 1024px)
+         - `Desktop` (width ≥ 1024px)
+
+      2. The current category should be available to all child components as a cascading value
+
+      3. When the user resizes their browser, the category should update in real time
+
+      4. The default category (before detection runs) should be `Desktop`
+
+      Usage:
+      ```razor
+      <ScreenSizeProvider>
+          <MyNavigation />   @* can read the cascading ScreenSize value *@
+          <MyContent />
+      </ScreenSizeProvider>
+      ```
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: CascadingValue
+      - type: output-contains
+        config:
+          substring: OnAfterRenderAsync
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-matches
+        config:
+          pattern: (export function|export \{)
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Provides the screen size category to children via CascadingValue — child components can consume it with [CascadingParameter]
+      - Uses a collocated .razor.js module with exported functions — not global scripts
+      - Sets up matchMedia listeners or resize listener in OnAfterRenderAsync(firstRender) — not in OnInitializedAsync
+      - Defaults to Desktop (or a sensible fallback) during prerendering before JavaScript is available
+      - Updates the category in real time when the browser is resized — uses event-based detection, not polling
+      - Uses DotNetObjectReference for the JS resize/matchMedia callback and disposes it in DisposeAsync
+      - The [JSInvokable] callback wraps state changes in InvokeAsync(StateHasChanged)
+      - Implements IAsyncDisposable and catches JSDisconnectedException in DisposeAsync
+      - Removes matchMedia/resize event listeners in the JS dispose function — no dangling listeners
+      - Does not call JS interop during prerendering — guards all JS calls behind firstRender or a flag
+      - Uses window.matchMedia or the resize event for viewport detection — not polling or server-side user-agent sniffing
+  - name: Infinite scroll list using IntersectionObserver
+    prompt: |
+      I need an `InfiniteScrollList` component for my Blazor Web App that loads more items
+      as the user scrolls.
+
+      Requirements:
+      - Displays items in a scrollable container
+      - When the user scrolls near the bottom, automatically triggers loading of more items
+      - Shows a loading spinner while fetching
+      - Stops triggering when there are no more items (parent signals this via a parameter)
+      - The component is generic — it accepts a `RenderFragment<TItem>` for rendering each item
+      - Uses an efficient browser API for scroll detection (not scroll event listeners)
+
+      Usage:
+      ```razor
+      <InfiniteScrollList Items="products" HasMore="hasMore"
+                          OnLoadMore="LoadNextPage" Context="product">
+          <div class="product-card">@product.Name — @product.Price</div>
+      </InfiniteScrollList>
+      ```
+    environment:
+      commands:
+        - dotnet new blazor --interactivity Server --no-https
+    graders:
+      - type: output-contains
+        config:
+          substring: IntersectionObserver
+      - type: output-contains
+        config:
+          substring: OnAfterRenderAsync
+      - type: output-contains
+        config:
+          substring: IAsyncDisposable
+      - type: output-contains
+        config:
+          substring: DotNetObjectReference
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - Uses a collocated .razor.js file with exported functions — not a global script
+      - Creates IntersectionObserver in OnAfterRenderAsync(firstRender) — not during prerendering
+      - Uses a sentinel element (observed by IntersectionObserver) at the bottom of the list to detect when to load more
+      - Uses DotNetObjectReference to receive the intersection callback from JS and disposes it in DisposeAsync
+      - The [JSInvokable] callback is public and wraps state changes in InvokeAsync(StateHasChanged)
+      - Calls observer.disconnect() in the JS dispose function — no dangling observers
+      - Implements IAsyncDisposable and catches JSDisconnectedException in DisposeAsync
+      - Uses ElementReference for the sentinel element — not a string ID
+      - Respects the HasMore parameter — does not trigger loads or observe the sentinel when there are no more items
+      - Uses IntersectionObserver (not scroll event listeners) for efficient visibility detection


### PR DESCRIPTION
## Summary

Ports all 9 `dotnet-blazor` skill evaluations to the newer **Vally** format (`eval.vally.yaml`), bringing the plugin in line with the already-migrated `dotnet-*` plugins. The legacy `eval.yaml` files are kept alongside (dual-format), matching how other migrated plugins operate during the transition.

Also registers a `dotnet-blazor` suite in the root `.vally.yaml` so the shadow Vally pipeline discovers these specs.

## Skills ported (27 stimuli total)

| Skill | Stimuli |
|---|---|
| author-component | 5 |
| collect-user-input | 2 |
| configure-auth | 2 |
| coordinate-components | 2 |
| create-blazor-project | 3 |
| fetch-and-send-data | 2 |
| plan-ui-change | 5 |
| support-prerendering | 2 |
| use-js-interop | 4 |

## Conversion details

Prompts, assertions, and rubric items are preserved verbatim. Mapping applied:

- `scenarios` -> `stimuli`; per-scenario `timeout` -> top-level `config.timeout` (max across the file).
- Assertions -> graders: `output_contains` -> `output-contains` (config.substring), `output_matches` -> `output-matches` (config.pattern), `file_contains` -> `file-contains` (config.path + value), `file_exists` -> `file-exists` (config.path); each stimulus also gets `prompt` and `pairwise` graders.
- Legacy `setup.commands` (the `dotnet new blazor ...` scaffolding) -> `environment.commands`.

## Verification

- All 9 files parse as YAML and pass `vally lint` (only the standard "scoring defaults applied" and `config` deprecation warnings shared by every existing eval).
- Parity check confirms 0 dropped scenarios/assertions/rubric items and identical prompts vs the legacy specs.
- Ran the `author-component` eval end-to-end (baseline + skilled + adapt). It passed the shadow improvement threshold, confirming the converted spec executes correctly through the full Vally -> adapter pipeline.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
