### PR TITLE
Scale vally token pool to any number of rotation tokens

### DIFF
--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -109,7 +109,7 @@ jobs:
           mapfile -t TOKENS < <(
             printf '%s' "$ALL_SECRETS" \
               | jq -r 'to_entries
-                       | map(select(.key | test("^COPILOT_GITHUB_TOKEN(_[0-9]+)?$"; "i")))
+                       | map(select(.key | test("^COPILOT_GITHUB_TOKEN(_[0-9]+)?$"; "i")) | select(.value != ""))
                        | sort_by(.key)[]
                        | .value'
           )

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -97,22 +97,38 @@ jobs:
       - name: Select Copilot token
         id: select-token
         env:
-          TOKEN_1: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          TOKEN_2: ${{ secrets.COPILOT_GITHUB_TOKEN_2 }}
+          # Expose every inherited secret as JSON so the token pool scales to any
+          # number of COPILOT_GITHUB_TOKEN[_N] entries without hard-coding each
+          # one here. The caller passes `secrets: inherit`, so all repo/org
+          # secrets are visible, and GitHub masks every secret value in logs.
+          ALL_SECRETS: ${{ toJson(secrets) }}
         run: |
-          TOKENS=()
-          for i in 1 2; do
-            var="TOKEN_$i"
-            val="${!var}"
-            if [ -n "$val" ]; then TOKENS+=("$val"); fi
-          done
+          # Collect every secret named COPILOT_GITHUB_TOKEN or
+          # COPILOT_GITHUB_TOKEN_<N> (case-insensitive), sorted by name for a
+          # stable, reproducible pool order.
+          mapfile -t TOKENS < <(
+            printf '%s' "$ALL_SECRETS" \
+              | jq -r 'to_entries
+                       | map(select(.key | test("^COPILOT_GITHUB_TOKEN(_[0-9]+)?$"; "i")))
+                       | sort_by(.key)[]
+                       | .value'
+          )
           if [ ${#TOKENS[@]} -eq 0 ]; then
             echo "::error::No COPILOT_GITHUB_TOKEN secrets are configured"
             exit 1
           fi
-          IDX=$(( ${RANDOM} % ${#TOKENS[@]} ))
+          # Assign deterministically by matrix job-index so jobs spread evenly
+          # across the pool and avoid random collisions; fall back to RANDOM when
+          # job-index is unavailable (e.g. workflow_dispatch single job).
+          JOB_INDEX="${{ strategy.job-index }}"
+          if [ -n "$JOB_INDEX" ]; then
+            IDX=$(( JOB_INDEX % ${#TOKENS[@]} ))
+          else
+            IDX=$(( RANDOM % ${#TOKENS[@]} ))
+          fi
+          echo "Selected token $((IDX + 1)) of ${#TOKENS[@]} available (job-index=${JOB_INDEX:-random})"
           echo "::add-mask::${TOKENS[$IDX]}"
-          echo "token=${TOKENS[$IDX]}" >> $GITHUB_OUTPUT
+          echo "token=${TOKENS[$IDX]}" >> "$GITHUB_OUTPUT"
 
       - name: Find eval specs
         id: find-evals


### PR DESCRIPTION
## Summary

The vally shadow-evaluation token selector in `vally-evaluation.yml` only read `COPILOT_GITHUB_TOKEN` and `COPILOT_GITHUB_TOKEN_2` — a hard-coded `for i in 1 2` loop — so any additional rotation tokens configured as repo/org secrets were silently ignored. With the reduced fan-out from #872 that is only two Copilot tokens backing the whole matrix.

This makes the pool **unbounded**: it enumerates secrets via `toJson(secrets)` and collects every one named `COPILOT_GITHUB_TOKEN` or `COPILOT_GITHUB_TOKEN_<N>` (case-insensitive). Adding more tokens now needs no workflow edit. The reusable workflow is called with `secrets: inherit`, so all secrets are visible.

It also assigns a token **deterministically by matrix `job-index`** (matching the approach already used in `evaluation.yml`) instead of pure `$RANDOM`, so concurrent jobs spread evenly across the pool and avoid randomly colliding on the same token.

## Validation

- `actionlint -shellcheck= -pyflakes= .github/workflows/vally-evaluation.yml` → exit 0
- jq filter verified against a sample secrets payload (matches `COPILOT_GITHUB_TOKEN`, `_2`, `_10`; excludes `github_token`/others)
