### PR TITLE
Improve dotnet-test-migration skill signal

### DIFF
--- a/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
@@ -58,6 +58,11 @@ MSTest v3 introduces these breaking changes from v1/v2. Address only the ones re
 | Timeout behavior unified across .NET Core / Framework | Tests with `[Timeout]` may behave differently | Verify timeout values; adjust if needed |
 | Dropped target frameworks: .NET 5, .NET Fx < 4.6.2, netstandard1.0, UWP < 16299, WinUI < 18362 | Build error | Update TFM: .NET 5 -> net8.0 (LTS) or net6.0+, netfx -> net462+, netstandard1.0 -> netstandard2.0. Note: net6.0, net8.0, net9.0 are all supported |
 | Not binary compatible with v1/v2 | Libraries compiled against v1/v2 must be recompiled | Recompile all dependencies against v3 |
+| Test ID generation changed | Playlists, filters, or CI history keyed by test ID may reset | Re-baseline IDs and verify affected filters |
+| `TargetInvocationException` is unwrapped | Tests or infrastructure expecting the wrapper observe the inner exception | Update exception handling to expect the underlying exception |
+| Initialization/cleanup messages now attach to test results | The first/last test output may gain lifecycle messages that were previously absent | Update log processing and inspect the first/last test results |
+| Deployment directory behavior is unified across TFMs | Tests with hard-coded deployment paths may fail | Use `TestContext.DeploymentDirectory` or deployed-item paths instead of assumptions |
+| Nullable annotations were added | Nullable-enabled projects may gain warnings | Fix the warnings without suppressing unrelated diagnostics |
 
 ## Response Guidelines
 
@@ -66,11 +71,11 @@ MSTest v3 introduces these breaking changes from v1/v2. Address only the ones re
 - **Preserve the test platform**: Keep VSTest or MTP unchanged during the framework upgrade unless the user separately requests a runner migration.
 - **Execute full migrations**: When the user asks you to migrate or upgrade the project, edit the files, build, and run tests. Do not stop after listing breaking changes. Advice-only responses are appropriate only when the user asks what to expect.
 - **Focused fix requests** (user has specific compilation errors after upgrading): Address only the relevant breaking change from the table above. Show a concise before/after fix. Do not walk through the full migration workflow.
-- **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that specific aspect with a concrete fix. Do not walk through the entire migration workflow or unrelated breaking changes.
-- **"What to expect" questions** (user asks about breaking changes before upgrading): Present only the breaking changes that are clearly relevant to the user's visible code and configuration. For each, give a one-line fix summary. Do not include every possible breaking change -- only the ones that apply. Do not walk through the full workflow.
+- **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that feature, but handle every active setting or affected usage in the supplied files. For `.testsettings`, map requested deployment, timeout, data collector, and other active configuration rather than stopping after the first setting. Do not walk through unrelated breaking changes.
+- **"What to expect" questions** (user asks about breaking changes before upgrading): Summarize every category in the Breaking Changes Summary, marking which ones directly apply to the visible project. Keep each item to one line and do not expand into release-note history.
 - **Full migration requests** (user wants complete migration): Follow the complete workflow below.
 - **Comparison questions** (user asks about v1 vs v2 differences): Explain concisely -- v1 uses assembly references and requires removing them first; v2 uses NuGet and just needs a version bump. Both converge on the same v3 packages and breaking changes.
-- **Keep findings project-specific**: Report only breaking changes found in the visible code/configuration. Do not dump the full compatibility table into every response.
+- **Keep execution project-specific**: For fixes and full migrations, change only patterns found in the visible code/configuration. Broader coverage is reserved for explicit "what should I expect?" questions.
 
 ## Migration Paths
 

--- a/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
@@ -63,6 +63,7 @@ MSTest v3 introduces these breaking changes from v1/v2. Address only the ones re
 
 - **Always identify the current version first**: Before recommending any migration steps, explicitly state the current MSTest version detected in the project (e.g., "Your project uses MSTest v2 (2.2.10)" or "This is an MSTest v1 project using QualityTools assembly references"). This grounds the migration advice and confirms you've read the project files.
 - **Require project evidence**: Do not assume v1/v2 from the wording alone. Read project or central package files and classify the source as QualityTools/v1, NuGet 1.x, or NuGet 2.x. If the project is already on v3+, stop and route to the appropriate skill.
+- **Preserve the test platform**: Keep VSTest or MTP unchanged during the framework upgrade unless the user separately requests a runner migration.
 - **Execute full migrations**: When the user asks you to migrate or upgrade the project, edit the files, build, and run tests. Do not stop after listing breaking changes. Advice-only responses are appropriate only when the user asks what to expect.
 - **Focused fix requests** (user has specific compilation errors after upgrading): Address only the relevant breaking change from the table above. Show a concise before/after fix. Do not walk through the full migration workflow.
 - **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that specific aspect with a concrete fix. Do not walk through the entire migration workflow or unrelated breaking changes.
@@ -82,13 +83,11 @@ Both paths converge at Step 3 -- the same v3 packages and breaking changes apply
 
 ### Step 1: Assess the project
 
-1. Identify which MSTest version is currently in use:
+1. In one discovery pass, batch-read project and central configuration files, search for affected APIs/settings, and identify which MSTest version is currently in use:
    - **Assembly reference**: Look for `Microsoft.VisualStudio.QualityTools.UnitTestFramework` in project references -> MSTest v1
    - **NuGet packages**: Check `MSTest.TestFramework` and `MSTest.TestAdapter` package versions -> v1 if 1.x, v2 if 2.x
-2. Read `Directory.Packages.props`, `Directory.Build.props`, and imported props/targets before editing; package versions may be centralized.
-3. Check whether the project uses `.testsettings` / `<LegacySettings>`, affected assertions, `DataRow`, or `[Timeout]`.
-4. Check if the target framework is dropped in v3 (see Step 4).
-5. Run the existing build and test command. Record discovered, passed, failed, and skipped counts as the parity baseline.
+2. Check whether the target framework is dropped in v3 (see Step 4).
+3. Run the existing test command. Record discovered, passed, failed, and skipped counts as the parity baseline.
 
 ### Step 2: Remove v1 assembly references (if applicable)
 
@@ -115,9 +114,9 @@ Keep `Microsoft.NET.Test.Sdk` when the project remains on VSTest, but update it 
 
 **Use MSTest.Sdk only when the user requests it or the repository already standardizes on it (SDK-style projects only):**
 
-Change `<Project Sdk="Microsoft.NET.Sdk">` to `<Project Sdk="MSTest.Sdk/3.8.0">`. MSTest.Sdk automatically provides MSTest.TestFramework, MSTest.TestAdapter, MSTest.Analyzers, and Microsoft.NET.Test.Sdk.
+Change `<Project Sdk="Microsoft.NET.Sdk">` to `<Project Sdk="MSTest.Sdk/3.8.0">`. MSTest.Sdk automatically provides the MSTest framework, adapter, and analyzers.
 
-> **Important**: MSTest.Sdk defaults to Microsoft.Testing.Platform (MTP) instead of VSTest. For VSTest compatibility (e.g., `vstest.console` in CI), add `<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />`.
+> **Important**: MSTest.Sdk defaults to Microsoft.Testing.Platform (MTP). When preserving VSTest, set `<UseVSTest>true</UseVSTest>`; the SDK then supplies the required `Microsoft.NET.Test.Sdk` reference. Do not switch runners merely as a side effect of the framework upgrade.
 
 When switching to MSTest.Sdk, remove these (SDK provides them automatically):
 
@@ -177,11 +176,10 @@ Key mappings:
 
 ### Step 7: Verify
 
-1. Run `dotnet build` -- confirm zero errors and review any new warnings
-2. Run the same test command, filter, and configuration used for the baseline
-3. Compare discovered, passed, failed, and skipped counts to the pre-migration baseline
-4. Investigate every count difference; do not accept silently dropped tests or data rows
-5. Confirm no QualityTools reference, 1.x/2.x MSTest package, `.testsettings`, or `<LegacySettings>` remains
+1. Run the same test command, filter, and configuration used for the baseline. `dotnet test` builds by default; run a separate build only to isolate a compilation failure.
+2. Compare discovered, passed, failed, and skipped counts to the pre-migration baseline.
+3. Investigate every count difference; do not accept silently dropped tests or data rows.
+4. Confirm no QualityTools reference, 1.x/2.x MSTest package, `.testsettings`, or `<LegacySettings>` remains.
 
 ## Validation
 
@@ -198,5 +196,5 @@ After v3 migration, use `migrate-mstest-v3-to-v4` for MSTest v4.
 
 | Pitfall | Solution |
 |---------|----------|
-| Missing `Microsoft.NET.Test.Sdk` | Add package reference -- required for test discovery with VSTest |
-| MSTest.Sdk tests not found by `vstest.console` | MSTest.Sdk defaults to Microsoft.Testing.Platform; add explicit `Microsoft.NET.Test.Sdk` for VSTest compatibility |
+| Non-MSTest.Sdk VSTest project missing `Microsoft.NET.Test.Sdk` | Add the package reference for VSTest discovery |
+| MSTest.Sdk tests not found by `vstest.console` | Set `<UseVSTest>true</UseVSTest>`; MSTest.Sdk then supplies `Microsoft.NET.Test.Sdk` |

--- a/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
@@ -8,8 +8,8 @@ description: >
   USE FOR: upgrading from MSTest v1 assembly references
   (Microsoft.VisualStudio.QualityTools.UnitTestFramework) or MSTest v2 NuGet
   (MSTest.TestFramework 1.x-2.x) to MSTest v3, fixing assertion overload
-  errors (AreEqual/AreNotEqual), updating DataRow constructors, replacing
-  .testsettings with .runsettings, timeout behavior changes, target framework
+  errors (AreEqual/AreNotEqual), updating DataRow constructors, replacing or
+  migrating .testsettings to .runsettings, timeout behavior changes, target framework
   compatibility (.NET 5 dropped -- use .NET 6+; .NET Fx older than 4.6.2 dropped),
   adopting MSTest.Sdk while moving from v1/v2.
   First step toward MSTest v4 -- after this, use migrate-mstest-v3-to-v4.
@@ -71,7 +71,7 @@ MSTest v3 introduces these breaking changes from v1/v2. Address only the ones re
 - **Preserve the test platform**: Keep VSTest or MTP unchanged during the framework upgrade unless the user separately requests a runner migration.
 - **Execute full migrations**: When the user asks you to migrate or upgrade the project, edit the files, build, and run tests. Do not stop after listing breaking changes. Advice-only responses are appropriate only when the user asks what to expect.
 - **Focused fix requests** (user has specific compilation errors after upgrading): Address only the relevant breaking change from the table above. Show a concise before/after fix. Do not walk through the full migration workflow.
-- **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that feature, but handle every active setting or affected usage in the supplied files. For `.testsettings`, map requested deployment, timeout, data collector, and other active configuration rather than stopping after the first setting. Do not walk through unrelated breaking changes.
+- **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that feature, but handle every active setting or affected usage in the supplied files. For `.testsettings`, put all MSTest settings under one `<MSTest>` element, map requested deployment, per-test timeout, data collector, and other active configuration, and do not add a session-wide timeout. Do not walk through unrelated breaking changes.
 - **"What to expect" questions** (user asks about breaking changes before upgrading): Summarize every category in the Breaking Changes Summary, marking which ones directly apply to the visible project. Keep each item to one line and do not expand into release-note history.
 - **Full migration requests** (user wants complete migration): Follow the complete workflow below.
 - **Comparison questions** (user asks about v1 vs v2 differences): Explain concisely -- v1 uses assembly references and requires removing them first; v2 uses NuGet and just needs a version bump. Both converge on the same v3 packages and breaking changes.
@@ -130,7 +130,7 @@ When switching to MSTest.Sdk, remove these (SDK provides them automatically):
 
 ### Step 4: Update target frameworks if needed
 
-MSTest v3 supports .NET 6+, .NET Core 3.1, .NET Framework 4.6.2+, .NET Standard 2.0, UWP 16299+, and WinUI 18362+. If the project targets a dropped framework version, update to a supported one:
+MSTest v3 supports .NET 6+, .NET Core 3.1, .NET Framework 4.6.2+, .NET Standard 2.0, UWP 16299+, and WinUI 18362+. .NET Core 3.1 is end-of-life but remains supported by MSTest v3; preserve it during this framework-only migration and recommend a separate runtime upgrade. If the project targets a framework version dropped by MSTest v3, update to a supported one:
 
 | Dropped | Recommended replacement |
 |---------|------------------------|
@@ -166,7 +166,7 @@ Assert.AreSame(expected, actual);         -> Assert.AreSame<MyType>(expected, ac
 
 ### Step 6: Replace .testsettings with .runsettings
 
-The `.testsettings` file and `<LegacySettings>` are no longer supported in MSTest v3. **Delete the `.testsettings` file** and create a `.runsettings` file -- do not keep both.
+The `.testsettings` file and `<LegacySettings>` are no longer supported in MSTest v3. **Delete the `.testsettings` file** and create a `.runsettings` file -- do not keep both. Consolidate all MSTest configuration under one `<MSTest>` element; do not create an `<MSTestV2>` section.
 
 Key mappings:
 

--- a/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-mstest-v1v2-to-v3/SKILL.md
@@ -37,6 +37,13 @@ Migrate a test project from MSTest v1 (assembly references) or MSTest v2 (NuGet 
 - Upgrading v3 to v4 -- use `migrate-mstest-v3-to-v4`
 - Migrating between frameworks (MSTest to xUnit/NUnit)
 
+## Boundary Gate
+
+Check package versions before any edit. If all MSTest references are already 3.x
+and no v1/v2-to-v3 error is reported, state that migration is complete and make
+no changes. Do not consolidate working v3 packages into the metapackage. Run the
+existing tests only if verification was requested. This overrides all steps below.
+
 ## Inputs
 
 | Input | Required | Description |
@@ -71,8 +78,9 @@ MSTest v3 introduces these breaking changes from v1/v2. Address only the ones re
 - **Preserve the test platform**: Keep VSTest or MTP unchanged during the framework upgrade unless the user separately requests a runner migration.
 - **Execute full migrations**: When the user asks you to migrate or upgrade the project, edit the files, build, and run tests. Do not stop after listing breaking changes. Advice-only responses are appropriate only when the user asks what to expect.
 - **Focused fix requests** (user has specific compilation errors after upgrading): Address only the relevant breaking change from the table above. Show a concise before/after fix. Do not walk through the full migration workflow.
+- **DataRow fix requests**: Compare every supplied `DataRow` with its method signature. Mismatches can build with only `MSTEST0014` and fail during test execution. Preserve the method contract and normally fix the literal (`1L` -> `1` for `int`), then run the affected tests.
 - **Specific feature migration** (user asks about one aspect like .testsettings, DataRow, or assertions): Address only that feature, but handle every active setting or affected usage in the supplied files. For `.testsettings`, put all MSTest settings under one `<MSTest>` element, map requested deployment, per-test timeout, data collector, and other active configuration, and do not add a session-wide timeout. Do not walk through unrelated breaking changes.
-- **"What to expect" questions** (user asks about breaking changes before upgrading): Summarize every category in the Breaking Changes Summary, marking which ones directly apply to the visible project. Keep each item to one line and do not expand into release-note history.
+- **"What to expect" questions** (user asks about breaking changes before upgrading): First state the concrete package update needed to reach v3, then summarize every category in the Breaking Changes Summary, marking which ones directly apply to the visible project. Keep each item to one line and do not expand into release-note history.
 - **Full migration requests** (user wants complete migration): Follow the complete workflow below.
 - **Comparison questions** (user asks about v1 vs v2 differences): Explain concisely -- v1 uses assembly references and requires removing them first; v2 uses NuGet and just needs a version bump. Both converge on the same v3 packages and breaking changes.
 - **Keep execution project-specific**: For fixes and full migrations, change only patterns found in the visible code/configuration. Broader coverage is reserved for explicit "what should I expect?" questions.
@@ -144,7 +152,9 @@ MSTest v3 supports .NET 6+, .NET Core 3.1, .NET Framework 4.6.2+, .NET Standard 
 
 ### Step 5: Resolve build errors and breaking changes
 
-Search the project for the affected APIs, then run the build and fix only the breaking changes that are present. Do not perform speculative rewrites.
+Search the supplied files first and fix only breaking changes that are present.
+A successful build does not prove compatibility; some failures surface only as
+analyzer warnings or during test execution.
 
 **Assertion overloads** -- MSTest v3 removed `Assert.AreEqual(object, object)` and `Assert.AreNotEqual(object, object)`. Add explicit generic type parameters:
 
@@ -161,6 +171,9 @@ Assert.AreSame(expected, actual);         -> Assert.AreSame<MyType>(expected, ac
 // Error: 1L (long) won't convert to int parameter -> fix: use 1 (int)
 // Error: 1.0 (double) won't convert to float parameter -> fix: use 1.0f (float)
 ```
+
+Preserve method parameter types unless independently wrong. `dotnet build` may
+succeed with `MSTEST0014`; run the test to prove each row binds and executes.
 
 **Timeout behavior** -- unified across .NET Core and .NET Framework. Verify `[Timeout]` values still work.
 

--- a/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
@@ -26,20 +26,20 @@ Do not combine this framework conversion with a target-framework upgrade or VSTe
 - **Focused compile error or API question:** inspect the relevant code and apply only that mapping. Do not narrate the entire workflow.
 - **Unsupported target framework:** stop before changing packages. MSTest v4 requires .NET 8+ or .NET Framework 4.6.2+ for test applications; offer a separately approved TFM upgrade or MSTest v3 as the intermediate target.
 
-For detailed mappings and examples, load [`references/mapping-cheatsheet.md`](references/mapping-cheatsheet.md) only for constructs actually present in the project. Do not reproduce the whole reference in the response.
+For detailed mappings and examples, search [`references/mapping-cheatsheet.md`](references/mapping-cheatsheet.md) for constructs actually present in the project and read only the matching sections. Do not load or reproduce the whole reference.
 
 ## Workflow
 
 ### 1. Establish the baseline
 
-1. Read the test projects plus `Directory.Build.props`, `Directory.Packages.props`, `global.json`, and runner configuration.
+1. In one discovery pass, batch-read the test projects plus `Directory.Build.props`, `Directory.Packages.props`, `global.json`, and runner configuration, and search the source for the high-risk constructs below.
 2. State the detected source version:
    - `xunit` 2.x and related packages -> xUnit v2
    - `xunit.v3` or `xunit.v3.*` -> xUnit v3
-3. Use `platform-detection` to identify VSTest or MTP. Preserve that platform.
+3. Identify VSTest or MTP from the project and repository configuration. Use `platform-detection` only when the platform is ambiguous, and preserve the detected platform.
 4. Record the target frameworks and stop if MSTest v4 does not support them.
-5. Run the existing build and test command. Record discovered, passed, failed, and skipped counts.
-6. Search for high-risk constructs before editing:
+5. Run the existing test command. Record discovered, passed, failed, and skipped counts; run a separate build only if needed to isolate a baseline compilation failure.
+6. Inventory high-risk constructs before editing:
    - `IClassFixture`, `ICollectionFixture`, `CollectionDefinition`, custom `FactAttribute`/`TheoryAttribute`/`DataAttribute`
    - `Assert.Throws`, `ThrowsAny`, `IsType`, `Record.Exception`, event assertions
    - `ITestOutputHelper`, `TestContext.Current`, `IAsyncLifetime`
@@ -92,7 +92,7 @@ Load the mapping cheatsheet for every high-risk construct found in Step 1. These
 - `TestContext.Current.CancellationToken` maps to an injected MSTest `TestContext.CancellationToken`; never replace it with `CancellationToken.None` or a new `CancellationTokenSource`.
 - Assertions with no MSTest equivalent (`Assert.Collection`, `Assert.All`, `Assert.Equivalent`, `Record.Exception`, event assertions) require an explicit manual rewrite. Never delete an assertion without replacing its verification.
 
-Build after the mechanical pass. Use compiler errors plus the inventory to drive only the remaining conversions.
+Apply the mechanical and semantic rewrites in one edit pass when the inventory makes the required mappings clear. Do not run an intermediate build by default; use compiler errors from final verification to drive only unresolved conversions.
 
 ### 5. Preserve lifecycle, fixture scope, and parallelization
 
@@ -111,15 +111,14 @@ Never use `ExecutionScope.MethodLevel` to emulate xUnit. Before applying a fixtu
 
 ### 6. Verify parity
 
-1. Run the build; it must complete with zero errors.
-2. Run tests with the same platform, filter, and configuration used for the baseline.
-3. Compare discovered, passed, failed, and skipped counts.
-4. Investigate every difference before declaring completion:
+1. Run tests once with the same platform, filter, and configuration used for the baseline. `dotnet test` builds by default; run a separate build only when needed to isolate a compilation failure.
+2. Compare discovered, passed, failed, and skipped counts.
+3. Investigate every difference before declaring completion:
    - missing cases -> discovery attributes, `DynamicData`, or `DataRow` literal types
    - changed exception behavior -> exact-vs-derived assertion mapping
    - shared-state failures or large duration changes -> fixture scope and parallelization
    - silently skipped tests -> missing `[TestMethod]` or incorrect runtime-skip conversion
-5. Confirm no xUnit package, namespace, attribute, runner configuration, or fixture interface remains unless explicitly documented for manual follow-up.
+4. Confirm no xUnit package, namespace, attribute, runner configuration, or fixture interface remains unless explicitly documented for manual follow-up.
 
 ## Completion Criteria
 

--- a/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
@@ -82,6 +82,7 @@ Apply the common rewrites first:
 | `[MemberData]` | `[DynamicData]` |
 | `[Fact(Skip = "...")]` | `[TestMethod]` + `[Ignore("...")]` |
 | `[Trait("Category", value)]` | `[TestCategory(value)]` |
+| `[Trait("Owner", value)]` | `[Owner(value)]` |
 | other `[Trait(key, value)]` | `[TestProperty(key, value)]` |
 | `Assert.Equal` / `NotEqual` | `Assert.AreEqual` / `AreNotEqual` |
 | `Assert.True` / `False` | `Assert.IsTrue` / `IsFalse` |
@@ -102,6 +103,7 @@ Load the mapping cheatsheet for every high-risk construct found in Step 1. These
 - `[Ignore]` and `[Timeout]` are modifiers; keep `[TestMethod]` so the test is discovered.
 - `[DataRow]` values must exactly match parameter types.
 - `TestContext.Current.CancellationToken` maps to an injected MSTest `TestContext.CancellationToken`; never replace it with `CancellationToken.None` or a new `CancellationTokenSource`.
+- `Owner` is a reserved VSTest property. Map `[Trait("Owner", value)]` to `[Owner(value)]`, not `[TestProperty("Owner", value)]`.
 - Assertions with no MSTest equivalent (`Assert.Collection`, `Assert.All`, `Assert.Equivalent`, `Record.Exception`, event assertions) require an explicit manual rewrite. Never delete an assertion without replacing its verification.
 
 Apply the mechanical and semantic rewrites in one edit pass when the inventory makes the required mappings clear. Do not run an intermediate build by default; use compiler errors from final verification to drive only unresolved conversions.

--- a/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/SKILL.md
@@ -28,6 +28,17 @@ Do not combine this framework conversion with a target-framework upgrade or VSTe
 
 For detailed mappings and examples, search [`references/mapping-cheatsheet.md`](references/mapping-cheatsheet.md) for constructs actually present in the project and read only the matching sections. Do not load or reproduce the whole reference.
 
+## Fast Path
+
+For a routine project migration, converge in four phases: one batched discovery read/search, one edit pass, one `dotnet test`, and one concise result. Do not:
+
+- list a directory and then reread the same files through another tool
+- try `dotnet test --no-restore` unless restore is already known to be current
+- run separate restore, build, and test commands when `dotnet test` is sufficient
+- rerun a passing test command or inspect unchanged files for confirmation
+
+Use an existing CI/test result as the parity baseline when available. Run a new pre-edit baseline only when counts are unavailable and the migration contains data-driven tests, fixtures, skips, custom extensions, shared state, or other behavior whose parity cannot be established from source alone.
+
 ## Workflow
 
 ### 1. Establish the baseline
@@ -38,7 +49,7 @@ For detailed mappings and examples, search [`references/mapping-cheatsheet.md`](
    - `xunit.v3` or `xunit.v3.*` -> xUnit v3
 3. Identify VSTest or MTP from the project and repository configuration. Use `platform-detection` only when the platform is ambiguous, and preserve the detected platform.
 4. Record the target frameworks and stop if MSTest v4 does not support them.
-5. Run the existing test command. Record discovered, passed, failed, and skipped counts; run a separate build only if needed to isolate a baseline compilation failure.
+5. If the Fast Path requires a new baseline, run the existing test command once and record discovered, passed, failed, and skipped counts.
 6. Inventory high-risk constructs before editing:
    - `IClassFixture`, `ICollectionFixture`, `CollectionDefinition`, custom `FactAttribute`/`TheoryAttribute`/`DataAttribute`
    - `Assert.Throws`, `ThrowsAny`, `IsType`, `Record.Exception`, event assertions
@@ -55,7 +66,7 @@ Default to the MSTest v4 metapackage for an incremental conversion:
 <PackageReference Include="MSTest" Version="4.1.0" />
 ```
 
-This keeps VSTest available through `Microsoft.NET.Test.Sdk`. Use `MSTest.Sdk` only when the project already uses it elsewhere or the user explicitly requests it. `MSTest.Sdk` defaults to MTP, so add `<UseVSTest>true</UseVSTest>` when preserving VSTest.
+This keeps VSTest available through the metapackage's compatible `Microsoft.NET.Test.Sdk` dependency. Remove a stale explicit `Microsoft.NET.Test.Sdk` reference or update it to the minimum required by the chosen MSTest version (MSTest 4.1.0 requires 18.0.1+); otherwise restore fails with `NU1605`. Use `MSTest.Sdk` only when the project already uses it elsewhere or the user explicitly requests it. `MSTest.Sdk` defaults to MTP, so add `<UseVSTest>true</UseVSTest>` when preserving VSTest.
 
 Do not change `TargetFramework`. Remove `xunit.runner.json` only after porting its relevant settings.
 
@@ -87,6 +98,7 @@ Load the mapping cheatsheet for every high-risk construct found in Step 1. These
 - xUnit `Assert.Throws<T>` is exact-type and maps to MSTest `Assert.ThrowsExactly<T>`.
 - xUnit `Assert.ThrowsAny<T>` permits derived types and maps to MSTest `Assert.Throws<T>`.
 - xUnit `Assert.IsType<T>` is exact-type and maps to `Assert.IsExactInstanceOfType<T>`; `Assert.IsAssignableFrom<T>` maps to `Assert.IsInstanceOfType<T>`.
+- xUnit `Assert.Equal` on sequences compares elements. Use `Assert.AreSequenceEqual` on MSTest 4.3+ or `CollectionAssert.AreEqual` with materialized lists on earlier v4; never replace sequence equality with reference-based `Assert.AreEqual`.
 - `[Ignore]` and `[Timeout]` are modifiers; keep `[TestMethod]` so the test is discovered.
 - `[DataRow]` values must exactly match parameter types.
 - `TestContext.Current.CancellationToken` maps to an injected MSTest `TestContext.CancellationToken`; never replace it with `CancellationToken.None` or a new `CancellationTokenSource`.

--- a/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -357,6 +357,8 @@ xUnit assembly attributes split into two groups: a few have direct MSTest equiva
 <PackageReference Include="MSTest" Version="4.1.0" />
 ```
 
+Remove an older explicit `Microsoft.NET.Test.Sdk` reference or update it to 18.0.1+; keeping 17.x alongside MSTest 4.1.0 causes `NU1605`.
+
 ```xml
 <!-- Option B: MSTest.Sdk -- defaults to MTP; set <UseVSTest>true</UseVSTest> to preserve VSTest. -->
 <!--           UseVSTest pulls in Microsoft.NET.Test.Sdk automatically -- no extra PackageReference needed. -->

--- a/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/plugins/dotnet-test-migration/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -41,16 +41,17 @@ Target framework throughout: **MSTest v4** (the few v3-only spellings are explic
 | `[Fact(Skip = "reason")]` | `[TestMethod]` + `[Ignore("reason")]` (the `[Ignore]` attribute alone does not discover a test -- you still need `[TestMethod]`) |
 | `[Fact(Timeout = 5000)]` | `[TestMethod]` + `[Timeout(5000)]` (same -- `[Timeout]` is a modifier, not a discovery attribute) |
 | `[Trait("Category", "Unit")]` | `[TestCategory("Unit")]` |
-| `[Trait("Owner", "alice")]` | `[TestProperty("Owner", "alice")]` |
+| `[Trait("Owner", "alice")]` | `[Owner("alice")]` (`Owner` is a reserved VSTest property and is rejected by `TestPropertyAttribute`) |
 | `[Collection("Db")]` | Step 8 + Step 11: `[DoNotParallelize]` (serialization) + `[ClassInitialize]` (sharing) -- preserve scope explicitly |
 | Custom `FactAttribute` subclass | Custom `TestMethodAttribute` subclass overriding `ExecuteAsync` (MSTest v4). See `writing-mstest-tests` and `migrate-mstest-v3-to-v4` for `CallerInfo` constructor pattern |
 | Custom `TheoryAttribute` subclass | Same -- subclass `TestMethodAttribute`; expose data via `ITestDataSource` |
 
 > Both `[TestCategory]` and `[TestProperty]` are **filterable** at runtime:
 > - `[TestCategory("Unit")]` -> `--filter "TestCategory=Unit"` (VSTest) / `--filter-trait "TestCategory=Unit"` (MTP); targets `Assembly`, `Class`, and `Method`
-> - `[TestProperty("Owner", "alice")]` -> `--filter "Owner=alice"` (VSTest) / `--filter-trait "Owner=alice"` (MTP); targets `Class` and `Method` only (no `AttributeTargets.Assembly`)
+> - `[Owner("alice")]` -> `--filter "Owner=alice"` (VSTest) / `--filter-trait "Owner=alice"` (MTP)
+> - `[TestProperty("Key", "Value")]` -> `--filter "Key=Value"` (VSTest) / `--filter-trait "Key=Value"` (MTP); targets `Class` and `Method` only (no `AttributeTargets.Assembly`)
 >
-> Use `[TestCategory]` for the conventional category trait; use `[TestProperty]` for arbitrary key/value metadata at class/method scope. An `[assembly: Trait("Category", ...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]`. An assembly-level `[Trait]` with an arbitrary key cannot map to `[assembly: TestProperty(...)]` -- collapse it to `[assembly: TestCategory(...)]` or move it down to every class (see Section 8).
+> Use `[TestCategory]` for the conventional category trait, `[Owner]` for the reserved owner property, and `[TestProperty]` for other key/value metadata at class/method scope. An `[assembly: Trait("Category", ...)]` in xUnit can be migrated to `[assembly: TestCategory(...)]`. An assembly-level `[Trait]` with an arbitrary key cannot map to `[assembly: TestProperty(...)]` -- collapse it to `[assembly: TestCategory(...)]` or move it down to every class (see Section 8).
 >
 > **Conditional skips** (xUnit `[Trait("OS", "Windows")]` patterns that gate execution): MSTest 3.10+ offers dedicated condition attributes -- `[OSCondition]` and `[CICondition]` -- which are usually a better fit than overloading `[TestCategory]` for environmental gating. (There is no `ArchitectureCondition` or `NonParallelizableCondition` attribute in MSTest; for non-parallel intent use `[DoNotParallelize]`, and for architecture gating fall back to `if (RuntimeInformation.OSArchitecture != ...) Assert.Inconclusive(...)`.) See Section 3.9.
 

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -56,8 +56,8 @@ stimuli:
     prompt: |
       I just upgraded my MSTest packages from v2 to v3 and now several of my
       tests no longer compile. I'm seeing errors like CS1501 on Assert.AreEqual,
-      Assert.AreNotEqual, and Assert.AreSame calls. Can you help me fix these
-      MSTest v3 compatibility issues?
+      Assert.AreNotEqual, and Assert.AreSame calls. Fix the affected source,
+      then build and run the tests to verify the changes.
     environment:
       files:
         - src: ./fixtures/fix-assert-areequal-object-overload-errors-after-v3-upgrade/TestProject.csproj
@@ -65,14 +65,31 @@ stimuli:
         - src: ./fixtures/fix-assert-areequal-object-overload-errors-after-v3-upgrade/ComparisonTests.cs
           dest: ComparisonTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: (generic|AreEqual<|<T>|type.?param)
+          path: ComparisonTests.cs
+          value: Assert.AreEqual<object>
+      - type: file-contains
+        config:
+          path: ComparisonTests.cs
+          value: Assert.AreNotEqual<object>
+      - type: file-contains
+        config:
+          path: ComparisonTests.cs
+          value: Assert.AreSame<object>
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          stdout_contains: Passed!
+          timeout: 3m
       - type: prompt
     rubric:
       - Explains that MSTest v3 removed the Assert.AreEqual(object, object) overload
       - "Recommends adding explicit generic type parameters: Assert.AreEqual<T>(expected, actual)"
-      - Applies the same fix pattern to AreNotEqual, AreSame, and AreNotSame
+      - Applies the same generic fix pattern to every affected assertion in the supplied source
+      - Leaves the already-upgraded MSTest v3 package and target framework unchanged
+      - Builds the project and runs all three tests successfully
       - Does not suggest downgrading to MSTest v2 as a solution
   - name: Migrate from .testsettings to .runsettings
     prompt: |
@@ -103,6 +120,14 @@ stimuli:
         config:
           command: grep -Eqi '<TestTimeout>[[:space:]]*30000[[:space:]]*</TestTimeout>' local.runsettings
           expected_exit_code: 0
+      - type: file-not-contains
+        config:
+          path: local.runsettings
+          value: MSTestV2
+      - type: file-not-contains
+        config:
+          path: local.runsettings
+          value: TestSessionTimeout
       - type: file-not-exists
         config:
           path: local.testsettings
@@ -110,6 +135,7 @@ stimuli:
     rubric:
       - Replaces the unsupported .testsettings file with .runsettings
       - Preserves deployment enablement and the 30000ms per-test timeout
+      - Places both settings under one MSTest section without adding a session-wide timeout
       - Removes assembly-resolution configuration that modern .NET no longer needs
       - Removes the obsolete .testsettings file instead of keeping both formats
   - name: Fix DataRow type mismatch errors after v3 upgrade
@@ -117,7 +143,7 @@ stimuli:
       I upgraded my MSTest packages from v2 to v3 and many of my data-driven tests no
       longer compile. The errors are on the DataRow constructors — implicit type conversions
       that worked in MSTest v2 now fail in v3. I also have a test with 17 parameters.
-      How do I fix these MSTest v2 to v3 migration issues?
+      Fix the supplied project for its current MSTest v3 version and run the tests.
     environment:
       files:
         - src: ./fixtures/fix-datarow-type-mismatch-errors-after-v3-upgrade/TestProject.csproj
@@ -125,15 +151,30 @@ stimuli:
         - src: ./fixtures/fix-datarow-type-mismatch-errors-after-v3-upgrade/DataDrivenTests.cs
           dest: DataDrivenTests.cs
     graders:
-      - type: output-matches
+      - type: file-not-contains
         config:
-          pattern: (DataRow|type.?match|constructor|16|param)
+          path: DataDrivenTests.cs
+          value: DataRow(1L
+      - type: file-not-contains
+        config:
+          path: DataDrivenTests.cs
+          value: DataRow(2L
+      - type: file-contains
+        config:
+          path: DataDrivenTests.cs
+          value: '[DataRow(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)]'
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          stdout_contains: Passed!
+          timeout: 3m
       - type: prompt
     rubric:
       - Explains that MSTest v3 requires DataRow values to match parameter types exactly
-      - Identifies the 1L (long) vs int mismatch and recommends fixing to 1 (int)
-      - Explains the 16-parameter constructor limit and suggests refactoring; if the project is on a later 3.x release,
-        it may also note the limitation is resolved
+      - Fixes the long literals passed to int parameters
+      - Preserves the valid 17-parameter row because the project uses MSTest 3.8, where the earlier limit is resolved
+      - Runs all data rows successfully
       - Does not suggest downgrading as a fix
   - name: Migrate to MSTest.Sdk project style
     prompt: |
@@ -169,16 +210,21 @@ stimuli:
       - type: output-matches
         config:
           pattern: (net5\.0|dropped|unsupported|net6\.0|net8\.0)
+      - type: output-matches
+        config:
+          pattern: (?i)(netcoreapp3\.1.{0,40}(supported|keep|preserve|no change)|(?:supported|keep|preserve|no change).{0,40}netcoreapp3\.1)
       - type: prompt
     rubric:
       - Identifies that .NET 5.0 is no longer supported by MSTest v3
       - Recommends upgrading to .NET 6.0 or later (preferably .NET 8.0 as a current LTS)
+      - Correctly preserves netcoreapp3.1 because MSTest v3 still supports it, while noting that its runtime is end-of-life
       - Does not suggest staying on .NET 5.0 with MSTest v3
   - name: Migrate complex MSTest v2 project with testsettings, DataRow issues, and dropped TFM
     prompt: |
       I have an MSTest v2 project on .NET 5.0 that uses a .testsettings file, data-driven
       tests with implicit type conversions, and Assert.AreEqual on objects. I want to
-      migrate to MSTest v3. What's the full list of changes I need to make?
+      migrate to MSTest v3 while keeping VSTest. Make all required project, source,
+      and settings changes, then run the tests to verify the migration.
     environment:
       files:
         - src: fixtures/v2-complex/TestProject.csproj
@@ -188,26 +234,54 @@ stimuli:
         - src: fixtures/v2-complex/local.testsettings
           dest: local.testsettings
     graders:
-      - type: output-matches
+      - type: file-not-contains
         config:
-          pattern: (net5\.0|dropped|unsupported|net8\.0)
-      - type: output-matches
+          path: TestProject.csproj
+          value: net5.0
+      - type: file-not-contains
         config:
-          pattern: (AreEqual|generic|<T>|object)
-      - type: output-matches
+          path: TestProject.csproj
+          value: 2.2.10
+      - type: file-contains
         config:
-          pattern: (DataRow|type.?match|long|int)
-      - type: output-matches
+          path: InventoryServiceTests.cs
+          value: Assert.AreEqual<object>
+      - type: file-contains
         config:
-          pattern: (testsettings|runsettings|legacy)
+          path: InventoryServiceTests.cs
+          value: Assert.AreNotEqual<object>
+      - type: file-contains
+        config:
+          path: InventoryServiceTests.cs
+          value: Assert.AreSame<object>
+      - type: file-not-contains
+        config:
+          path: InventoryServiceTests.cs
+          value: DataRow(1L
+      - type: file-exists
+        config:
+          path: local.runsettings
+      - type: file-not-exists
+        config:
+          path: local.testsettings
+      - type: run-command
+        config:
+          command: grep -Eqi '<TestTimeout>[[:space:]]*60000[[:space:]]*</TestTimeout>' local.runsettings
+          expected_exit_code: 0
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          stdout_contains: Passed!
+          timeout: 3m
       - type: prompt
     rubric:
-      - Identifies that .NET 5.0 is dropped in MSTest v3 and recommends upgrading to net8.0
-      - Identifies the Assert.AreEqual/AreNotEqual/AreSame object overload removal and recommends generic type parameters
-      - Identifies the DataRow 1L (long) to int type mismatch and recommends exact type matching
-      - Identifies the DataRow 17-parameter test exceeds the 16-parameter limit
-      - Recommends migrating the .testsettings file to .runsettings
-      - Recommends updating MSTest packages from 2.2.10 to 3.x
+      - Replaces the dropped net5.0 target with a supported current target framework
+      - Updates the project to one consistent MSTest v3 package model while preserving VSTest
+      - Fixes all affected object assertion overloads and DataRow literal mismatches
+      - Preserves the valid 17-parameter row on the selected later v3 release
+      - Replaces .testsettings with .runsettings and preserves its 60000ms per-test timeout
+      - Builds the migrated project and runs every test successfully
   - name: Correctly identify MSTest v1 vs v2 and recommend different migration paths
     prompt: |
       I have two test projects. One uses QualityTools assembly references and the other
@@ -270,6 +344,14 @@ stimuli:
         config:
           path: UserServiceTests.cs
           value: DataRow(1L
+      - type: file-contains
+        config:
+          path: UserServiceTests.cs
+          value: Assert.AreEqual<object>
+      - type: file-contains
+        config:
+          path: UserServiceTests.cs
+          value: Assert.AreSame<object>
       - type: run-command
         config:
           command: dotnet test
@@ -312,6 +394,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -95,14 +95,14 @@ stimuli:
       - type: file-exists
         config:
           path: local.runsettings
-      - type: file-contains
+      - type: run-command
         config:
-          path: local.runsettings
-          value: <DeploymentEnabled>true</DeploymentEnabled>
-      - type: file-contains
+          command: grep -Eqi '<DeploymentEnabled>[[:space:]]*true[[:space:]]*</DeploymentEnabled>' local.runsettings
+          expected_exit_code: 0
+      - type: run-command
         config:
-          path: local.runsettings
-          value: <TestTimeout>30000</TestTimeout>
+          command: grep -Eqi '<TestTimeout>[[:space:]]*30000[[:space:]]*</TestTimeout>' local.runsettings
+          expected_exit_code: 0
       - type: file-not-exists
         config:
           path: local.testsettings

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -51,6 +51,7 @@ stimuli:
       - Warns about Assert.AreEqual/AreNotEqual object overload removal
       - Mentions DataRow constructor changes and strict type matching
       - Mentions timeout behavior unification across .NET Core and .NET Framework
+      - Covers non-compilation risks such as test ID/history changes, exception unwrapping, lifecycle logging, or deployment paths
   - name: Fix Assert.AreEqual object overload errors after v3 upgrade
     prompt: |
       I just upgraded my MSTest packages from v2 to v3 and now several of my
@@ -75,10 +76,9 @@ stimuli:
       - Does not suggest downgrading to MSTest v2 as a solution
   - name: Migrate from .testsettings to .runsettings
     prompt: |
-      I'm migrating my test project from MSTest v2 to MSTest v3. The project has a
-      .testsettings file that configures test deployment and timeout. After the MSTest v3
-      upgrade, the .testsettings file seems to be ignored. How do I migrate this configuration
-      as part of the MSTest v2 to v3 upgrade?
+      Replace this project's ignored local.testsettings file with a local.runsettings
+      file for MSTest v3. Preserve its deployment and per-test timeout behavior,
+      remove obsolete configuration, and make the edits rather than only describing them.
     environment:
       files:
         - src: ./fixtures/migrate-from-testsettings-to-runsettings/TestProject.csproj
@@ -92,12 +92,26 @@ stimuli:
       - type: output-matches
         config:
           pattern: (testsettings|legacy|no longer supported)
+      - type: file-exists
+        config:
+          path: local.runsettings
+      - type: file-contains
+        config:
+          path: local.runsettings
+          value: <DeploymentEnabled>true</DeploymentEnabled>
+      - type: file-contains
+        config:
+          path: local.runsettings
+          value: <TestTimeout>30000</TestTimeout>
+      - type: file-not-exists
+        config:
+          path: local.testsettings
       - type: prompt
     rubric:
-      - Explains that .testsettings and LegacySettings are no longer supported in MSTest v3
-      - Provides guidance on creating a .runsettings file as a replacement
-      - Shows how to configure timeout and other settings in .runsettings XML format
-      - Does not suggest keeping the .testsettings file alongside .runsettings
+      - Replaces the unsupported .testsettings file with .runsettings
+      - Preserves deployment enablement and the 30000ms per-test timeout
+      - Removes assembly-resolution configuration that modern .NET no longer needs
+      - Removes the obsolete .testsettings file instead of keeping both formats
   - name: Fix DataRow type mismatch errors after v3 upgrade
     prompt: |
       I upgraded my MSTest packages from v2 to v3 and many of my data-driven tests no

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -143,9 +143,13 @@ stimuli:
       I upgraded my MSTest packages from v2 to v3 and many of my data-driven tests no
       longer compile. The errors are on the DataRow constructors — implicit type conversions
       that worked in MSTest v2 now fail in v3. I also have a test with 17 parameters.
-      Fix the supplied project for its current MSTest v3 version and run the tests.
+      The supplied TestProject.csproj and DataDrivenTests.cs are in the current
+      working directory. Fix the project without changing the test method
+      signatures, then run the tests with the current MSTest v3 version.
     environment:
       files:
+        - src: ./fixtures/v2-nuget/global.json
+          dest: global.json
         - src: ./fixtures/fix-datarow-type-mismatch-errors-after-v3-upgrade/TestProject.csproj
           dest: TestProject.csproj
         - src: ./fixtures/fix-datarow-type-mismatch-errors-after-v3-upgrade/DataDrivenTests.cs
@@ -163,6 +167,10 @@ stimuli:
         config:
           path: DataDrivenTests.cs
           value: '[DataRow(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)]'
+      - type: file-contains
+        config:
+          path: DataDrivenTests.cs
+          value: public void ProcessUser(int id, string name, bool active)
       - type: run-command
         config:
           command: dotnet test
@@ -172,7 +180,7 @@ stimuli:
       - type: prompt
     rubric:
       - Explains that MSTest v3 requires DataRow values to match parameter types exactly
-      - Fixes the long literals passed to int parameters
+      - Fixes the long literals passed to int parameters without changing the method contract
       - Preserves the valid 17-parameter row because the project uses MSTest 3.8, where the earlier limit is resolved
       - Runs all data rows successfully
       - Does not suggest downgrading as a fix
@@ -368,8 +376,9 @@ stimuli:
       - Builds the migrated project and confirms all tests pass
   - name: Stop when the project already uses MSTest v3
     prompt: |
-      Upgrade this test project to MSTest v3 and make any required migration
-      changes. Do not upgrade it beyond v3.
+      The supplied project files are in the current working directory. Upgrade
+      this test project to MSTest v3 and make only changes required for that
+      migration. Do not upgrade it beyond v3.
     environment:
       files:
         - src: fixtures/already-v3/global.json
@@ -385,7 +394,15 @@ stimuli:
       - type: file-contains
         config:
           path: TestProject.csproj
-          value: Version="3.8.0"
+          value: PackageReference Include="MSTest.TestFramework" Version="3.8.0"
+      - type: file-contains
+        config:
+          path: TestProject.csproj
+          value: PackageReference Include="MSTest.TestAdapter" Version="3.8.0"
+      - type: file-not-contains
+        config:
+          path: TestProject.csproj
+          value: PackageReference Include="MSTest" Version=
       - type: file-not-contains
         config:
           path: TestProject.csproj

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/eval.yaml
@@ -225,7 +225,8 @@ stimuli:
   - name: Execute and verify MSTest v2 to v3 migration
     prompt: |
       Upgrade this MSTest v2 project to MSTest v3. Make the required project
-      and source changes, then build and run the tests to verify the migration.
+      and source changes, keep the current VSTest runner, then build and run the
+      tests to verify the migration.
     environment:
       files:
         - src: fixtures/v2-nuget/global.json
@@ -243,6 +244,14 @@ stimuli:
         config:
           path: TestProject.csproj
           value: 17.5.0
+      - type: file-contains
+        config:
+          path: TestProject.csproj
+          value: Microsoft.NET.Test.Sdk
+      - type: file-not-contains
+        config:
+          path: TestProject.csproj
+          value: MSTest.Sdk
       - type: file-not-contains
         config:
           path: UserServiceTests.cs
@@ -257,5 +266,41 @@ stimuli:
     rubric:
       - Updates the project from MSTest 2.2.10 to a consistent MSTest 3.x package model, including a compatible Microsoft.NET.Test.Sdk version
       - Fixes the DataRow literal incompatibility present in the source
+      - Fixes the removed untyped assertion overloads present in the source
       - Leaves the supported net8.0 target framework unchanged
+      - Preserves VSTest rather than switching to MSTest.Sdk's default MTP runner
       - Builds the migrated project and confirms all tests pass
+  - name: Stop when the project already uses MSTest v3
+    prompt: |
+      Upgrade this test project to MSTest v3 and make any required migration
+      changes. Do not upgrade it beyond v3.
+    environment:
+      files:
+        - src: fixtures/already-v3/global.json
+          dest: global.json
+        - src: fixtures/already-v3/TestProject.csproj
+          dest: TestProject.csproj
+        - src: fixtures/already-v3/CurrentTests.cs
+          dest: CurrentTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: (?i)(already.{0,40}(MSTest )?v?3|(MSTest )?v?3.{0,40}already|no.{0,30}migration|migration.{0,20}(complete|not needed))
+      - type: file-contains
+        config:
+          path: TestProject.csproj
+          value: Version="3.8.0"
+      - type: file-not-contains
+        config:
+          path: TestProject.csproj
+          value: Version="4.
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
+      - type: prompt
+    rubric:
+      - Correctly identifies from the package references that the project already uses MSTest v3
+      - Makes no package, target-framework, runner, or source changes
+      - Clearly reports that the requested v1/v2-to-v3 migration is already complete

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/CurrentTests.cs
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/CurrentTests.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Current.Tests;
+
+[TestClass]
+public sealed class CurrentTests
+{
+    [TestMethod]
+    public void CurrentVersion_Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/TestProject.csproj
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/TestProject.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/global.json
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/already-v3/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/migrate-from-testsettings-to-runsettings/local.testsettings
+++ b/tests/dotnet-test-migration/migrate-mstest-v1v2-to-v3/fixtures/migrate-from-testsettings-to-runsettings/local.testsettings
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestSettings name="Local">
   <Execution>
+    <Deployment enabled="true" />
     <TestTypeSpecific>
       <UnitTestRunConfig testTypeId="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b">
         <AssemblyResolution>

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -50,13 +50,17 @@ stimuli:
           value: using Xunit;
       - type: run-command
         config:
+          command: grep -Eq '(Assert\.AreSequenceEqual|CollectionAssert\.AreEqual)' SemanticTests.cs
+          expected_exit_code: 0
+      - type: run-command
+        config:
           command: dotnet test
           expected_exit_code: 0
           timeout: 3m
       - type: prompt
     rubric:
       - Removes xunit, xunit.runner.visualstudio package references
-      - Adds the MSTest metapackage (Microsoft.NET.Test.Sdk stays for VSTest)
+      - Adds the MSTest metapackage and removes or updates the stale explicit Microsoft.NET.Test.Sdk reference
       - Replaces 'using Xunit;' with 'using Microsoft.VisualStudio.TestTools.UnitTesting;'
       - Adds [TestClass] to the test class and converts [Fact] to [TestMethod]
       - Converts Assert.Equal -> Assert.AreEqual and Assert.True -> Assert.IsTrue
@@ -101,7 +105,7 @@ stimuli:
     rubric:
       - Removes all xunit.v3.* and xunit.runner.visualstudio packages and adds MSTest
       - Converts [Theory] + [InlineData(...)] to [TestMethod] + [DataRow(...)]
-      - 'Preserves the VSTest runner: keeps Microsoft.NET.Test.Sdk, does not switch to MSTest.Sdk default MTP'
+      - 'Preserves the VSTest runner through a compatible Microsoft.NET.Test.Sdk dependency and does not switch to MSTest.Sdk default MTP'
       - Does NOT silently change TargetFramework
   - name: Stop when target framework is unsupported by MSTest v4
     prompt: |
@@ -270,33 +274,48 @@ stimuli:
       - Maps xUnit Assert.ThrowsAny<T> to MSTest Assert.Throws<T> (preserves derived-type semantics)
       - Maps xUnit Assert.ThrowsAsync<T> to MSTest Assert.ThrowsExactlyAsync<T>
       - Does NOT silently flip the semantic by mapping Throws -> Throws
-  - name: Answer a focused exception mapping question directly
+  - name: Preserve type and sequence assertion semantics
     prompt: |
-      I have already converted the packages, attributes, and runner configuration
-      from xUnit to MSTest v4. I only need the assertion replacements for these
-      three xUnit calls, preserving their exact behavior:
-
-      - Assert.Throws<InvalidOperationException>(...)
-      - Assert.ThrowsAny<Exception>(...)
-      - await Assert.ThrowsAsync<InvalidOperationException>(...)
-
-      Please answer only this focused mapping question.
+      Convert this xUnit.net v2 project to MSTest v4 without changing its target
+      framework or VSTest runner. Preserve the exact-vs-assignable type checks and
+      the element-by-element sequence comparison, then run the tests.
+    environment:
+      files:
+        - src: ./fixtures/preserve-type-and-sequence-assertion-semantics/global.json
+          dest: global.json
+        - src: ./fixtures/preserve-type-and-sequence-assertion-semantics/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/preserve-type-and-sequence-assertion-semantics/SemanticTests.cs
+          dest: SemanticTests.cs
     graders:
-      - type: output-matches
+      - type: file-contains
         config:
-          pattern: ThrowsExactly<InvalidOperationException>
-      - type: output-matches
+          path: '**/*.cs'
+          value: Assert.IsExactInstanceOfType<Dog>
+      - type: file-contains
         config:
-          pattern: Throws<Exception>
-      - type: output-matches
+          path: '**/*.cs'
+          value: Assert.IsInstanceOfType<IAnimal>
+      - type: file-not-contains
         config:
-          pattern: ThrowsExactlyAsync<InvalidOperationException>
+          path: '**/*.cs'
+          value: Assert.AreEqual(expected, actual)
+      - type: file-not-contains
+        config:
+          path: '**/*.cs'
+          value: using Xunit;
+      - type: run-command
+        config:
+          command: dotnet test
+          expected_exit_code: 0
+          timeout: 3m
       - type: prompt
     rubric:
-      - Directly answers the focused assertion question without narrating the full migration workflow
-      - Preserves exact-type semantics for synchronous and asynchronous xUnit Throws calls
-      - Preserves derived-type semantics for xUnit ThrowsAny
-      - Does not propose unrelated package, runner, target-framework, fixture, or parallelization changes
+      - Preserves the distinction between exact-type and assignable-type assertions
+      - Preserves the typed return values used by the tests
+      - Preserves element-by-element sequence equality instead of using reference equality
+      - Completes the framework migration without changing the target framework or VSTest runner
+      - Runs the migrated tests successfully
   - name: Convert MemberData and TheoryData to DynamicData
     prompt: |
       Convert this test project from xUnit.net v2 to MSTest.

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -52,6 +52,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -96,6 +97,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -151,6 +153,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -189,6 +192,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -228,6 +232,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -263,6 +268,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -300,6 +306,22 @@ stimuli:
         config:
           path: '**/*.cs'
           value: using Xunit;
+      - type: file-not-contains
+        config:
+          path: '**/*.csproj'
+          value: xunit
+      - type: file-contains
+        config:
+          path: TestProject.csproj
+          value: PackageReference Include="MSTest"
+      - type: file-contains
+        config:
+          path: SemanticTests.cs
+          value: '[TestClass]'
+      - type: run-command
+        config:
+          command: test "$(grep -c '\[TestMethod\]' SemanticTests.cs)" -eq 3
+          expected_exit_code: 0
       - type: run-command
         config:
           command: grep -Eq '(Assert\.AreSequenceEqual|CollectionAssert\.AreEqual|SequenceEqual)' SemanticTests.cs
@@ -308,6 +330,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -344,6 +367,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -374,7 +398,7 @@ stimuli:
       - type: file-contains
         config:
           path: '**/*.cs'
-          value: '[TestProperty("Owner"'
+          value: '[Owner("alice")]'
       - type: file-contains
         config:
           path: '**/*.cs'
@@ -387,12 +411,13 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
       - Converts [Fact(Skip = ...)] to [TestMethod] + [Ignore(...)] (both attributes required -- [Ignore] alone does not discover the test)
       - Converts [Trait("Category", X)] to [TestCategory(X)]
-      - Converts other [Trait(k, v)] to [TestProperty(k, v)]
+      - Converts the reserved Owner trait to [Owner(value)] rather than the invalid [TestProperty("Owner", value)]
       - Converts [Fact(Timeout = N)] to [TestMethod] + [Timeout(N)]
   - name: 'Preserve xUnit parallelization default with [assembly: Parallelize]'
     prompt: |
@@ -418,6 +443,10 @@ stimuli:
         config:
           path: '**/*.cs'
           value: ExecutionScope.ClassLevel
+      - type: file-contains
+        config:
+          path: '**/*.cs'
+          value: Workers = 0
       - type: file-not-contains
         config:
           path: '**/*.cs'
@@ -426,6 +455,7 @@ stimuli:
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:
@@ -446,21 +476,23 @@ stimuli:
         - src: ./fixtures/convert-xunit-v3-testcontext-current-cancellationtoken/CancellationTests.cs
           dest: CancellationTests.cs
     graders:
-      # Positive grader stays on prose because it uses regex alternation
-      # (TestContext.CancellationToken or _testContext.CancellationToken);
-      # file-contains is literal-only and cannot express OR. The file is
-      # still checked indirectly via the build/test run-command below.
-      - type: output-matches
+      - type: run-command
         config:
-          pattern: TestContext\.CancellationToken|_testContext\.CancellationToken
+          command: grep -Eq '(TestContext|_testContext)\.CancellationToken([^A-Za-z]|$)' CancellationTests.cs
+          expected_exit_code: 0
       - type: file-not-contains
         config:
           path: '**/*.cs'
           value: TestContext.Current.CancellationToken
+      - type: file-not-contains
+        config:
+          path: '**/*.cs'
+          value: CancellationTokenSource
       - type: run-command
         config:
           command: dotnet test
           expected_exit_code: 0
+          stdout_contains: Passed!
           timeout: 3m
       - type: prompt
     rubric:

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -324,7 +324,7 @@ stimuli:
           expected_exit_code: 0
       - type: run-command
         config:
-          command: grep -Eq '(Assert\.AreSequenceEqual|CollectionAssert\.AreEqual|SequenceEqual)' SemanticTests.cs
+          command: grep -Eq '(Assert[.]AreSequenceEqual|CollectionAssert[.]AreEqual)[[:space:]]*[(]|Assert[.]IsTrue[[:space:]]*[(][^;]*[.]SequenceEqual[[:space:]]*[(]' SemanticTests.cs
           expected_exit_code: 0
       - type: run-command
         config:
@@ -443,10 +443,10 @@ stimuli:
         config:
           path: '**/*.cs'
           value: ExecutionScope.ClassLevel
-      - type: file-contains
+      - type: run-command
         config:
-          path: '**/*.cs'
-          value: Workers = 0
+          command: grep -ERq --include='*.cs' 'Workers[[:space:]]*=[[:space:]]*0([^0-9]|$)' .
+          expected_exit_code: 0
       - type: file-not-contains
         config:
           path: '**/*.cs'

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -320,7 +320,7 @@ stimuli:
           value: '[TestClass]'
       - type: run-command
         config:
-          command: test "$(grep -c '\[TestMethod\]' SemanticTests.cs)" -eq 3
+          command: sh -c "test \"$(grep -c '\[TestMethod\]' SemanticTests.cs)\" -eq 3"
           expected_exit_code: 0
       - type: run-command
         config:

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -270,6 +270,33 @@ stimuli:
       - Maps xUnit Assert.ThrowsAny<T> to MSTest Assert.Throws<T> (preserves derived-type semantics)
       - Maps xUnit Assert.ThrowsAsync<T> to MSTest Assert.ThrowsExactlyAsync<T>
       - Does NOT silently flip the semantic by mapping Throws -> Throws
+  - name: Answer a focused exception mapping question directly
+    prompt: |
+      I have already converted the packages, attributes, and runner configuration
+      from xUnit to MSTest v4. I only need the assertion replacements for these
+      three xUnit calls, preserving their exact behavior:
+
+      - Assert.Throws<InvalidOperationException>(...)
+      - Assert.ThrowsAny<Exception>(...)
+      - await Assert.ThrowsAsync<InvalidOperationException>(...)
+
+      Please answer only this focused mapping question.
+    graders:
+      - type: output-matches
+        config:
+          pattern: ThrowsExactly<InvalidOperationException>
+      - type: output-matches
+        config:
+          pattern: Throws<Exception>
+      - type: output-matches
+        config:
+          pattern: ThrowsExactlyAsync<InvalidOperationException>
+      - type: prompt
+    rubric:
+      - Directly answers the focused assertion question without narrating the full migration workflow
+      - Preserves exact-type semantics for synchronous and asynchronous xUnit Throws calls
+      - Preserves derived-type semantics for xUnit ThrowsAny
+      - Does not propose unrelated package, runner, target-framework, fixture, or parallelization changes
   - name: Convert MemberData and TheoryData to DynamicData
     prompt: |
       Convert this test project from xUnit.net v2 to MSTest.

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/eval.yaml
@@ -50,10 +50,6 @@ stimuli:
           value: using Xunit;
       - type: run-command
         config:
-          command: grep -Eq '(Assert\.AreSequenceEqual|CollectionAssert\.AreEqual)' SemanticTests.cs
-          expected_exit_code: 0
-      - type: run-command
-        config:
           command: dotnet test
           expected_exit_code: 0
           timeout: 3m
@@ -304,6 +300,10 @@ stimuli:
         config:
           path: '**/*.cs'
           value: using Xunit;
+      - type: run-command
+        config:
+          command: grep -Eq '(Assert\.AreSequenceEqual|CollectionAssert\.AreEqual|SequenceEqual)' SemanticTests.cs
+          expected_exit_code: 0
       - type: run-command
         config:
           command: dotnet test

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/SemanticTests.cs
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/SemanticTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+
+namespace Semantic.Tests;
+
+public interface IAnimal
+{
+    string Name { get; }
+}
+
+public sealed class Dog : IAnimal
+{
+    public string Name => "Rex";
+}
+
+public class SemanticTests
+{
+    [Fact]
+    public void ExactType_ReturnsTypedValue()
+    {
+        object value = new Dog();
+
+        var dog = Assert.IsType<Dog>(value);
+
+        Assert.Equal("Rex", dog.Name);
+    }
+
+    [Fact]
+    public void AssignableType_ReturnsTypedValue()
+    {
+        object value = new Dog();
+
+        var animal = Assert.IsAssignableFrom<IAnimal>(value);
+
+        Assert.Equal("Rex", animal.Name);
+    }
+
+    [Fact]
+    public void SequenceEquality_ComparesElements()
+    {
+        IEnumerable<int> expected = [1, 2, 3];
+        IEnumerable<int> actual = [1, 2, 3];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/TestProject.csproj
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/TestProject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/global.json
+++ b/tests/dotnet-test-migration/migrate-xunit-to-mstest/fixtures/preserve-type-and-sequence-assertion-semantics/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}


### PR DESCRIPTION
## Summary

- trim `migrate-xunit-to-mstest` overhead by batching discovery, avoiding redundant builds, and reading only relevant mapping-reference sections
- strengthen `migrate-mstest-v1v2-to-v3` with evidence-based activation, explicit runner preservation, and consistent `MSTest.Sdk`/VSTest guidance
- add a focused xUnit assertion-mapping eval, strengthen the executable v2-to-v3 migration eval, and add an already-on-v3 boundary fixture
- leave the two exemplar skills unchanged and avoid content changes for the v3-to-v4 no-verdict finding, which #900 identifies as judge/scoring infrastructure

## Validation

- new already-v3 fixture passes with `dotnet test`
- changed eval YAML files parse successfully
- diff review completed with all findings addressed
- local skill-validator execution was blocked while its Copilot SDK package attempted to download an npm payload and hit an external TLS handshake failure; `/evaluate` is requested below for the full harness run

Fixes #900