### PR TITLE
Enable VS Code subagent fan-out for the dotnet-test code-testing agents

### DIFF
--- a/plugins/dotnet-test/README.md
+++ b/plugins/dotnet-test/README.md
@@ -101,6 +101,14 @@ These are pipeline stages invoked automatically by the agents above (`user-invoc
 | **code-testing-fixer** | code-testing-implementer | Fixes compilation errors in source or test files |
 | **code-testing-linter** | code-testing-implementer | Runs code formatting and linting |
 
+> **VS Code — enabling full multi-level fan-out:** The pipeline delegates in two levels: `code-testing-generator` → researcher / planner / implementer, and `code-testing-implementer` → builder / tester / fixer / linter. VS Code gates *nested* delegation (a subagent spawning its own subagents) behind a setting that is **off by default**, so the first level runs out of the box but the second one does not. For large scopes — many files or modules, where parallel build/test/fix/lint workers help — enable it in your VS Code settings:
+>
+> ```jsonc
+> "chat.subagents.allowInvocationsFromSubagents": true
+> ```
+>
+> Without it, `code-testing-implementer` still builds, tests, fixes, and lints — it just does that work inline instead of delegating to the worker subagents, so results are unaffected. The GitHub Copilot CLI has no such gate and always fans out.
+
 ## Prerequisites
 
 ### For polyglot skills and agents

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -6,6 +6,7 @@ description: >-
   errors, verifying project builds successfully.
 name: code-testing-builder
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -6,7 +6,7 @@ description: >-
   errors, verifying project builds successfully.
 name: code-testing-builder
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -6,6 +6,7 @@ description: >-
   imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -6,7 +6,7 @@ description: >-
   imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,6 +6,15 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
+tools: ["agent", "read", "search", "edit", "execute"]
+agents:
+  - code-testing-researcher
+  - code-testing-planner
+  - code-testing-implementer
+  - code-testing-builder
+  - code-testing-tester
+  - code-testing-fixer
+  - code-testing-linter
 license: MIT
 ---
 
@@ -56,40 +65,25 @@ Based on the request scope, pick exactly one strategy and follow it:
 
 ### Step 3: Research Phase
 
-Call the `code-testing-researcher` subagent:
+Delegate to the `code-testing-researcher` subagent with this task:
 
-```text
-runSubagent({
-  agent: "code-testing-researcher",
-  prompt: "Research the codebase at [PATH] for test generation. Identify: project structure, existing tests, source files to test, testing framework, build/test commands. Build a dependency graph and estimate preexisting coverage."
-})
-```
+> Research the codebase at [PATH] for test generation. Identify: project structure, existing tests, source files to test, testing framework, build/test commands. Build a dependency graph and estimate preexisting coverage.
 
 Output: `.testagent/research.md`
 
 ### Step 4: Planning Phase
 
-Call the `code-testing-planner` subagent:
+Delegate to the `code-testing-planner` subagent with this task:
 
-```text
-runSubagent({
-  agent: "code-testing-planner",
-  prompt: "Create a test implementation plan based on .testagent/research.md. Create phased approach with specific files and test cases."
-})
-```
+> Create a test implementation plan based on .testagent/research.md. Create phased approach with specific files and test cases.
 
 Output: `.testagent/plan.md`
 
 ### Step 5: Implementation Phase
 
-Execute each phase by calling the `code-testing-implementer` subagent — once per phase, sequentially:
+Execute each phase by delegating to the `code-testing-implementer` subagent — once per phase, sequentially. For each phase, delegate with this task:
 
-```text
-runSubagent({
-  agent: "code-testing-implementer",
-  prompt: "Implement Phase N from .testagent/plan.md: [phase description]. Ensure tests compile and pass."
-})
-```
+> Implement Phase N from .testagent/plan.md: [phase description]. Ensure tests compile and pass.
 
 ### Step 6: Final Build Validation
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,7 +6,7 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
-tools: ["agent", "read", "search", "edit", "execute"]
+tools: ["agent", "skill", "read", "search", "edit", "execute"]
 agents:
   - code-testing-researcher
   - code-testing-planner

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -7,6 +7,12 @@ description: >-
   running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false
+tools: ["agent", "read", "search", "edit", "execute"]
+agents:
+  - code-testing-builder
+  - code-testing-tester
+  - code-testing-fixer
+  - code-testing-linter
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -7,7 +7,7 @@ description: >-
   running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false
-tools: ["agent", "read", "search", "edit", "execute"]
+tools: ["agent", "skill", "read", "search", "edit", "execute"]
 agents:
   - code-testing-builder
   - code-testing-tester

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -6,7 +6,7 @@ description: >-
   applying lint fixes.
 name: code-testing-linter
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -6,6 +6,7 @@ description: >-
   applying lint fixes.
 name: code-testing-linter
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -6,6 +6,7 @@ description: >-
   creating .testagent/plan.md from research.
 name: code-testing-planner
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -6,7 +6,7 @@ description: >-
   creating .testagent/plan.md from research.
 name: code-testing-planner
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -6,6 +6,7 @@ description: >-
   discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -6,7 +6,7 @@ description: >-
   discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -6,7 +6,7 @@ description: >-
   checking test results and failures.
 name: code-testing-tester
 user-invocable: false
-tools: ["read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -6,6 +6,7 @@ description: >-
   checking test results and failures.
 name: code-testing-tester
 user-invocable: false
+tools: ["read", "search", "edit", "execute"]
 license: MIT
 ---
 


### PR DESCRIPTION
## Problem

The `dotnet-test` plugin's `code-testing-*` agents implement a Research -> Plan -> Implement pipeline that delegates to subagents. In VS Code, the published agents carried only `name` / `description` / `license` frontmatter — no subagent metadata (`tools:` / `agents:`) — so VS Code never delegated and `code-testing-generator` ran the whole pipeline inline. (The GitHub Copilot CLI was unaffected.)

## Changes

All under `plugins/dotnet-test/`:

- **Orchestrators** (`code-testing-generator`, `code-testing-implementer`): add an `agents:` list of the subagents they delegate to, plus an explicit `tools: ["agent", "read", "search", "edit", "execute"]` that includes the `agent` (runSubagent) tool.
- **Workers** (`code-testing-researcher`, `code-testing-planner`, `code-testing-builder`, `code-testing-tester`, `code-testing-fixer`, `code-testing-linter`): add an explicit role-scoped `tools: ["read", "search", "edit", "execute"]`.
- Soften the generator's three `runSubagent({ agent, prompt })` blocks to tool-agnostic delegation prose.
- `README.md`: document the per-user VS Code setting `chat.subagents.allowInvocationsFromSubagents` (off by default) needed for the nested `code-testing-implementer` -> builder/tester/fixer/linter layer; the CLI has no such gate.

### Why explicit tool aliases, not `tools: ["*"]`

VS Code has no all-tools wildcard for `tools:`, and a subagent's `tools:` **overrides** (not extends) the toolset it would otherwise inherit — so a catch-all entry would leave subagents with no file/terminal access in VS Code. The named portable aliases (`read`, `search`, `edit`, `execute`, `agent`) map to real tools in **both** VS Code and the Copilot CLI; `agents:` is ignored by the CLI.

## Validation

- **VS Code (Insiders 1.127):** selecting `code-testing-generator` on a multi-module Python project produced real fan-out — `runSubagent` to `code-testing-researcher` -> `code-testing-planner` -> `code-testing-implementer`, with the subagents performing their own file I/O (`research.md`, `plan.md`, test files). 72 generated tests pass; no "subagents lack file tools" warnings.
- **Copilot CLI:** the same plugin via `--plugin-dir` delegated to the `code-testing-*` subagents (researcher / planner / implementer / tester), skills still loaded (`code-testing-extensions`, `test-gap-analysis`), and the generated tests pass. An all-tools baseline run used only tools within the enumerated set, confirming no CLI capability is restricted.
