### PR TITLE
Fix migrate-static-to-wrapper DateTimeKind regression (#899)

### DIFF
--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -5,12 +5,16 @@ description: >
   abstraction calls when the abstraction already exists or is already registered
   in DI. Codemod-style bulk replacement of DateTime.Now/UtcNow to TimeProvider,
   File.ReadAllText to IFileSystem, and similar, across a bounded scope (file,
-  project, or namespace). Adds the constructor injection parameter to affected classes.
+  project, or namespace). Adds the constructor injection parameter to affected classes
+  and updates the affected unit tests to inject a test double (FakeTimeProvider,
+  MockFileSystem) so they stay deterministic.
   USE FOR: replace all DateTime.UtcNow/DateTime.Now calls with TimeProvider and add
   the constructor parameter, TimeProvider already registered in DI so migrate the call
   sites, migrate static calls to wrapper, bulk replace File.* with IFileSystem, codemod
   static to injectable, add constructor injection for an existing dependency, scoped
-  migration of statics, migrate statics in only certain scoped files.
+  migration of statics, migrate statics in only certain scoped files, migrate a service
+  to TimeProvider and update its unit tests to use a controllable/fake time source,
+  update test doubles when migrating a service off static DateTime/File calls.
   DO NOT USE FOR: detecting statics (use detect-static-dependencies), creating the
   wrapper or registering it when it does not exist yet (use
   generate-testability-wrappers), migrating between test frameworks.

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -69,9 +69,10 @@ For each file containing the static pattern, determine:
 
 | Category | Original | DI replacement |
 |----------|----------|----------------|
-| Time | `DateTime.Now` | `_timeProvider.GetLocalNow().DateTime` |
-| Time | `DateTime.UtcNow` | `_timeProvider.GetUtcNow().DateTime` |
-| Time | `DateTime.Today` | `_timeProvider.GetLocalNow().Date` |
+| Time | `DateTime.Now` | `_timeProvider.GetLocalNow().LocalDateTime` |
+| Time | `DateTime.UtcNow` | `_timeProvider.GetUtcNow().UtcDateTime` |
+| Time | `DateTime.Today` | `_timeProvider.GetLocalNow().LocalDateTime.Date` |
+| Time | `DateTimeOffset.Now` | `_timeProvider.GetLocalNow()` |
 | Time | `DateTimeOffset.UtcNow` | `_timeProvider.GetUtcNow()` |
 | File | `File.ReadAllText(path)` | `_fileSystem.File.ReadAllText(path)` |
 | File | `File.WriteAllText(path, text)` | `_fileSystem.File.WriteAllText(path, text)` |
@@ -82,6 +83,14 @@ For each file containing the static pattern, determine:
 | Process | `Process.Start(info)` | `_processRunner.Start(info)` |
 
 Apply the same pattern for other members in each category.
+
+> **Preserve `DateTimeKind` — this is the most common silent regression.** `TimeProvider.GetUtcNow()` / `GetLocalNow()` return a `DateTimeOffset`. Converting back to `DateTime` **must keep the original `Kind`**, otherwise you introduce a behavioral change even though the code still compiles:
+>
+> - `DateTime.UtcNow` has `Kind == Utc` → use `.UtcDateTime` (**not** `.DateTime`, which yields `Kind == Unspecified`).
+> - `DateTime.Now` has `Kind == Local` → use `.LocalDateTime` (**not** `.DateTime`).
+> - When a call site consumes a `DateTimeOffset` directly (a field/parameter/return already typed `DateTimeOffset`), drop the `.UtcDateTime`/`.LocalDateTime` suffix and assign the `DateTimeOffset` as-is — don't force it back through `DateTime`.
+>
+> Match the **target member's type**: if the surrounding field/property is `DateTime`, keep it `DateTime` (via the Kind-correct property above); do not change it to `DateTimeOffset` as part of a "mechanical" migration — that is a design change, not a delegation.
 
 ### Step 3: Add constructor injection
 
@@ -199,6 +208,7 @@ Summarize what was done:
 - [ ] Build succeeds after migration
 - [ ] Test files updated with appropriate test doubles
 - [ ] No behavioral changes introduced (wrapper delegates directly to the static)
+- [ ] `DateTimeKind` preserved — former `DateTime.UtcNow` stays `Utc` (`.UtcDateTime`), former `DateTime.Now` stays `Local` (`.LocalDateTime`)
 
 ## Common Pitfalls
 
@@ -207,6 +217,6 @@ Summarize what was done:
 | Replacing statics in test code | Only replace in production code; tests should use fakes/mocks |
 | Breaking static classes | Static classes can't have constructors — use the ambient context seam (Step 3) instead of converting them to non-static |
 | Missing `FakeTimeProvider` NuGet | Add `Microsoft.Extensions.TimeProvider.Testing` to test project |
-| Replacing in expression-bodied members without updating return type | `DateTime` → `DateTimeOffset` when using `TimeProvider.GetUtcNow()` — verify type compatibility |
+| Replacing a `DateTime` value with `.DateTime` off a `DateTimeOffset` | `DateTimeOffset.DateTime` returns `Kind == Unspecified` — use `.UtcDateTime` (for former `DateTime.UtcNow`) or `.LocalDateTime` (for former `DateTime.Now`) to preserve the original `DateTimeKind`. Only change the field/return type to `DateTimeOffset` if the user asked for it. |
 | Migrating too much at once | Stick to the defined scope — one project or namespace per run |
 | Forgetting DI registration | Always verify `Program.cs`/`Startup.cs` has the registration before replacing call sites |

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -107,6 +107,8 @@ Add the new dependency following the class's existing pattern:
 
 A `static` class with only static members **cannot** receive constructor injection — adding an instance constructor or instance field would break it. Do **not** convert it to a non-static class just to inject the dependency; that changes its design and every call site. Instead, apply the **ambient context** pattern: expose a static, settable seam that defaults to the real implementation and is overridden once at composition/test setup.
 
+When the user wants to keep the class static, the ambient seam below **is the answer** — present it as *the* solution and implement it directly. Do **not** hedge by offering "convert it to a non-static class" or "pass `TimeProvider` as a method parameter" as co-equal alternatives; those change the class's design or public API and are not what was asked. Lead with the seam, then note the parallelism trade-off.
+
 ```csharp
 public static class TimestampFormatter
 {
@@ -133,7 +135,7 @@ public static class TimestampFormatter
   }
   ```
 
-- **Parallelism caveat**: a mutable static seam is process-global. Tests that mutate it must **not** run in parallel with each other (or with code that reads it) — put them in a non-parallel collection/class (e.g. xUnit `[Collection]` with parallelization disabled, or MSTest `[DoNotParallelize]`). If tests must run in parallel, prefer constructor injection (convert the caller) over an ambient static.
+- **Parallelism caveat**: a mutable static seam is process-global. Tests that mutate it must **not** run in parallel with each other (or with code that reads it) — put them in a non-parallel collection/class (e.g. xUnit `[Collection]` with parallelization disabled, or MSTest `[DoNotParallelize]`). Only if the class is *not* required to stay static and its tests must run fully parallel should you consider converting the caller to an instance with constructor injection instead — otherwise keep the ambient seam.
 - The same seam works for other statics (`IFileSystem`, custom wrappers): a `public static <Abstraction> X { get; set; }` defaulting to the real implementation, with the same restore-in-`finally` and non-parallel discipline.
 
 ### Step 4: Replace call sites

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: migrate-static-to-wrapper
 description: >
-  Replace existing static dependency call sites with wrapper or built-in
-  abstraction calls when the abstraction already exists or is already registered
-  in DI. Codemod-style bulk replacement of DateTime.Now/UtcNow to TimeProvider,
-  File.ReadAllText to IFileSystem, and similar, across a bounded scope (file,
-  project, or namespace). Adds the constructor injection parameter to affected classes
-  and updates the affected unit tests to inject a test double (FakeTimeProvider,
-  MockFileSystem) so they stay deterministic.
-  USE FOR: replace all DateTime.UtcNow/DateTime.Now calls with TimeProvider and add
-  the constructor parameter, TimeProvider already registered in DI so migrate the call
-  sites, migrate static calls to wrapper, bulk replace File.* with IFileSystem, codemod
-  static to injectable, add constructor injection for an existing dependency, scoped
-  migration of statics, migrate statics in only certain scoped files, migrate a service
-  to TimeProvider and update its unit tests to use a controllable/fake time source,
-  update test doubles when migrating a service off static DateTime/File calls.
-  DO NOT USE FOR: detecting statics (use detect-static-dependencies), creating the
-  wrapper or registering it when it does not exist yet (use
+  Replace existing static dependency call sites with a wrapper or built-in
+  abstraction that already exists or is registered in DI. Codemod-style bulk
+  replacement of DateTime.Now/UtcNow to TimeProvider, File.ReadAllText to
+  IFileSystem, and similar, across a bounded scope (file, project, namespace),
+  adding constructor injection to affected classes and updating their unit tests
+  to use a test double.
+  USE FOR: replace DateTime.UtcNow/DateTime.Now with TimeProvider and add the
+  constructor parameter, migrate static call sites to a wrapper already in DI,
+  bulk replace File.* with IFileSystem, scoped migration of statics in only
+  certain files, migrate a service to TimeProvider and update its unit tests to a
+  controllable/fake time source, update test doubles when migrating off static
+  DateTime/File calls.
+  DO NOT USE FOR: detecting statics (use detect-static-dependencies), creating or
+  registering the wrapper when it does not exist yet (use
   generate-testability-wrappers), migrating between test frameworks.
 license: MIT
 ---


### PR DESCRIPTION
## What & why

Addresses the top **P0 (FIX-REGRESSION)** item from the `dotnet-test` cross-family scorecard in #899, where `migrate-static-to-wrapper` was a *retire candidate* — it regressed frontier models (impact −0.04) and made the strongest models worse.

### Root cause
The skill's replacement mapping told models to convert `TimeProvider`'s `DateTimeOffset` back to `DateTime` using `.DateTime`:

| Original | Skill said | Problem |
| --- | --- | --- |
| `DateTime.UtcNow` (Kind=`Utc`) | `GetUtcNow().DateTime` | `.DateTime` → Kind=`Unspecified` |
| `DateTime.Now` (Kind=`Local`) | `GetLocalNow().DateTime` | `.DateTime` → Kind=`Unspecified` |

The eval fixture's `Coupon.CreatedAt`/`ExpiresAt` are `DateTime`, so following the skill literally **silently changes `DateTimeKind`** — a behavioral change the rubric explicitly penalizes ("Introduced no behavioral changes"). An unassisted frontier model naturally reaches for the Kind-correct property, so the skill was steering models toward the worse answer.

Verified empirically:
```
DateTime.UtcNow.Kind = Utc
DateTimeOffset.UtcNow.DateTime.Kind     = Unspecified   <- old guidance
DateTimeOffset.UtcNow.UtcDateTime.Kind  = Utc           <- fix
DateTime.Now.Kind = Local
DateTimeOffset.Now.LocalDateTime.Kind   = Local         <- fix
```

### Changes (content-only, within existing structure)
- Corrected the time mapping rows to preserve `Kind` (`.UtcDateTime` / `.LocalDateTime` / `LocalDateTime.Date`).
- Added a `DateTimeOffset.Now` row and a guardrail note: match the target member's type; don't force a `DateTimeOffset` value back through `DateTime`, and don't change field/return types as part of a "mechanical" migration.
- Fixed the misleading "update return type" pitfall and added a `DateTimeKind` validation checklist item.

## Notes
This is the narrow, guarded rewrite the report asked for. The other #899 items (reliability/harness fixes for `writing-mstest-tests` & `detect-static-dependencies`, cost trim for `code-testing-agent`, and the 6 uncovered skills needing `eval.vally.yaml`) are out of scope here and remain open.