### PR TITLE
dotnet-test: make code-testing agent tools portable across Copilot CLI, Claude Code & Gemini CLI + add portability check

### DIFF
--- a/eng/allowed-external-deps.txt
+++ b/eng/allowed-external-deps.txt
@@ -7,6 +7,7 @@
 #   invokes:SKILL-NAME                 - INVOKES pattern in a skill description
 #   tool-ref:NAME:#tool:reference      - Non-built-in #tool: reference in skill/agent content
 #   agent-tool:AGENT-NAME:tool-name    - Non-built-in tool in agent frontmatter tools array
+#   agent-tool-portability:AGENT-NAME:capability - Agent tool declared for one host but not another
 #   mcp-server:PLUGIN-NAME:server-name - MCP server declaration in plugin.json
 #
 # To get clean, remove entries as the underlying dependency is resolved.

--- a/eng/skill-validator/src/Check/CheckCommand.cs
+++ b/eng/skill-validator/src/Check/CheckCommand.cs
@@ -450,6 +450,8 @@ public static class CheckCommand
         {
             foreach (var warning in ExternalDependencyChecker.CheckAgent(agent, allowed))
                 builder.ExternalDependencies.Add(new ExternalDependencyResult(ExternalDependencyKind.Agent, agent.Name, agent.Path, warning));
+            foreach (var warning in ExternalDependencyChecker.CheckAgentToolPortability(agent, allowed))
+                builder.ExternalDependencies.Add(new ExternalDependencyResult(ExternalDependencyKind.Agent, agent.Name, agent.Path, warning));
         }
 
         foreach (var plugin in plugins)

--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -147,28 +147,40 @@ public static partial class ExternalDependencyChecker
 
     /// <summary>
     /// A capability an agent can grant through its <c>tools:</c> list, together
-    /// with the tool names each supported host uses to expose it. Every host
-    /// (Copilot CLI / VS Code, Claude Code, Gemini CLI) matches tool names by
-    /// exact spelling, so an agent that lists only one host's spelling silently
-    /// loses the capability on the others. A host with an empty list has no
-    /// <c>tools:</c>-level spelling for the capability and is not required.
+    /// with the tool names each supported host uses to expose it. Each host's
+    /// array holds interchangeable spellings for the <em>same</em> capability
+    /// (any one suffices on that host) — complementary tools that do different
+    /// things belong to separate capabilities. Every host (Copilot CLI / VS Code,
+    /// Claude Code, Gemini CLI) matches tool names by exact spelling, so an agent
+    /// that lists only one host's spelling silently loses the capability on the
+    /// others. A host with an empty list has no <c>tools:</c>-level spelling for
+    /// the capability and is not required.
     /// </summary>
     private sealed record ToolCapability(string Name, string[] CopilotCli, string[] ClaudeCode, string[] GeminiCli);
 
     /// <summary>
-    /// Cross-host tool-name equivalences. Only capabilities whose host spellings
-    /// actually differ are listed — names that are identical modulo case
-    /// (e.g. <c>read</c>/<c>Read</c>, <c>bash</c>/<c>Bash</c>) still need every
-    /// spelling because the hosts match case-sensitively. "invoke subagents" and
-    /// "invoke skills" have no Gemini CLI <c>tools:</c> entry (Gemini delegates
-    /// via <c>@agent</c> and loads skills implicitly), so their Gemini list is
-    /// empty and not enforced.
+    /// Cross-host tool-name equivalences. Each entry is an <em>atomic</em>
+    /// capability: a host's list holds only interchangeable spellings for that
+    /// one capability, so "any present" correctly means the host can perform it.
+    /// Where one host exposes a capability through a single broad tool while
+    /// another splits it in two, the capability is split to match the finer
+    /// granularity — e.g. the Copilot CLI's single <c>search</c> covers both
+    /// "find files" and "search file contents", which Claude Code and Gemini CLI
+    /// expose as separate tools (<c>Glob</c>/<c>Grep</c>, <c>glob</c>/
+    /// <c>grep_search</c>). This lets the check flag a partial declaration such
+    /// as <c>Glob</c> without <c>Grep</c>. Names identical modulo case
+    /// (e.g. <c>read</c>/<c>Read</c>) still need every spelling because the hosts
+    /// match case-sensitively. "invoke subagents" and "invoke skills" have no
+    /// Gemini CLI <c>tools:</c> entry (Gemini delegates via <c>@agent</c> and
+    /// loads skills implicitly), so their Gemini list is empty and not enforced.
     /// </summary>
     private static readonly ToolCapability[] ToolCapabilities =
     [
         new("read files", ["read"], ["Read"], ["read_file"]),
-        new("modify files", ["edit", "create"], ["Edit", "Write"], ["replace", "write_file"]),
-        new("search", ["search"], ["Glob", "Grep"], ["glob", "grep_search"]),
+        new("edit files", ["edit"], ["Edit"], ["replace"]),
+        new("create files", ["create", "edit"], ["Write"], ["write_file"]),
+        new("find files", ["search"], ["Glob"], ["glob"]),
+        new("search file contents", ["search"], ["Grep"], ["grep_search"]),
         new("run commands", ["execute"], ["Bash"], ["run_shell_command"]),
         new("invoke subagents", ["agent"], ["Task"], []),
         new("invoke skills", ["skill"], ["Skill"], []),

--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -18,13 +18,19 @@ public static partial class ExternalDependencyChecker
         "read", "search", "edit", "create", "task", "skill", "web_search", "web_fetch",
         "ask_user", "bash", "powershell", "grep", "glob", "view", "sql",
         "report_intent", "store_memory", "fetch_copilot_cli_documentation",
-        // Cross-harness spellings that are not case-insensitive matches of the
-        // names above: "agent" is the Copilot CLI / VS Code subagent fan-out
-        // tool (Claude Code spells it "task"); "write" is the Claude Code
-        // file-creation tool (the Copilot CLI / VS Code spelling is "create");
-        // "execute" is the Copilot CLI / VS Code run-command tool (Claude Code
-        // spells it "bash").
+        // Cross-host spellings that are not case-insensitive matches of the names
+        // above. Each supported host (Copilot CLI / VS Code, Claude Code, Gemini
+        // CLI) spells some built-in tools differently:
+        //   "agent"             Copilot CLI / VS Code subagent fan-out (Claude: "task")
+        //   "write"             Claude Code file creation   (Copilot: "create", Gemini: "write_file")
+        //   "execute"           Copilot CLI / VS Code run-command (Claude: "bash", Gemini: "run_shell_command")
+        //   "read_file"         Gemini CLI file read        (Copilot: "read", Claude: "Read")
+        //   "replace"           Gemini CLI file edit        (Copilot: "edit", Claude: "Edit")
+        //   "write_file"        Gemini CLI file creation    (Copilot: "create", Claude: "Write")
+        //   "grep_search"       Gemini CLI content search   (Copilot: "search", Claude: "Grep")
+        //   "run_shell_command" Gemini CLI shell            (Copilot: "execute", Claude: "Bash")
         "agent", "write", "execute",
+        "read_file", "replace", "write_file", "grep_search", "run_shell_command",
     };
 
     private static readonly HashSet<string> ScriptExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -141,36 +147,41 @@ public static partial class ExternalDependencyChecker
 
     /// <summary>
     /// A capability an agent can grant through its <c>tools:</c> list, together
-    /// with the tool names each supported host uses to expose it. The Copilot
-    /// CLI / VS Code and Claude Code both match tool names by exact spelling, so
-    /// an agent that lists only one host's spelling silently loses the
-    /// capability on the other host.
+    /// with the tool names each supported host uses to expose it. Every host
+    /// (Copilot CLI / VS Code, Claude Code, Gemini CLI) matches tool names by
+    /// exact spelling, so an agent that lists only one host's spelling silently
+    /// loses the capability on the others. A host with an empty list has no
+    /// <c>tools:</c>-level spelling for the capability and is not required.
     /// </summary>
-    private sealed record ToolCapability(string Name, string[] CopilotCli, string[] ClaudeCode);
+    private sealed record ToolCapability(string Name, string[] CopilotCli, string[] ClaudeCode, string[] GeminiCli);
 
     /// <summary>
     /// Cross-host tool-name equivalences. Only capabilities whose host spellings
     /// actually differ are listed — names that are identical modulo case
-    /// (e.g. <c>read</c>/<c>Read</c>, <c>bash</c>/<c>Bash</c>) still need both
-    /// spellings because the hosts match case-sensitively.
+    /// (e.g. <c>read</c>/<c>Read</c>, <c>bash</c>/<c>Bash</c>) still need every
+    /// spelling because the hosts match case-sensitively. "invoke subagents" and
+    /// "invoke skills" have no Gemini CLI <c>tools:</c> entry (Gemini delegates
+    /// via <c>@agent</c> and loads skills implicitly), so their Gemini list is
+    /// empty and not enforced.
     /// </summary>
     private static readonly ToolCapability[] ToolCapabilities =
     [
-        new("read files", ["read"], ["Read"]),
-        new("modify files", ["edit", "create"], ["Edit", "Write"]),
-        new("search", ["search"], ["Glob", "Grep"]),
-        new("run commands", ["execute"], ["Bash"]),
-        new("invoke subagents", ["agent"], ["Task"]),
-        new("invoke skills", ["skill"], ["Skill"]),
+        new("read files", ["read"], ["Read"], ["read_file"]),
+        new("modify files", ["edit", "create"], ["Edit", "Write"], ["replace", "write_file"]),
+        new("search", ["search"], ["Glob", "Grep"], ["glob", "grep_search"]),
+        new("run commands", ["execute"], ["Bash"], ["run_shell_command"]),
+        new("invoke subagents", ["agent"], ["Task"], []),
+        new("invoke skills", ["skill"], ["Skill"], []),
     ];
 
     /// <summary>
     /// Check that an agent's <c>tools:</c> list is portable across every
     /// supported host. When a capability is granted for one host (e.g. the
     /// Copilot CLI alias <c>edit</c>) but the equivalent for another host
-    /// (Claude Code's <c>Edit</c>) is absent, the agent works on one host and is
-    /// silently tool-less on the other. Returns advisory messages for human
-    /// review. Entries matching the allowlist are skipped.
+    /// (Claude Code's <c>Edit</c> or Gemini CLI's <c>replace</c>) is absent, the
+    /// agent works on one host and is silently tool-less on the others. Returns
+    /// advisory messages for human review. Entries matching the allowlist are
+    /// skipped.
     /// </summary>
     public static IReadOnlyList<string> CheckAgentToolPortability(AgentInfo agent, IReadOnlySet<string>? allowed = null)
     {
@@ -184,25 +195,34 @@ public static partial class ExternalDependencyChecker
 
         foreach (var capability in ToolCapabilities)
         {
-            bool copilotPresent = Array.Exists(capability.CopilotCli, declared.Contains);
-            bool claudePresent = Array.Exists(capability.ClaudeCode, declared.Contains);
+            (string Label, string[] Names)[] hosts =
+            [
+                ("the Copilot CLI / VS Code", capability.CopilotCli),
+                ("Claude Code", capability.ClaudeCode),
+                ("Gemini CLI", capability.GeminiCli),
+            ];
 
-            // Portable (declared for both hosts) or unused (declared for neither).
-            if (copilotPresent == claudePresent)
+            // Only hosts that actually expose this capability via a tools entry.
+            var relevant = Array.FindAll(hosts, host => host.Names.Length > 0);
+            var present = Array.FindAll(relevant, host => Array.Exists(host.Names, declared.Contains));
+            var missing = Array.FindAll(relevant, host => !Array.Exists(host.Names, declared.Contains));
+
+            // Fully portable (every relevant host present) or unused (none present).
+            if (present.Length == 0 || missing.Length == 0)
                 continue;
 
             var key = $"agent-tool-portability:{agent.Name}:{capability.Name}";
             if (allowed?.Contains(key) == true)
                 continue;
 
-            string haveHost = copilotPresent ? "the Copilot CLI / VS Code" : "Claude Code";
-            string missingHost = copilotPresent ? "Claude Code" : "the Copilot CLI / VS Code";
-            string[] missingSource = copilotPresent ? capability.ClaudeCode : capability.CopilotCli;
-            string missing = string.Join(", ", Array.FindAll(missingSource, name => !declared.Contains(name)));
+            string presentLabel = string.Join(", ", Array.ConvertAll(present, host => host.Label));
+            string missingLabel = string.Join(", ", Array.ConvertAll(missing, host => host.Label));
+            string additions = string.Join("; ", Array.ConvertAll(missing, host =>
+                $"{string.Join(", ", Array.FindAll(host.Names, name => !declared.Contains(name)))} for {host.Label}"));
 
             findings.Add(
-                $"Agent tool '{capability.Name}' is declared for {haveHost} but not {missingHost} — " +
-                $"add {missing} to the tools list so the agent works across all supported hosts. (allow: {key})");
+                $"Agent tool '{capability.Name}' is declared for {presentLabel} but not {missingLabel} — " +
+                $"add {additions} to the tools list so the agent works across all supported hosts. (allow: {key})");
         }
 
         return findings;

--- a/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
+++ b/eng/skill-validator/src/Check/ExternalDependencyChecker.cs
@@ -18,6 +18,13 @@ public static partial class ExternalDependencyChecker
         "read", "search", "edit", "create", "task", "skill", "web_search", "web_fetch",
         "ask_user", "bash", "powershell", "grep", "glob", "view", "sql",
         "report_intent", "store_memory", "fetch_copilot_cli_documentation",
+        // Cross-harness spellings that are not case-insensitive matches of the
+        // names above: "agent" is the Copilot CLI / VS Code subagent fan-out
+        // tool (Claude Code spells it "task"); "write" is the Claude Code
+        // file-creation tool (the Copilot CLI / VS Code spelling is "create");
+        // "execute" is the Copilot CLI / VS Code run-command tool (Claude Code
+        // spells it "bash").
+        "agent", "write", "execute",
     };
 
     private static readonly HashSet<string> ScriptExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -127,6 +134,75 @@ public static partial class ExternalDependencyChecker
                         findings.Add($"Non-built-in tool '{tool}' in tools list — review needed: verify this tool is intentional and available in the target environment. (allow: {key})");
                 }
             }
+        }
+
+        return findings;
+    }
+
+    /// <summary>
+    /// A capability an agent can grant through its <c>tools:</c> list, together
+    /// with the tool names each supported host uses to expose it. The Copilot
+    /// CLI / VS Code and Claude Code both match tool names by exact spelling, so
+    /// an agent that lists only one host's spelling silently loses the
+    /// capability on the other host.
+    /// </summary>
+    private sealed record ToolCapability(string Name, string[] CopilotCli, string[] ClaudeCode);
+
+    /// <summary>
+    /// Cross-host tool-name equivalences. Only capabilities whose host spellings
+    /// actually differ are listed — names that are identical modulo case
+    /// (e.g. <c>read</c>/<c>Read</c>, <c>bash</c>/<c>Bash</c>) still need both
+    /// spellings because the hosts match case-sensitively.
+    /// </summary>
+    private static readonly ToolCapability[] ToolCapabilities =
+    [
+        new("read files", ["read"], ["Read"]),
+        new("modify files", ["edit", "create"], ["Edit", "Write"]),
+        new("search", ["search"], ["Glob", "Grep"]),
+        new("run commands", ["execute"], ["Bash"]),
+        new("invoke subagents", ["agent"], ["Task"]),
+        new("invoke skills", ["skill"], ["Skill"]),
+    ];
+
+    /// <summary>
+    /// Check that an agent's <c>tools:</c> list is portable across every
+    /// supported host. When a capability is granted for one host (e.g. the
+    /// Copilot CLI alias <c>edit</c>) but the equivalent for another host
+    /// (Claude Code's <c>Edit</c>) is absent, the agent works on one host and is
+    /// silently tool-less on the other. Returns advisory messages for human
+    /// review. Entries matching the allowlist are skipped.
+    /// </summary>
+    public static IReadOnlyList<string> CheckAgentToolPortability(AgentInfo agent, IReadOnlySet<string>? allowed = null)
+    {
+        var findings = new List<string>();
+
+        if (agent.Tools is null || agent.Tools.Count == 0)
+            return findings;
+
+        // Hosts resolve tool names by exact spelling, so compare case-sensitively.
+        var declared = new HashSet<string>(agent.Tools, StringComparer.Ordinal);
+
+        foreach (var capability in ToolCapabilities)
+        {
+            bool copilotPresent = Array.Exists(capability.CopilotCli, declared.Contains);
+            bool claudePresent = Array.Exists(capability.ClaudeCode, declared.Contains);
+
+            // Portable (declared for both hosts) or unused (declared for neither).
+            if (copilotPresent == claudePresent)
+                continue;
+
+            var key = $"agent-tool-portability:{agent.Name}:{capability.Name}";
+            if (allowed?.Contains(key) == true)
+                continue;
+
+            string haveHost = copilotPresent ? "the Copilot CLI / VS Code" : "Claude Code";
+            string missingHost = copilotPresent ? "Claude Code" : "the Copilot CLI / VS Code";
+            string[] missingSource = copilotPresent ? capability.ClaudeCode : capability.CopilotCli;
+            string missing = string.Join(", ", Array.FindAll(missingSource, name => !declared.Contains(name)));
+
+            findings.Add(
+                $"Agent tool '{capability.Name}' is declared for {haveHost} but not {missingHost} — " +
+                $"add {missing} to the tools list so the agent works across all supported hosts. (allow: {key})");
         }
 
         return findings;

--- a/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
+++ b/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
@@ -277,7 +277,8 @@ public class ExternalDependencyCheckerTests
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
         Assert.Contains(findings, f => f.Contains("read files") && f.Contains("Read") && f.Contains("read_file"));
-        Assert.Contains(findings, f => f.Contains("search") && f.Contains("Glob") && f.Contains("grep_search"));
+        Assert.Contains(findings, f => f.Contains("find files") && f.Contains("Glob") && f.Contains("glob"));
+        Assert.Contains(findings, f => f.Contains("search file contents") && f.Contains("Grep") && f.Contains("grep_search"));
         Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("Bash") && f.Contains("run_shell_command"));
     }
 
@@ -288,9 +289,28 @@ public class ExternalDependencyCheckerTests
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
-        Assert.Contains(findings, f => f.Contains("search") && f.Contains("not the Copilot CLI / VS Code") && f.Contains("search") && f.Contains("glob, grep_search"));
+        Assert.Contains(findings, f => f.Contains("find files") && f.Contains("not the Copilot CLI / VS Code") && f.Contains("search") && f.Contains("glob"));
+        Assert.Contains(findings, f => f.Contains("search file contents") && f.Contains("search") && f.Contains("grep_search"));
         Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("execute") && f.Contains("run_shell_command"));
-        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("edit, create") && f.Contains("replace, write_file"));
+        Assert.Contains(findings, f => f.Contains("create files") && f.Contains("create, edit") && f.Contains("write_file"));
+    }
+
+    [Fact]
+    public void AgentPortability_PartialClaudeSearch_FlagsMissingContentSearch()
+    {
+        // Glob (file-name search) present, but Grep (content search) missing —
+        // the atomic "search file contents" capability must still be flagged.
+        var agent = MakeAgent(tools: new[]
+        {
+            "search", "Glob", "glob",
+            "read", "Read", "read_file"
+        });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+
+        Assert.Contains(findings, f => f.Contains("search file contents") && f.Contains("Grep") && f.Contains("grep_search"));
+        Assert.DoesNotContain(findings, f => f.Contains("find files"));
+        Assert.DoesNotContain(findings, f => f.Contains("read files"));
     }
 
     [Fact]
@@ -301,7 +321,8 @@ public class ExternalDependencyCheckerTests
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
         Assert.Contains(findings, f => f.Contains("read files") && f.Contains("not Gemini CLI") && f.Contains("read_file"));
-        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("replace, write_file for Gemini CLI"));
+        Assert.Contains(findings, f => f.Contains("edit files") && f.Contains("replace for Gemini CLI"));
+        Assert.Contains(findings, f => f.Contains("create files") && f.Contains("write_file for Gemini CLI"));
     }
 
     [Fact]
@@ -332,7 +353,8 @@ public class ExternalDependencyCheckerTests
         var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "agent-tool-portability:test-agent:read files",
-            "agent-tool-portability:test-agent:modify files"
+            "agent-tool-portability:test-agent:edit files",
+            "agent-tool-portability:test-agent:create files"
         };
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent, allowed);

--- a/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
+++ b/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
@@ -256,12 +256,13 @@ public class ExternalDependencyCheckerTests
     // ========================================
 
     [Fact]
-    public void AgentPortability_WithBothHostSpellings_NoWarning()
+    public void AgentPortability_WithAllThreeHostSpellings_NoWarning()
     {
         var agent = MakeAgent(tools: new[]
         {
             "skill", "read", "search", "edit", "execute",
-            "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"
+            "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash",
+            "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"
         });
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
@@ -269,27 +270,38 @@ public class ExternalDependencyCheckerTests
     }
 
     [Fact]
-    public void AgentPortability_CopilotOnly_FlagsMissingClaudeEquivalents()
+    public void AgentPortability_CopilotOnly_FlagsMissingClaudeAndGeminiEquivalents()
     {
         var agent = MakeAgent(tools: new[] { "read", "search", "edit", "execute", "skill" });
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
-        Assert.Contains(findings, f => f.Contains("read files") && f.Contains("Read") && f.Contains("not Claude Code"));
-        Assert.Contains(findings, f => f.Contains("search") && f.Contains("Glob") && f.Contains("Grep"));
-        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("Bash"));
+        Assert.Contains(findings, f => f.Contains("read files") && f.Contains("Read") && f.Contains("read_file"));
+        Assert.Contains(findings, f => f.Contains("search") && f.Contains("Glob") && f.Contains("grep_search"));
+        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("Bash") && f.Contains("run_shell_command"));
     }
 
     [Fact]
-    public void AgentPortability_ClaudeOnly_FlagsMissingCopilotEquivalents()
+    public void AgentPortability_ClaudeOnly_FlagsMissingCopilotAndGeminiEquivalents()
     {
         var agent = MakeAgent(tools: new[] { "Read", "Glob", "Grep", "Edit", "Write", "Bash", "Skill" });
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
-        Assert.Contains(findings, f => f.Contains("search") && f.Contains("not the Copilot CLI / VS Code") && f.Contains("search"));
-        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("execute"));
-        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("edit, create"));
+        Assert.Contains(findings, f => f.Contains("search") && f.Contains("not the Copilot CLI / VS Code") && f.Contains("search") && f.Contains("glob, grep_search"));
+        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("execute") && f.Contains("run_shell_command"));
+        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("edit, create") && f.Contains("replace, write_file"));
+    }
+
+    [Fact]
+    public void AgentPortability_MissingGeminiOnly_FlagsGeminiEquivalents()
+    {
+        var agent = MakeAgent(tools: new[] { "read", "Read", "edit", "Edit", "Write" });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+
+        Assert.Contains(findings, f => f.Contains("read files") && f.Contains("not Gemini CLI") && f.Contains("read_file"));
+        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("replace, write_file for Gemini CLI"));
     }
 
     [Fact]
@@ -304,11 +316,13 @@ public class ExternalDependencyCheckerTests
     [Fact]
     public void AgentPortability_SubagentFanOutOnlyCopilot_FlagsTask()
     {
-        var agent = MakeAgent(tools: new[] { "agent", "read", "Read" });
+        var agent = MakeAgent(tools: new[] { "agent", "read", "Read", "read_file" });
 
         var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
 
         Assert.Contains(findings, f => f.Contains("invoke subagents") && f.Contains("Task"));
+        // Gemini has no tools-level subagent spelling, so it must not be demanded.
+        Assert.DoesNotContain(findings, f => f.Contains("invoke subagents") && f.Contains("Gemini CLI"));
     }
 
     [Fact]

--- a/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
+++ b/eng/skill-validator/tests/Check/ExternalDependencyTests.cs
@@ -252,6 +252,80 @@ public class ExternalDependencyCheckerTests
     }
 
     // ========================================
+    // Agent: Cross-host tool portability
+    // ========================================
+
+    [Fact]
+    public void AgentPortability_WithBothHostSpellings_NoWarning()
+    {
+        var agent = MakeAgent(tools: new[]
+        {
+            "skill", "read", "search", "edit", "execute",
+            "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"
+        });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void AgentPortability_CopilotOnly_FlagsMissingClaudeEquivalents()
+    {
+        var agent = MakeAgent(tools: new[] { "read", "search", "edit", "execute", "skill" });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+
+        Assert.Contains(findings, f => f.Contains("read files") && f.Contains("Read") && f.Contains("not Claude Code"));
+        Assert.Contains(findings, f => f.Contains("search") && f.Contains("Glob") && f.Contains("Grep"));
+        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("Bash"));
+    }
+
+    [Fact]
+    public void AgentPortability_ClaudeOnly_FlagsMissingCopilotEquivalents()
+    {
+        var agent = MakeAgent(tools: new[] { "Read", "Glob", "Grep", "Edit", "Write", "Bash", "Skill" });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+
+        Assert.Contains(findings, f => f.Contains("search") && f.Contains("not the Copilot CLI / VS Code") && f.Contains("search"));
+        Assert.Contains(findings, f => f.Contains("run commands") && f.Contains("execute"));
+        Assert.Contains(findings, f => f.Contains("modify files") && f.Contains("edit, create"));
+    }
+
+    [Fact]
+    public void AgentPortability_NoToolsArray_NoWarning()
+    {
+        var agent = MakeAgent(tools: null);
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void AgentPortability_SubagentFanOutOnlyCopilot_FlagsTask()
+    {
+        var agent = MakeAgent(tools: new[] { "agent", "read", "Read" });
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent);
+
+        Assert.Contains(findings, f => f.Contains("invoke subagents") && f.Contains("Task"));
+    }
+
+    [Fact]
+    public void AgentPortability_WithAllowedGap_NoWarning()
+    {
+        var agent = MakeAgent(tools: new[] { "read", "edit" });
+        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "agent-tool-portability:test-agent:read files",
+            "agent-tool-portability:test-agent:modify files"
+        };
+
+        var findings = ExternalDependencyChecker.CheckAgentToolPortability(agent, allowed);
+        Assert.Empty(findings);
+    }
+
+    // ========================================
     // Plugin: MCP server detection
     // ========================================
 

--- a/plugins/dotnet-diag/agents/optimizing-dotnet-performance.agent.md
+++ b/plugins/dotnet-diag/agents/optimizing-dotnet-performance.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Analyzes .NET code for performance bottlenecks, recommends concrete optimizations, and guides benchmarking. Scans for ~50 anti-patterns across async, memory, strings, collections, LINQ, regex, serialization, and I/O. Use when reviewing .NET code performance, optimizing hot paths, reducing allocations, or tuning async/concurrency patterns."
 name: optimizing-dotnet-performance
-tools: ['read', 'search', 'edit', 'task', 'skill', 'web_search', 'web_fetch', 'ask_user']
+tools: ['read', 'search', 'edit', 'task', 'skill', 'web_search', 'web_fetch', 'ask_user', 'Read', 'Glob', 'Grep', 'Edit', 'Write', 'Skill']
 license: MIT
 ---
 

--- a/plugins/dotnet-diag/agents/optimizing-dotnet-performance.agent.md
+++ b/plugins/dotnet-diag/agents/optimizing-dotnet-performance.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Analyzes .NET code for performance bottlenecks, recommends concrete optimizations, and guides benchmarking. Scans for ~50 anti-patterns across async, memory, strings, collections, LINQ, regex, serialization, and I/O. Use when reviewing .NET code performance, optimizing hot paths, reducing allocations, or tuning async/concurrency patterns."
 name: optimizing-dotnet-performance
-tools: ['read', 'search', 'edit', 'task', 'skill', 'web_search', 'web_fetch', 'ask_user', 'Read', 'Glob', 'Grep', 'Edit', 'Write', 'Skill']
+tools: ['read', 'search', 'edit', 'task', 'skill', 'web_search', 'web_fetch', 'ask_user', 'Read', 'Glob', 'Grep', 'Edit', 'Write', 'Skill', 'read_file', 'replace', 'write_file', 'glob', 'grep_search']
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -6,7 +6,7 @@ description: >-
   errors, verifying project builds successfully.
 name: code-testing-builder
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -6,7 +6,7 @@ description: >-
   errors, verifying project builds successfully.
 name: code-testing-builder
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -6,7 +6,7 @@ description: >-
   imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-fixer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-fixer.agent.md
@@ -6,7 +6,7 @@ description: >-
   imports, correcting type mismatches, fixing compilation failures.
 name: code-testing-fixer
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,7 +6,7 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
-tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 agents:
   - code-testing-researcher
   - code-testing-planner

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -6,7 +6,7 @@ description: >-
   coverage plateaus or project-wide coverage/CRAP analysis without writing tests
   (use coverage-analysis); targeted method/class CRAP scores (use crap-score).
 name: code-testing-generator
-tools: ["agent", "skill", "read", "search", "edit", "execute"]
+tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 agents:
   - code-testing-researcher
   - code-testing-planner

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -7,7 +7,7 @@ description: >-
   running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false
-tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 agents:
   - code-testing-builder
   - code-testing-tester

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -7,7 +7,7 @@ description: >-
   running build-test-fix cycle for generated tests.
 name: code-testing-implementer
 user-invocable: false
-tools: ["agent", "skill", "read", "search", "edit", "execute"]
+tools: ["agent", "skill", "read", "search", "edit", "execute", "Task", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 agents:
   - code-testing-builder
   - code-testing-tester

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -6,7 +6,7 @@ description: >-
   applying lint fixes.
 name: code-testing-linter
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -6,7 +6,7 @@ description: >-
   applying lint fixes.
 name: code-testing-linter
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -6,7 +6,7 @@ description: >-
   creating .testagent/plan.md from research.
 name: code-testing-planner
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -6,7 +6,7 @@ description: >-
   creating .testagent/plan.md from research.
 name: code-testing-planner
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -6,7 +6,7 @@ description: >-
   discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -6,7 +6,7 @@ description: >-
   discovering test frameworks and build commands, producing .testagent/research.md.
 name: code-testing-researcher
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -6,7 +6,7 @@ description: >-
   checking test results and failures.
 name: code-testing-tester
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
 license: MIT
 ---
 

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -6,7 +6,7 @@ description: >-
   checking test results and failures.
 name: code-testing-tester
 user-invocable: false
-tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash"]
+tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
 license: MIT
 ---
 


### PR DESCRIPTION
## Problem

[#847](https://github.com/dotnet/skills/pull/847) added `tools: ["agent", "skill", "read", "search", "edit", "execute"]` to the `code-testing-*` agents to enable subagent fan-out. As that PR notes, those lowercase aliases are portable across **VS Code and the Copilot CLI**.

They are **not** portable to the other CLI hosts that load these same agents from a marketplace/`--plugin-dir`:

- **Claude Code** matches `tools:` against `Task`, `Skill`, `Read`, `Glob`, `Grep`, `Edit`, `Write`, `Bash` — and treats the list as an explicit, case-sensitive allow-list. None of the lowercase aliases match, so the agent is granted **zero tools**. A tool-less model asked to generate tests emits a textual `<tool_call>` block and exits after one turn with an empty diff. This surfaced as `code-testing-generator` scoring 0 on a Claude-Code-hosted benchmark run ("no changes detected").
- **Gemini CLI** (which added custom subagents in 2026, defined the same way) uses a third, snake_case vocabulary: `read_file`, `replace`, `write_file`, `glob`, `grep_search`, `run_shell_command`.

## Fix

Make each agent's `tools:` list a **union** of all three hosts' spellings, so one declaration works everywhere — each host honors the names it recognizes and ignores the rest (verified for Claude Code; Gemini/Copilot ignore unknown names too).

| Capability | Copilot CLI / VS Code | Claude Code | Gemini CLI |
|---|---|---|---|
| read files | `read` | `Read` | `read_file` |
| modify files | `edit` / `create` | `Edit` / `Write` | `replace` / `write_file` |
| search | `search` | `Glob`, `Grep` | `glob`, `grep_search` |
| run commands | `execute` | `Bash` | `run_shell_command` |
| subagents | `agent` | `Task` | `@agent` (no tools entry) |
| skills | `skill` | `Skill` | (implicit, no tools entry) |

The additions are purely to the `tools:` frontmatter line of the 8 code-testing agents — no prose or behavior changes — so #847's fan-out is preserved.

## skill-validator changes (prevention + review feedback)

**1. Complete the validator's `BuiltInTools` set.** The Copilot review flagged `Write` as non-built-in. Rather than temporary `allowed-external-deps.txt` entries (that file is meant to trend to empty), I added the host tool spellings that are legitimate built-ins but weren't case-insensitive matches of existing entries: `write`, `agent`, `execute` (the last two were already flagged pre-branch, from #847), plus the Gemini names `read_file`, `replace`, `write_file`, `grep_search`, `run_shell_command`.

**2. Add a cross-host tool portability check** (`CheckAgentToolPortability`). An agent that declares a capability for only one host is now flagged, with an actionable message ("add `Read` for Claude Code; `read_file` for Gemini CLI"). Names are matched **case-sensitively** (hosts resolve tools by exact spelling), so the exact bug this PR fixes is caught going forward. The capability table is per-host and generalizes to N hosts; capabilities with no `tools:`-level spelling on a host (Gemini subagents/skills) are not demanded there. Findings are **advisory** (they do not fail CI) and allowlistable via `agent-tool-portability:AGENT:capability`.

I also made the one pre-existing single-host agent (`optimizing-dotnet-performance`) portable so the check reports a clean tree.

## Validation

- `skill-validator` builds with 0 warnings; 32 `ExternalDependencyCheckerTests` pass.
- Full `skill-validator check` across all 16 plugins passes with **0 findings**.