### PR TITLE
Map dotnet11 CODEOWNERS to @dotnet/skills-csharp-language-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -145,8 +145,8 @@
 /tests/dotnet-nuget/ @dotnet/area-infrastructure-libraries @kartheekp-ms
 
 # dotnet11 (.NET 11 new APIs and language features)
-/plugins/dotnet11/ @ManishJayaswal @JanKrivanek @ViktorHofer
-/tests/dotnet11/ @ManishJayaswal @JanKrivanek @ViktorHofer
+/plugins/dotnet11/ @dotnet/skills-csharp-language-reviewers
+/tests/dotnet11/ @dotnet/skills-csharp-language-reviewers
 
-/plugins/dotnet11/skills/system-text-json-net11/ @JanKrivanek @ViktorHofer
-/tests/dotnet11/system-text-json-net11/ @JanKrivanek @ViktorHofer
+/plugins/dotnet11/skills/system-text-json-net11/ @dotnet/skills-csharp-language-reviewers
+/tests/dotnet11/system-text-json-net11/ @dotnet/skills-csharp-language-reviewers


### PR DESCRIPTION
This aligns dotnet11 review ownership with the shared `@dotnet/skills-csharp-language-reviewers` team already used across the `dotnet` and `dotnet-advanced` plugins, replacing the previous individual owners (@ManishJayaswal, @JanKrivanek, @ViktorHofer) on all four dotnet11 lines.

Note that the `system-text-json-net11` sub-entries are now identical to the parent `/plugins/dotnet11/` and `/tests/dotnet11/` lines and could optionally be removed in a follow-up as redundant, but were left in place here to keep this change minimal.