### PR TITLE
Improve .NET performance skill review workflow

### DIFF
--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -37,23 +37,23 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 
 ### Step 1: Read Source and Load Needed References
 
-For review requests, read but do not modify the supplied source unless the user explicitly asks for changes. If a named file is not at the supplied path, make one targeted filename/path search before concluding that source is unavailable.
+For review requests, read the supplied source before loading references and do not modify it unless the user explicitly asks for changes. If a named file is not at the supplied path, make one targeted filename/path search before concluding that source is unavailable.
 
-Then load the reference for each topic selected by the scan depth. Load `references/critical-patterns.md` only for critical signals or a comprehensive scan, and load `references/structural-patterns.md` only when a structural finding or exclusion needs inheritance/value-type review. Skip other references.
+Load `references/critical-patterns.md` for every scan depth. For `standard`, also load only the topic-specific references selected by the signals in Step 2; use the structural reference when class or struct declarations are present. For `comprehensive`, load all topic references. Do not load other references.
 
-**If a needed reference file is not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
+**If reference files are not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
 
 ### Step 2: Detect Code Signals and Select Topic Recipes
 
 Scan the code for signals that indicate which pattern categories to check. If reference files were loaded, use their `## Detection` sections. Otherwise, use the inline recipes in Step 3.
 
-| Signal in Code | Topic | Reference |
-|----------------|-------|-----------|
-| `async`, `await`, `Task`, `ValueTask` | Async patterns | `references/async-patterns.md` |
-| `Span<`, `Memory<`, `stackalloc`, `ArrayPool`, `string.Substring`, `.Replace(`, `.ToLower()`, `+=` in loops, `params` | Memory & strings | `references/memory-and-strings.md` |
-| `Regex`, `[GeneratedRegex]`, `Regex.Match`, `RegexOptions.Compiled` | Regex patterns | `references/regex-patterns.md` |
-| `Dictionary<`, `List<`, `.ToList()`, `.Where(`, `.Select(`, LINQ methods, `static readonly Dictionary<` | Collections & LINQ | `references/collections-and-linq.md` |
-| `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization | `references/io-and-serialization.md` |
+| Signal in Code | Topic |
+|----------------|-------|
+| `async`, `await`, `Task`, `ValueTask` | Async patterns |
+| `Span<`, `Memory<`, `stackalloc`, `ArrayPool`, `string.Substring`, `.Replace(`, `.ToLower()`, `+=` in loops, `params` | Memory & strings |
+| `Regex`, `[GeneratedRegex]`, `Regex.Match`, `RegexOptions.Compiled` | Regex patterns |
+| `Dictionary<`, `List<`, `.ToList()`, `.Where(`, `.Select(`, LINQ methods, `static readonly Dictionary<` | Collections & LINQ |
+| `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization |
 
 Always check structural patterns (unsealed classes) regardless of signals.
 
@@ -64,11 +64,9 @@ Always check structural patterns (unsealed classes) regardless of signals.
 
 ### Step 3: Scan and Report
 
-**For files under 500 lines, read the entire file first.** Use one batched search per applicable category to confirm counts, locations, and positive/inverse patterns; do not run a separate search for each recipe.
+**For files under 500 lines, read the entire file first** — you'll spot most patterns faster than running individual grep recipes.
 
-Maintain an internal coverage ledger for every applicable recipe and manual-review pattern from the loaded references or inline guidance. Reconcile each as checked with hits, checked with no hits, or not applicable. This is a completeness contract, not an output format or a requirement for one tool call per recipe.
-
-Search hits are candidates, not findings. Inspect their context and report exact executable-site counts and locations; for per-instance patterns, scale the count by constructed instances.
+For each relevant pattern category, run every applicable detection recipe. Batch related recipes into one search command or tool call where possible; batching changes execution, not coverage. Inspect matches in source context and use the batched searches to confirm exact executable-site counts and locations, not raw textual hits.
 
 **Core scan recipes** (run these when reference files aren't available):
 ```
@@ -98,11 +96,11 @@ grep -n ': IEquatable' FILE                    # Positive: struct equality
 ```
 
 **Rules:**
-- Reconcile every applicable recipe and manual-review pattern, combining related confirmation searches by category
-- **Emit a concise category checklist** before classifying findings — report actionable counts or `none`, not individual zero-hit searches
-- For each detected category, check the relevant optimized/inverse patterns and preserve them as positive findings or exclusions
-- If a reference file was loaded, use its `## Detection` and manual-review guidance for that topic
-- Do not elevate an ambiguous allocation or performance claim without confirming it from the code; state uncertainty when context is insufficient
+- Run every relevant recipe for the detected pattern categories
+- Keep a recipe-level internal checklist, but **emit a concise category checklist** before classifying findings — report actionable hit counts or `none`, not individual zero-hit searches
+- A result of **0 hits** is valid and valuable (confirms good practice)
+- If reference files were loaded, also run their `## Detection` recipes and manual-review checks
+- Check the relevant optimized/inverse patterns and report them as positive findings or exclusions
 
 **Verify-the-Inverse Rule:** For absence patterns, always count both sides and report the ratio (e.g., "N of M classes are sealed"). The ratio determines severity — 0/185 is systematic, 12/15 is a consistency fix.
 
@@ -119,13 +117,6 @@ After running scan recipes, look for these multi-allocation patterns that single
 3. **Compound `+=` with embedded allocating calls:** Lines like `result += $"...{Foo().ToLower()}"` are 2+ allocations (interpolation + ToLower + concatenation) — flag the compound cost, not just the `.ToLower()`.
 4. **`string.Format` specificity:** Distinguish resource-loaded format strings (not fixable) from compile-time literal format strings (fixable with interpolation). Enumerate the actionable sites.
 
-### Step 3d: Category Completeness Guardrails
-
-- **Strings & LINQ:** Trace the complete hot call chain. Include every branched `Replace` location and preserve existing span-based helpers.
-- **Regex:** Compare compiled and generated regexes, scale constructor sites by created instances, and distinguish static literals from dynamic patterns.
-- **Structural:** Search inheritance before recommending `sealed`; keep bases unsealed and identify leaf derivatives.
-- **Collections:** Verify mutation and lifetime before recommending frozen collections; preserve intentionally mutable caches and report correct `Ordinal`/`OrdinalIgnoreCase` comparers as positives.
-
 ### Step 4: Classify and Prioritize Findings
 
 Assign each finding a severity:
@@ -136,10 +127,10 @@ Assign each finding a severity:
 | 🟡 **Moderate** | 2-10x improvement opportunity, best practice for hot paths | Should fix on hot paths |
 | ℹ️ **Info** | Pattern applies but code may not be on a hot path | Consider if profiling shows impact |
 
-**Critical evidence gate:** Allocation/API-use patterns such as LINQ, `params`, `Replace`, `stackalloc`, or sealing remain Moderate unless a supplied benchmark or directly matching reference demonstrates >10x end-to-end impact or an explicit performance objective is missed. Frequency and hot-path context alone do not make them Critical.
+**Critical evidence gate:** Any allocation or API-usage finding is at most Moderate unless the user supplied a benchmark of this code showing a >10x end-to-end regression. Hot-path frequency and reference benchmark numbers do not make it Critical. Deadlocks, crashes or corruption, security/DoS risks such as catastrophic regex backtracking, and other correctness failures remain eligible for Critical without a benchmark.
 
 **Prioritization rules:**
-1. If the user identified hot-path code, prioritize findings and use the highest severity supported by evidence; hot-path context alone does not make an allocation finding Critical
+1. If the user identified hot-path code, prioritize findings in that code without bypassing the Critical evidence gate
 2. If hot-path context is unknown, report 🔴 Critical findings unconditionally; report 🟡 Moderate findings with a note: _"Impactful if this code is on a hot path"_
 3. Never suggest micro-optimizations on code that is clearly not performance-sensitive
 
@@ -149,7 +140,7 @@ When the same pattern appears across many instances, escalate severity:
 - 11-50 instances → escalate ℹ️ Info patterns to 🟡 Moderate
 - 50+ instances → escalate to 🟡 Moderate with elevated priority; flag as a codebase-wide systematic issue
 
-Never state nanosecond, percentage, throughput, or allocation multipliers unless they come from a supplied measurement or a loaded reference whose code shape and runtime assumptions match. Label reference data as such.
+Always report exact verified counts, not estimates or agent summaries. Do not state nanosecond, percentage, throughput, or allocation multipliers unless the user supplied measurements for the reviewed code; reference or blog figures are not measurements of that code.
 
 ### Step 5: Generate Findings
 
@@ -171,7 +162,7 @@ Format per finding:
 - **File locations as inline comma-separated list**, not a table. Use `File.cs:L42` format.
 - **No explanatory prose** beyond the Impact line — the severity icon already conveys urgency.
 - **Merge related findings** that share the same fix (e.g., all `.ToLower()` calls go in one finding, not split by file).
-- **Positive findings** in a bullet list, not a table. Include the relevant inverse/optimized evidence for detected categories: `✅ Pattern — evidence`.
+- **Positive findings** in a bullet list, not a table. One line per relevant optimized/inverse pattern: `✅ Pattern — evidence`.
 
 End with a summary table and disclaimer:
 
@@ -185,17 +176,18 @@ End with a summary table and disclaimer:
 > ⚠️ **Disclaimer:** These results are generated by an AI assistant and are non-deterministic. Findings may include false positives, miss real issues, or suggest changes that are incorrect for your specific context. Always verify recommendations with benchmarks and human review before applying changes to production code.
 ```
 
-## Validation
+## Mandatory Final Audit
 
-Before delivering results, verify:
+Do not deliver the review until every item passes:
 
-- [ ] Source was read without modification unless implementation was requested
-- [ ] Available references were loaded only for selected topics and applicable critical/structural checks
-- [ ] Coverage ledger reconciles every applicable recipe and manual-review pattern
-- [ ] Each finding has verified counts, locations, evidence, and a concrete fix
-- [ ] Relevant positive/inverse patterns and exclusions were preserved
-- [ ] Category checklist covers all applicable performance categories
-- [ ] Summary table included at end
+- [ ] Supplied source was read and not modified unless implementation was requested
+- [ ] Every applicable recipe and manual-review check was reconciled in the internal checklist
+- [ ] Category checklist covers all applicable categories
+- [ ] Every finding has verified executable-site counts, locations, evidence, and a concrete fix
+- [ ] Relevant optimized/inverse patterns and exclusions are reported
+- [ ] Allocation/API findings without a user-supplied >10x benchmark are not Critical
+- [ ] No numeric performance estimate appears unless supplied by the user for the reviewed code
+- [ ] Summary table and disclaimer are included
 
 ## Common Pitfalls
 

--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -33,13 +33,22 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 | Target framework | Recommended | .NET version (some patterns require .NET 8+) |
 | Scan depth | Optional | `critical-only`, `standard` (default), or `comprehensive` |
 
+### Non-Negotiable Review Contract
+
+For a review request:
+
+1. **Never edit source or use write/edit commands.** Report findings and fixes only, then stop; do not implement or validate changes.
+2. **Performance API/allocation findings are at most Moderate.** Critical is reserved for correctness, security/DoS, crashes/deadlocks, or a user-supplied benchmark showing a >10x end-to-end regression in the reviewed code.
+3. **Never state numeric performance estimates** from source comments, references, or inference. Only repeat measurements the user supplied for the reviewed code.
+4. **Complete coverage before brevity.** Reconcile every applicable recipe and manual check, verify executable counts/locations, and report relevant optimized/inverse patterns.
+
 ## Workflow
 
 ### Step 1: Read Source and Load Needed References
 
 For review requests, read the supplied source before loading references and do not modify it unless the user explicitly asks for changes. If a named file is not at the supplied path, make one targeted filename/path search before concluding that source is unavailable.
 
-Load `references/critical-patterns.md` for every scan depth. For `standard`, also load only the topic-specific references selected by the signals in Step 2; use the structural reference when class or struct declarations are present. For `comprehensive`, load all topic references. Do not load other references.
+For `standard`, load only the `## Detection` and `### Patterns Requiring Manual Review` sections of topic references selected by Step 2. For `critical-only` or `comprehensive`, also load `references/critical-patterns.md`; for `comprehensive`, load all topic references. Reference severity and benchmark claims are background material and never override the review contract.
 
 **If reference files are not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
 
@@ -56,6 +65,10 @@ Scan the code for signals that indicate which pattern categories to check. If re
 | `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization |
 
 Always check structural patterns (unsealed classes) regardless of signals.
+
+Also always check the critical cases not repeated by topic references: sync-over-async, multiple awaits of one `ValueTask`, `stackalloc` inside loops, nested regex quantifiers, repeated `IEnumerable` enumeration, and repeated set searches suited to `SearchValues<T>`.
+
+For structural checks, count sealed/unsealed declarations and search for derived types before recommending `sealed`; keep genuine base classes unsealed and identify sealable leaves.
 
 **Scan depth controls scope:**
 - `critical-only`: Only critical patterns (deadlocks, >10x regressions)
@@ -101,6 +114,7 @@ grep -n ': IEquatable' FILE                    # Positive: struct equality
 - A result of **0 hits** is valid and valuable (confirms good practice)
 - If reference files were loaded, also run their `## Detection` recipes and manual-review checks
 - Check the relevant optimized/inverse patterns and report them as positive findings or exclusions
+- For string-keyed collections, explicitly preserve correct `Ordinal`/`OrdinalIgnoreCase` comparers as positives
 
 **Verify-the-Inverse Rule:** For absence patterns, always count both sides and report the ratio (e.g., "N of M classes are sealed"). The ratio determines severity — 0/185 is systematic, 12/15 is a consistency fix.
 
@@ -112,7 +126,7 @@ If an optimized pattern is found in one file, check whether sibling files (same 
 
 After running scan recipes, look for these multi-allocation patterns that single-line recipes miss:
 
-1. **Branched `.Replace()` chains:** Methods that call `.Replace()` across multiple `if/else` branches — report total allocation count across all branches, not just per-line.
+1. **Branched `.Replace()` chains:** Methods that call `.Replace()` across multiple `if/else` branches — report every actionable site, the maximum executed per path, and a behavior-preserving single-pass fix such as `StringBuilder` or `string.Create` when appropriate.
 2. **Cross-method chaining:** When a public method delegates to another method that itself allocates intermediates (e.g., A calls B which does 3 regex replaces, then A calls C), report the total chain cost as one finding.
 3. **Compound `+=` with embedded allocating calls:** Lines like `result += $"...{Foo().ToLower()}"` are 2+ allocations (interpolation + ToLower + concatenation) — flag the compound cost, not just the `.ToLower()`.
 4. **`string.Format` specificity:** Distinguish resource-loaded format strings (not fixable) from compile-time literal format strings (fixable with interpolation). Enumerate the actionable sites.
@@ -123,14 +137,12 @@ Assign each finding a severity:
 
 | Severity | Criteria | Action |
 |----------|----------|--------|
-| 🔴 **Critical** | Deadlocks, crashes, security vulnerabilities, >10x regression | Must fix |
-| 🟡 **Moderate** | 2-10x improvement opportunity, best practice for hot paths | Should fix on hot paths |
+| 🔴 **Critical** | Correctness, security/DoS, crashes/deadlocks, or user-benchmarked >10x regression | Must fix |
+| 🟡 **Moderate** | Performance API/allocation issue or meaningful hot-path opportunity | Should fix on hot paths |
 | ℹ️ **Info** | Pattern applies but code may not be on a hot path | Consider if profiling shows impact |
 
-**Critical evidence gate:** Any allocation or API-usage finding is at most Moderate unless the user supplied a benchmark of this code showing a >10x end-to-end regression. Hot-path frequency and reference benchmark numbers do not make it Critical. Deadlocks, crashes or corruption, security/DoS risks such as catastrophic regex backtracking, and other correctness failures remain eligible for Critical without a benchmark.
-
 **Prioritization rules:**
-1. If the user identified hot-path code, prioritize findings in that code without bypassing the Critical evidence gate
+1. If the user identified hot-path code, prioritize findings in that code without bypassing the review contract
 2. If hot-path context is unknown, report 🔴 Critical findings unconditionally; report 🟡 Moderate findings with a note: _"Impactful if this code is on a hot path"_
 3. Never suggest micro-optimizations on code that is clearly not performance-sensitive
 
@@ -140,7 +152,7 @@ When the same pattern appears across many instances, escalate severity:
 - 11-50 instances → escalate ℹ️ Info patterns to 🟡 Moderate
 - 50+ instances → escalate to 🟡 Moderate with elevated priority; flag as a codebase-wide systematic issue
 
-Always report exact verified counts, not estimates or agent summaries. Do not state nanosecond, percentage, throughput, or allocation multipliers unless the user supplied measurements for the reviewed code; reference or blog figures are not measurements of that code.
+Always report exact verified counts, not estimates or agent summaries.
 
 ### Step 5: Generate Findings
 
@@ -178,7 +190,7 @@ End with a summary table and disclaimer:
 
 ## Mandatory Final Audit
 
-Do not deliver the review until every item passes:
+Before writing the response, correct or remove anything that fails this audit:
 
 - [ ] Supplied source was read and not modified unless implementation was requested
 - [ ] Every applicable recipe and manual-review check was reconciled in the internal checklist

--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: analyzing-dotnet-performance
 description: >-
-  Scans .NET code for ~50 performance anti-patterns across async, memory,
-  strings, collections, LINQ, regex, serialization, and I/O with tiered
-  severity classification. Use when analyzing .NET code for optimization
-  opportunities, reviewing hot paths, or auditing allocation-heavy patterns.
+  Review C#/.NET source for performance issues and optimization opportunities
+  across async, memory, strings, collections, LINQ, regex, serialization, and
+  I/O. USE FOR: "review for performance", "analyze performance", hot-path
+  reviews, allocation audits, optimization reviews, and .NET performance
+  anti-pattern scans. Produces read-only, evidence-based findings with exact
+  locations and fixes.
 license: MIT
 ---
 
@@ -37,10 +39,11 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 
 For a review request:
 
-1. **Never edit source or use write/edit commands.** Report findings and fixes only, then stop; do not implement or validate changes.
+1. **Use read-only tools only:** source/code view, search, and read-only shell inspection. Never use edit/create/write tools, scripts that write files, builds, or tests. Report findings and fixes only, then stop.
 2. **Performance API/allocation findings are at most Moderate.** Critical is reserved for correctness, security/DoS, crashes/deadlocks, or a user-supplied benchmark showing a >10x end-to-end regression in the reviewed code.
 3. **Never state numeric performance estimates** from source comments, references, or inference. Only repeat measurements the user supplied for the reviewed code.
 4. **Complete coverage before brevity.** Reconcile every applicable recipe and manual check, verify executable counts/locations, and report relevant optimized/inverse patterns.
+5. **Omit speculative findings.** Report a closure/delegate allocation only when the code captures state and evidence shows a delegate or display-class allocation at that exact site.
 
 ## Workflow
 
@@ -175,6 +178,8 @@ Format per finding:
 - **No explanatory prose** beyond the Impact line — the severity icon already conveys urgency.
 - **Merge related findings** that share the same fix (e.g., all `.ToLower()` calls go in one finding, not split by file).
 - **Positive findings** in a bullet list, not a table. One line per relevant optimized/inverse pattern: `✅ Pattern — evidence`.
+- If no correctness/security/DoS/crash/deadlock issue exists, write `🔴 Critical: none`; place all performance API/allocation findings under Moderate or Info.
+- Keep Impact qualitative. Do not include performance numbers unless the user supplied measurements for the reviewed code.
 
 End with a summary table and disclaimer:
 
@@ -199,6 +204,7 @@ Before writing the response, correct or remove anything that fails this audit:
 - [ ] Relevant optimized/inverse patterns and exclusions are reported
 - [ ] Allocation/API findings without a user-supplied >10x benchmark are not Critical
 - [ ] No numeric performance estimate appears unless supplied by the user for the reviewed code
+- [ ] Closure/delegate findings prove capture and allocation at the reported site
 - [ ] Summary table and disclaimer are included
 
 ## Common Pitfalls

--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -39,7 +39,7 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 
 For review requests, read but do not modify the supplied source unless the user explicitly asks for changes. If a named file is not at the supplied path, make one targeted filename/path search before concluding that source is unavailable.
 
-Then load `references/critical-patterns.md`, `references/structural-patterns.md`, and the reference for each topic selected by the scan depth. Skip unselected topic references.
+Then load the reference for each topic selected by the scan depth. Load `references/critical-patterns.md` only for critical signals or a comprehensive scan, and load `references/structural-patterns.md` only when a structural finding or exclusion needs inheritance/value-type review. Skip other references.
 
 **If a needed reference file is not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
 
@@ -124,7 +124,7 @@ After running scan recipes, look for these multi-allocation patterns that single
 - **Strings & LINQ:** Trace the complete hot call chain. Include every branched `Replace` location and preserve existing span-based helpers.
 - **Regex:** Compare compiled and generated regexes, scale constructor sites by created instances, and distinguish static literals from dynamic patterns.
 - **Structural:** Search inheritance before recommending `sealed`; keep bases unsealed and identify leaf derivatives.
-- **Collections:** Verify mutation and lifetime before recommending frozen collections; preserve intentionally mutable caches.
+- **Collections:** Verify mutation and lifetime before recommending frozen collections; preserve intentionally mutable caches and report correct `Ordinal`/`OrdinalIgnoreCase` comparers as positives.
 
 ### Step 4: Classify and Prioritize Findings
 
@@ -135,6 +135,8 @@ Assign each finding a severity:
 | 🔴 **Critical** | Deadlocks, crashes, security vulnerabilities, >10x regression | Must fix |
 | 🟡 **Moderate** | 2-10x improvement opportunity, best practice for hot paths | Should fix on hot paths |
 | ℹ️ **Info** | Pattern applies but code may not be on a hot path | Consider if profiling shows impact |
+
+**Critical evidence gate:** Allocation/API-use patterns such as LINQ, `params`, `Replace`, `stackalloc`, or sealing remain Moderate unless a supplied benchmark or directly matching reference demonstrates >10x end-to-end impact or an explicit performance objective is missed. Frequency and hot-path context alone do not make them Critical.
 
 **Prioritization rules:**
 1. If the user identified hot-path code, prioritize findings and use the highest severity supported by evidence; hot-path context alone does not make an allocation finding Critical
@@ -147,7 +149,7 @@ When the same pattern appears across many instances, escalate severity:
 - 11-50 instances → escalate ℹ️ Info patterns to 🟡 Moderate
 - 50+ instances → escalate to 🟡 Moderate with elevated priority; flag as a codebase-wide systematic issue
 
-Do not invent throughput or allocation multipliers. Use reference measurements only when code shape and runtime assumptions match, and label them as reference data.
+Never state nanosecond, percentage, throughput, or allocation multipliers unless they come from a supplied measurement or a loaded reference whose code shape and runtime assumptions match. Label reference data as such.
 
 ### Step 5: Generate Findings
 
@@ -188,7 +190,7 @@ End with a summary table and disclaimer:
 Before delivering results, verify:
 
 - [ ] Source was read without modification unless implementation was requested
-- [ ] Available references were loaded for critical, structural, and selected topics
+- [ ] Available references were loaded only for selected topics and applicable critical/structural checks
 - [ ] Coverage ledger reconciles every applicable recipe and manual-review pattern
 - [ ] Each finding has verified counts, locations, evidence, and a concrete fix
 - [ ] Relevant positive/inverse patterns and exclusions were preserved

--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -37,7 +37,9 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 
 ### Step 1: Read Source and Load Needed References
 
-Read the supplied source first. For a focused file review, use the inline recipes below by default. Load only the relevant reference file when its additional detection guidance is needed; do not load multiple references merely to repeat the inline recipes.
+For review requests, read but do not modify the supplied source unless the user explicitly asks for changes. If a named file is not at the supplied path, make one targeted filename/path search before concluding that source is unavailable.
+
+Then load `references/critical-patterns.md`, `references/structural-patterns.md`, and the reference for each topic selected by the scan depth. Skip unselected topic references.
 
 **If a needed reference file is not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
 
@@ -45,13 +47,13 @@ Read the supplied source first. For a focused file review, use the inline recipe
 
 Scan the code for signals that indicate which pattern categories to check. If reference files were loaded, use their `## Detection` sections. Otherwise, use the inline recipes in Step 3.
 
-| Signal in Code | Topic |
-|----------------|-------|
-| `async`, `await`, `Task`, `ValueTask` | Async patterns |
-| `Span<`, `Memory<`, `stackalloc`, `ArrayPool`, `string.Substring`, `.Replace(`, `.ToLower()`, `+=` in loops, `params` | Memory & strings |
-| `Regex`, `[GeneratedRegex]`, `Regex.Match`, `RegexOptions.Compiled` | Regex patterns |
-| `Dictionary<`, `List<`, `.ToList()`, `.Where(`, `.Select(`, LINQ methods, `static readonly Dictionary<` | Collections & LINQ |
-| `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization |
+| Signal in Code | Topic | Reference |
+|----------------|-------|-----------|
+| `async`, `await`, `Task`, `ValueTask` | Async patterns | `references/async-patterns.md` |
+| `Span<`, `Memory<`, `stackalloc`, `ArrayPool`, `string.Substring`, `.Replace(`, `.ToLower()`, `+=` in loops, `params` | Memory & strings | `references/memory-and-strings.md` |
+| `Regex`, `[GeneratedRegex]`, `Regex.Match`, `RegexOptions.Compiled` | Regex patterns | `references/regex-patterns.md` |
+| `Dictionary<`, `List<`, `.ToList()`, `.Where(`, `.Select(`, LINQ methods, `static readonly Dictionary<` | Collections & LINQ | `references/collections-and-linq.md` |
+| `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization | `references/io-and-serialization.md` |
 
 Always check structural patterns (unsealed classes) regardless of signals.
 
@@ -62,9 +64,11 @@ Always check structural patterns (unsealed classes) regardless of signals.
 
 ### Step 3: Scan and Report
 
-**For files under 500 lines, read the entire file first** — you'll spot most patterns faster than running individual grep recipes. Check every applicable pattern category selected by the scan depth, but use a single batched search per category only when it is needed to confirm counts or locations. Do not run a separate search for each recipe or re-scan signals the source read has already ruled out.
+**For files under 500 lines, read the entire file first.** Use one batched search per applicable category to confirm counts, locations, and positive/inverse patterns; do not run a separate search for each recipe.
 
-The detection recipes below are a coverage guide, not a command-by-command checklist. Report exact counts when a finding depends on the count.
+Maintain an internal coverage ledger for every applicable recipe and manual-review pattern from the loaded references or inline guidance. Reconcile each as checked with hits, checked with no hits, or not applicable. This is a completeness contract, not an output format or a requirement for one tool call per recipe.
+
+Search hits are candidates, not findings. Inspect their context and report exact executable-site counts and locations; for per-instance patterns, scale the count by constructed instances.
 
 **Core scan recipes** (run these when reference files aren't available):
 ```
@@ -94,10 +98,11 @@ grep -n ': IEquatable' FILE                    # Positive: struct equality
 ```
 
 **Rules:**
-- Cover every relevant pattern category, combining related searches when confirmation is needed
-- **Emit a concise category checklist** before classifying findings — report the finding count or `none` for each category without listing individual zero-hit searches
-- A result of **0 hits** is valid and valuable (confirms good practice)
-- If a reference file was loaded, use its additional `## Detection` guidance for that topic
+- Reconcile every applicable recipe and manual-review pattern, combining related confirmation searches by category
+- **Emit a concise category checklist** before classifying findings — report actionable counts or `none`, not individual zero-hit searches
+- For each detected category, check the relevant optimized/inverse patterns and preserve them as positive findings or exclusions
+- If a reference file was loaded, use its `## Detection` and manual-review guidance for that topic
+- Do not elevate an ambiguous allocation or performance claim without confirming it from the code; state uncertainty when context is insufficient
 
 **Verify-the-Inverse Rule:** For absence patterns, always count both sides and report the ratio (e.g., "N of M classes are sealed"). The ratio determines severity — 0/185 is systematic, 12/15 is a consistency fix.
 
@@ -114,6 +119,13 @@ After running scan recipes, look for these multi-allocation patterns that single
 3. **Compound `+=` with embedded allocating calls:** Lines like `result += $"...{Foo().ToLower()}"` are 2+ allocations (interpolation + ToLower + concatenation) — flag the compound cost, not just the `.ToLower()`.
 4. **`string.Format` specificity:** Distinguish resource-loaded format strings (not fixable) from compile-time literal format strings (fixable with interpolation). Enumerate the actionable sites.
 
+### Step 3d: Category Completeness Guardrails
+
+- **Strings & LINQ:** Trace the complete hot call chain. Include every branched `Replace` location and preserve existing span-based helpers.
+- **Regex:** Compare compiled and generated regexes, scale constructor sites by created instances, and distinguish static literals from dynamic patterns.
+- **Structural:** Search inheritance before recommending `sealed`; keep bases unsealed and identify leaf derivatives.
+- **Collections:** Verify mutation and lifetime before recommending frozen collections; preserve intentionally mutable caches.
+
 ### Step 4: Classify and Prioritize Findings
 
 Assign each finding a severity:
@@ -125,7 +137,7 @@ Assign each finding a severity:
 | ℹ️ **Info** | Pattern applies but code may not be on a hot path | Consider if profiling shows impact |
 
 **Prioritization rules:**
-1. If the user identified hot-path code, elevate all findings in that code to their maximum severity
+1. If the user identified hot-path code, prioritize findings and use the highest severity supported by evidence; hot-path context alone does not make an allocation finding Critical
 2. If hot-path context is unknown, report 🔴 Critical findings unconditionally; report 🟡 Moderate findings with a note: _"Impactful if this code is on a hot path"_
 3. Never suggest micro-optimizations on code that is clearly not performance-sensitive
 
@@ -135,7 +147,7 @@ When the same pattern appears across many instances, escalate severity:
 - 11-50 instances → escalate ℹ️ Info patterns to 🟡 Moderate
 - 50+ instances → escalate to 🟡 Moderate with elevated priority; flag as a codebase-wide systematic issue
 
-Always report exact counts (from scan recipes), not estimates or agent summaries.
+Do not invent throughput or allocation multipliers. Use reference measurements only when code shape and runtime assumptions match, and label them as reference data.
 
 ### Step 5: Generate Findings
 
@@ -157,7 +169,7 @@ Format per finding:
 - **File locations as inline comma-separated list**, not a table. Use `File.cs:L42` format.
 - **No explanatory prose** beyond the Impact line — the severity icon already conveys urgency.
 - **Merge related findings** that share the same fix (e.g., all `.ToLower()` calls go in one finding, not split by file).
-- **Positive findings** in a bullet list, not a table. One line per pattern: `✅ Pattern — evidence`.
+- **Positive findings** in a bullet list, not a table. Include the relevant inverse/optimized evidence for detected categories: `✅ Pattern — evidence`.
 
 End with a summary table and disclaimer:
 
@@ -175,10 +187,12 @@ End with a summary table and disclaimer:
 
 Before delivering results, verify:
 
-- [ ] All critical patterns were checked (from reference files or inline recipes)
-- [ ] Topic-specific recipes run only when matching signals detected
-- [ ] Each finding includes a concrete code fix
-- [ ] Category checklist covers applicable performance patterns
+- [ ] Source was read without modification unless implementation was requested
+- [ ] Available references were loaded for critical, structural, and selected topics
+- [ ] Coverage ledger reconciles every applicable recipe and manual-review pattern
+- [ ] Each finding has verified counts, locations, evidence, and a concrete fix
+- [ ] Relevant positive/inverse patterns and exclusions were preserved
+- [ ] Category checklist covers all applicable performance categories
 - [ ] Summary table included at end
 
 ## Common Pitfalls
@@ -186,6 +200,7 @@ Before delivering results, verify:
 | Pitfall | Correct Approach |
 |---------|-----------------|
 | Flagging every `Dictionary` as needing `FrozenDictionary` | Only flag if the dictionary is never mutated after construction |
+| Treating a local function or lambda as a heap allocation by default | Confirm it captures state and that the delegate/closure is allocated or escapes before reporting it |
 | Suggesting `Span<T>` in async methods | Use `Memory<T>` in async code; `Span<T>` only in sync hot paths |
 | Reporting LINQ outside hot paths | Only flag LINQ in identified hot paths or tight loops; LINQ is acceptable in code that runs infrequently. Since .NET 7, LINQ Min/Max/Sum/Average are vectorized — blanket bans on LINQ are misguided |
 | Suggesting `ConfigureAwait(false)` in app code | Only applicable in library code; not primarily a performance concern |

--- a/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
+++ b/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md
@@ -35,11 +35,11 @@ Scan C#/.NET code for performance anti-patterns and produce prioritized findings
 
 ## Workflow
 
-### Step 1: Load Reference Files (if available)
+### Step 1: Read Source and Load Needed References
 
-Try to load `references/critical-patterns.md` and the topic-specific reference files listed below. These contain detailed detection recipes and grep commands.
+Read the supplied source first. For a focused file review, use the inline recipes below by default. Load only the relevant reference file when its additional detection guidance is needed; do not load multiple references merely to repeat the inline recipes.
 
-**If reference files are not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **skip file loading and proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
+**If a needed reference file is not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
 
 ### Step 2: Detect Code Signals and Select Topic Recipes
 
@@ -62,9 +62,9 @@ Always check structural patterns (unsealed classes) regardless of signals.
 
 ### Step 3: Scan and Report
 
-**For files under 500 lines, read the entire file first** — you'll spot most patterns faster than running individual grep recipes. Use grep to confirm counts and catch patterns you might miss visually.
+**For files under 500 lines, read the entire file first** — you'll spot most patterns faster than running individual grep recipes. Check every applicable pattern category selected by the scan depth, but use a single batched search per category only when it is needed to confirm counts or locations. Do not run a separate search for each recipe or re-scan signals the source read has already ruled out.
 
-For each relevant pattern category, run the detection recipes below. Report exact counts, not estimates.
+The detection recipes below are a coverage guide, not a command-by-command checklist. Report exact counts when a finding depends on the count.
 
 **Core scan recipes** (run these when reference files aren't available):
 ```
@@ -94,10 +94,10 @@ grep -n ': IEquatable' FILE                    # Positive: struct equality
 ```
 
 **Rules:**
-- Run every relevant recipe for the detected pattern categories
-- **Emit a scan execution checklist** before classifying findings — list each recipe and the hit count
+- Cover every relevant pattern category, combining related searches when confirmation is needed
+- **Emit a concise category checklist** before classifying findings — report the finding count or `none` for each category without listing individual zero-hit searches
 - A result of **0 hits** is valid and valuable (confirms good practice)
-- If reference files were loaded, also run their `## Detection` recipes
+- If a reference file was loaded, use its additional `## Detection` guidance for that topic
 
 **Verify-the-Inverse Rule:** For absence patterns, always count both sides and report the ratio (e.g., "N of M classes are sealed"). The ratio determines severity — 0/185 is systematic, 12/15 is a consistency fix.
 
@@ -178,7 +178,7 @@ Before delivering results, verify:
 - [ ] All critical patterns were checked (from reference files or inline recipes)
 - [ ] Topic-specific recipes run only when matching signals detected
 - [ ] Each finding includes a concrete code fix
-- [ ] Scan execution checklist is complete (all recipes run)
+- [ ] Category checklist covers applicable performance patterns
 - [ ] Summary table included at end
 
 ## Common Pitfalls


### PR DESCRIPTION
Follow-up to #886.

This stacked PR applies only the evidence-backed skill guidance changes after the eval criteria introduced by #905:

- read source before selecting confirmation searches
- load only references needed for the detected categories
- batch confirmation searches by category
- report a concise category checklist instead of per-recipe zero-hit tool calls

## Baseline coverage support

The automated skill coverage report is unchanged at **11/21 units (52.4%)** on the frozen evaluator and this stacked follow-up. The ten uncovered units are five final-output validation checks (including the checklist requirement) and five separate pitfall guardrails; this PR therefore does not claim increased declarative coverage or broaden the evaluator. It preserves the existing baseline while changing how the agent gathers evidence during covered focused reviews.

Scenarios 8 and 9 provide the targeted behavioral probe for this workflow: they review hot-path string/collection code with outcome-focused criteria and no prescribed search vocabulary. In the independent five-family combined rerun used as supporting—not causal—evidence, both scenarios activated in all 10 skilled cells, all 10 graders passed, 53/55 rubric criteria were satisfied, average skilled tool calls fell 41.3% versus the historical run, and skilled-versus-baseline overhead fell from +5.93 to +1.36 calls (-77%). Those results support source-first review and batched confirmation while the unchanged 11/21 coverage boundary makes clear what remains untested.

#905 must merge first so the evaluation criteria are frozen before this skill-only treatment is considered. This PR intentionally does not modify eval YAML, fixtures, workflows, the vally adapter, or reliability behavior.

Validation:
- `skill-validator check --skills plugins/dotnet-diag/skills/analyzing-dotnet-performance`
- `markdownlint-cli2 plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md`
- base-relative diff contains exactly `plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md`