### PR TITLE
fix(ci): unblock vally eval on the reusable PR path

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -930,8 +930,26 @@ jobs:
     with:
       entries: ${{ needs.discover.outputs.entries }}
       head_sha: ${{ needs.gate.outputs.head_sha }}
-    # No secrets are passed — the copilot-pat-pool secrets are injected via the
-    # `environment:` on the reusable workflow's job, not across this boundary.
+    # Forward ONLY the Copilot PAT pool across the workflow_call boundary. A
+    # reusable workflow does not inherit the caller's org/repo secrets, so the
+    # pool would read empty on this path unless it is passed explicitly. We map
+    # the 10 named tokens rather than using `secrets: inherit` — inherit would
+    # forward every repo/org secret into the reusable workflow and reverse the
+    # blast-radius reduction from #868; named mapping crosses only these tokens.
+    # This job is a top-level caller, so `secrets.COPILOT_PAT_*` resolves from the
+    # existing ORG secrets — the same pool the scheduled validate-pat-pool workflow
+    # reads — so no `copilot-pat-pool` environment-secret configuration is needed.
+    secrets:
+      COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+      COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+      COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+      COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+      COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+      COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+      COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+      COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+      COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+      COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
 
   # ==========================================================================
   # COMMENT ON PR

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -73,7 +73,7 @@ jobs:
     # the event alone would (wrongly) run this during the reusable call, where
     # the plugin/skill dispatch inputs are empty and validation throws. When the
     # caller supplies `entries`, skip prepare entirely.
-    if: github.event_name == 'workflow_dispatch' && inputs.entries == ''
+    if: github.event_name == 'workflow_dispatch' && !inputs.entries
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.build.outputs.entries }}

--- a/.github/workflows/vally-evaluation.yml
+++ b/.github/workflows/vally-evaluation.yml
@@ -22,13 +22,16 @@ on:
         type: string
         default: ''
     secrets:
-      # These are NOT passed by the caller — the copilot-pat-pool secrets are
-      # injected at runtime via the vally-evaluate job's `environment:`. They are
-      # declared here only so actionlint can type the `secrets.COPILOT_PAT_*`
-      # references; without this block the actionlint CI gate fails with
-      # "property is not defined in object type". No wildcard exists, so GitHub
-      # requires each name (0..9) enumerated, matching shared/pat_pool.md. Names
-      # with no backing secret simply resolve empty and are skipped by the selector.
+      # Passed by the caller via an explicit named mapping (see the vally-evaluate
+      # job in evaluation.yml). A reusable workflow does not inherit the caller's
+      # org/repo secrets, so the pool is forwarded explicitly — only these 10
+      # tokens cross the boundary, never `secrets: inherit` (which would forward
+      # every secret and reverse the blast-radius reduction from #868). Each name
+      # must be enumerated (no wildcard exists), matching shared/pat_pool.md, and
+      # the block is also what lets actionlint type the `secrets.COPILOT_PAT_*`
+      # references. The `environment: copilot-pat-pool` on the job below can still
+      # override individual entries via environment secrets if ever configured.
+      # Names with no backing secret resolve empty and are skipped by the selector.
       COPILOT_PAT_0: { required: false }
       COPILOT_PAT_1: { required: false }
       COPILOT_PAT_2: { required: false }
@@ -65,7 +68,12 @@ jobs:
   # For workflow_dispatch: build a single-entry matrix
   # --------------------------------------------------------------------------
   prepare:
-    if: github.event_name == 'workflow_dispatch'
+    # Only build the single-entry matrix for a *direct* manual dispatch. The
+    # workflow_dispatch event name propagates into workflow_call, so guarding on
+    # the event alone would (wrongly) run this during the reusable call, where
+    # the plugin/skill dispatch inputs are empty and validation throws. When the
+    # caller supplies `entries`, skip prepare entirely.
+    if: github.event_name == 'workflow_dispatch' && inputs.entries == ''
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.build.outputs.entries }}


### PR DESCRIPTION
The PR-evaluation path (`evaluation.yml` → reusable `vally-evaluation.yml`) couldn't start vally, while the skill-validator `evaluate` jobs passed. Two independent problems, both fixed here in code.

## 1. Spurious `prepare` run
The `prepare` job was gated only on `github.event_name == 'workflow_dispatch'`. That event name **propagates into `workflow_call`**, so `prepare` ran during the reusable call, read empty dispatch inputs, and threw `Invalid plugin ''`. Now additionally gated on `&& inputs.entries == ''`, so it runs only for a **direct** manual dispatch and is skipped whenever the caller supplies `entries`.

## 2. Empty `COPILOT_PAT_0..9` pool
Reusable workflows called via `workflow_call` do **not** inherit the caller's org/repo secrets, and the `copilot-pat-pool` environment holds no environment secrets — so `secrets.COPILOT_PAT_*` read empty across the boundary and the vally jobs failed with `No copilot-pat-pool entries are configured`.

The caller is a **top-level** job, so it can read the existing org-level pool (the same pool the scheduled `validate-pat-pool.yml` reads daily). `evaluation.yml` now forwards it via an explicit **named `secrets:` mapping** of the 10 tokens — mirroring how skill-validator sources its own token set in-workflow. This needs **no admin configuration** and goes green on merge.

### Security note (#868)
This deliberately does **not** use `secrets: inherit`, which would forward every repo/org secret into the reusable workflow and reverse the blast-radius reduction established in #868. The named mapping crosses **only** those 10 `COPILOT_PAT_*` tokens — the minimum the reusable workflow needs — so the exposure surface is the pool and nothing else. `environment: copilot-pat-pool` is retained, so environment secrets can still override the mapped values later with no code change.

## Scope
- Scoped to the `vally-evaluate` reusable-call job only; the skill-validator `evaluate` job is unchanged.
- Separate infra PR (distinct from #878). Must land on `main` to take effect for all PR evaluations.

## Validation
- `actionlint` 1.7.7 → exit 0 on both workflow files.
- Reviewed reusable-workflow secret semantics (rubber-duck): named mapping populates the pool with existing org secrets; only edge case is fork-PR secret availability, which matches skill-validator's existing (already-accepted) behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>