### PR TITLE
fix: add .claude-plugin manifest for dotnet-msbuild binlog MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,19 @@
     {
       "name": "dotnet-msbuild",
       "source": "./plugins/dotnet-msbuild",
-      "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization."
+      "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization.",
+      "mcpServers": {
+        "binlog": {
+          "type": "stdio",
+          "command": "dotnet",
+          "args": [
+            "dnx",
+            "Microsoft.AITools.BinlogMcp",
+            "--yes"
+          ],
+          "tools": ["*"]
+        }
+      }
     },
     {
       "name": "dotnet-nuget",

--- a/plugins/dotnet-msbuild/.claude-plugin/plugin.json
+++ b/plugins/dotnet-msbuild/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "dotnet-msbuild",
+  "version": "0.1.0",
+  "description": "Comprehensive MSBuild and .NET build skills: failure diagnosis, performance optimization, code quality, and modernization.",
+  "skills": ["./skills/"],
+  "agents": [
+    "./agents/build-perf.agent.md",
+    "./agents/msbuild-code-review.agent.md",
+    "./agents/msbuild.agent.md"
+  ],
+  "mcpServers": {
+    "binlog": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "Microsoft.AITools.BinlogMcp",
+        "--yes"
+      ],
+      "tools": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a \.claude-plugin/plugin.json\ manifest to the \dotnet-msbuild\ plugin so that Claude Code can discover and load the binlog MCP server. Also declares \mcpServers\ inline in the root marketplace manifest entry for belt-and-suspenders coverage.

## Problem

Claude Code discovers plugin capabilities (skills, agents, MCP servers) via \.claude-plugin/plugin.json\ inside each plugin directory. The existing \.codex-plugin/\ manifest only works for Codex CLI. Without the Claude Code-specific manifest, installing \dotnet-msbuild\ via \/plugin install\ loads skills and agents but **not** the binlog MCP server.

## Changes

- \plugins/dotnet-msbuild/.claude-plugin/plugin.json\ — new manifest with inline \mcpServers\ config
- \.claude-plugin/marketplace.json\ — added \mcpServers\ to the \dotnet-msbuild\ entry

## Verification

After this change, running \/plugin install dotnet-msbuild@dotnet-agent-skills\ in Claude Code should surface the \inlog\ MCP server tools.

Fixes #840