### PR TITLE
Fix two cross-family vally eval silent drops

### DIFF
--- a/tests/dotnet-msbuild/binlog-failure-analysis/eval.vally.yaml
+++ b/tests/dotnet-msbuild/binlog-failure-analysis/eval.vally.yaml
@@ -14,9 +14,23 @@ stimuli:
         - src: .
           dest: .
       commands:
-        - dotnet build BuildDiag.sln -bl:build.binlog
-        - node -e "const fs=require('fs'); fs.readdirSync('.').filter(f=>!f.endsWith('.binlog'))
-          .forEach(f=>fs.rmSync(f,{recursive:true,force:true}))"
+        # The solution is intentionally broken (missing Newtonsoft.Json reference), so
+        # `dotnet build` exits non-zero. `-bl` still writes the binlog regardless, so
+        # tolerate the failure. The .NET skill-validator ignores setup exit codes (it
+        # never checks ExitCode), but vally's `experiment run` harness treats a non-zero
+        # setup command as a fatal trial error and drops all events. `|| exit 0` swallows
+        # the failure portably: `true` is not a cmd.exe builtin (vally shells out via
+        # `cmd /c` on Windows), whereas `exit 0` returns 0 in both cmd and POSIX sh, so
+        # the eval works on Linux CI, Windows local runs, and the skill-validator alike.
+        - dotnet build BuildDiag.sln -bl:build.binlog || exit 0
+        # Strip all source so the agent must diagnose from build.binlog alone. Keep
+        # *.binlog AND any staged skill directory: vally copies environment.skills into
+        # the workdir as <skill>/ (with SKILL.md) BEFORE running these setup commands, so
+        # a naive "delete everything except *.binlog" wipes the skill and the skilled
+        # variant aborts with "contains no SKILL.md". Excluding SKILL.md-bearing dirs is a
+        # harmless no-op for the baseline variant (no skill staged) and the skill-validator.
+        - node -e "const fs=require('fs'),p=require('path'); fs.readdirSync('.').filter(f=>!f.endsWith('.binlog')
+          && !fs.existsSync(p.join(f,'SKILL.md'))).forEach(f=>fs.rmSync(f,{recursive:true,force:true}))"
     graders:
       - type: output-contains
         config:

--- a/tests/dotnet-test/run-tests/eval.vally.yaml
+++ b/tests/dotnet-test/run-tests/eval.vally.yaml
@@ -94,7 +94,7 @@ stimuli:
       tests on net9.0 using dotnet test.
     environment:
       files:
-        - src: fixtures/multi-tfm/TestProject.csproj
+        - src: fixtures/multi-tfm-mtp-sdk9/TestProject.csproj
           dest: TestProject.csproj
     graders:
       - type: output-matches


### PR DESCRIPTION
## What

Fixes two `dotnet/skills` evals that silently produced **zero verdicts** under vally's `experiment run` harness (0.7) during a cross-family evaluation run.

Vally treats a **non-zero setup command as a fatal trial error** and drops all recorded events, whereas the .NET skill-validator never inspects setup exit codes. Two evals tripped on this (or a related fixture bug):

### 1. `dotnet-msbuild/binlog-failure-analysis`
The eval's solution is *intentionally broken* (missing `Newtonsoft.Json` reference) so the agent must diagnose from the binlog. `dotnet build -bl` therefore exits non-zero — the binlog is still written, but vally aborts the trial.
- Guard the build with `|| exit 0`. This is portable: `true` is **not** a `cmd.exe` builtin (vally shells out via `cmd /c` on Windows), while `exit 0` returns 0 in both `cmd` and POSIX `sh`.
- Also preserve any **staged skill directory** in the source-strip step. Vally copies `environment.skills` into the workdir as `<skill>/SKILL.md` *before* setup runs, so the previous "delete everything except `*.binlog`" wiped the skill and the skilled variant aborted with *"contains no SKILL.md"*. The strip now skips `SKILL.md`-bearing dirs (a harmless no-op for the baseline variant and the skill-validator).

### 2. `dotnet-test/run-tests`
The multi-TFM SDK 9 scenario pointed at a **removed fixture** (`fixtures/multi-tfm/`), which no longer exists on `main` — a dangling reference. Repointed to the existing `fixtures/multi-tfm-mtp-sdk9/`, matching the sibling skill-validator `eval.yaml` which already uses it.

## Scope

Only the `.vally.yaml` variants need changes; the sibling skill-validator `eval.yaml` files are already correct (the validator ignores setup exit codes and stages skills differently, and its `run-tests` eval already references the correct fixture).

## Not included (upstream)

A third eval, `dotnet-test-migration/migrate-mstest-v3-to-v4`, hits the **same vally setup-exit mechanism** but is deliberately left as-is: the skill-validator would not hit it, so the right fix is a first-class "tolerate setup failure" option **upstream in vally** rather than a shell idiom in the eval. Tracked separately.

## Validation

- Both files parse cleanly (PyYAML).
- `binlog-failure-analysis` re-scored **3/5 pass** (token-efficient, −112k) and `run-tests` re-scored **3/5 pass** after the fix in the cross-family run.