### PR TITLE
Add missing Vally configs for 3 evals

### DIFF
--- a/tests/dotnet-aspnetcore/convert-blazor-server-to-webapp/eval.vally.yaml
+++ b/tests/dotnet-aspnetcore/convert-blazor-server-to-webapp/eval.vally.yaml
@@ -1,0 +1,124 @@
+name: convert-blazor-server-to-webapp
+description: Evaluates the dotnet-aspnetcore/convert-blazor-server-to-webapp skill
+type: capability
+config:
+  timeout: 10m
+stimuli:
+  - name: Blazor Server app with CascadingAuthenticationState
+    prompt: |
+      Convert this .NET 7 Blazor Server app to a .NET 8 Blazor Web App. The app uses
+      authentication with CascadingAuthenticationState. Provide the complete updated files.
+      The app should no longer use AddServerSideBlazor or MapBlazorHub.
+
+      Program.cs:
+      ```csharp
+      using BlazorAuthApp;
+
+      var builder = WebApplication.CreateBuilder(args);
+
+      builder.Services.AddRazorPages();
+      builder.Services.AddServerSideBlazor();
+
+      var app = builder.Build();
+
+      if (!app.Environment.IsDevelopment())
+      {
+          app.UseExceptionHandler("/Error");
+          app.UseHsts();
+      }
+
+      app.UseHttpsRedirection();
+      app.UseStaticFiles();
+      app.UseRouting();
+
+      app.UseAuthentication();
+      app.UseAuthorization();
+
+      app.MapControllers();
+      app.MapBlazorHub();
+      app.MapFallbackToPage("/_Host");
+
+      app.Run();
+      ```
+
+      App.razor:
+      ```razor
+      <CascadingAuthenticationState>
+          <Router AppAssembly="@typeof(Program).Assembly">
+              <Found Context="routeData">
+                  <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                      <NotAuthorized>
+                          <RedirectToLogin />
+                      </NotAuthorized>
+                  </AuthorizeRouteView>
+                  <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+              </Found>
+              <NotFound>
+                  <LayoutView Layout="@typeof(MainLayout)">
+                      <p>Sorry, there's nothing at this address.</p>
+                  </LayoutView>
+              </NotFound>
+          </Router>
+      </CascadingAuthenticationState>
+      ```
+
+      Pages/_Host.cshtml:
+      ```html
+      @page "/"
+      @using Microsoft.AspNetCore.Components.Web
+      @namespace BlazorAuthApp.Pages
+      @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <base href="~/" />
+          <link href="BlazorAuthApp.styles.css" rel="stylesheet" />
+          <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+      </head>
+      <body>
+          <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+          <div id="blazor-error-ui">
+              <environment include="Staging,Production">
+                  An error has occurred. This application may no longer respond until reloaded.
+              </environment>
+              <environment include="Development">
+                  An unhandled exception has occurred. See browser dev tools for details.
+              </environment>
+              <a href="" class="reload">Reload</a>
+              <a class="dismiss">🗙</a>
+          </div>
+
+          <script src="_framework/blazor.server.js"></script>
+      </body>
+      </html>
+      ```
+    graders:
+      - type: output-contains
+        config:
+          substring: AddCascadingAuthenticationState
+      - type: output-contains
+        config:
+          substring: AddRazorComponents
+      - type: output-contains
+        config:
+          substring: MapRazorComponents
+      - type: output-contains
+        config:
+          substring: UseAntiforgery
+      - type: output-not-matches
+        config:
+          pattern: 'AddServerSideBlazor\s*\('
+      - type: output-not-matches
+        config:
+          pattern: 'MapBlazorHub\s*\('
+      - type: prompt
+    rubric:
+      - Removes the CascadingAuthenticationState component wrapper from App.razor/Routes.razor
+      - Adds builder.Services.AddCascadingAuthenticationState() to Program.cs
+      - Places UseAntiforgery after UseAuthentication and UseAuthorization in the middleware pipeline
+      - Keeps AuthorizeRouteView in the Routes component
+      - Does NOT switch to static rendering — preserves interactive server rendering

--- a/tests/dotnet-aspnetcore/dotnet-webapi/eval.vally.yaml
+++ b/tests/dotnet-aspnetcore/dotnet-webapi/eval.vally.yaml
@@ -1,0 +1,162 @@
+name: dotnet-webapi
+description: Evaluates the dotnet-aspnetcore/dotnet-webapi skill
+type: capability
+config:
+  timeout: 15m
+stimuli:
+  - name: Create a CRUD Web API with minimal APIs, OpenAPI, and proper HTTP semantics
+    prompt: |
+      Create an ASP.NET Core Web API (.NET 10) project for managing products.
+      Each product has a name, price, category (an enum: Electronics, Clothing,
+      Food, Books), and a createdAt timestamp.
+
+      The API should have these endpoints:
+      - GET /api/products (list all)
+      - GET /api/products/{id} (get by ID)
+      - POST /api/products (create a product)
+
+      Use an in-memory service behind an interface for data storage.
+      Add OpenAPI documentation with rich metadata on each endpoint.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (MapGet|MapPost)
+      - type: output-matches
+        config:
+          pattern: (TypedResults|Results<)
+      - type: output-matches
+        config:
+          pattern: sealed
+      - type: output-contains
+        config:
+          substring: DateTimeOffset
+      - type: output-matches
+        config:
+          pattern: '/// <summary>'
+      - type: output-contains
+        config:
+          substring: AddOpenApi
+      - type: output-contains
+        config:
+          substring: MapOpenApi
+      - type: output-matches
+        config:
+          pattern: (WithName|WithSummary|WithDescription)
+      - type: output-not-contains
+        config:
+          substring: Swashbuckle
+      - type: output-not-matches
+        config:
+          pattern: (UseSwagger|UseSwaggerUI)
+      - type: output-contains
+        config:
+          substring: JsonStringEnumConverter
+      - type: output-contains
+        config:
+          substring: CancellationToken
+      - type: prompt
+    rubric:
+      - Uses minimal APIs (MapGet, MapPost, etc.) rather than controllers for new projects
+      - POST endpoint returns 201 Created with a Location header, not 200 OK
+      - Uses TypedResults with explicit Results<T1, T2> return types for compile-time type safety
+      - DTOs are sealed records, not mutable classes
+      - Uses a service layer with interfaces instead of injecting a data store directly into endpoints
+      - CancellationToken is accepted in endpoint signatures and forwarded through all async calls
+      - Date/time properties use DateTimeOffset, not DateTime
+      - All request and response DTOs include XML doc summary comments
+      - Enum properties serialize as strings by default using JsonStringEnumConverter
+      - Uses builder.Services.AddOpenApi() and app.MapOpenApi() (built-in .NET 9+ support)
+      - Does NOT add any Swashbuckle NuGet packages
+      - Chains .WithName(), .WithSummary(), and .WithDescription() on endpoints for OpenAPI metadata
+
+  - name: Add error handling with ProblemDetails and IExceptionHandler
+    prompt: |
+      I have an existing ASP.NET Core minimal API project. I need to add
+      global error handling so that:
+      - All error responses use RFC 7807 Problem Details format
+      - KeyNotFoundException maps to 404
+      - ArgumentException maps to 400
+      - InvalidOperationException maps to 409
+      - Unhandled exceptions return 500 with no sensitive details
+
+      Show me how to implement this without adding try-catch blocks in
+      every endpoint.
+    graders:
+      - type: output-contains
+        config:
+          substring: IExceptionHandler
+      - type: output-contains
+        config:
+          substring: ProblemDetails
+      - type: output-contains
+        config:
+          substring: AddProblemDetails
+      - type: output-contains
+        config:
+          substring: UseExceptionHandler
+      - type: prompt
+    rubric:
+      - Implements IExceptionHandler (the modern .NET 8+ approach) rather than convention-based middleware
+      - Returns ProblemDetails for all error responses (RFC 7807)
+      - Maps exception types to appropriate HTTP status codes (404, 400, 409)
+      - Does not expose internal exception details in production error responses
+      - Registers the handler with AddExceptionHandler<T>() and AddProblemDetails()
+      - Exception handler class is sealed
+      - Exception handler is placed in a Middleware/ folder
+
+  - name: Add a new API endpoint to an existing controller-based project
+    prompt: |
+      I have an existing ASP.NET Core Web API that uses controllers. Here is
+      one of the existing controllers:
+
+      ```csharp
+      [ApiController]
+      [Route("api/[controller]")]
+      public class CustomersController : ControllerBase
+      {
+          private readonly ICustomerService _service;
+
+          public CustomersController(ICustomerService service)
+          {
+              _service = service;
+          }
+
+          [HttpGet]
+          public async Task<ActionResult<List<CustomerResponse>>> GetAll()
+          {
+              return Ok(await _service.GetAllAsync());
+          }
+      }
+      ```
+
+      Add a new OrdersController with a GET endpoint to list orders and a
+      POST endpoint to create an order. Each order has a customer ID, a
+      placedAt timestamp, a total amount, and an OrderStatus (Pending,
+      Processing, Shipped, Delivered, Cancelled).
+    graders:
+      - type: output-contains
+        config:
+          substring: ControllerBase
+      - type: output-contains
+        config:
+          substring: '[ApiController]'
+      - type: output-contains
+        config:
+          substring: CancellationToken
+      - type: output-not-matches
+        config:
+          pattern: 'app\.(MapGet|MapPost|MapPut|MapDelete|MapPatch)|\b(MapGet|MapPost|MapPut|MapDelete|MapPatch)\b'
+      - type: output-contains
+        config:
+          substring: DateTimeOffset
+      - type: output-matches
+        config:
+          pattern: '/// <summary>'
+      - type: prompt
+    rubric:
+      - Continues with the controller pattern since the existing project uses controllers (does not mix minimal APIs)
+      - Includes CancellationToken in all endpoint signatures
+      - POST create returns CreatedAtAction with 201 status, not Ok with 200
+      - Uses sealed record DTOs with proper naming (CreateOrderRequest, OrderResponse)
+      - Date/time properties use DateTimeOffset, not DateTime
+      - All request and response DTOs include XML doc summary comments

--- a/tests/dotnet/setup-local-sdk/eval.vally.yaml
+++ b/tests/dotnet/setup-local-sdk/eval.vally.yaml
@@ -1,0 +1,149 @@
+name: setup-local-sdk
+description: Evaluates the dotnet/setup-local-sdk skill
+type: capability
+config:
+  timeout: 10m
+stimuli:
+  - name: Detect incompatible .NET host version
+    prompt: I already ran dotnet --version and it printed 9.0.306. I want to set up a local .NET 11 preview SDK for my project using the global.json SDK paths feature. Is that possible?
+    constraints:
+      reject_tools:
+        - bash
+        - powershell
+        - web_fetch
+    graders:
+      - type: output-contains
+        config:
+          substring: 9.0.306
+      - type: output-matches
+        config:
+          pattern: '(\.NET 10\+|\.NET 10 or later|10 or higher|10 or later|requires.{0,40}10|version 10)'
+      - type: output-matches
+        config:
+          pattern: '("paths"|global\.json.{0,80}paths|paths.{0,80}global\.json)'
+      - type: output-matches
+        config:
+          pattern: '(install|upgrade).{0,80}(\.NET 10|10)'
+      - type: output-not-matches
+        config:
+          pattern: '(--install-dir|Let me download|Downloading and installing|dotnet-install\.(sh|ps1))'
+      - type: prompt
+    rubric:
+      - The agent detected that version 9.0.306 is below the .NET 10 requirement
+      - The agent explained that .NET 10+ is required for the paths feature
+      - The agent told the user to install .NET 10+ system-wide first
+      - The agent did not proceed with local SDK installation commands before the host SDK prerequisite was met
+
+  - name: Create team install scripts
+    prompt: This repo already has a global.json for a .NET 11 preview. Create install scripts and repo configuration, including a clear missing-SDK message, so teammates can reproduce the project-local SDK setup on any OS after cloning. Preserve the existing global.json sections. Don't download the SDK now.
+    environment:
+      files:
+        - src: ./fixtures/create-team-install-scripts/global.json
+          dest: global.json
+    graders:
+      - type: file-exists
+        config:
+          path: install*.sh
+      - type: file-exists
+        config:
+          path: install*.ps1
+      - type: output-matches
+        config:
+          pattern: 'install[^\s]*\.sh'
+      - type: output-matches
+        config:
+          pattern: 'install[^\s]*\.ps1'
+      - type: file-contains
+        config:
+          path: global.json
+          value: paths
+      - type: file-contains
+        config:
+          path: global.json
+          value: version
+      - type: file-contains
+        config:
+          path: global.json
+          value: msbuild-sdks
+      - type: file-contains
+        config:
+          path: global.json
+          value: tools
+      - type: file-contains
+        config:
+          path: global.json
+          value: errorMessage
+      - type: file-contains
+        config:
+          path: global.json
+          value: 11.0.100-preview.3.26207.106
+      - type: file-contains
+        config:
+          path: global.json
+          value: Example.Sdk
+      - type: file-contains
+        config:
+          path: global.json
+          value: 1.2.3
+      - type: file-contains
+        config:
+          path: global.json
+          value: dotnet-example
+      - type: file-contains
+        config:
+          path: global.json
+          value: 4.5.6
+      - type: output-matches
+        config:
+          pattern: '(merge|preserve|backup|back up|existing)'
+      - type: output-matches
+        config:
+          pattern: '(teammates|team|clone|after cloning)'
+      - type: file-not-contains
+        config:
+          path: install*.sh
+          value: export PATH
+      - type: file-not-contains
+        config:
+          path: install*.ps1
+          value: $env:PATH
+      - type: prompt
+    rubric:
+      - The agent created cross-platform scripts that teammates can run after cloning
+      - The agent configured missing-SDK guidance that points teammates to the install scripts
+      - The agent avoided dropping existing global.json settings
+      - The agent made the setup reproducible without requiring teammates to change PATH
+
+  - name: Plan a project-local .NET 11 preview setup without downloading
+    prompt: I want to try the latest .NET 11 preview in my project without affecting my global install. Show me the exact commands and configuration you would use to set it up locally, but do not download or install anything now.
+    constraints:
+      reject_tools:
+        - bash
+        - powershell
+        - web_fetch
+    graders:
+      - type: output-contains
+        config:
+          substring: dotnet-install
+      - type: output-contains
+        config:
+          substring: global.json
+      - type: output-contains
+        config:
+          substring: .dotnet
+      - type: output-matches
+        config:
+          pattern: '("paths"|global\.json.{0,80}paths|paths.{0,80}global\.json)'
+      - type: output-matches
+        config:
+          pattern: '(\.gitignore|gitignore|source control|committed|commit)'
+      - type: output-not-matches
+        config:
+          pattern: '(export\s+PATH|setx\s+PATH|\$env:PATH\s*=|set\s+PATH=)'
+      - type: prompt
+    rubric:
+      - The agent described a project-local SDK setup that does not change the system-wide installation
+      - The agent configured SDK resolution (global.json paths) so the local SDK is preferred with the host install as fallback
+      - The agent excluded the local SDK directory from source control
+      - The agent explained how to clean up
+      - The agent presented the plan/commands without actually downloading or installing the SDK

--- a/tests/dotnet/setup-local-sdk/fixtures/create-team-install-scripts/global.json
+++ b/tests/dotnet/setup-local-sdk/fixtures/create-team-install-scripts/global.json
@@ -1,0 +1,13 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.3.26207.106",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Example.Sdk": "1.2.3"
+  },
+  "tools": {
+    "dotnet-example": "4.5.6"
+  }
+}


### PR DESCRIPTION
## What

Adds `eval.vally.yaml` for three skills that shipped a base `eval.yaml` but had **no** `eval.vally.yaml`, so the cross-family evaluation harness silently never scored them (root cause behind #903):

- `tests/dotnet/setup-local-sdk/eval.vally.yaml` (+ `fixtures/create-team-install-scripts/global.json`)
- `tests/dotnet-aspnetcore/dotnet-webapi/eval.vally.yaml`
- `tests/dotnet-aspnetcore/convert-blazor-server-to-webapp/eval.vally.yaml`

## Why

The matrix scores a skill only when `tests/<plugin>/<skill>/eval.vally.yaml` exists. These three were never measured — not a runtime/harness failure, a missing config. Landing them makes the skills appear in every future scorecard.

## Verification

Measured in cross-family run [`29785538175`](https://github.com/dotnet/skills/actions/runs/29785538175) — executors {opus, sonnet46, gpt}, **n=3/stimulus**, **judge ≠ executor family**, **0 errored trials**:

| Skill | opus | sonnet46 | gpt |
|---|:--:|:--:|:--:|
| setup-local-sdk | ✅ | ✅ (1.0) | ✅ |
| dotnet-webapi | ✅ | ✅ | ✅ |
| convert-blazor-server-to-webapp | ✅* | ❌* | ❌* |

`setup-local-sdk` passes on all three (McNemar p 0.016–0.031).

### Notes
- **`setup-local-sdk` is deterministic / network-free by design** (host-version gating, team install-script generation, dry-run install-plan composition). This closes the cross-family coverage gap; it intentionally does **not** cover live SDK/workload installation — those stay on the interactive base `eval.yaml` — to avoid re-introducing #909-class transient noise.
- `*` **`convert-blazor` is under-powered** (single stimulus, n=3). All three executors show positive observed effects; the opus-pass/others-fail split is a statistical-power artifact of the CI-lower-bound>0 rule, not evidence opus is better. Follow-up: add stimuli / raise n before trusting its per-executor flags.
- `grade-tests` was initially flagged too but already gained a config on `main` via #916, so it's intentionally excluded here.

Closes #903 (on merge).