### PR TITLE
Strengthen mcp-csharp-test with prescriptive MCP-specific steps

### DIFF
--- a/plugins/dotnet-ai/skills/mcp-csharp-test/SKILL.md
+++ b/plugins/dotnet-ai/skills/mcp-csharp-test/SKILL.md
@@ -93,7 +93,9 @@ public class ApiToolTests
 
 ### Step 3: Write integration tests with MCP client
 
-Test the full MCP protocol using a client-server connection:
+Test the full MCP protocol through a real MCP client.
+
+> **Default to in-memory testing.** Use the SDK's `ClientServerTestBase` (see [references/test-patterns.md](references/test-patterns.md)) — it wires client and server in-process, so tests are fast and deterministic with no spawned process. Reserve the process-spawning `StdioClientTransport` below for **one** end-to-end smoke test, not your whole suite — spawning `dotnet run` per fixture is the #1 cause of flaky, hanging integration tests.
 
 ```csharp
 using ModelContextProtocol.Client;
@@ -120,6 +122,14 @@ public class ServerIntegrationTests : IAsyncLifetime
     {
         var tools = await _client.ListToolsAsync();
         tools.Should().Contain(t => t.Name == "echo");
+    }
+
+    [Fact]
+    public async Task Tools_AllHaveDescriptions()
+    {
+        // MCP clients rely on descriptions to choose tools — enforce they exist.
+        var tools = await _client.ListToolsAsync();
+        tools.Should().OnlyContain(t => !string.IsNullOrWhiteSpace(t.Description));
     }
 
     [Fact]
@@ -160,7 +170,9 @@ For the evaluation format, example questions, and detailed guidance, see [refere
 ## Validation
 
 - [ ] Unit tests cover all tool methods, including edge cases
+- [ ] Integration tests use in-memory `ClientServerTestBase` (process-spawning limited to one E2E smoke test)
 - [ ] Integration tests verify tool listing via `ListToolsAsync()`
+- [ ] Every tool exposes a non-empty `Description` (asserted in a test)
 - [ ] Integration tests verify tool invocation via `CallToolAsync()`
 - [ ] All tests pass: `dotnet test`
 - [ ] Tests run in CI without manual setup


### PR DESCRIPTION
## What

Strengthens `mcp-csharp-test` with prescriptive, MCP-specific guidance so it helps strong models, not just weak ones.

## Why

The cross-family skills-eval (#889) rated this skill **high-impact (0.65)** but **STRENGTHEN 0/5** — it misses both frontier models because it *"assumes context they solve unaided."* The body largely showed generic xUnit patterns a frontier model already knows, so a skilled run tied with baseline.

## Changes (kept lean — the skill is already token-efficient)

- **Default integration tests to the SDK's in-memory `ClientServerTestBase`** instead of spawning `dotnet run` via `StdioClientTransport`; reserve the process-spawning transport for a single end-to-end smoke test. (Per-fixture process spawning is the top cause of flaky/hanging integration tests — the skill's own Pitfalls section calls this out.)
- Add an **MCP-specific quality assertion**: every tool must expose a non-empty `Description` (MCP clients rely on descriptions to choose tools) — a check frontier models don't write by default.
- Add matching **Validation** checklist items.

## Verification

`skill-validator check` runs in CI. Recommend a cross-family eval re-run (`-f skills="mcp-csharp-test" -f executors="opus,gpt" -f runs=5`; prior `avgN` was ~2.8, so use more runs).

Refs #889
