### PR TITLE
Fix incorrect MapMcp default-path guidance in mcp-csharp-create

### DIFF
--- a/plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md
+++ b/plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md
@@ -207,12 +207,12 @@ builder.Services.AddMcpServer()
 // builder.Services.AddSingleton<IMyService, MyService>();
 
 var app = builder.Build();
-app.MapMcp();                     // exposes MCP endpoint at /mcp (Streamable HTTP)
+app.MapMcp("/mcp");               // exposes MCP endpoint at /mcp (Streamable HTTP)
 app.MapGet("/health", () => "ok"); // health check for container orchestrators
 app.Run();
 ```
 
-**Key HTTP details:** `MapMcp()` defaults to `/mcp` path. For containers, set `ASPNETCORE_URLS=http://+:8080` and `EXPOSE 8080`. The MCP HTTP protocol uses Streamable HTTP — no special client config needed beyond the URL.
+**Key HTTP details:** `MapMcp(pattern)` maps the endpoint at `pattern` — `MapMcp("/mcp")` serves at `/mcp`, while plain `MapMcp()` defaults to the root route (`/`). Pass the pattern explicitly and point clients at a matching URL (e.g. `http://localhost:<port>/mcp`). For containers, set `ASPNETCORE_URLS=http://+:8080` and `EXPOSE 8080`. The MCP HTTP protocol uses Streamable HTTP — no special client config needed beyond the URL.
 
 **For transport configuration details** (stateless mode, auth, path prefix, `HttpContextAccessor`), see [references/transport-config.md](references/transport-config.md).
 


### PR DESCRIPTION
## Summary

Fixes factually incorrect HTTP-endpoint path guidance in `mcp-csharp-create` that could cause frontier models to emit `/mcp` client URLs against a root-mapped server (404s). Part of the dotnet-ai skills-eval follow-up (#889); this is the "protect + surgical fix" action for `mcp-csharp-create`, which is otherwise an efficient win on Sonnet/Haiku.

## What was wrong

The HTTP transport example and **Key HTTP details** claimed plain `app.MapMcp()` "defaults to `/mcp`". Verified against the C# MCP SDK source ([`McpEndpointRouteBuilderExtensions.MapMcp`](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs)):

```csharp
public static IEndpointConventionBuilder MapMcp(
    this IEndpointRouteBuilder endpoints,
    [StringSyntax("Route")] string pattern = "")
```

The default `pattern = ""` maps the server at the **root route** (`/`), not `/mcp`. A client told to connect to `/mcp` against a default-mapped server gets a 404.

## Change

- `app.MapMcp();` → `app.MapMcp("/mcp");` in the HTTP `Program.cs` example (matches the inline comment's stated intent).
- Rewrote **Key HTTP details** to describe the `pattern` argument accurately and tell clients to use a matching URL.

Consistent with `references/transport-config.md`, which already documents `MapMcp("/custom-mcp-path")` as a custom path prefix. Surgical, 2-line change — no expansion of an already-winning skill.

Refs #889.

---
_Moved from fork branch to the primary dotnet/skills repo; supersedes #937._
