### PR TITLE
Bump dotnet-test to 0.2.0

### DIFF
--- a/plugins/dotnet-test/.codex-plugin/plugin.json
+++ b/plugins/dotnet-test/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/plugin.json
+++ b/plugins/dotnet-test/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [


### PR DESCRIPTION
## Problem
PR #847 enabled VS Code subagent fan-out for the `dotnet-test` plugin's `code-testing-*` agents (it added `tools:`/`agents:` frontmatter and the `skill` tool). That merged as a content change **without a version bump**, so `plugins/dotnet-test/plugin.json` still reads `0.1.0` and existing installs may not receive an update signal.

## Changes
- Bump `plugins/dotnet-test/plugin.json` version `0.1.0` -> `0.2.0`.

Minor bump. No breaking changes and no behavior change beyond advertising the already-merged agent update.

## Tests
Metadata-only change; no code paths affected. Plugin structure and skills are unchanged.