### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ You can also install individual skills using the `skill-installer` CLI with the 
 $ skill-installer install https://github.com/dotnet/skills/tree/main/plugins/<plugin>/skills/<skill-name>
 ```
 
+### Autohand Code
+
+Autohand Code users can install the indexed aggregate skill or individual .NET plugin entries from the Autohand catalog:
+
+```bash
+# Install the aggregate dotnet/skills entry globally
+autohand --skill-install dotnet-skills
+
+# Or install a focused plugin entry
+autohand --skill-install dotnet-test
+autohand --skill-install dotnet-msbuild
+
+# Use --project for a workspace-level install
+autohand --skill-install dotnet-test --project
+```
+
+Autohand Code reads global skills from `~/.autohand/skills/` and project skills from `<project>/.autohand/skills/`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and how to add a new plugin.


### PR DESCRIPTION
## Summary

Adds an Autohand Code install section to the root README.

The new section points Autohand Code users at the existing cataloged entries for this repository, including:

- `dotnet-skills`
- focused plugin entries such as `dotnet-test` and `dotnet-msbuild`
- `--project` for workspace-level installs

It also documents the global and project skill paths that Autohand Code reads.

## Validation

- `git diff --check`

I kept this as a root README-only change and did not run the repository's broader evaluation/build suite.