### PR TITLE
dotnet-test: raise timeout for assertion-quality decline-write-tests scenario

### DIFF
--- a/tests/dotnet-test/assertion-quality/eval.yaml
+++ b/tests/dotnet-test/assertion-quality/eval.yaml
@@ -158,7 +158,7 @@ scenarios:
     rubric:
       - "Wrote test methods for the InventoryTracker class"
       - "Covered multiple methods of the class"
-    timeout: 300
+    timeout: 360
 
   # ==========================================================================
   # Scenario: Polyglot — shallow assertions in a Jest/TypeScript suite


### PR DESCRIPTION
## What

Raises the per-scenario `timeout` from `300` to `360` for the **"Decline request to write new tests from scratch"** scenario in `tests/dotnet-test/assertion-quality/eval.yaml`.

## Why

This non-activation scenario asks the agent to write a full MSTest test suite from scratch — a code-generation task — and its rubric requires the agent to actually produce the tests. It was hitting its 300s wall-clock timeout, producing empty output and failing all assertions.

Per `eng/skill-validator/src/docs/InvestigatingResults.md`, timeouts are the highest-priority failure mode and code-generation scenarios often need 360s. This follows the same fix pattern as #850, which raised timeouts for chronic-timeout eval scenarios (including the identically-named test-gap-analysis scenario).