### PR TITLE
lsp.json の lspServers ラッパーを削除

### DIFF
--- a/plugins/dotnet/.claude-plugin/plugin.json
+++ b/plugins/dotnet/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "dotnet",
+  "version": "0.2.0",
+  "description": "C# language server (LSP) integration for coding agents and high-level .NET development skills.",
+  "skills": ["./skills/"],
+  "lspServers": "./lsp.json"
+}

--- a/plugins/dotnet/lsp.json
+++ b/plugins/dotnet/lsp.json
@@ -1,22 +1,20 @@
 {
-  "lspServers": {
-    "csharp": {
-      "command": "dotnet",
-      "args": [
-        "dnx",
-        "roslyn-language-server",
-        "--yes",
-        "--prerelease",
-        "--",
-        "--stdio",
-        "--autoLoadProjects"
-      ],
-      "extensionToLanguage": {
-        ".cs": "csharp",
-        ".razor": "aspnetcorerazor",
-        ".cshtml": "aspnetcorerazor"
-      },
-      "startupTimeout": 120000
-    }
+  "csharp": {
+    "command": "dotnet",
+    "args": [
+      "dnx",
+      "roslyn-language-server",
+      "--yes",
+      "--prerelease",
+      "--",
+      "--stdio",
+      "--autoLoadProjects"
+    ],
+    "extensionToLanguage": {
+      ".cs": "csharp",
+      ".razor": "aspnetcorerazor",
+      ".cshtml": "aspnetcorerazor"
+    },
+    "startupTimeout": 120000
   }
 }

--- a/plugins/dotnet/lsp.json
+++ b/plugins/dotnet/lsp.json
@@ -1,8 +1,9 @@
 {
   "lspServers": {
     "csharp": {
-      "command": "dnx",
+      "command": "dotnet",
       "args": [
+        "dnx",
         "roslyn-language-server",
         "--yes",
         "--prerelease",
@@ -10,13 +11,12 @@
         "--stdio",
         "--autoLoadProjects"
       ],
-      "cwd": "${PLUGIN_ROOT}",
-      "fileExtensions": {
+      "extensionToLanguage": {
         ".cs": "csharp",
         ".razor": "aspnetcorerazor",
         ".cshtml": "aspnetcorerazor"
       },
-      "warmupTimeoutMs": 120000
+      "startupTimeout": 120000
     }
   }
 }


### PR DESCRIPTION
## Summary
- plugin.json が `lspServers` に lsp.json 自体へのパスを指定しているため、lsp.json の中身が直接サーバー名のマップである必要がある
- 不要な "lspServers" ラッパーキーを削除し、"csharp" 設定をトップレベルに配置

## Test plan
- [ ] Claude Code でプラグインを読み込み、C# 言語サーバーが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)