### PR TITLE
[eval-verify] Exercise Vally PR gate + /evaluate on convert-to-cpm

### DIFF
--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -16,7 +16,7 @@ license: MIT
 
 # Convert to Central Package Management
 
-Migrate .NET projects from per-project package versioning to NuGet Central Package Management (CPM). CPM centralizes all package versions into a single `Directory.Packages.props` file, making version governance and upgrades easier across multi-project repositories.
+Migrate .NET projects from per-project package versioning to NuGet Central Package Management (CPM). CPM centralizes all package versions into a single `Directory.Packages.props` file at the repository root, making version governance and upgrades easier across multi-project repositories.
 
 ## When to Use
 


### PR DESCRIPTION
Verification-only draft PR (not for merge). Touches a single skill (dotnet-nuget/convert-to-cpm) so the discover matrix is minimal, to prove the post-#877 Vally end-to-end PR path on merged main: gate -> discover -> evaluate (Vally worker) -> comment-on-pr. A maintainer/agent will post /evaluate. Will be closed after verification.