### PR TITLE
Document SetTargetFramework bin/obj clash on single-targeting ProjectReferences

### DIFF
--- a/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-bin-obj-clash
-description: "Detects MSBuild projects with conflicting OutputPath or IntermediateOutputPath. USE FOR: builds failing with 'Cannot create a file when that file already exists', 'The process cannot access the file because it is being used by another process', intermittent build failures that succeed on retry, missing outputs in multi-project builds, multi-targeting builds where project.assets.json conflicts. Diagnoses when multiple projects or TFMs write to the same bin/obj directories due to shared OutputPath, missing AppendTargetFrameworkToOutputPath, or extra global properties like PublishReadyToRun creating redundant evaluations. DO NOT USE FOR: file access errors unrelated to MSBuild (OS-level locking), single-project single-TFM builds, non-MSBuild build systems."
+description: "Detects MSBuild projects with conflicting OutputPath or IntermediateOutputPath. USE FOR: builds failing with 'Cannot create a file when that file already exists', 'The process cannot access the file because it is being used by another process', intermittent build failures that succeed on retry, missing outputs in multi-project builds, multi-targeting builds where project.assets.json conflicts. Diagnoses when multiple projects or TFMs write to the same bin/obj directories due to shared OutputPath, missing AppendTargetFrameworkToOutputPath, or extra global properties like PublishReadyToRun creating redundant evaluations, or SetTargetFramework metadata on a ProjectReference to a single-targeting project. DO NOT USE FOR: file access errors unrelated to MSBuild (OS-level locking), single-project single-TFM builds, non-MSBuild build systems."
 license: MIT
 ---
 
@@ -360,6 +360,30 @@ Either way this forks a distinct instance of the target project (`path` + `{_IsP
 
 See the `msbuild-antipatterns` skill (AP-22) for the authoring-time smell and rationale.
 
+### `SetTargetFramework` on a `ProjectReference` to a non-multi-targeting project
+
+**Problem:** A `ProjectReference` sets `SetTargetFramework="TargetFramework=<tfm>"` metadata pointing at a **single-targeting** project (one that uses singular `<TargetFramework>`, not `<TargetFrameworks>`). `SetTargetFramework` injects `TargetFramework` as a **global property** on the referenced project's build.
+
+```xml
+<!-- BAD: Tool.csproj single-targets net8.0 -->
+<ProjectReference Include="..\Tool\Tool.csproj" SetTargetFramework="TargetFramework=net8.0" />
+```
+
+For a single-targeting project that extra `TargetFramework` global property is **path-neutral** — the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own. So it doesn't change the output path; it only forks a distinct instance `(project, {TargetFramework=net8.0})`. The solution/graph builds the very same project as `(project, {})`. Both share the same `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** to the same location — a bin/obj clash under parallel builds.
+
+**How to detect:** Follow the Primary workflow above. The `evaluations` and `evaluation_global_properties` tools surface two evaluations of the referenced project that share the same `OutputPath`/`IntermediateOutputPath` and differ only by a `TargetFramework` global property, while the project itself is single-targeting (its own `TargetFramework` already equals the injected value). The `double_writes` tool flags the resulting shared-file writes directly.
+
+**Note:** The P2P protocol itself does **not** inject `TargetFramework` for a non-multi-targeting reference — the clash comes specifically from the explicit `SetTargetFramework` metadata overriding that safe default.
+
+**Fix:** Remove `SetTargetFramework` from references to single-targeting projects:
+
+```xml
+<!-- GOOD -->
+<ProjectReference Include="..\Tool\Tool.csproj" />
+```
+
+Only use `SetTargetFramework` when the referenced project is **multi-targeting** (`<TargetFrameworks>`) and you deliberately need one specific TFM — there each TFM has a distinct output path, so no clash. See the `msbuild-antipatterns` skill (AP-23) for the authoring-time smell and rationale.
+
 ## Example Workflow
 
 ```bash
@@ -401,7 +425,7 @@ When multiple evaluations share an output path, compare these global properties 
 
 | Property | Affects OutputPath? | Notes |
 |----------|---------------------|-------|
-| `TargetFramework` | Yes | Different TFMs should have different paths |
+| `TargetFramework` | Yes | Different TFMs should have different paths. **Exception:** injecting it (e.g. via `SetTargetFramework`) on a *single-targeting* project is path-neutral — it forks a redundant instance sharing the output path (see "`SetTargetFramework` on a `ProjectReference`...") |
 | `RuntimeIdentifier` | Yes | Different RIDs should have different paths |
 | `Configuration` | Yes | Debug vs Release |
 | `Platform` | Yes | AnyCPU vs x64 etc. |

--- a/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
@@ -360,29 +360,42 @@ Either way this forks a distinct instance of the target project (`path` + `{_IsP
 
 See the `msbuild-antipatterns` skill (AP-22) for the authoring-time smell and rationale.
 
-### `SetTargetFramework` on a `ProjectReference` to a non-multi-targeting project
+### `SetTargetFramework` re-injecting a single-targeting project's own TFM on a `ProjectReference`
 
-**Problem:** A `ProjectReference` sets `SetTargetFramework="TargetFramework=<tfm>"` metadata pointing at a **single-targeting** project (one that uses singular `<TargetFramework>`, not `<TargetFrameworks>`). `SetTargetFramework` injects `TargetFramework` as a **global property** on the referenced project's build.
+**Problem:** A `ProjectReference` sets `SetTargetFramework="TargetFramework=<tfm>"` metadata pointing at a **single-targeting** project (one that uses singular `<TargetFramework>`, not `<TargetFrameworks>`), where the injected `<tfm>` **equals the TFM the project already targets**. `SetTargetFramework` injects `TargetFramework` as a **global property** on the referenced project's build.
 
 ```xml
-<!-- BAD: Tool.csproj single-targets net8.0 -->
+<!-- BAD: Tool.csproj single-targets net8.0 and we inject that SAME net8.0 -->
 <ProjectReference Include="..\Tool\Tool.csproj" SetTargetFramework="TargetFramework=net8.0" />
 ```
 
-For a single-targeting project that extra `TargetFramework` global property is **path-neutral** — the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own. So it doesn't change the output path; it only forks a distinct instance `(project, {TargetFramework=net8.0})`. The solution/graph builds the very same project as `(project, {})`. Both share the same `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** to the same location — a bin/obj clash under parallel builds.
+Injecting the TFM the project already targets is **path-neutral** — the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own. So it doesn't change the output path; it only forks a distinct instance `(project, {TargetFramework=net8.0})`. The solution/graph builds the very same project as `(project, {})`. Both share the same `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** to the same location — a bin/obj clash under parallel builds.
 
 **How to detect:** Follow the Primary workflow above. The `evaluations` and `evaluation_global_properties` tools surface two evaluations of the referenced project that share the same `OutputPath`/`IntermediateOutputPath` and differ only by a `TargetFramework` global property, while the project itself is single-targeting (its own `TargetFramework` already equals the injected value). The `double_writes` tool flags the resulting shared-file writes directly.
 
 **Note:** The P2P protocol itself does **not** inject `TargetFramework` for a non-multi-targeting reference — the clash comes specifically from the explicit `SetTargetFramework` metadata overriding that safe default.
 
-**Fix:** Remove `SetTargetFramework` from references to single-targeting projects:
+**Fix:** Remove the redundant `SetTargetFramework` when it just restates the project's own single TFM:
 
 ```xml
 <!-- GOOD -->
 <ProjectReference Include="..\Tool\Tool.csproj" />
 ```
 
-Only use `SetTargetFramework` when the referenced project is **multi-targeting** (`<TargetFrameworks>`) and you deliberately need one specific TFM — there each TFM has a distinct output path, so no clash. See the `msbuild-antipatterns` skill (AP-23) for the authoring-time smell and rationale.
+**When `SetTargetFramework` is legitimate (not a clash):**
+
+- **Multi-targeting reference** — the referenced project uses `<TargetFrameworks>` and you need one specific TFM. Each TFM has a distinct output path, so no clash.
+- **Overriding to a *different* TFM** — you may use `SetTargetFramework` on a single-targeting project to build it under a TFM *other than* the one it declares. Because the injected TFM then changes the output path (`obj\<config>\<different-tfm>\`), the instance no longer collides with `(project, {})`. Only the *same-TFM* case is path-neutral and clashing.
+- **Framework-incompatible override** — when the referencing and referenced projects are incompatible (e.g. a `.NETFramework` test project referencing a single-targeting `.NETCoreApp` project), also set `SkipGetTargetFrameworkProperties="true"` (the automatic TFM-compatibility negotiation would otherwise fail) and `ReferenceOutputAssembly="false"` (a `.NETCoreApp` assembly can't be consumed by a `.NETFramework` project — you only want to trigger/sequence the build):
+
+  ```xml
+  <ProjectReference Include="..\Tool\Tool.csproj"
+                    SetTargetFramework="TargetFramework=net8.0"
+                    SkipGetTargetFrameworkProperties="true"
+                    ReferenceOutputAssembly="false" />
+  ```
+
+See the `msbuild-antipatterns` skill (AP-23) for the authoring-time smell and rationale.
 
 ## Example Workflow
 
@@ -425,7 +438,7 @@ When multiple evaluations share an output path, compare these global properties 
 
 | Property | Affects OutputPath? | Notes |
 |----------|---------------------|-------|
-| `TargetFramework` | Yes | Different TFMs should have different paths. **Exception:** injecting it (e.g. via `SetTargetFramework`) on a *single-targeting* project is path-neutral — it forks a redundant instance sharing the output path (see "`SetTargetFramework` on a `ProjectReference`...") |
+| `TargetFramework` | Yes | Different TFMs should have different paths. **Exception:** re-injecting a *single-targeting* project's own TFM (e.g. via `SetTargetFramework` with the same value) is path-neutral — it forks a redundant instance sharing the output path (see "`SetTargetFramework` re-injecting...") |
 | `RuntimeIdentifier` | Yes | Different RIDs should have different paths |
 | `Configuration` | Yes | Debug vs Release |
 | `Platform` | Yes | AnyCPU vs x64 etc. |

--- a/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
@@ -394,7 +394,14 @@ Injecting the TFM the project already targets is **path-neutral** — the projec
                     ReferenceOutputAssembly="false" />
   ```
 
-  Add `SetTargetFramework` on top only if you also need to pin the referenced build to a specific TFM.
+  With `SkipGetTargetFrameworkProperties="true"`, the negotiation no longer stops the **referencing** project's own `TargetFramework` global property (present when it builds for a specific TFM, e.g. it is multi-targeting) from flowing into the referenced project. For a **single-targeting** referenced project that would force it to build under the wrong TFM / output path. Prevent it by either setting `SetTargetFramework="TargetFramework=<tfm>"` (pin the TFM) **or** `UndefineProperties="TargetFramework"` (strip the inherited global property so the project builds as it declares) — use one, not both:
+
+  ```xml
+  <ProjectReference Include="..\Tool\Tool.csproj"
+                    SkipGetTargetFrameworkProperties="true"
+                    UndefineProperties="TargetFramework"
+                    ReferenceOutputAssembly="false" />
+  ```
 
 See the `msbuild-antipatterns` skill (AP-23) for the authoring-time smell and rationale.
 

--- a/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md
@@ -386,14 +386,15 @@ Injecting the TFM the project already targets is **path-neutral** — the projec
 
 - **Multi-targeting reference** — the referenced project uses `<TargetFrameworks>` and you need one specific TFM. Each TFM has a distinct output path, so no clash.
 - **Overriding to a *different* TFM** — you may use `SetTargetFramework` on a single-targeting project to build it under a TFM *other than* the one it declares. Because the injected TFM then changes the output path (`obj\<config>\<different-tfm>\`), the instance no longer collides with `(project, {})`. Only the *same-TFM* case is path-neutral and clashing.
-- **Framework-incompatible override** — when the referencing and referenced projects are incompatible (e.g. a `.NETFramework` test project referencing a single-targeting `.NETCoreApp` project), also set `SkipGetTargetFrameworkProperties="true"` (the automatic TFM-compatibility negotiation would otherwise fail) and `ReferenceOutputAssembly="false"` (a `.NETCoreApp` assembly can't be consumed by a `.NETFramework` project — you only want to trigger/sequence the build):
+- **Framework-incompatible reference** — whenever the referencing and referenced projects target **incompatible frameworks** (e.g. a `.NETFramework` project referencing a `.NETCoreApp` project, or vice-versa) — **regardless of single- or multi-targeting on either side** — set `SkipGetTargetFrameworkProperties="true"` (the P2P `GetTargetFrameworkProperties` negotiation would otherwise fail) and `ReferenceOutputAssembly="false"` (an assembly built for an incompatible framework can't be consumed as a reference — you only want to trigger/sequence the build):
 
   ```xml
   <ProjectReference Include="..\Tool\Tool.csproj"
-                    SetTargetFramework="TargetFramework=net8.0"
                     SkipGetTargetFrameworkProperties="true"
                     ReferenceOutputAssembly="false" />
   ```
+
+  Add `SetTargetFramework` on top only if you also need to pin the referenced build to a specific TFM.
 
 See the `msbuild-antipatterns` skill (AP-23) for the authoring-time smell and rationale.
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md
@@ -406,4 +406,4 @@ MSBuild's evaluator normalizes `\` → `/` on Unix-like systems before resolving
 
 ---
 
-For additional anti-patterns (AP-16 through AP-22) and a quick-reference checklist, see [additional-antipatterns.md](references/additional-antipatterns.md).
+For additional anti-patterns (AP-16 through AP-23) and a quick-reference checklist, see [additional-antipatterns.md](references/additional-antipatterns.md).

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
@@ -227,6 +227,34 @@ For (b), the consumer must not fork the producer with path-neutral global proper
 
 ---
 
+## AP-23: `SetTargetFramework` Metadata on a `ProjectReference` to a Non-Multi-Targeting Project
+
+**Smell**: A `<ProjectReference>` carries `SetTargetFramework="TargetFramework=net8.0"` (or similar) metadata, but the referenced project is **single-targeting** (uses singular `<TargetFramework>`, not `<TargetFrameworks>`).
+
+```xml
+<!-- BAD: referenced project single-targets net8.0; SetTargetFramework is redundant AND harmful -->
+<ItemGroup>
+  <ProjectReference Include="..\Tool\Tool.csproj" SetTargetFramework="TargetFramework=net8.0" />
+</ItemGroup>
+```
+
+**Why it's bad**: `SetTargetFramework` injects `TargetFramework` as a **global property** on the referenced project's build. That mechanism exists so a consumer can pick *one specific TFM* of a **multi-targeting** project — different TFM values produce different output paths, so each build is distinct and safe.
+
+For a **single-targeting** project the injected `TargetFramework` global property is **path-neutral**: the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own, so the extra global property doesn't change the output path — it only creates a *distinct* MSBuild project instance `(project, {TargetFramework=net8.0})`. Meanwhile the solution/graph builds that same project as `(project, {})` with no global properties. Both instances resolve to the **same** `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** and the two instances write the same files (assemblies, PDBs, `project.assets.json`, etc.). Under a parallel build this is a classic bin/obj clash — `The process cannot access the file because it is being used by another process` or intermittent, retry-flaky failures.
+
+Note the healthy contrast: the P2P protocol itself does **not** inject `TargetFramework` when it sees a non-multi-targeting reference — it correctly omits the global property. `SetTargetFramework` overrides that safe default and is what reintroduces the clash. Use the `check-bin-obj-clash` skill to confirm two evaluations of the referenced project differ only by a path-neutral `TargetFramework` global property while sharing an output path.
+
+```xml
+<!-- GOOD: single-targeting reference needs no SetTargetFramework — just reference it -->
+<ItemGroup>
+  <ProjectReference Include="..\Tool\Tool.csproj" />
+</ItemGroup>
+```
+
+**When `SetTargetFramework` IS appropriate**: only when the referenced project is **multi-targeting** (`<TargetFrameworks>`) and you deliberately need to consume a specific TFM. There, each TFM has its own output path, so the forked instance doesn't collide.
+
+---
+
 ## Quick-Reference Checklist
 
 When reviewing an MSBuild file, scan for these in order:
@@ -237,6 +265,7 @@ When reviewing an MSBuild file, scan for these in order:
 | AP-19 | Side effects in evaluation | 🔴 Dangerous |
 | AP-21 | Property conditioned on TargetFramework in .props | 🔴 Silent failure |
 | AP-22 | Forking a project instance via `<MSBuild>` with path-neutral global properties (self or cross-project) | 🔴 Race/duplicate build |
+| AP-23 | `SetTargetFramework` on a `ProjectReference` to a non-multi-targeting project | 🔴 Race/duplicate build |
 | AP-03 | Hardcoded absolute paths | 🔴 Broken on other machines |
 | AP-06 | `<Reference>` with HintPath for NuGet | 🟡 Legacy |
 | AP-07 | Missing `PrivateAssets="all"` on tools | 🟡 Leaks to consumers |

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
@@ -268,7 +268,19 @@ Note the healthy contrast: the P2P protocol itself does **not** inject `TargetFr
                   ReferenceOutputAssembly="false" />
 ```
 
-Add `SetTargetFramework` on top of these **only** if you also need to pin the referenced build to a specific TFM (a multi-targeting project, or a single-targeting project you're overriding to a *different* TFM per case 2 above).
+**⚠️ Prevent the referencing project's `TargetFramework` from leaking.** When `SkipGetTargetFrameworkProperties="true"` bypasses the negotiation, nothing stops the referencing project's own `TargetFramework` **global property** (present whenever the referencing project is being built for a specific TFM — e.g. it is multi-targeting) from flowing down into the referenced project. If it flows into a **single-targeting** referenced project, that project builds under the *wrong* TFM (and to a different, wrong output path). Guard against it one of two ways:
+- set `SetTargetFramework="TargetFramework=<tfm>"` to explicitly pin the referenced build's TFM (also required for multi-targeting references), **or**
+- for a single-targeting referenced project you want to build as-declared, set `UndefineProperties="TargetFramework"` to strip the inherited global property so the project uses its own `<TargetFramework>`.
+
+```xml
+<!-- OK: strip the referencing project's TargetFramework so the single-targeting tool builds as it declares -->
+<ProjectReference Include="..\Tool\Tool.csproj"
+                  SkipGetTargetFrameworkProperties="true"
+                  UndefineProperties="TargetFramework"
+                  ReferenceOutputAssembly="false" />
+```
+
+Add `SetTargetFramework` on top of these **only** if you also need to pin the referenced build to a specific TFM (a multi-targeting project, or a single-targeting project you're overriding to a *different* TFM per case 2 above). Use `SetTargetFramework` **or** `UndefineProperties="TargetFramework"`, not both — the former sets the property, the latter removes it.
 
 ---
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
@@ -257,17 +257,18 @@ Note the healthy contrast: the P2P protocol itself does **not** inject `TargetFr
 
 2. **Deliberately overriding a single-targeting project's TFM to a *different* value** — you can use `SetTargetFramework` on a single-targeting reference to build it under a TFM *other than* the one it declares. This is only valid when the passed-in TFM **differs** from what the project single-targets: because the injected `TargetFramework` then changes the output path (`obj\<config>\<different-tfm>\`), the instance no longer collides with the `(project, {})` build. It is **only** the redundant case — passing the *same* TFM the project already targets (path-neutral) — that causes the clash.
 
-   When the referencing and referenced projects are **framework-incompatible** (e.g. a `.NETFramework` test project referencing a single-targeting `.NETCoreApp` project), overriding the TFM alone isn't enough. The P2P protocol's `GetTargetFrameworkProperties` negotiation will fail because the frameworks aren't compatible, so you must also set:
-   - `SkipGetTargetFrameworkProperties="true"` — bypass the automatic TFM-compatibility negotiation, and
-   - `ReferenceOutputAssembly="false"` — because a `.NETCoreApp` assembly can't be consumed as a reference by a `.NETFramework` project; you only want to trigger the build / sequence it, not reference its output.
+**Related: referencing a framework-incompatible project.** Independently of the clash above, whenever the referencing and referenced projects target **incompatible frameworks** (e.g. a `.NETFramework` project referencing a `.NETCoreApp` project, or vice-versa) — **regardless of whether either side is single- or multi-targeting** — you must set both:
+- `SkipGetTargetFrameworkProperties="true"` — bypass the P2P `GetTargetFrameworkProperties` negotiation, which would otherwise fail because the frameworks aren't compatible, and
+- `ReferenceOutputAssembly="false"` — because an assembly built for an incompatible framework can't be consumed as a reference; you only want to trigger/sequence the build, not reference its output.
 
-   ```xml
-   <!-- OK: .NETFramework test project builds a single-targeting .NETCoreApp tool without referencing its assembly -->
-   <ProjectReference Include="..\Tool\Tool.csproj"
-                     SetTargetFramework="TargetFramework=net8.0"
-                     SkipGetTargetFrameworkProperties="true"
-                     ReferenceOutputAssembly="false" />
-   ```
+```xml
+<!-- OK: .NETFramework project builds an incompatible .NETCoreApp tool without referencing its assembly -->
+<ProjectReference Include="..\Tool\Tool.csproj"
+                  SkipGetTargetFrameworkProperties="true"
+                  ReferenceOutputAssembly="false" />
+```
+
+Add `SetTargetFramework` on top of these **only** if you also need to pin the referenced build to a specific TFM (a multi-targeting project, or a single-targeting project you're overriding to a *different* TFM per case 2 above).
 
 ---
 

--- a/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
+++ b/plugins/dotnet-msbuild/skills/msbuild-antipatterns/references/additional-antipatterns.md
@@ -229,10 +229,10 @@ For (b), the consumer must not fork the producer with path-neutral global proper
 
 ## AP-23: `SetTargetFramework` Metadata on a `ProjectReference` to a Non-Multi-Targeting Project
 
-**Smell**: A `<ProjectReference>` carries `SetTargetFramework="TargetFramework=net8.0"` (or similar) metadata, but the referenced project is **single-targeting** (uses singular `<TargetFramework>`, not `<TargetFrameworks>`).
+**Smell**: A `<ProjectReference>` carries `SetTargetFramework="TargetFramework=net8.0"` (or similar) metadata, the referenced project is **single-targeting** (uses singular `<TargetFramework>`, not `<TargetFrameworks>`), **and the injected TFM equals the TFM the project already targets**.
 
 ```xml
-<!-- BAD: referenced project single-targets net8.0; SetTargetFramework is redundant AND harmful -->
+<!-- BAD: Tool.csproj single-targets net8.0 and we inject that SAME net8.0 — redundant AND harmful -->
 <ItemGroup>
   <ProjectReference Include="..\Tool\Tool.csproj" SetTargetFramework="TargetFramework=net8.0" />
 </ItemGroup>
@@ -240,7 +240,7 @@ For (b), the consumer must not fork the producer with path-neutral global proper
 
 **Why it's bad**: `SetTargetFramework` injects `TargetFramework` as a **global property** on the referenced project's build. That mechanism exists so a consumer can pick *one specific TFM* of a **multi-targeting** project — different TFM values produce different output paths, so each build is distinct and safe.
 
-For a **single-targeting** project the injected `TargetFramework` global property is **path-neutral**: the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own, so the extra global property doesn't change the output path — it only creates a *distinct* MSBuild project instance `(project, {TargetFramework=net8.0})`. Meanwhile the solution/graph builds that same project as `(project, {})` with no global properties. Both instances resolve to the **same** `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** and the two instances write the same files (assemblies, PDBs, `project.assets.json`, etc.). Under a parallel build this is a classic bin/obj clash — `The process cannot access the file because it is being used by another process` or intermittent, retry-flaky failures.
+For a **single-targeting** project, injecting the TFM it **already targets** is **path-neutral**: the project already resolves to `bin\<config>\net8.0\` and `obj\<config>\net8.0\` on its own, so the extra global property doesn't change the output path — it only creates a *distinct* MSBuild project instance `(project, {TargetFramework=net8.0})`. Meanwhile the solution/graph builds that same project as `(project, {})` with no global properties. Both instances resolve to the **same** `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** and the two instances write the same files (assemblies, PDBs, `project.assets.json`, etc.). Under a parallel build this is a classic bin/obj clash — `The process cannot access the file because it is being used by another process` or intermittent, retry-flaky failures. (Injecting a *different* TFM changes the output path and is a legitimate override — see below.)
 
 Note the healthy contrast: the P2P protocol itself does **not** inject `TargetFramework` when it sees a non-multi-targeting reference — it correctly omits the global property. `SetTargetFramework` overrides that safe default and is what reintroduces the clash. Use the `check-bin-obj-clash` skill to confirm two evaluations of the referenced project differ only by a path-neutral `TargetFramework` global property while sharing an output path.
 
@@ -251,7 +251,23 @@ Note the healthy contrast: the P2P protocol itself does **not** inject `TargetFr
 </ItemGroup>
 ```
 
-**When `SetTargetFramework` IS appropriate**: only when the referenced project is **multi-targeting** (`<TargetFrameworks>`) and you deliberately need to consume a specific TFM. There, each TFM has its own output path, so the forked instance doesn't collide.
+**When `SetTargetFramework` IS appropriate**:
+
+1. **Multi-targeting reference** — the referenced project is multi-targeting (`<TargetFrameworks>`) and you deliberately need to consume a specific TFM. Each TFM has its own output path, so the forked instance doesn't collide.
+
+2. **Deliberately overriding a single-targeting project's TFM to a *different* value** — you can use `SetTargetFramework` on a single-targeting reference to build it under a TFM *other than* the one it declares. This is only valid when the passed-in TFM **differs** from what the project single-targets: because the injected `TargetFramework` then changes the output path (`obj\<config>\<different-tfm>\`), the instance no longer collides with the `(project, {})` build. It is **only** the redundant case — passing the *same* TFM the project already targets (path-neutral) — that causes the clash.
+
+   When the referencing and referenced projects are **framework-incompatible** (e.g. a `.NETFramework` test project referencing a single-targeting `.NETCoreApp` project), overriding the TFM alone isn't enough. The P2P protocol's `GetTargetFrameworkProperties` negotiation will fail because the frameworks aren't compatible, so you must also set:
+   - `SkipGetTargetFrameworkProperties="true"` — bypass the automatic TFM-compatibility negotiation, and
+   - `ReferenceOutputAssembly="false"` — because a `.NETCoreApp` assembly can't be consumed as a reference by a `.NETFramework` project; you only want to trigger the build / sequence it, not reference its output.
+
+   ```xml
+   <!-- OK: .NETFramework test project builds a single-targeting .NETCoreApp tool without referencing its assembly -->
+   <ProjectReference Include="..\Tool\Tool.csproj"
+                     SetTargetFramework="TargetFramework=net8.0"
+                     SkipGetTargetFrameworkProperties="true"
+                     ReferenceOutputAssembly="false" />
+   ```
 
 ---
 
@@ -265,7 +281,7 @@ When reviewing an MSBuild file, scan for these in order:
 | AP-19 | Side effects in evaluation | 🔴 Dangerous |
 | AP-21 | Property conditioned on TargetFramework in .props | 🔴 Silent failure |
 | AP-22 | Forking a project instance via `<MSBuild>` with path-neutral global properties (self or cross-project) | 🔴 Race/duplicate build |
-| AP-23 | `SetTargetFramework` on a `ProjectReference` to a non-multi-targeting project | 🔴 Race/duplicate build |
+| AP-23 | `SetTargetFramework` re-injecting a single-targeting project's own TFM on a `ProjectReference` | 🔴 Race/duplicate build |
 | AP-03 | Hardcoded absolute paths | 🔴 Broken on other machines |
 | AP-06 | `<Reference>` with HintPath for NuGet | 🟡 Legacy |
 | AP-07 | Missing `PrivateAssets="all"` on tools | 🟡 Leaks to consumers |

--- a/tests/dotnet-msbuild/check-bin-obj-clash/ClashTest.slnx
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/ClashTest.slnx
@@ -2,4 +2,6 @@
   <Project Path="LibraryA/LibraryA.csproj" />
   <Project Path="LibraryB/LibraryB.csproj" />
   <Project Path="MultiTargetLib/MultiTargetLib.csproj" />
+  <Project Path="ToolLib/ToolLib.csproj" />
+  <Project Path="ConsumerApp/ConsumerApp.csproj" />
 </Solution>

--- a/tests/dotnet-msbuild/check-bin-obj-clash/ConsumerApp/Consumer.cs
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/ConsumerApp/Consumer.cs
@@ -1,0 +1,6 @@
+namespace ConsumerApp;
+
+public class Consumer
+{
+    public string Describe() => new ToolLib.Tool().GetName();
+}

--- a/tests/dotnet-msbuild/check-bin-obj-clash/ConsumerApp/ConsumerApp.csproj
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/ConsumerApp/ConsumerApp.csproj
@@ -1,0 +1,24 @@
+<Project>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- CLASH: ToolLib single-targets net8.0. Re-injecting that SAME net8.0 via
+       SetTargetFramework is path-neutral (ToolLib already resolves to obj/bin\Debug\net8.0
+       on its own), so it does not change the output path. It only forks a distinct instance
+       (ToolLib + {TargetFramework=net8.0}) that shares ToolLib's bin/obj with the instance the
+       solution already builds (ToolLib + {}). ToolLib is built twice to the same location.
+       SetTargetFramework here is redundant and should be removed — it is only appropriate for a
+       multi-targeting reference, or to deliberately override to a DIFFERENT target framework. -->
+  <ItemGroup>
+    <ProjectReference Include="..\ToolLib\ToolLib.csproj" SetTargetFramework="TargetFramework=net8.0" />
+  </ItemGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+</Project>

--- a/tests/dotnet-msbuild/check-bin-obj-clash/ToolLib/Tool.cs
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/ToolLib/Tool.cs
@@ -1,0 +1,6 @@
+namespace ToolLib;
+
+public class Tool
+{
+    public string GetName() => "ToolLib";
+}

--- a/tests/dotnet-msbuild/check-bin-obj-clash/ToolLib/ToolLib.csproj
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/ToolLib/ToolLib.csproj
@@ -1,0 +1,15 @@
+<Project>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <!-- Single-targeting: TargetFramework (singular), not TargetFrameworks.
+         Uses SDK-default output paths (obj/bin/Debug/net8.0) — no shared-path issues here. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+</Project>

--- a/tests/dotnet-msbuild/check-bin-obj-clash/eval.vally.yaml
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/eval.vally.yaml
@@ -29,5 +29,10 @@ stimuli:
         other
       - Identified LibraryA and LibraryB share ../SharedObj/ as IntermediateOutputPath causing project.assets.json
         conflicts
+      - Identified that ConsumerApp's ProjectReference to the single-targeting ToolLib sets SetTargetFramework to net8.0 —
+        the TFM ToolLib already targets — which re-injects a path-neutral TargetFramework global property, forking a
+        second ToolLib instance that builds to the same bin/obj as the solution-rooted build
+      - Recommended removing the redundant SetTargetFramework from the ToolLib reference (noting it is only appropriate
+        for multi-targeting references or overriding to a different TFM)
       - Suggested giving each project unique output and intermediate output paths
       - Referenced BaseIntermediateOutputPath vs IntermediateOutputPath concepts

--- a/tests/dotnet-msbuild/check-bin-obj-clash/eval.yaml
+++ b/tests/dotnet-msbuild/check-bin-obj-clash/eval.yaml
@@ -15,6 +15,8 @@ scenarios:
       - "Identified MultiTargetLib has AppendTargetFrameworkToOutputPath=false causing net8.0 and net9.0 to write to the same output directory"
       - "Identified LibraryA and LibraryB share ../SharedOutput/ as OutputPath causing build artifacts to overwrite each other"
       - "Identified LibraryA and LibraryB share ../SharedObj/ as IntermediateOutputPath causing project.assets.json conflicts"
+      - "Identified that ConsumerApp's ProjectReference to the single-targeting ToolLib sets SetTargetFramework to net8.0 — the TFM ToolLib already targets — which re-injects a path-neutral TargetFramework global property, forking a second ToolLib instance that builds to the same bin/obj as the solution-rooted build"
+      - "Recommended removing the redundant SetTargetFramework from the ToolLib reference (noting it is only appropriate for multi-targeting references or overriding to a different TFM)"
       - "Suggested giving each project unique output and intermediate output paths"
       - "Referenced BaseIntermediateOutputPath vs IntermediateOutputPath concepts"
     timeout: 160

--- a/tests/dotnet-msbuild/msbuild-antipatterns/LibB/LibB.csproj
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/LibB/LibB.csproj
@@ -13,7 +13,14 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!-- BUG (AP-23): SetTargetFramework re-injects LibA's OWN single target framework
+       (net8.0) as a global property. LibA is single-targeting, so this is path-neutral:
+       it doesn't change LibA's output path, it just forks a second instance
+       (LibA + {TargetFramework=net8.0}) that shares LibA's bin/obj with the instance the
+       solution already builds (LibA + {}). LibA builds twice to the same location and the
+       two instances can race on writes. SetTargetFramework is only appropriate for a
+       multi-targeting reference, or to override to a DIFFERENT tfm. Should be removed. -->
   <ItemGroup>
-    <ProjectReference Include="..\LibA\LibA.csproj" />
+    <ProjectReference Include="..\LibA\LibA.csproj" SetTargetFramework="TargetFramework=net8.0" />
   </ItemGroup>
 </Project>

--- a/tests/dotnet-msbuild/msbuild-antipatterns/eval.vally.yaml
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/eval.vally.yaml
@@ -32,6 +32,9 @@ stimuli:
       - Identified LibA's publish-on-build target that re-invokes the project via the <MSBuild> task with a path-neutral
         global property (_IsPublishing), forking a duplicate project instance that shares the output path and can race on
         writes
+      - Identified LibB's ProjectReference to LibA sets SetTargetFramework to net8.0 — the TFM LibA already single-targets
+        — which forks a redundant LibA instance that shares LibA's output path, and recommended removing it
+        (SetTargetFramework is only for multi-targeting references or overriding to a different TFM)
 
   - name: Add a module to an F# project
     prompt: |

--- a/tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml
+++ b/tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml
@@ -16,6 +16,7 @@ scenarios:
       - "Identified DefineConstants overwrites existing constants instead of appending"
       - "Identified analyzer PackageReference missing PrivateAssets, unquoted MSBuild condition, mixed Include/Update in same ItemGroup, or Exec instead of Message task"
       - "Identified LibA's publish-on-build target that re-invokes the project via the <MSBuild> task with a path-neutral global property (_IsPublishing), forking a duplicate project instance that shares the output path and can race on writes"
+      - "Identified LibB's ProjectReference to LibA sets SetTargetFramework to net8.0 — the TFM LibA already single-targets — which forks a redundant LibA instance that shares LibA's output path, and recommended removing it (SetTargetFramework is only for multi-targeting references or overriding to a different TFM)"
     timeout: 160
 
   - name: "Add a module to an F# project"


### PR DESCRIPTION
## Summary

Documents that `SetTargetFramework` metadata must **not** be set on a `ProjectReference` pointing to a **non-multi-targeting** (single-targeting) project.

Setting `SetTargetFramework="TargetFramework=<tfm>"` on such a reference injects `TargetFramework` as a **global property** on the referenced project. For a single-targeting project that property is **path-neutral** — the project already resolves to `bin\<config>\<tfm>\` / `obj\<config>\<tfm>\` on its own — so it does not change the output path; it only forks a *distinct* MSBuild project instance `(project, {TargetFramework=<tfm>})`. Meanwhile the solution/graph builds the same project as `(project, {})`. Both share the same `OutputPath`/`IntermediateOutputPath`, so the project is **built twice** to the same location — a bin/obj clash under parallel builds.

The P2P protocol itself correctly omits the `TargetFramework` global property for non-multi-targeting references; `SetTargetFramework` overrides that safe default and reintroduces the clash.

Motivated by https://github.com/dotnet/sdk/pull/55109#pullrequestreview-4614809313.

## Changes

- **`msbuild-antipatterns`**: new **AP-23** with BAD/GOOD examples, mechanism, detection, and when `SetTargetFramework` is legitimate (multi-targeting only); added to the quick-reference checklist; updated the SKILL.md pointer to "AP-16 through AP-23".
- **`check-bin-obj-clash`**: new "Common Causes and Fixes" subsection cross-referencing AP-23, a note on the `TargetFramework` row in the global-properties table, and an extended USE FOR clause for discoverability.