### PR TITLE
Fix mtp-hot-reload SDK 9 eval timeout

### DIFF
--- a/tests/dotnet-test/mtp-hot-reload/eval.vally.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.vally.yaml
@@ -33,9 +33,6 @@ stimuli:
       - Instructs setting TESTINGPLATFORM_HOTRELOAD_ENABLED=1 environment variable
       - Uses 'dotnet run --project' to run the test host, not 'dotnet test'
       - "Explains the iterative workflow: edit code, hot reload picks up changes, re-runs tests"
-    constraints:
-      expect_tools:
-        - bash
   - name: Suggest hot reload for failing test in MTP project (SDK 10)
     prompt: My RemoveStock_ExceedsAvailable_ThrowsException test is failing. I want to iterate fixes rapidly. How can I set
       up hot reload for this test project?


### PR DESCRIPTION
## Problem

The `mtp-hot-reload` / **"Suggest hot reload for failing test in MTP project (SDK 9)"** eval was timing out.

## Root cause

In `tests/dotnet-test/mtp-hot-reload/eval.vally.yaml`, the SDK 9 stimulus carried an `expect_tools: [bash]` constraint. This forced the agent to invoke bash for what is a purely *advisory* question ("what's the fastest workflow?"). Because the fixture pins `global.json` to SDK `9.0.200` (`rollForward: latestFeature`), the forced bash invocation triggered a real NuGet restore / SDK resolution, which is slow and exceeded the timeout.

The source-of-truth `eval.yaml` never applied `expect_tools` to this scenario — the constraint was mistakenly re-introduced during the Vally port. This mirrors prior fixes (#546 removing `expect_tools: bash`, #542 SDK 9.0.200 pinning timeouts).

## Fix

Removed the `constraints.expect_tools: [bash]` block from the SDK 9 stimulus in `eval.vally.yaml`, aligning it with `eval.yaml`. The agent can now answer directly from text without an unnecessary build; the `output-matches` graders still validate the required content.