### PR TITLE
Reclaim runner disk space before session/eval-data publish

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1051,6 +1051,21 @@ jobs:
       group: publish-session-data
       cancel-in-progress: false
     steps:
+      - name: Free up runner disk space
+        shell: bash
+        run: |
+          # This job shallow-clones the multi-GB dashboard-session-data branch and
+          # stages this run's session logs, which purge-replay-sessions.ps1 then
+          # copies through a temp dir (transiently ~2-3x the data). On a valid-token
+          # run that produces real trajectory logs this can exhaust the runner disk.
+          # Reclaim ~20GB of preinstalled tooling this job never uses (no dotnet
+          # build here; pwsh 7 lives under /opt/microsoft, not /usr/share/dotnet).
+          # The df output makes any future disk pressure diagnosable from the log.
+          echo "=== disk before cleanup ==="; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          echo "=== disk after cleanup ==="; df -h /
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
@@ -1163,6 +1178,18 @@ jobs:
       cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
+      - name: Free up runner disk space
+        shell: bash
+        run: |
+          # Scheduled runs stage benchmark + eval data for all plugins and clone the
+          # dashboard-eval-data branch, so reclaim ~20GB of preinstalled tooling this
+          # job never uses to avoid runner-disk exhaustion as the branch grows. The
+          # df output makes any future disk pressure diagnosable from the log.
+          echo "=== disk before cleanup ==="; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          echo "=== disk after cleanup ==="; df -h /
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:

--- a/plugins/dotnet-advanced/skills/csharp-scripts/SKILL.md
+++ b/plugins/dotnet-advanced/skills/csharp-scripts/SKILL.md
@@ -11,7 +11,6 @@ license: MIT
 - Testing a C# concept, API, or language feature with a quick file-based app
 - Prototyping logic before integrating it into a larger project
 - Building a small utility from one entry-point file and a few helper `.cs` files
-- Sharing a minimal, self-contained repro as a single runnable `.cs` file
 
 ## When Not to Use
 

--- a/plugins/dotnet-advanced/skills/csharp-scripts/SKILL.md
+++ b/plugins/dotnet-advanced/skills/csharp-scripts/SKILL.md
@@ -11,6 +11,7 @@ license: MIT
 - Testing a C# concept, API, or language feature with a quick file-based app
 - Prototyping logic before integrating it into a larger project
 - Building a small utility from one entry-point file and a few helper `.cs` files
+- Sharing a minimal, self-contained repro as a single runnable `.cs` file
 
 ## When Not to Use
 


### PR DESCRIPTION
## Problem

`publish-session-data` intermittently fails with `System.IO.IOException: No space left on device`. Root cause is **runner disk exhaustion**, not a code bug:

- The job shallow-clones the `dashboard-session-data` branch of `dotnet/skills-data`, whose working tree is **~8.66 GB** and growing.
- `purge-replay-sessions.ps1` then copies the merged session set through a temp dir (transiently ~2–3× the data).
- On a run that draws a **valid** Copilot token and produces real trajectory logs, the new session data stacked on top of the ~8.66 GB clone tips the runner over its free-disk limit. Runs that drew the expired pool token produced empty trajectories and so never stressed the disk — which is why this only surfaced intermittently.

`publish-eval-data` (scheduled) faces the same risk as its branch grows.

## Fix

Add a first-step **disk reclaim** to both `publish-session-data` and `publish-eval-data` that removes ~20 GB of preinstalled tooling neither job uses (no `dotnet build`; pwsh 7 lives under `/opt/microsoft`, not `/usr/share/dotnet`), plus `df -h` logging so any future disk pressure is diagnosable from the log.

## Validation

- `actionlint -shellcheck= -pyflakes=` on `evaluation.yml` — clean (exit 0)
- `bash -n` syntax check of the reclaim snippet — clean (exit 0)
- Behavioral dry-run: removes present paths, tolerates absent paths + unset vars (`|| true`), `df -h /` works
- Definitive last-mile proof happens on a runner (passwordless `sudo` on `ubuntu-latest`).

## Follow-ups (not in this PR)

- Rotate the expired `COPILOT_PAT_*` org secret in the copilot-pat-pool (masks disk failures and silently empties eval legs).
- Optional: `Copy`→`Move` in `purge-replay-sessions.ps1` to halve transient footprint.
