### PR TITLE
dotnet-test: reduce assertion-quality over-structuring on small suites

### DIFF
--- a/plugins/dotnet-test/skills/assertion-quality/SKILL.md
+++ b/plugins/dotnet-test/skills/assertion-quality/SKILL.md
@@ -116,6 +116,8 @@ Before reporting, calibrate findings:
 
 ### Step 6: Report findings
 
+**Scale the report depth to the size and complexity of the suite.** The structure below is the full template for a substantial suite (roughly 15+ tests or a multi-file project). For a small or simple input (a single file with only a handful of tests), do not emit every section — a padded multi-section dashboard on a trivial input reads as noise and buries the answer. Instead, answer the user's question directly and concisely: which tests are assertion-free or trivial-only, the overall assertion-quality verdict, and concrete recommendations (still distinguishing intentional smoke tests from tests masquerading as real verification). Use only the sections that carry real signal for the input at hand; a short metric summary plus the assertion-free list and recommendations is often enough. Never omit the rubric-relevant substance (assertion-free/trivial identification, the quality verdict, and concrete recommendations) — only trim structural overhead that adds no information.
+
 Present the analysis in this structure:
 
 1. **Summary Dashboard** — A quick-reference table of key metrics:


### PR DESCRIPTION
## Problem

In the skill-validator dashboard, the assertion-quality scenario **"Flag assertion-free tests and trivial-only assertions"** regressed: baseline **4.3/5** vs SKILLED **4.0/5** (−0.3 quality decline). The fixture is tiny (8 test methods in one file), and the skill pushes a heavy multi-section structured report (Summary Dashboard + 12 categories + Category Breakdown + Gap Analysis + Recommendations). On a trivial input this over-structuring/verbosity scores below a focused freeform baseline.

## Change

A single, principle-based addition to Step 6 ("Report findings") in `plugins/dotnet-test/skills/assertion-quality/SKILL.md`: scale report depth to suite size/complexity. For small/simple inputs, answer directly and concisely (which tests are assertion-free/trivial, the overall verdict, concrete recommendations) rather than emitting every dashboard section. The full template remains the default for substantial suites, and no rubric-relevant substance is dropped.

## Safety

- Generic and principle-based — not overfit to this scenario.
- Full capability preserved for large suites.
- Does not weaken rubric behaviors: still identifies assertion-free tests, distinguishes intentional smoke tests from real verification, and gives concrete recommendations.
- Independent of PR #862 (branched from main).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>