### PR TITLE
Harden vally comparison reliability

### DIFF
--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -398,7 +398,7 @@ jobs:
         run: |
           echo "## 🔬 Vally Shadow Results: $ENTRY_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a credible improvement (mean preference > 0 with its 95% CI above 0)." >> $GITHUB_STEP_SUMMARY
+          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible improvement (mean preference > 0 with its 95% CI above 0)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           RESULTS_DIR="artifacts/TestResults/vally/$ENTRY_NAME"
@@ -406,9 +406,16 @@ jobs:
             if [ ! -f "$RESULTS_JSON" ]; then continue; fi
             EVAL_NAME=$(basename "$(dirname "$RESULTS_JSON")")
 
+            CONCLUSIVE=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].conclusive)")
             PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].passed)")
             REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].reason)")
-            ICON=$([ "$PASSED" = "true" ] && echo "✅" || echo "❌")
+            if [ "$CONCLUSIVE" != "true" ]; then
+              ICON="⚠️"
+            elif [ "$PASSED" = "true" ]; then
+              ICON="✅"
+            else
+              ICON="❌"
+            fi
 
             echo "### $ICON $EVAL_NAME" >> $GITHUB_STEP_SUMMARY
             echo "$REASON" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -406,9 +406,9 @@ jobs:
             if [ ! -f "$RESULTS_JSON" ]; then continue; fi
             EVAL_NAME=$(basename "$(dirname "$RESULTS_JSON")")
 
-            CONCLUSIVE=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].conclusive)")
-            PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].passed)")
-            REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync('$RESULTS_JSON','utf-8')); console.log(r.verdicts[0].reason)")
+            CONCLUSIVE=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].conclusive)" "$RESULTS_JSON")
+            PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].passed)" "$RESULTS_JSON")
+            REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].reason)" "$RESULTS_JSON")
             if [ "$CONCLUSIVE" != "true" ]; then
               ICON="⚠️"
             elif [ "$PASSED" = "true" ]; then
@@ -425,7 +425,7 @@ jobs:
             echo "| Scenario | Mean preference | Trials (W/T/L) |" >> $GITHUB_STEP_SUMMARY
             echo "|----------|-----------------|----------------|" >> $GITHUB_STEP_SUMMARY
             node -e "
-              const r = JSON.parse(require('fs').readFileSync('$RESULTS_JSON', 'utf-8'));
+              const r = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8'));
               for (const s of r.verdicts[0].scenarios) {
                 const icon = s.meanScore > 0 ? '▲' : s.meanScore < 0 ? '▼' : '=';
                 const pct = (s.meanScore >= 0 ? '+' : '') + (s.meanScore * 100).toFixed(1) + '%';
@@ -433,6 +433,6 @@ jobs:
                 for (const tr of (s.trials||[])) { if (tr.score>0) w++; else if (tr.score<0) l++; else t++; }
                 console.log('| ' + icon + ' ' + s.scenarioName + ' | ' + pct + ' | ' + w + '/' + t + '/' + l + ' |');
               }
-            " >> $GITHUB_STEP_SUMMARY
+            " "$RESULTS_JSON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           done < <(find "$RESULTS_DIR" -name results.json | sort)

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -16,6 +16,16 @@ If you need to run the investigation manually, follow the [Quick start](#quick-s
 4. **Identify the failure pattern** using the categories below — most failures match multiple patterns; fix them in priority order (timeouts first, then activation, then quality/rubric issues)
 5. **Apply the fix** and re-run with `/evaluate`
 
+### Vally shadow evaluation errors
+
+Vally comparison results separate two reliability signals:
+
+- `erroredCount` counts matched baseline/treatment trials whose comparison judge failed. The repository adapter retries these comparisons once because model or transport timeouts can be transient. If the retry also fails, the original errored result remains visible.
+- `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not be paired, commonly because one agent arm timed out or failed before grading. The adapted verdict preserves these arrays and reports their combined `unmatchedTrialCount`.
+- `conclusive` is `false` when either signal is nonzero. An inconclusive verdict cannot pass and appears as a warning in the workflow summary rather than as evidence that the skill failed.
+
+Inspect the raw variant `results.jsonl` before changing a skill. A `status: "error"` record with an agent timeout is different from a successful pair whose comparison evidence says `Comparison judge failed`. Do not add fixture setup, SDK pinning, or skill instructions unless the failure occurred during that phase.
+
 ## Finding the artifacts
 
 ### Via CLI (recommended for AI agents)

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -18,7 +18,7 @@ If you need to run the investigation manually, follow the [Quick start](#quick-s
 
 ### Vally shadow evaluation errors
 
-Vally comparison results separate two reliability signals:
+This section describes `results.json` files emitted by the **Vally shadow adapter**, not the skill-validator evaluation schema documented below. Vally comparison results separate two reliability signals:
 
 - `erroredCount` counts matched baseline/treatment trials whose comparison judge failed. The repository adapter retries these comparisons once because model or transport timeouts can be transient. If the retry also fails, the original errored result remains visible.
 - `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not be paired, commonly because one agent arm timed out or failed before grading. The adapted verdict preserves these arrays and reports their combined `unmatchedTrialCount`.

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -16,16 +16,6 @@ If you need to run the investigation manually, follow the [Quick start](#quick-s
 4. **Identify the failure pattern** using the categories below — most failures match multiple patterns; fix them in priority order (timeouts first, then activation, then quality/rubric issues)
 5. **Apply the fix** and re-run with `/evaluate`
 
-### Vally shadow evaluation errors
-
-This section describes `results.json` files emitted by the **Vally shadow adapter**, not the skill-validator evaluation schema documented below. Vally comparison results separate two reliability signals:
-
-- `erroredCount` counts matched baseline/treatment trials whose comparison judge failed. The repository adapter retries these comparisons once because model or transport timeouts can be transient. If the retry also fails, the original errored result remains visible.
-- `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not be paired, commonly because one agent arm timed out or failed before grading. The adapted verdict preserves these arrays and reports their combined `unmatchedTrialCount`.
-- `conclusive` is `false` when either signal is nonzero. An inconclusive verdict cannot pass and appears as a warning in the workflow summary rather than as evidence that the skill failed.
-
-Inspect the raw variant `results.jsonl` before changing a skill. A `status: "error"` record with an agent timeout is different from a successful pair whose comparison evidence says `Comparison judge failed`. Do not add fixture setup, SDK pinning, or skill instructions unless the failure occurred during that phase.
-
 ## Finding the artifacts
 
 ### Via CLI (recommended for AI agents)

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -1,0 +1,28 @@
+# Vally shadow evaluation adapter
+
+`adapt.mjs` converts a Vally experiment's baseline and skilled `results.jsonl`
+files into per-skill `results.json` verdicts for the shadow-evaluation
+workflow. `run-vally-evals.sh` runs the experiment and then invokes the
+adapter.
+
+## Reliability signals
+
+The adapter keeps infrastructure reliability distinct from a skill-quality
+result:
+
+- `erroredCount` counts matched baseline/treatment trials whose comparison judge
+  failed. The adapter retries a comparison once because model or transport
+  timeouts can be transient. If the retry does not reduce errors, the original
+  report remains visible.
+- `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not
+  be paired, commonly because one arm timed out or failed before grading.
+  `unmatchedTrialCount` is their combined count.
+- `conclusive` is `false` when either signal is nonzero. An inconclusive verdict
+  cannot pass and is rendered as a workflow warning rather than as evidence
+  that a skill regressed.
+
+Inspect the raw variant `results.jsonl` before changing a skill. A
+`status: "error"` agent timeout is different from a successful pair whose
+comparison evidence says `Comparison judge failed`. Do not add fixture setup,
+SDK pinning, or skill instructions unless the failure occurred during that
+phase.

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -154,6 +154,31 @@ function runCompare(baselineSlice, skilledSlice, outFile) {
   return records[0] ?? null;
 }
 
+function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
+  const report = runCompare(baselineSlice, skilledSlice, outFile);
+  const errorCount = report?.summary?.erroredCount ?? 0;
+  if (errorCount === 0) return report;
+
+  warn(`vally compare returned ${errorCount} errored trial(s); retrying once`);
+
+  let retryReport;
+  try {
+    retryReport = runCompare(baselineSlice, skilledSlice, `${outFile}.retry`);
+  } catch (err) {
+    warn(`vally compare retry failed; keeping the original result (${err instanceof Error ? err.message : String(err)})`);
+    return report;
+  }
+
+  const retryErrorCount = retryReport?.summary?.erroredCount ?? Number.POSITIVE_INFINITY;
+  if (retryErrorCount < errorCount) {
+    warn(`vally compare retry reduced errored trials from ${errorCount} to ${retryErrorCount}`);
+    return retryReport;
+  }
+
+  warn(`vally compare retry did not reduce errored trials; keeping the original result`);
+  return report;
+}
+
 // ---------------------------------------------------------------------------
 // Comparison report -> per-skill verdict
 // ---------------------------------------------------------------------------
@@ -164,7 +189,11 @@ function pct(x) {
 
 function comparisonToVerdict(report, identity) {
   const s = report.summary;
-  const passed = s.meanScore > 0 && s.ciLow > 0;
+  const unmatchedBaseline = report.unmatchedBaseline ?? [];
+  const unmatchedTreatment = report.unmatchedTreatment ?? [];
+  const unmatchedTrialCount = unmatchedBaseline.length + unmatchedTreatment.length;
+  const conclusive = s.erroredCount === 0 && unmatchedTrialCount === 0;
+  const passed = conclusive && s.meanScore > 0 && s.ciLow > 0;
 
   const scenarios = (report.stimuli ?? []).map((st) => ({
     scenarioName: st.stimulusName,
@@ -180,21 +209,28 @@ function comparisonToVerdict(report, identity) {
     })),
   }));
 
-  const credibility = passed
-    ? "credibly better"
-    : s.meanScore <= 0
-      ? "no improvement"
-      : "not credible (95% CI includes 0)";
+  const credibility =
+    s.erroredCount > 0
+      ? "inconclusive (comparison errors)"
+      : unmatchedTrialCount > 0
+        ? "inconclusive (unmatched trajectories)"
+        : passed
+          ? "credibly better"
+          : s.meanScore <= 0
+            ? "no improvement"
+            : "not credible (95% CI includes 0)";
 
   const reason =
     `Mean preference ${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)} ` +
     `[95% CI ${pct(s.ciLow)}, ${pct(s.ciHigh)}], ` +
     `win rate ${pct(s.winRate)} (${s.wins}W/${s.ties}T/${s.losses}L over ${s.trialCount} trial(s)` +
-    `${s.erroredCount ? `, ${s.erroredCount} errored` : ""}) — ${credibility}`;
+    `${s.erroredCount ? `, ${s.erroredCount} errored` : ""}` +
+    `${unmatchedTrialCount ? `, ${unmatchedTrialCount} unmatched` : ""}) — ${credibility}`;
 
   return {
     skillName: identity.skill,
     skillPath: identity.skillPath,
+    conclusive,
     passed,
     meanScore: s.meanScore,
     confidenceInterval: { low: s.ciLow, high: s.ciHigh, level: 0.95 },
@@ -204,6 +240,9 @@ function comparisonToVerdict(report, identity) {
     losses: s.losses,
     trialCount: s.trialCount,
     erroredCount: s.erroredCount,
+    unmatchedTrialCount,
+    unmatchedBaseline,
+    unmatchedTreatment,
     mcnemar: s.mcnemar,
     metricDeltas: s.metricDeltas,
     scenarios,
@@ -212,7 +251,7 @@ function comparisonToVerdict(report, identity) {
 }
 
 function verdictSummaryLine(v) {
-  const icon = v.passed ? "✅" : "❌";
+  const icon = !v.conclusive ? "⚠️" : v.passed ? "✅" : "❌";
   const scenarios = v.scenarios
     .map((s) => `    ${s.meanScore > 0 ? "▲" : s.meanScore < 0 ? "▼" : "="} ${s.scenarioName} (${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)})`)
     .join("\n");
@@ -270,7 +309,7 @@ function main() {
 
       let report;
       try {
-        report = runCompare(baselineSlice, skilledSlice, compareOut);
+        report = runCompareWithRetry(baselineSlice, skilledSlice, compareOut);
       } catch (err) {
         warn(`${plugin}/${skill}: vally compare failed — no verdict written (${err instanceof Error ? err.message : String(err)})`);
         incomplete++;
@@ -280,6 +319,11 @@ function main() {
         warn(`${plugin}/${skill}: vally compare produced no comparison record — no verdict written`);
         incomplete++;
         continue;
+      }
+      const unmatchedCount =
+        (report.unmatchedBaseline?.length ?? 0) + (report.unmatchedTreatment?.length ?? 0);
+      if (unmatchedCount > 0) {
+        warn(`${plugin}/${skill}: vally compare reported ${unmatchedCount} unmatched trajectory(s)`);
       }
 
       const verdict = comparisonToVerdict(report, { skill, plugin, skillPath });

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const adapterPath = fileURLToPath(new URL("./adapt.mjs", import.meta.url));
+const evalFile = "tests/dotnet-diag/analyzing-dotnet-performance/eval.vally.yaml";
+
+function writeJsonl(path, records) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+}
+
+function createExperiment(root) {
+  const runDir = join(root, "experiment");
+  const record = {
+    type: "trial-result",
+    experiment: { evalFile },
+    status: "success",
+    stimulus: "Scenario",
+  };
+  writeJsonl(join(runDir, "baseline", "results.jsonl"), [{ ...record, variant: "baseline" }]);
+  writeJsonl(join(runDir, "skilled", "results.jsonl"), [{ ...record, variant: "skilled" }]);
+  return runDir;
+}
+
+function createFakeVally(root, mode) {
+  const scriptPath = join(root, "fake-vally.mjs");
+  const statePath = join(root, "compare-count.txt");
+  writeFileSync(
+    scriptPath,
+    `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const [statePath, mode, command, ...args] = process.argv.slice(2);
+if (command !== "compare") process.exit(2);
+const count = existsSync(statePath) ? Number(readFileSync(statePath, "utf8")) + 1 : 1;
+writeFileSync(statePath, String(count));
+const output = args[args.indexOf("--output") + 1];
+const errored = mode === "persistent" || (mode === "recover" && count === 1);
+const unmatched = mode === "unmatched";
+const report = {
+  type: "comparison-report",
+  summary: {
+    trialCount: errored ? 0 : 1,
+    erroredCount: errored ? 1 : 0,
+    meanScore: errored ? 0 : 0.4,
+    ciLow: errored ? 0 : 0.1,
+    ciHigh: errored ? 0 : 0.7,
+    wins: errored ? 0 : 1,
+    ties: 0,
+    losses: 0,
+    winRate: errored ? 0 : 1,
+    mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: 1, pValue: 1, exact: true },
+    metricDeltas: []
+  },
+  stimuli: [{
+    stimulusName: "Scenario",
+    meanScore: errored ? 0 : 0.4,
+    trials: [{
+      trialIndex: 0,
+      winner: errored ? "tie" : "treatment",
+      magnitude: errored ? "equal" : "slightly-better",
+      score: errored ? 0 : 0.4,
+      evidence: errored ? "Comparison judge failed: timeout" : "Treatment was better",
+      baselinePassed: true,
+      treatmentPassed: true,
+      errored
+    }]
+  }],
+  unmatchedBaseline: unmatched ? ["Baseline only (trial 0)"] : [],
+  unmatchedTreatment: unmatched ? ["Treatment only (trial 0)"] : []
+};
+writeFileSync(output, JSON.stringify(report) + "\\n");
+`,
+  );
+  return { command: `${process.execPath} ${scriptPath} ${statePath} ${mode}`, statePath };
+}
+
+function runAdapter(root, mode) {
+  const runDir = createExperiment(root);
+  const outputRoot = join(root, "output");
+  const fakeVally = createFakeVally(root, mode);
+  const result = spawnSync(
+    process.execPath,
+    [
+      adapterPath,
+      "--experiment-dir",
+      runDir,
+      "--output-root",
+      outputRoot,
+      "--vally",
+      fakeVally.command,
+    ],
+    { encoding: "utf8" },
+  );
+  const verdictPath = join(
+    outputRoot,
+    "dotnet-diag",
+    "analyzing-dotnet-performance",
+    "results.json",
+  );
+  return {
+    result,
+    compareCount: Number(readFileSync(fakeVally.statePath, "utf8")),
+    verdict: JSON.parse(readFileSync(verdictPath, "utf8")).verdicts[0],
+  };
+}
+
+function withTempDir(action) {
+  const root = mkdtempSync(join(tmpdir(), "vally-adapter-test-"));
+  try {
+    return action(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("retries a transient comparison error once", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "recover");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.erroredCount, 0);
+    assert.equal(verdict.conclusive, true);
+    assert.equal(verdict.passed, true);
+    assert.match(result.stderr, /reduced errored trials from 1 to 0/);
+  });
+});
+
+test("keeps a persistent comparison error visible after one retry", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "persistent");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.erroredCount, 1);
+    assert.equal(verdict.conclusive, false);
+    assert.equal(verdict.passed, false);
+    assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
+    assert.match(result.stderr, /did not reduce errored trials/);
+  });
+});
+
+test("surfaces unmatched trajectories in the verdict", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "unmatched");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 1);
+    assert.equal(verdict.unmatchedTrialCount, 2);
+    assert.deepEqual(verdict.unmatchedBaseline, ["Baseline only (trial 0)"]);
+    assert.deepEqual(verdict.unmatchedTreatment, ["Treatment only (trial 0)"]);
+    assert.equal(verdict.conclusive, false);
+    assert.equal(verdict.passed, false);
+    assert.match(verdict.reason, /2 unmatched.*inconclusive \(unmatched trajectories\)/);
+  });
+});

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -38,6 +38,7 @@ const [statePath, mode, command, ...args] = process.argv.slice(2);
 if (command !== "compare") process.exit(2);
 const count = existsSync(statePath) ? Number(readFileSync(statePath, "utf8")) + 1 : 1;
 writeFileSync(statePath, String(count));
+if (mode === "fails") process.exit(3);
 const output = args[args.indexOf("--output") + 1];
 const errored = mode === "persistent" || (mode === "recover" && count === 1);
 const unmatched = mode === "unmatched";
@@ -104,8 +105,12 @@ function runAdapter(root, mode) {
   );
   return {
     result,
-    compareCount: Number(readFileSync(fakeVally.statePath, "utf8")),
-    verdict: JSON.parse(readFileSync(verdictPath, "utf8")).verdicts[0],
+    compareCount: existsSync(fakeVally.statePath)
+      ? Number(readFileSync(fakeVally.statePath, "utf8"))
+      : undefined,
+    verdict: existsSync(verdictPath)
+      ? JSON.parse(readFileSync(verdictPath, "utf8")).verdicts[0]
+      : undefined,
   };
 }
 
@@ -127,6 +132,15 @@ test("retries a transient comparison error once", () => {
     assert.equal(verdict.conclusive, true);
     assert.equal(verdict.passed, true);
     assert.match(result.stderr, /reduced errored trials from 1 to 0/);
+  });
+});
+
+test("preserves adapter diagnostics when compare fails", () => {
+  withTempDir((root) => {
+    const { result, verdict } = runAdapter(root, "fails");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(verdict, undefined);
+    assert.match(result.stderr, /vally compare failed/);
   });
 });
 


### PR DESCRIPTION
## Summary

- retry `vally compare` once when its report contains comparison-judge errors, keeping the result with fewer errors
- preserve unmatched baseline/treatment trajectories and mark degraded reports as inconclusive
- render inconclusive shadow results as warnings instead of skill failures
- document failure classification and add focused adapter tests

The investigation confirmed the reported `analyzing-dotnet-performance` failure was a transient comparison timeout, while baseline agent timeouts were silently omitted as unmatched treatment trajectories. No skill, fixture, or eval content changes are needed.

## Validation

- `node --check eng/vally-adapter/adapt.mjs`
- `node --test eng/vally-adapter/adapt.test.mjs`
- `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-diag`
- `actionlint -shellcheck= -pyflakes=` for all hand-authored workflows
- replayed the captured Sonnet comparison data and confirmed three unmatched trajectories produce an inconclusive warning
- reran the affected `analyzing-dotnet-performance` Sonnet 4.6 experiment locally with five workers: 18 of 22 trials succeeded and four baseline trials timed out at `session.idle` after 180 seconds; all 11 skilled trials completed. The updated adapter emitted `conclusive: false`, `erroredCount: 0`, and four named unmatched treatment trajectories rather than treating the seven matched comparisons as a complete result.

This validates the adapter’s containment behavior. The recurring baseline executor timeout remains an upstream Vally reliability issue.

## Upstream tracking

- [Baseline executor timeouts bias skill-vs-baseline experiments](https://github.com/microsoft/vally/issues/727)
- [Transient comparison-judge timeout makes identical comparisons non-reproducible](https://github.com/microsoft/vally/issues/728)

Fixes #885

Quality and overfitting improvements remain separate in #886.