### PR TITLE
Reduce evaluation fan-out to avoid Copilot rate limits

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -454,14 +454,29 @@ jobs:
           # resource usage across ~90 min of continuous MCP traffic
           # consistently triggered host-level termination.
           function Get-PluginShardEntries {
-            param([string]$plugin, [string]$contentRoot = ".")
+            param(
+              [string]$plugin,
+              [string]$contentRoot = ".",
+              [string[]]$selectedSkills = @()
+            )
             $skillsDir = "plugins/$plugin/skills"
             $skillsRoot = Join-Path $contentRoot $skillsDir
             $singleEntry = @{ name = $plugin; plugin = $plugin; skills_path = $skillsDir }
-            if (-not (Test-Path $skillsRoot)) { return @($singleEntry) }
+            if (-not (Test-Path $skillsRoot)) {
+              if ($selectedSkills.Count -gt 0) { return @() }
+              return @($singleEntry)
+            }
             $skillDirs = @(Get-ChildItem -Path $skillsRoot -Directory -ErrorAction SilentlyContinue |
               Sort-Object Name | Select-Object -ExpandProperty Name)
-            if ($skillDirs.Count -eq 0) { return @($singleEntry) }
+            if ($selectedSkills.Count -gt 0) {
+              $selected = @{}
+              foreach ($skill in $selectedSkills) { $selected[$skill] = $true }
+              $skillDirs = @($skillDirs | Where-Object { $selected.ContainsKey($_) })
+            }
+            if ($skillDirs.Count -eq 0) {
+              if ($selectedSkills.Count -gt 0) { return @() }
+              return @($singleEntry)
+            }
             $shardGroups = @{}
             foreach ($skill in $skillDirs) {
               $evalPath = Join-Path $contentRoot "tests" $plugin $skill "eval.yaml"
@@ -476,7 +491,14 @@ jobs:
               if (-not $shardGroups.ContainsKey($shard)) { $shardGroups[$shard] = @() }
               $shardGroups[$shard] += $skill
             }
-            if ($shardGroups.Count -le 1) { return @($singleEntry) }
+            if ($shardGroups.Count -le 1) {
+              if ($selectedSkills.Count -gt 0) {
+                $paths = ($skillDirs | ForEach-Object { "$skillsDir/$_" }) -join ' '
+                $name = if ($skillDirs.Count -eq 1) { "$plugin--$($skillDirs[0])" } else { $plugin }
+                return @(@{ name = $name; plugin = $plugin; skills_path = $paths })
+              }
+              return @($singleEntry)
+            }
             return @($shardGroups.Keys | Sort-Object | ForEach-Object {
               $shardName = $_
               $paths = ($shardGroups[$shardName] | ForEach-Object { "$skillsDir/$_" }) -join ' '
@@ -535,23 +557,25 @@ jobs:
                 } |
                 Sort-Object -Unique)
 
-              # Filter to skills that have a SKILL.md and a tests directory.
-              # Sharding does not apply to per-skill PR runs — each changed
-              # skill gets its own matrix entry already.
-              $entries = @($changedPairs | ForEach-Object {
+              # Filter to skills that have a SKILL.md and a tests directory,
+              # then group the changed skills by plugin and apply the same
+              # executionShard bucketing used by schedule/full-plugin runs.
+              $changedSkillsByPlugin = @{}
+              $changedPairs | ForEach-Object {
                 $parts = $_ -split '/'
                 $plugin = $parts[0]
                 $skill = $parts[1]
                 $skillMd = Join-Path $contentRoot "plugins" $plugin "skills" $skill "SKILL.md"
                 $testsDir = Join-Path $contentRoot "tests" $plugin
                 if ((Test-Path $skillMd) -and (Test-Path $testsDir)) {
-                  @{
-                    name = "$plugin--$skill"
-                    plugin = $plugin
-                    skills_path = "plugins/$plugin/skills/$skill"
-                  }
+                  if (-not $changedSkillsByPlugin.ContainsKey($plugin)) { $changedSkillsByPlugin[$plugin] = @() }
+                  $changedSkillsByPlugin[$plugin] += $skill
                 }
-              } | Where-Object { $_ })
+              }
+              $entries = @($changedSkillsByPlugin.Keys | Sort-Object | ForEach-Object {
+                $plugin = $_
+                Get-PluginShardEntries -plugin $plugin -contentRoot $contentRoot -selectedSkills ($changedSkillsByPlugin[$plugin] | Sort-Object -Unique)
+              })
 
               $plugins = @($entries | ForEach-Object { $_.plugin } | Sort-Object -Unique)
             }
@@ -684,6 +708,9 @@ jobs:
     name: evaluate (${{ matrix.entry.name }})
     strategy:
       fail-fast: false
+      # Keep PR runs below the token storm threshold; scheduled runs can keep
+      # the broader throughput because they already use plugin/shard fan-out.
+      max-parallel: ${{ needs.gate.outputs.pr_number != '' && 4 || 8 }}
       matrix:
         entry: ${{ fromJson(needs.discover.outputs.entries || '[]') }}
 
@@ -806,7 +833,7 @@ jobs:
           # Both mitigations are required; either alone reproduces a
           # different failure. RUNS stays unchanged so CV remains meaningful.
           RUNS: ${{ needs.discover.outputs.is_infra == 'true' && '1' || (github.event_name == 'schedule' && '5' || '3') }}
-          PARALLEL_SKILLS: ${{ steps.detect-mcp.outputs.has_mcp == 'true' && '1' || ((needs.discover.outputs.is_infra == 'true' || github.event_name == 'schedule') && '2' || '5') }}
+          PARALLEL_SKILLS: ${{ steps.detect-mcp.outputs.has_mcp == 'true' && '1' || (needs.gate.outputs.pr_number != '' && '1') || ((needs.discover.outputs.is_infra == 'true' || github.event_name == 'schedule') && '2' || '5') }}
           PARALLEL_SCENARIOS: ${{ steps.detect-mcp.outputs.has_mcp == 'true' && '3' || ((needs.discover.outputs.is_infra == 'true' || github.event_name == 'schedule') && '3' || '5') }}
           PARALLEL_RUNS: ${{ steps.detect-mcp.outputs.has_mcp == 'true' && '1' || ((needs.discover.outputs.is_infra == 'true' || github.event_name == 'schedule') && '3' || '5') }}
         run: |

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -276,6 +276,7 @@ jobs:
         if: always() && steps.find-evals.outputs.has_evals == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
+          if-no-files-found: ignore
           name: vally-results-${{ matrix.entry.name }}
           path: artifacts/TestResults/vally/${{ matrix.entry.name }}/
           include-hidden-files: true

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   prepare:
-    if: inputs.entries == ''
+    if: ${{ !inputs.entries }}
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.build.outputs.entries }}
@@ -219,13 +219,20 @@ jobs:
           fi
 
           # Model + comparison-judge model come from the experiment file's
-          # `overrides:` block (single source of truth), matching run-vally-evals.sh.
+          # `overrides:` block (single source of truth).
           read_override() {
-            awk -v k="$1" '
+            value="$(
+              awk -v k="$1" '
               /^overrides:/ { f = 1; next }
               /^[^[:space:]]/ { f = 0 }
               f && $1 == k":" { print $2; exit }
-            ' "$EXPERIMENT_FILE"
+              ' "$EXPERIMENT_FILE"
+            )"
+            case "$value" in
+              \"*\") value="${value#\"}"; value="${value%\"}" ;;
+              \'*\') value="${value#\'}"; value="${value%\'}" ;;
+            esac
+            printf '%s\n' "$value"
           }
           MODEL="$(read_override model)"; MODEL="${MODEL:-${{ env.FALLBACK_MODEL }}}"
           JUDGE_MODEL="$(read_override judge_model)"; JUDGE_MODEL="${JUDGE_MODEL:-${{ env.FALLBACK_JUDGE_MODEL }}}"

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -34,31 +34,32 @@ on:
         type: string
 
 env:
-  MODEL: claude-opus-4.6
-  JUDGE_MODEL: claude-opus-4.6
+  # Fallback model/judge used only if the experiment file's `overrides:` block
+  # can't be parsed. The experiment file is the source of truth (see below).
+  FALLBACK_MODEL: claude-opus-4.6
+  FALLBACK_JUDGE_MODEL: claude-opus-4.6
 
 permissions:
   contents: read
 
 jobs:
-  # --------------------------------------------------------------------------
-  # For workflow_dispatch: build a single-entry matrix
-  # --------------------------------------------------------------------------
   prepare:
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.entries == ''
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.build.outputs.entries }}
     steps:
       - id: build
+        shell: pwsh
         run: |
-          PLUGIN="${{ inputs.plugin }}"
-          SKILL="${{ inputs.skill }}"
-          if [ -n "$SKILL" ]; then
-            echo "entries=[{\"name\":\"${PLUGIN}--${SKILL}\",\"plugin\":\"${PLUGIN}\",\"skills_path\":\"plugins/${PLUGIN}/skills/${SKILL}\"}]" >> $GITHUB_OUTPUT
-          else
-            echo "entries=[{\"name\":\"${PLUGIN}\",\"plugin\":\"${PLUGIN}\",\"skills_path\":\"plugins/${PLUGIN}/skills\"}]" >> $GITHUB_OUTPUT
-          fi
+          $p = "${{ inputs.plugin }}"
+          $s = "${{ inputs.skill }}"
+          if ($s) {
+            $json = @(@{ name = "$p--$s"; plugin = $p; skills_path = "plugins/$p/skills/$s" }) | ConvertTo-Json -Compress -AsArray
+          } else {
+            $json = @(@{ name = $p; plugin = $p; skills_path = "plugins/$p/skills" }) | ConvertTo-Json -Compress -AsArray
+          }
+          "entries=$json" >> $env:GITHUB_OUTPUT
 
   # --------------------------------------------------------------------------
   # Run vally evaluation (shadow mode)
@@ -72,6 +73,9 @@ jobs:
     name: vally (${{ matrix.entry.name }})
     strategy:
       fail-fast: false
+      # Cap concurrent Copilot sessions: max-parallel jobs * --workers per job.
+      # vally has only two tokens, so keep this well below skill-validator's fan-out.
+      max-parallel: 4
       matrix:
         entry: ${{ fromJson(inputs.entries || needs.prepare.outputs.entries || '[]') }}
 
@@ -133,8 +137,7 @@ jobs:
             echo "has_evals=false" >> $GITHUB_OUTPUT
           else
             echo "has_evals=true" >> $GITHUB_OUTPUT
-            echo "$EVALS" > /tmp/eval-specs.txt
-            echo "Found $(wc -l < /tmp/eval-specs.txt) eval specs"
+            echo "Found $(echo "$EVALS" | wc -l | tr -d ' ') eval specs"
           fi
 
       - name: Run vally evaluations
@@ -144,79 +147,95 @@ jobs:
           RESULTS_DIR: artifacts/TestResults/vally/${{ matrix.entry.name }}
         run: |
           PLUGIN="${{ matrix.entry.plugin }}"
+          SKILLS_PATH="${{ matrix.entry.skills_path }}"
 
-          while IFS= read -r EVAL_SPEC; do
-            EVAL_NAME=$(basename $(dirname "$EVAL_SPEC"))
-            echo "::group::Evaluating $EVAL_NAME"
+          # Scope the canonical experiment with --eval-filter (repeatable),
+          # which intersects each pattern with the experiment's `evals:` glob.
+          # `agent.*` evals are excluded by that glob, so they drop out
+          # automatically; a missing plugins/<plugin>/skills/<skill> dir surfaces
+          # as a skilled-variant failure that adapt.mjs warns on.
+          #
+          # Honor the matrix entry's skills_path so per-skill PR entries and
+          # sharded entries run only their targeted skills, not the whole plugin:
+          #   plugins/<plugin>/skills            -> tests/<plugin>/**   (whole plugin)
+          #   plugins/<plugin>/skills/<skill>    -> tests/<plugin>/<skill>
+          # A workflow_dispatch skill input overrides to that single skill.
+          FILTER_ARGS=()
+          if [ -n "${{ inputs.skill }}" ]; then
+            FILTER_ARGS=(--eval-filter "tests/$PLUGIN/${{ inputs.skill }}/eval.vally.yaml")
+          else
+            for token in $SKILLS_PATH; do
+              rel="${token#plugins/}"       # <plugin>/skills[/<skill>]
+              tp="${rel%%/skills*}"         # <plugin>
+              skill="${rel#*/skills}"       # "" or "/<skill>"
+              skill="${skill#/}"            # "" or "<skill>"
+              if [ -n "$skill" ]; then
+                if [[ "$skill" == agent.* ]]; then
+                  echo "Skipping $tp/$skill (agent.* evals are excluded from dotnet-skills.experiment.yaml)"
+                  continue
+                fi
+                candidate="tests/$tp/$skill/eval.vally.yaml"
+                if [ ! -f "$candidate" ]; then
+                  echo "Skipping $tp/$skill (no eval.vally.yaml)"
+                  continue
+                fi
+                FILTER_ARGS+=(--eval-filter "$candidate")
+              else
+                FILTER_ARGS+=(--eval-filter "tests/$tp/**/eval.vally.yaml")
+              fi
+            done
+          fi
+          if [ ${#FILTER_ARGS[@]} -eq 0 ]; then
+            echo "No matching vally eval filters for $PLUGIN"
+            exit 0
+          fi
 
-            BASELINE_DIR="$RESULTS_DIR/$EVAL_NAME/baseline"
-            SKILLED_DIR="$RESULTS_DIR/$EVAL_NAME/skilled"
-            mkdir -p "$BASELINE_DIR" "$SKILLED_DIR"
+          # Model + comparison-judge model come from the experiment file's
+          # `overrides:` block (single source of truth), matching run-vally-evals.sh.
+          read_override() {
+            awk -v k="$1" '
+              /^overrides:/ { f = 1; next }
+              /^[^[:space:]]/ { f = 0 }
+              f && $1 == k":" { print $2; exit }
+            ' dotnet-skills.experiment.yaml
+          }
+          MODEL="$(read_override model)"; MODEL="${MODEL:-${{ env.FALLBACK_MODEL }}}"
+          JUDGE_MODEL="$(read_override judge_model)"; JUDGE_MODEL="${JUDGE_MODEL:-${{ env.FALLBACK_JUDGE_MODEL }}}"
 
-            # Each eval targets a single skill named after the eval folder.
-            # Evals that do not map 1:1 to a skill (e.g. `agent.*` evals that
-            # exercise multi-skill orchestrator agents and declare their own
-            # `environment.skills`) are skipped — they are out of scope for
-            # the skill-vs-baseline pipeline.
-            PER_SKILL_DIR="./plugins/$PLUGIN/skills/$EVAL_NAME"
-            if [ ! -f "$PER_SKILL_DIR/SKILL.md" ]; then
-              echo "::warning::Skipping $EVAL_NAME — no SKILL.md at $PER_SKILL_DIR (likely an agent eval; not supported by the skill-isolation pipeline)"
-              echo "::endgroup::"
-              continue
-            fi
+          # Run baseline (no skills) + skilled (the one skill) in a single
+          # experiment pass. The baseline is a true skill-free control because
+          # vally does no ambient skill discovery — skills load only from
+          # environment.skills.
+          EXPERIMENT_OUT="$RESULTS_DIR/_experiment"
+          mkdir -p "$EXPERIMENT_OUT"
+          vally experiment run dotnet-skills.experiment.yaml \
+            "${FILTER_ARGS[@]}" \
+            --output-dir "$EXPERIMENT_OUT" \
+            --workers 5 \
+            2>&1 || echo "::warning::vally experiment run reported failures for $PLUGIN"
 
-            # Empty dir used as `--skill-dir` for the baseline so vally
-            # discovers zero skills. Without this, vally walks up to the repo's
-            # .vally.yaml and loads every skill under plugins/, contaminating
-            # the baseline.
-            EMPTY_SKILL_DIR=$(mktemp -d -t vally-empty-skills-XXXXXX)
+          RUN_DIR=$(find "$EXPERIMENT_OUT" -mindepth 1 -maxdepth 1 -type d | sort | tail -1)
+          if [ -z "$RUN_DIR" ]; then
+            echo "::warning::No experiment output produced for $PLUGIN"
+            exit 0
+          fi
 
-            # Baseline run (no skills)
-            echo "--- Baseline run ---"
-            vally eval \
-              --eval-spec "$EVAL_SPEC" \
-              --skill-dir "$EMPTY_SKILL_DIR" \
-              --model ${{ env.MODEL }} \
-              --runs 1 --workers 3 \
-              --skip-validate \
-              --judge-model ${{ env.JUDGE_MODEL }} \
-              --output-dir "$BASELINE_DIR" \
-              2>&1 || echo "::warning::Baseline eval failed for $EVAL_NAME"
+          # Split the per-variant experiment output by eval and run `vally
+          # compare` per skill (in the adapter) to produce the per-skill
+          # results.json the shadow summary consumes. `vally` is on PATH here.
+          node eng/vally-adapter/adapt.mjs \
+            --experiment-dir "$RUN_DIR" \
+            --output-root "$RESULTS_DIR" \
+            --vally "vally" \
+            --model "$MODEL" \
+            --judge-model "$JUDGE_MODEL"
 
-            # Skilled run (exactly the one skill under evaluation)
-            echo "--- Skilled run ---"
-            vally eval \
-              --eval-spec "$EVAL_SPEC" \
-              --skill-dir "$PER_SKILL_DIR" \
-              --model ${{ env.MODEL }} \
-              --runs 1 --workers 3 \
-              --skip-validate \
-              --judge-model ${{ env.JUDGE_MODEL }} \
-              --output-dir "$SKILLED_DIR" \
-              2>&1 || echo "::warning::Skilled eval failed for $EVAL_NAME"
-
-            rm -rf "$EMPTY_SKILL_DIR"
-
-            # Adapt results — find JSONL in timestamped subdirs
-            BASELINE_JSONL=$(find "$BASELINE_DIR" -name "*.jsonl" -type f 2>/dev/null | head -1)
-            SKILLED_JSONL=$(find "$SKILLED_DIR" -name "*.jsonl" -type f 2>/dev/null | head -1)
-
-            if [ -n "$BASELINE_JSONL" ] && [ -n "$SKILLED_JSONL" ]; then
-              echo "--- Adapting results ---"
-              node eng/vally-adapter/adapt.mjs \
-                --baseline "$(dirname "$BASELINE_JSONL")" \
-                --skilled "$(dirname "$SKILLED_JSONL")" \
-                --skill-name "$EVAL_NAME" \
-                --skill-path "plugins/$PLUGIN/skills/$EVAL_NAME" \
-                --model "${{ env.MODEL }}" \
-                --judge-model "${{ env.JUDGE_MODEL }}" \
-                --output "$RESULTS_DIR/$EVAL_NAME/results.json"
-            else
-              echo "::warning::Skipping adapt for $EVAL_NAME — missing JSONL output"
-            fi
-
-            echo "::endgroup::"
-          done < /tmp/eval-specs.txt
+          # Informational shadow job: surface how many verdicts were produced.
+          PRODUCED=$(find "$RESULTS_DIR" -name results.json -not -path "$EXPERIMENT_OUT/*" | wc -l | tr -d ' ')
+          echo "Produced $PRODUCED skill verdict(s) for $PLUGIN"
+          if [ "$PRODUCED" -eq 0 ]; then
+            echo "::warning::vally produced no skill verdicts for $PLUGIN — evals failed to run or validate (see logs above)"
+          fi
 
       - name: Upload results
         if: always() && steps.find-evals.outputs.has_evals == 'true'
@@ -232,13 +251,14 @@ jobs:
         run: |
           echo "## 🔬 Vally Shadow Results: ${{ matrix.entry.name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a credible improvement (mean preference > 0 with its 95% CI above 0)." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
 
           RESULTS_DIR="artifacts/TestResults/vally/${{ matrix.entry.name }}"
-          for RESULTS_JSON in "$RESULTS_DIR"/*/results.json; do
+          while IFS= read -r RESULTS_JSON; do
             if [ ! -f "$RESULTS_JSON" ]; then continue; fi
             EVAL_NAME=$(basename $(dirname "$RESULTS_JSON"))
 
-            # Extract verdict from JSON
             PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].passed)")
             REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].reason)")
             ICON=$([ "$PASSED" = "true" ] && echo "✅" || echo "❌")
@@ -247,17 +267,18 @@ jobs:
             echo "$REASON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            # Per-scenario table
-            echo "| Scenario | Assertions | Improvement |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|------------|-------------|" >> $GITHUB_STEP_SUMMARY
+            # Per-scenario table: mean preference score and win/tie/loss.
+            echo "| Scenario | Mean preference | Trials (W/T/L) |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|-----------------|----------------|" >> $GITHUB_STEP_SUMMARY
             node -e "
               const r = JSON.parse(require('fs').readFileSync('$RESULTS_JSON', 'utf-8'));
               for (const s of r.verdicts[0].scenarios) {
-                const allPass = s.withSkill.metrics.assertionResults.every(a => a.passed);
-                const icon = allPass ? '✔' : '✘';
-                const pct = (s.improvementScore * 100).toFixed(1);
-                console.log('| ' + icon + ' ' + s.scenarioName + ' | ' + s.withSkill.metrics.assertionResults.length + ' passed | ' + pct + '% |');
+                const icon = s.meanScore > 0 ? '▲' : s.meanScore < 0 ? '▼' : '=';
+                const pct = (s.meanScore >= 0 ? '+' : '') + (s.meanScore * 100).toFixed(1) + '%';
+                let w=0,t=0,l=0;
+                for (const tr of (s.trials||[])) { if (tr.score>0) w++; else if (tr.score<0) l++; else t++; }
+                console.log('| ' + icon + ' ' + s.scenarioName + ' | ' + pct + ' | ' + w + '/' + t + '/' + l + ' |');
               }
             " >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-          done
+          done < <(find "$RESULTS_DIR" -name results.json | sort)

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -171,7 +171,7 @@ jobs:
               skill="${skill#/}"            # "" or "<skill>"
               if [ -n "$skill" ]; then
                 if [[ "$skill" == agent.* ]]; then
-                  echo "Skipping $tp/$skill (agent.* evals are excluded from dotnet-skills.experiment.yaml)"
+                  echo "Skipping $tp/$skill (agent.* evals are excluded from the vally experiment)"
                   continue
                 fi
                 candidate="tests/$tp/$skill/eval.vally.yaml"
@@ -190,6 +190,34 @@ jobs:
             exit 0
           fi
 
+          # Prefer the repo's canonical experiment file when present (PR 854+).
+          # On main, that file does not exist yet, so synthesize an equivalent
+          # temporary experiment that scopes each eval to its single skill.
+          EXPERIMENT_FILE="dotnet-skills.experiment.yaml"
+          if [ ! -f "$EXPERIMENT_FILE" ]; then
+            EXPERIMENT_FILE="$RUNNER_TEMP/dotnet-skills.experiment.yaml"
+            cat > "$EXPERIMENT_FILE" <<'EOF'
+          name: dotnet-skills
+          evals:
+            - tests/*/!(agent.*)/eval.vally.yaml
+          overrides:
+            model: claude-opus-4.6
+            judge_model: claude-opus-4.6
+            runs: 1
+          vary:
+            - /environment/skills
+          baseline: baseline
+          variants:
+            baseline:
+              environment:
+                skills: []
+            skilled:
+              environment:
+                skills:
+                  - plugins/${eval.grandparent}/skills/${eval.parent}
+          EOF
+          fi
+
           # Model + comparison-judge model come from the experiment file's
           # `overrides:` block (single source of truth), matching run-vally-evals.sh.
           read_override() {
@@ -197,7 +225,7 @@ jobs:
               /^overrides:/ { f = 1; next }
               /^[^[:space:]]/ { f = 0 }
               f && $1 == k":" { print $2; exit }
-            ' dotnet-skills.experiment.yaml
+            ' "$EXPERIMENT_FILE"
           }
           MODEL="$(read_override model)"; MODEL="${MODEL:-${{ env.FALLBACK_MODEL }}}"
           JUDGE_MODEL="$(read_override judge_model)"; JUDGE_MODEL="${JUDGE_MODEL:-${{ env.FALLBACK_JUDGE_MODEL }}}"
@@ -208,7 +236,7 @@ jobs:
           # environment.skills.
           EXPERIMENT_OUT="$RESULTS_DIR/_experiment"
           mkdir -p "$EXPERIMENT_OUT"
-          vally experiment run dotnet-skills.experiment.yaml \
+          vally experiment run "$EXPERIMENT_FILE" \
             "${FILTER_ARGS[@]}" \
             --output-dir "$EXPERIMENT_OUT" \
             --workers 5 \


### PR DESCRIPTION
## Problem

PR #854 exposed two separate rate-limit issues in the evaluation pipeline:

1. **skill-validator** still launched one PR matrix leg per changed skill, which meant ~85 jobs on a large PR.
2. **vally** needed to stay grouped/capped as well, but the reusable-workflow handoff had to preserve the existing workflow-call matrix behavior.

## What this branch does

### 1. Reduce PR skill-validator fan-out in `evaluation.yml`
- Group changed PR skills by plugin instead of emitting one matrix leg per skill.
- Reuse the existing `executionShard` bucketing for grouped PR entries, so plugins like `dotnet-msbuild` still split into `default` / `medium` / `heavy` legs.
- Cap PR `evaluate` matrix concurrency with `max-parallel: 4`.
- Force `parallel-skills=1` on PR runs so grouped legs do not overload a single assigned Copilot token.

For PR #854, that collapses the skill-validator matrix from about **85 jobs to 17 grouped/plugin-shard legs**.

### 2. Keep vally on the proven reusable-workflow matrix pattern
- Keep `vally-evaluation.yml` on the working main-branch pattern where reusable runs consume `inputs.entries` directly and manual runs synthesize one entry via `prepare`.
- Cap vally concurrency with `max-parallel: 4`.
- Skip `agent.*` and skills without `eval.vally.yaml` while building `--eval-filter` arguments, so grouped plugin entries don't need a separate checkout-time pruning phase.
- Run the vally `prepare` job only when `inputs.entries` is empty, which avoids synthesizing a bogus empty manual entry during workflow-dispatch-driven reusable runs.

## Branch / PR hygiene

- The earlier merged PR #871 commit was reverted out of PR #854's branch, so this branch is again isolated for experimentation.
- This PR supersedes merged #871 and carries the follow-up evaluation + vally fixes on the same stacked branch.

## Validation so far

- `actionlint -shellcheck= -pyflakes=` passes on both `evaluation.yml` and `vally-evaluation.yml`.
- Local simulation of PR #854 now produces **17** grouped PR discover entries, including preserved `dotnet-msbuild--shard-*` buckets.
- Validation workflow runs are being exercised from this branch against PR #854's live head.