### PR TITLE
dotnet-test: fix writing-mstest-tests eval timeout and skill activation

### DIFF
--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -2,17 +2,18 @@
 name: writing-mstest-tests
 description: >
   Write, create, modernize, or fix comprehensive MSTest unit tests with MSTest 3.x/4.x APIs.
-  USE FOR: write or create MSTest unit tests, fix/modernize MSTest assertions,
-  better MSTest assertion than Assert.IsTrue, replace hard cast with type check (IsInstanceOfType),
+  USE FOR: write, create, review, or modernize MSTest tests and assertions,
+  better MSTest assertion than Assert.IsTrue, replace hard cast with IsInstanceOfType,
   MSTest assertion APIs (Contains, ContainsSingle, HasCount, IsEmpty, IsNotEmpty, DoesNotContain,
   AreSame, IsNull, StartsWith, EndsWith, MatchesRegex, IsGreaterThan, IsLessThan, IsInRange),
-  swapped Assert.AreEqual args, replace ExpectedException with Assert.Throws,
+  swapped/reversed Assert.AreEqual args (Expected/Actual backwards),
+  replace ExpectedException with Assert.Throws,
   data-driven (DataRow, DynamicData, ValueTuples),
   lifecycle (TestInitialize, TestCleanup, TestContext),
-  async tests and cancellation tokens, conditional execution/retry/cleanup (OSCondition, Retry),
+  async and cancellation tests, conditional execution/retry/cleanup (OSCondition, Retry),
   parallelization (Parallelize/DoNotParallelize), MSTest.Sdk setup, MSTESTxxxx analyzer fixes.
   DO NOT USE FOR: test quality audits (use test-anti-patterns),
-  running tests (use run-tests), MSTest version migration (use the migrate-mstest skills),
+  running tests (use run-tests), MSTest version migration (use migrate-mstest skills),
   xUnit/NUnit/TUnit, or non-.NET languages.
 license: MIT
 ---

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -410,7 +410,7 @@ scenarios:
       - "Tests boundary conditions at grade thresholds (e.g., exactly 90 vs 89)"
       - "Tests that NormalizeScore caps the result at 100 when rawScore exceeds maxRaw"
       - "Seals the test class"
-    timeout: 240
+    timeout: 360
 
   # ============================================================================
   # Goal 7: Collection, null, and reference assertions


### PR DESCRIPTION
## Summary

Two fixes for the `dotnet-test/writing-mstest-tests` eval.

### 1. Timeout (`eval.yaml`)
The **"Use comparison assertions for boundary testing"** scenario chronically hit its 240s wall-clock timeout. Raised `timeout: 240` → `360`, matching the other code-generation scenarios in this file and following `eng/skill-validator/src/docs/InvestigatingResults.md` guidance.

### 2. Skill activation (`SKILL.md` description)
Three scenarios showed plugin-arm **skill non-activation**:
- *Fix swapped Assert.AreEqual arguments* (not activated, no headroom)
- *Modernize legacy test patterns* (isolated ✅ / plugin ⚠️)
- *Use proper type assertions instead of casts* (isolated ✅ / plugin ⚠️)

Root cause is **sibling-skill competition**, not menu-budget truncation — the plugin arm loads only `dotnet-test` (13.3k < 15k char budget), so descriptions aren't cut. The prompts use audit/review phrasing ("**review** these tests/assertions") that routes the model to `test-anti-patterns`/`assertion-quality` when all 20 skills are present.

Fix: tuned the frontmatter `description` (per `InvestigatingResults.md` §5) to claim the scenario keywords — added **"review"** (Modernize scenario) and **"swapped/reversed Assert.AreEqual args (Expected/Actual backwards)"** matching the swapped-args prompt's symptom wording. Change is budget-neutral (still ≤ 1,024 chars, validated by `check`) and keeps every assertion keyword the other passing scenarios depend on.

## Validation
- `skill-validator check --plugin plugins/dotnet-test` → ✅ All checks passed (20 skills, 10 agents, 1 plugin).