### PR TITLE
Close the dotnet-test skill-coverage gaps from the PR 945 report

### DIFF
--- a/eng/skill-coverage/Measure-SkillCoverage.ps1
+++ b/eng/skill-coverage/Measure-SkillCoverage.ps1
@@ -293,89 +293,169 @@ function Get-SignificantTerms([string]$text) {
 #  eval.yaml Parsing - extract test evidence
 # ═══════════════════════════════════════════════════════════
 
+function Get-LineIndent([string]$line) {
+    if ($line -match '^(\s*)\S') { return $Matches[1].Length }
+    return -1   # blank or whitespace-only
+}
+
+function Remove-YamlQuoting([string]$text) {
+    $t = $text.Trim()
+    if ($t.Length -ge 2 -and $t.StartsWith('"') -and $t.EndsWith('"')) {
+        return ($t.Substring(1, $t.Length - 2) -replace '\\\\', '\')
+    }
+    if ($t.Length -ge 2 -and $t.StartsWith("'") -and $t.EndsWith("'")) {
+        return $t.Substring(1, $t.Length - 2)
+    }
+    return $t
+}
+
+# Reads a YAML scalar that may be a block scalar (| or >) or a plain/quoted
+# scalar folded across several more-indented continuation lines. Returns the
+# joined value plus the index of the last line consumed.
+function Read-YamlScalar {
+    param([string[]]$Lines, [int]$Index, [int]$KeyIndent, [string]$Inline)
+
+    $inline = $Inline.Trim()
+    $buffer = @()
+    $last = $Index
+
+    if ($inline -match '^[|>][+-]?\d*$') { $inline = '' }
+    elseif ($inline) { $buffer += $inline }
+
+    for ($j = $Index + 1; $j -lt $Lines.Count; $j++) {
+        $candidate = $Lines[$j].TrimEnd()
+        $indent = Get-LineIndent $candidate
+        if ($indent -lt 0) { break }
+        if ($indent -le $KeyIndent) { break }
+
+        $trimmed = $candidate.Trim()
+        if ($trimmed.StartsWith('#')) { break }
+        if ($trimmed -match '^-(\s|$)') { break }
+        if ($trimmed -match '^[A-Za-z_][\w.-]*:(\s|$)') { break }
+
+        $buffer += $trimmed
+        $last = $j
+    }
+
+    [PSCustomObject]@{
+        Value     = ($buffer -join ' ').Trim()
+        LastIndex = $last
+    }
+}
+
+<#
+.SYNOPSIS
+    Extracts test evidence from an eval.yaml spec.
+
+.DESCRIPTION
+    Evidence is anything the eval actually checks: grader configuration
+    (regex patterns, literal substrings, expected values, commands) and
+    LLM-judged rubric items. Both are matched against SKILL.md teaching
+    points by the coverage engine.
+
+    The parser is indentation-driven so it handles the real spec shape:
+    graders are a list of `- type:` entries each carrying a nested `config:`
+    map, and rubric items are plain (usually unquoted) scalars that commonly
+    wrap across several lines.
+#>
 function Get-EvalEvidence([string]$yamlContent) {
+    # Grader config keys whose value is a regular expression.
+    $regexKeys = @('pattern', 'stdout_matches')
+    # Grader config keys whose value is a literal string.
+    $literalKeys = @('substring', 'value', 'stdout_contains', 'command')
+
     $evidence = @()
     $scenarioCount = 0
     $scenario = '(unknown)'
     $section = 'none'
-    $assertType = $null
+    $sectionIndent = -1
+    $graderType = $null
 
-    foreach ($rawLine in $yamlContent -split "`n") {
-        $line = $rawLine.TrimEnd()
+    $lines = $yamlContent -split "`n"
 
-        # Scenario name
-        if ($line -match '^\s+-?\s*name:\s*[''"]?(.+?)[''"]?\s*$') {
-            $scenario = $Matches[1]
-            $scenarioCount++
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i].TrimEnd()
+        $indent = Get-LineIndent $line
+        if ($indent -lt 0) { continue }
+        $trimmed = $line.Trim()
+        if ($trimmed.StartsWith('#')) { continue }
+
+        # Leaving the current block ends the section.
+        if ($section -ne 'none' -and $indent -le $sectionIndent) {
             $section = 'none'
-            $assertType = $null
+            $sectionIndent = -1
+            $graderType = $null
         }
 
-        # Section transitions
-        if ($line -match '^\s{2,6}assertions:\s*$')  { $section = 'assertions'; continue }
-        if ($line -match '^\s{2,6}rubric:\s*$')       { $section = 'rubric'; continue }
-        if ($line -match '^\s{2,6}(prompt|setup|timeout|reject_tools|expect_tools|expect_activation):' -and $section -ne 'none') {
+        # Stimulus boundary: `- name: <scenario>` inside the stimuli list.
+        if ($indent -ge 2 -and $trimmed -match '^-\s+name:\s*(.+)$') {
+            $scenario = Remove-YamlQuoting $Matches[1]
+            $scenarioCount++
             $section = 'none'
+            $sectionIndent = -1
+            $graderType = $null
             continue
         }
 
-        # Assertion fields
-        if ($section -eq 'assertions') {
-            if ($line -match '^\s+-\s*type:\s*[''"]?(\S+?)[''"]?\s*$') {
-                $assertType = $Matches[1]
-                if ($assertType -eq 'exit_success') {
+        if ($trimmed -eq 'graders:') {
+            $section = 'graders'; $sectionIndent = $indent; $graderType = $null; continue
+        }
+        if ($trimmed -eq 'rubric:') {
+            $section = 'rubric'; $sectionIndent = $indent; continue
+        }
+
+        if ($section -eq 'graders') {
+            if ($trimmed -match '^-\s+type:\s*(.+)$') {
+                $graderType = (Remove-YamlQuoting $Matches[1]) -replace '[^\w.-]', ''
+                if ($graderType -eq 'exit-success') {
                     $evidence += [PSCustomObject]@{
                         Scenario     = $scenario
-                        EvidenceType = 'assertion:exit_success'
-                        Content      = 'exit_success: project builds and tests pass'
+                        EvidenceType = 'assertion:exit-success'
+                        Content      = 'exit-success: project builds and tests pass'
                         RawPattern   = $null
                     }
                 }
+                continue
             }
-            if ($line -match '^\s+pattern:\s*"(.+?)"\s*$') {
-                $regex = $Matches[1] -replace '\\\\', '\'
+
+            if ($trimmed -match '^([A-Za-z_][\w.-]*):\s*(.*)$') {
+                $key = $Matches[1]
+                $rest = $Matches[2]
+
+                $isRegex = $regexKeys -contains $key
+                $isLiteral = $literalKeys -contains $key
+                # For file-exists style graders the path *is* the assertion.
+                $isPath = ($key -eq 'path' -and $graderType -match '^file-(not-)?exists$')
+
+                if (-not ($isRegex -or $isLiteral -or $isPath)) { continue }
+
+                $scalar = Read-YamlScalar -Lines $lines -Index $i -KeyIndent $indent -Inline $rest
+                $i = $scalar.LastIndex
+                $value = Remove-YamlQuoting $scalar.Value
+                if (-not $value) { continue }
+
                 $evidence += [PSCustomObject]@{
                     Scenario     = $scenario
-                    EvidenceType = "assertion:$assertType"
-                    Content      = $regex
-                    RawPattern   = $regex
+                    EvidenceType = "assertion:$graderType"
+                    Content      = $value
+                    # Literal values are escaped so the code-pattern matcher
+                    # treats them as text rather than as a regex.
+                    RawPattern   = if ($isRegex) { $value } else { [regex]::Escape($value) }
                 }
             }
-            elseif ($line -match "^\s+pattern:\s*'(.+?)'\s*$") {
-                $regex = $Matches[1]
-                $evidence += [PSCustomObject]@{
-                    Scenario     = $scenario
-                    EvidenceType = "assertion:$assertType"
-                    Content      = $regex
-                    RawPattern   = $regex
-                }
-            }
-            # Unquoted pattern (bare YAML scalar)
-            elseif ($line -match '^\s+pattern:\s*([^''"\s].+?)\s*$') {
-                $regex = $Matches[1]
-                $evidence += [PSCustomObject]@{
-                    Scenario     = $scenario
-                    EvidenceType = "assertion:$assertType"
-                    Content      = $regex
-                    RawPattern   = $regex
-                }
-            }
-            if ($line -match '^\s+value:\s*[''"](.+?)[''"]') {
-                $evidence += [PSCustomObject]@{
-                    Scenario     = $scenario
-                    EvidenceType = "assertion:$assertType"
-                    Content      = $Matches[1]
-                    RawPattern   = $null
-                }
-            }
+            continue
         }
 
-        # Rubric items
-        if ($section -eq 'rubric' -and $line -match '^\s+-\s*[''"](.+?)[''"]') {
+        if ($section -eq 'rubric' -and $trimmed -match '^-\s*(.*)$') {
+            $scalar = Read-YamlScalar -Lines $lines -Index $i -KeyIndent $indent -Inline $Matches[1]
+            $i = $scalar.LastIndex
+            $value = Remove-YamlQuoting $scalar.Value
+            if (-not $value) { continue }
+
             $evidence += [PSCustomObject]@{
                 Scenario     = $scenario
                 EvidenceType = 'rubric'
-                Content      = $Matches[1]
+                Content      = $value
                 RawPattern   = $null
             }
         }

--- a/eng/skill-coverage/Measure-SkillCoverage.ps1
+++ b/eng/skill-coverage/Measure-SkillCoverage.ps1
@@ -217,11 +217,23 @@ function Get-CodePatterns([string]$content) {
     }
 
     $seen.get_Values() | ForEach-Object {
+        # Split the pattern into word keywords, and for an attribute pattern
+        # also keep the open bracket form. A skill writes the teaching point
+        # closed, `[Category]`, but an eval asserts the real usage, which is
+        # always open: `[Category(` or `[Category("positive")]`. Without the
+        # open form a file-contains grader checking the attribute never
+        # credits the pattern, which pushes eval authors into adding a second
+        # grader that makes the agent echo the syntax in its prose. The `[`
+        # prefix also marks it as a distinctive code term to the matcher, so
+        # a single hit is enough.
+        $words = @($_[0].ToLower() -replace '[^a-z0-9._]', ' ' -split '\s+' | Where-Object { $_.Length -gt 1 })
+        if ($_[0] -match '^\[(\w+)\]$') { $words += "[$($Matches[1].ToLower())" }
+
         [PSCustomObject]@{
             Category    = 'CodePattern'
             Description = $_[0]
             Line        = $_[1]
-            Keywords    = @($_[0].ToLower() -replace '[^a-z0-9._]', ' ' -split '\s+' | Where-Object { $_.Length -gt 1 })
+            Keywords    = $words
         }
     }
 }

--- a/eng/skill-coverage/Measure-SkillCoverage.ps1
+++ b/eng/skill-coverage/Measure-SkillCoverage.ps1
@@ -298,43 +298,114 @@ function Get-LineIndent([string]$line) {
     return -1   # blank or whitespace-only
 }
 
+# Strips YAML quoting and applies the escape rules of each quoting style, so
+# parsed evidence matches what a real YAML parser would produce: double-quoted
+# scalars honour backslash escapes, single-quoted scalars honour '' -> '.
 function Remove-YamlQuoting([string]$text) {
     $t = $text.Trim()
+
     if ($t.Length -ge 2 -and $t.StartsWith('"') -and $t.EndsWith('"')) {
-        return ($t.Substring(1, $t.Length - 2) -replace '\\\\', '\')
+        $inner = $t.Substring(1, $t.Length - 2)
+        $sb = [System.Text.StringBuilder]::new()
+        for ($k = 0; $k -lt $inner.Length; $k++) {
+            if ($inner[$k] -ne '\' -or $k -eq $inner.Length - 1) {
+                [void]$sb.Append($inner[$k])
+                continue
+            }
+            $k++
+            switch ($inner[$k]) {
+                'n'     { [void]$sb.Append("`n") }
+                't'     { [void]$sb.Append("`t") }
+                'r'     { [void]$sb.Append("`r") }
+                '0'     { [void]$sb.Append("`0") }
+                default { [void]$sb.Append($inner[$k]) }
+            }
+        }
+        return $sb.ToString()
     }
+
     if ($t.Length -ge 2 -and $t.StartsWith("'") -and $t.EndsWith("'")) {
-        return $t.Substring(1, $t.Length - 2)
+        return $t.Substring(1, $t.Length - 2).Replace("''", "'")
     }
+
     return $t
+}
+
+# True when $text either is not a quoted scalar or is one whose closing quote
+# has already been seen, honouring \" inside double quotes and '' inside
+# single quotes.
+function Test-YamlQuotedScalarComplete([string]$text) {
+    $t = $text.Trim()
+    if ($t.Length -lt 1) { return $true }
+
+    $quote = $t[0]
+    if ($quote -ne '"' -and $quote -ne "'") { return $true }
+    if ($t.Length -lt 2) { return $false }
+
+    if ($quote -eq '"') {
+        for ($k = 1; $k -lt $t.Length; $k++) {
+            if ($t[$k] -eq '\') { $k++; continue }
+            if ($t[$k] -eq '"') { return $true }
+        }
+        return $false
+    }
+
+    $k = 1
+    while ($k -lt $t.Length) {
+        if ($t[$k] -eq "'") {
+            if ($k + 1 -lt $t.Length -and $t[$k + 1] -eq "'") { $k += 2; continue }
+            return $true
+        }
+        $k++
+    }
+    return $false
 }
 
 # Reads a YAML scalar that may be a block scalar (| or >) or a plain/quoted
 # scalar folded across several more-indented continuation lines. Returns the
 # joined value plus the index of the last line consumed.
+#
+# Block scalars, and quoted scalars whose closing quote has not been reached,
+# are consumed by indentation alone: everything more indented than the key is
+# content, including blank lines, comment-looking lines, `- ` bullets and
+# `key:`-shaped lines. Applying the structural breaks used for plain scalars
+# would truncate such a value and silently drop evidence.
 function Read-YamlScalar {
     param([string[]]$Lines, [int]$Index, [int]$KeyIndent, [string]$Inline)
 
     $inline = $Inline.Trim()
     $buffer = @()
     $last = $Index
+    $isBlock = $false
 
-    if ($inline -match '^[|>][+-]?\d*$') { $inline = '' }
+    if ($inline -match '^[|>][+-]?\d*$') { $inline = ''; $isBlock = $true }
     elseif ($inline) { $buffer += $inline }
+
+    $inQuoted = -not $isBlock -and -not (Test-YamlQuotedScalarComplete ($buffer -join ' '))
+    $literal = $isBlock -or $inQuoted
 
     for ($j = $Index + 1; $j -lt $Lines.Count; $j++) {
         $candidate = $Lines[$j].TrimEnd()
         $indent = Get-LineIndent $candidate
-        if ($indent -lt 0) { break }
+        if ($indent -lt 0) {
+            # A blank line ends a plain scalar but is interior content of a
+            # block or still-open quoted scalar, which only end on dedent.
+            if (-not $literal) { break }
+            continue
+        }
         if ($indent -le $KeyIndent) { break }
 
         $trimmed = $candidate.Trim()
-        if ($trimmed.StartsWith('#')) { break }
-        if ($trimmed -match '^-(\s|$)') { break }
-        if ($trimmed -match '^[A-Za-z_][\w.-]*:(\s|$)') { break }
+        if (-not $literal) {
+            if ($trimmed.StartsWith('#')) { break }
+            if ($trimmed -match '^-(\s|$)') { break }
+            if ($trimmed -match '^[A-Za-z_][\w.-]*:(\s|$)') { break }
+        }
 
         $buffer += $trimmed
         $last = $j
+
+        if ($inQuoted -and (Test-YamlQuotedScalarComplete ($buffer -join ' '))) { break }
     }
 
     [PSCustomObject]@{
@@ -370,6 +441,11 @@ function Get-EvalEvidence([string]$yamlContent) {
     $section = 'none'
     $sectionIndent = -1
     $graderType = $null
+    # Indent of the `- name:` entries that open a stimulus, learned from the
+    # first one seen. Anchoring to it keeps a deeper `- name:` — a rubric
+    # bullet, say — from being mistaken for a new scenario and wiping the
+    # surrounding evidence.
+    $scenarioIndent = -1
 
     $lines = $yamlContent -split "`n"
 
@@ -387,11 +463,13 @@ function Get-EvalEvidence([string]$yamlContent) {
             $graderType = $null
         }
 
-        # Stimulus boundary: `- name: <scenario>` inside the stimuli list.
-        if ($indent -ge 2 -and $trimmed -match '^-\s+name:\s*(.+)$') {
+        # Stimulus boundary: `- name: <scenario>` at the stimulus list indent,
+        # outside any graders/rubric block.
+        if ($section -eq 'none' -and $indent -ge 2 -and $trimmed -match '^-\s+name:\s*(.+)$' -and
+            ($scenarioIndent -lt 0 -or $indent -eq $scenarioIndent)) {
+            $scenarioIndent = $indent
             $scenario = Remove-YamlQuoting $Matches[1]
             $scenarioCount++
-            $section = 'none'
             $sectionIndent = -1
             $graderType = $null
             continue

--- a/tests/dotnet-test/assertion-quality/eval.yaml
+++ b/tests/dotnet-test/assertion-quality/eval.yaml
@@ -69,6 +69,8 @@ stimuli:
       - Recommended specific meaningful assertions for at least some of the assertion-free tests
       - Separated tests that merely execute code without verifying it from tests that are deliberately only checking
         "this does not throw", instead of lumping every assertion-free test together
+      - Metric counts add up correctly - the 5 assertion-free tests plus the 3 trivial-only tests reconcile to the
+        8 test methods in the file, and any percentage reported matches those counts
   - name: Recognize well-diversified assertion usage
     prompt: |
       Can you evaluate the assertion quality in my UserService.Tests project?
@@ -93,6 +95,8 @@ stimuli:
         actually changing) as genuine verification rather than counting them as weak
       - Acknowledged the exception assertions with specific exception types and parameter name verification
       - If any gaps were identified, they were presented as minor enhancement opportunities rather than problems
+      - The report acknowledges outright that this suite has good assertion diversity, instead of manufacturing
+        problems so it has something to flag
   - name: Identify self-referential assertions in identity and round-trip tests
     prompt: |
       I want an assertion quality analysis of my Config tests. They all pass

--- a/tests/dotnet-test/detect-static-dependencies/eval.yaml
+++ b/tests/dotnet-test/detect-static-dependencies/eval.yaml
@@ -162,6 +162,48 @@ stimuli:
       - Provided a structured summary or report of findings with categories or counts
       - Recommended wrapping or abstracting the detected static dependencies
 
+  - name: Keep one authoritative total with file line locations and no seam for pure helpers
+    prompt: >
+      Scan StaticHeavy/ and give me an audit I can act on directly. For every
+      dependency you report I need the file and the line number so I can jump
+      straight to it, and I need the arithmetic to hold: one grand total that
+      the category table, the top-pattern table and the per-file table all
+      agree with. Also tell me explicitly which calls you decided are NOT
+      worth putting behind a seam, and why.
+    environment:
+      files:
+        - src: ./fixtures/static-heavy-project
+          dest: StaticHeavy
+    graders:
+      - type: output-matches
+        config:
+          pattern: (\w+\.cs:\d+|\w+\.cs.{0,20}[Ll]ine\s*\d+)
+      - type: output-matches
+        config:
+          pattern: Path\.Combine
+      - type: output-matches
+        config:
+          pattern: (Guid\.NewGuid|random|identity)
+      - type: output-matches
+        config:
+          pattern: (JsonSerializer|serializ)
+      - type: exit-success
+      - type: prompt
+    rubric:
+      - Every reported occurrence carries a file and line location, not just a file name
+      - Reported a single authoritative grand total and did not park real call sites in a trailing
+        "additional observations" or "also noticed" section that the totals exclude
+      - The category totals, the top-patterns ranking, and the per-file counts all reconcile to the same
+        grand total
+      - Classified Path.Combine as a deterministic pure helper that needs no seam, and did not recommend
+        wrapping, abstracting, or injecting it
+      - Counted Path.GetTempPath as a File System dependency (it reads ambient machine state) while keeping
+        Path.Combine out of the needs-wrapping total
+      - Reported the Guid.NewGuid call site in OrderProcessor.CreateOrder under a randomness or identity
+        category
+      - Reported the JsonSerializer.Serialize call site in OrderProcessor.ArchiveOrder under a
+        culture or serialization category
+
   - name: Detect statics inside lambda expressions and LINQ queries
     prompt: >
       My ReportGenerator class in LambdaStatics/ uses a lot of LINQ and

--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -136,3 +136,46 @@ stimuli:
       - Defaulted the seam to TimeProvider.System so existing callers behave exactly as before
       - Replaced all three DateTime.UtcNow call sites with the seam
       - Did not convert the static class into an instance class or change any public method signature
+
+  - name: Add the required using directive and update tests with a test double
+    prompt: >
+      Billing/Services/SubscriptionService.cs still calls DateTime.UtcNow directly. I already
+      have an IClock seam under Billing/Abstractions and it is registered in my composition
+      root. Migrate SubscriptionService to take IClock through its constructor and fix
+      Billing.Tests so the project still builds and the tests still pass. Only touch
+      SubscriptionService and its tests — the rest of the project is a later pass.
+    environment:
+      files:
+        - src: ./fixtures/with-tests
+          dest: WithTests
+    graders:
+      - type: file-contains
+        config:
+          path: "**/SubscriptionService.cs"
+          value: Billing.Abstractions
+      - type: file-not-contains
+        config:
+          path: "**/SubscriptionService.cs"
+          value: DateTime.UtcNow
+      - type: file-contains
+        config:
+          path: "**/SubscriptionServiceTests.cs"
+          value: Clock
+      - type: file-contains
+        config:
+          path: "**/InvoiceService.cs"
+          value: DateTime.UtcNow
+      - type: exit-success
+      - type: prompt
+    rubric:
+      - Added the required using directive for the Billing.Abstractions namespace to SubscriptionService.cs so
+        the IClock type resolves without fully qualifying it
+      - Injected IClock through the SubscriptionService constructor and stored it in a readonly field that follows
+        the existing naming convention
+      - Replaced every DateTime.UtcNow call site in SubscriptionService with the injected clock
+      - Test files were updated with an appropriate test double - a hand-rolled fake IClock or a mock - rather than
+        the production SystemClock or the real system time
+      - Ran the build and the tests, and reported the result that the commands actually produced
+      - Kept the change to the single class the user scoped it to instead of migrating the whole project or
+        namespace in one run, and left InvoiceService on DateTime.UtcNow
+      - Reported which production files and which test files were modified

--- a/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
+++ b/tests/dotnet-test/migrate-static-to-wrapper/eval.yaml
@@ -135,7 +135,8 @@ stimuli:
         against the static API directly without routing through a new type
       - Defaulted the seam to TimeProvider.System so existing callers behave exactly as before
       - Replaced all three DateTime.UtcNow call sites with the seam
-      - Did not convert the static class into an instance class or change any public method signature
+      - Did not convert the static class into an instance class or change any public method signature — static
+        classes cannot take constructors, so the ambient context seam is used instead of converting the type
 
   - name: Add the required using directive and update tests with a test double
     prompt: >
@@ -178,4 +179,5 @@ stimuli:
       - Ran the build and the tests, and reported the result that the commands actually produced
       - Kept the change to the single class the user scoped it to instead of migrating the whole project or
         namespace in one run, and left InvoiceService on DateTime.UtcNow
-      - Reported which production files and which test files were modified
+      - Reported the changes as a migration summary — which production files changed, which test files changed, and
+        what was deliberately left out of scope

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing.Tests/Billing.Tests.csproj
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing.Tests/Billing.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Billing/Billing.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing.Tests/SubscriptionServiceTests.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing.Tests/SubscriptionServiceTests.cs
@@ -1,0 +1,46 @@
+using Billing.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Billing.Tests;
+
+[TestClass]
+public sealed class SubscriptionServiceTests
+{
+    [TestMethod]
+    public void Start_RenewsAtIsStartPlusTerm()
+    {
+        var service = new SubscriptionService();
+
+        var subscription = service.Start("pro", 30);
+
+        Assert.AreEqual(30d, (subscription.RenewsAt - subscription.StartedAt).TotalDays, 0.001);
+    }
+
+    [TestMethod]
+    public void IsActive_ReturnsFalse_WhenRenewalDateHasPassed()
+    {
+        var service = new SubscriptionService();
+        var subscription = new Subscription
+        {
+            PlanId = "pro",
+            StartedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            RenewsAt = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        Assert.IsFalse(service.IsActive(subscription));
+    }
+
+    [TestMethod]
+    public void DaysUntilRenewal_ReturnsZero_WhenRenewalDateHasPassed()
+    {
+        var service = new SubscriptionService();
+        var subscription = new Subscription
+        {
+            PlanId = "pro",
+            StartedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            RenewsAt = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        Assert.AreEqual(0, service.DaysUntilRenewal(subscription));
+    }
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Abstractions/IClock.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Abstractions/IClock.cs
@@ -1,0 +1,9 @@
+namespace Billing.Abstractions;
+
+/// <summary>
+/// Ambient clock seam. Registered as a singleton in the composition root.
+/// </summary>
+public interface IClock
+{
+    DateTime UtcNow { get; }
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Abstractions/SystemClock.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Abstractions/SystemClock.cs
@@ -1,0 +1,6 @@
+namespace Billing.Abstractions;
+
+public sealed class SystemClock : IClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Billing.csproj
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Billing.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Services/InvoiceService.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Services/InvoiceService.cs
@@ -1,0 +1,15 @@
+namespace Billing.Services;
+
+/// <summary>
+/// Deliberately left on the static clock — this class is scheduled for a later migration pass.
+/// </summary>
+public sealed class InvoiceService
+{
+    public DateTime NextInvoiceDate(int dayOfMonth)
+    {
+        var today = DateTime.UtcNow.Date;
+        var candidate = new DateTime(today.Year, today.Month, dayOfMonth, 0, 0, 0, DateTimeKind.Utc);
+
+        return candidate > today ? candidate : candidate.AddMonths(1);
+    }
+}

--- a/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Services/SubscriptionService.cs
+++ b/tests/dotnet-test/migrate-static-to-wrapper/fixtures/with-tests/Billing/Services/SubscriptionService.cs
@@ -1,0 +1,33 @@
+namespace Billing.Services;
+
+public sealed class SubscriptionService
+{
+    public Subscription Start(string planId, int termDays)
+    {
+        var now = DateTime.UtcNow;
+
+        return new Subscription
+        {
+            PlanId = planId,
+            StartedAt = now,
+            RenewsAt = now.AddDays(termDays)
+        };
+    }
+
+    public bool IsActive(Subscription subscription) => DateTime.UtcNow < subscription.RenewsAt;
+
+    public int DaysUntilRenewal(Subscription subscription)
+    {
+        var remaining = subscription.RenewsAt - DateTime.UtcNow;
+        return remaining > TimeSpan.Zero ? (int)Math.Ceiling(remaining.TotalDays) : 0;
+    }
+}
+
+public sealed class Subscription
+{
+    public string PlanId { get; set; } = "";
+
+    public DateTime StartedAt { get; set; }
+
+    public DateTime RenewsAt { get; set; }
+}

--- a/tests/dotnet-test/test-anti-patterns/eval.yaml
+++ b/tests/dotnet-test/test-anti-patterns/eval.yaml
@@ -51,6 +51,11 @@ stimuli:
         ArgumentNullException
       - Identified that the static HttpClient field is never disposed and appears unused
       - Provided concrete fixes for the critical and high severity findings
+      - Every finding names a specific location — the test method it applies to — rather than issuing a general
+        warning about the suite
+      - The severity summary counts match the findings actually enumerated in the report; nothing is counted that
+        is not listed, and nothing listed is left out of the counts
+      - Recommendations are prioritized by severity, telling the user which findings to fix first
     constraints:
       reject_tools:
         - bash

--- a/tests/dotnet-test/test-gap-analysis/eval.yaml
+++ b/tests/dotnet-test/test-gap-analysis/eval.yaml
@@ -42,6 +42,14 @@ stimuli:
       - Identified that the heavy item fee boundary (weight > 10kg) is not tested
       - Identified that the coupon minimum floor (total cannot go below 1.00) is not tested
       - Recommended concrete test cases that would kill the survived mutations
+      - Ran the test suite and empirically confirmed every reported survivor by applying the mutation and re-running
+        the covering tests, or explicitly labelled the findings as unverified static reasoning
+      - Every survived mutation is labeled with its correct mutation category (boundary, relational operator,
+        arithmetic, return value, null check)
+      - Findings are prioritized by risk rather than listed in source order, with the discount and coupon-floor
+        survivors ahead of lower-impact ones
+      - Published a settled verdict — the report contains no in-flight reasoning such as "wait, this is actually
+        killed, let me recalibrate"
   - name: Find logic and null-check mutation gaps in access control code
     prompt: |
       I have an access control system and I'm worried the tests might not catch

--- a/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine.Tests/DiscountCalculatorTests.cs
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine.Tests/DiscountCalculatorTests.cs
@@ -46,7 +46,7 @@ public sealed class DiscountCalculatorTests
     public void CalculateDiscount_NegativeAmount_Throws()
     {
         var calc = new DiscountCalculator();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => calc.CalculateDiscount(-1m));
     }
 
@@ -75,7 +75,7 @@ public sealed class DiscountCalculatorTests
     public void CalculateShipping_ZeroWeight_Throws()
     {
         var calc = new DiscountCalculator();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => calc.CalculateShipping(50m, 0, false));
     }
 
@@ -103,7 +103,7 @@ public sealed class DiscountCalculatorTests
     public void ApplyCoupon_NullCoupon_Throws()
     {
         var calc = new DiscountCalculator();
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => calc.ApplyCoupon(100m, null!));
     }
 }

--- a/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine.Tests/PricingEngine.Tests.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine.Tests/PricingEngine.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine/PricingEngine.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/boundary-gaps/PricingEngine/PricingEngine.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl.Tests/AccessCheckerTests.cs
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl.Tests/AccessCheckerTests.cs
@@ -51,7 +51,7 @@ public sealed class AccessCheckerTests
     public void GetPermission_NullResource_Throws()
     {
         var checker = new AccessChecker();
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => checker.GetPermission(Role.Admin, null!));
     }
 

--- a/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl.Tests/AccessControl.Tests.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl.Tests/AccessControl.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl/AccessControl.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/logic-gaps/AccessControl/AccessControl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing.Tests/Billing.Tests.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing.Tests/Billing.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing.Tests/InvoiceProcessorTests.cs
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing.Tests/InvoiceProcessorTests.cs
@@ -20,7 +20,7 @@ public class InvoiceProcessorTests
     public void ComputeAmountDue_NegativeSubtotal_Throws()
     {
         var processor = new InvoiceProcessor();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => processor.ComputeAmountDue(-1m, 0, false));
     }
 }

--- a/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing/Billing.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/report-quality/Billing/Billing.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory.Tests/Inventory.Tests.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory.Tests/Inventory.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory.Tests/StockManagerTests.cs
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory.Tests/StockManagerTests.cs
@@ -29,7 +29,7 @@ public sealed class StockManagerTests
     public void AddStock_ZeroQuantity_Throws()
     {
         var mgr = new StockManager();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => mgr.AddStock("SKU-A", 0));
     }
 
@@ -37,7 +37,7 @@ public sealed class StockManagerTests
     public void AddStock_NegativeQuantity_Throws()
     {
         var mgr = new StockManager();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => mgr.AddStock("SKU-A", -1));
     }
 
@@ -45,7 +45,7 @@ public sealed class StockManagerTests
     public void AddStock_NullSku_Throws()
     {
         var mgr = new StockManager();
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => mgr.AddStock(null!, 5));
     }
 
@@ -89,7 +89,7 @@ public sealed class StockManagerTests
     public void RemoveStock_ZeroQuantity_Throws()
     {
         var mgr = new StockManager();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => mgr.RemoveStock("SKU-A", 0));
     }
 
@@ -132,7 +132,7 @@ public sealed class StockManagerTests
     public void NeedsReorder_NegativeThreshold_Throws()
     {
         var mgr = new StockManager();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
             () => mgr.NeedsReorder("SKU-A", -1));
     }
 }

--- a/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory/Inventory.csproj
+++ b/tests/dotnet-test/test-gap-analysis/fixtures/well-tested/Inventory/Inventory.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-smell-detection/eval.yaml
+++ b/tests/dotnet-test/test-smell-detection/eval.yaml
@@ -98,6 +98,52 @@ stimuli:
       - Identified BulkInsert_RunsWithoutErrors as having no assertions — it exercises code but verifies nothing
       - Distinguished between the legitimate integration patterns (setup/teardown, multi-step persistence) and the
         actual smells (sleep, conditional, assertion-free)
+
+  - name: Separate reasoned skips and self-documenting numbers from real smells
+    prompt: |
+      Audit `Inventory.Tests/InventoryServiceTests.cs` against the
+      testsmells.org catalog. Name each finding using the academic
+      taxonomy, and for every finding give me the severity plus the
+      reason you assigned that severity, and the fixed code — I don't
+      want "fix this", I want the replacement. If something looks like a
+      smell but isn't, tell me that too and say why.
+    environment:
+      files:
+        - src: fixtures/skip-and-magic/Inventory/Inventory.csproj
+          dest: Inventory/Inventory.csproj
+        - src: fixtures/skip-and-magic/Inventory/InventoryService.cs
+          dest: Inventory/InventoryService.cs
+        - src: fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj
+          dest: Inventory.Tests/Inventory.Tests.csproj
+        - src: fixtures/skip-and-magic/Inventory.Tests/InventoryServiceTests.cs
+          dest: Inventory.Tests/InventoryServiceTests.cs
+    graders:
+      - type: output-matches
+        config:
+          pattern: (Ignored Test|skip|Skip)
+      - type: output-matches
+        config:
+          pattern: (Sleepy|Thread\.Sleep|sleep)
+      - type: output-matches
+        config:
+          pattern: (Assertion.?Free|no assert|without.*assert)
+      - type: output-matches
+        config:
+          pattern: (High|Medium|Low|severity)
+      - type: exit-success
+      - type: prompt
+    rubric:
+      - Flagged the Thread.Sleep(3000) in Replenish_AsyncJob_Completes as a High-severity Sleepy Test
+      - Flagged Audit_RunsWithoutError as an Assertion-Free Test — it exercises the service but verifies nothing
+      - Reported both skipped tests as Ignored Test, but treated the bare `Skip = "skip"` on
+        Restock_FromSupplier_UpdatesQuantities as more concerning than the reasoned skip on
+        Reserve_AcrossWarehouses_BalancesStock, which documents why and links a tracking issue
+      - Did not flag the contextually obvious numbers as Magic Number Test — asserting a count of 3 right after
+        adding three items, and a count of 1 after removing one of two, is self-documenting
+      - Severity levels are justified with a stated rationale rather than assigned arbitrarily
+      - Every finding includes a concrete fix example — the rewritten code — rather than a bare "fix this"
+        instruction
+      - Used xUnit terminology and APIs (Fact, Skip, Assert.Equal) rather than describing the suite in MSTest terms
   - name: Decline request to write new tests from scratch
     prompt: |
       I need to write unit tests for my ShoppingCart class. It supports

--- a/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj
+++ b/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory.Tests/Inventory.Tests.csproj
@@ -11,4 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Inventory/Inventory.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory/Inventory.csproj
+++ b/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory/Inventory.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory/InventoryService.cs
+++ b/tests/dotnet-test/test-smell-detection/fixtures/skip-and-magic/Inventory/InventoryService.cs
@@ -1,0 +1,40 @@
+namespace Inventory;
+
+public sealed class InventoryService
+{
+    private readonly Dictionary<string, int> _quantities = [];
+    private readonly HashSet<string> _replenished = [];
+
+    public int ItemCount => _quantities.Count;
+
+    public void Add(string sku, int quantity) => _quantities[sku] = quantity;
+
+    public void Remove(string sku) => _quantities.Remove(sku);
+
+    public int QuantityOf(string sku) => _quantities.TryGetValue(sku, out var q) ? q : 0;
+
+    public bool Reserve(string sku, int quantity)
+    {
+        if (QuantityOf(sku) < quantity)
+        {
+            return false;
+        }
+
+        _quantities[sku] -= quantity;
+        return true;
+    }
+
+    public void Restock(string sku, int quantity) => _quantities[sku] = QuantityOf(sku) + quantity;
+
+    public void ReplenishAsync(string sku) => _replenished.Add(sku);
+
+    public bool WasReplenished(string sku) => _replenished.Contains(sku);
+
+    public void Audit()
+    {
+        foreach (var sku in _quantities.Keys)
+        {
+            _ = QuantityOf(sku);
+        }
+    }
+}

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -30,7 +30,7 @@ stimuli:
           pattern: positive|negative
       - type: output-matches
         config:
-          pattern: (distribution|summary|trait|count)
+          pattern: (distribution|summary|breakdown|tally|table|total|trait|count)
       - type: prompt
     rubric:
       - Tagged the happy-path PlaceOrder tests (ValidInput, MultipleItems, SendsConfirmationEmail) as positive
@@ -66,7 +66,7 @@ stimuli:
           pattern: positive|negative
       - type: output-matches
         config:
-          pattern: (distribution|summary|trait|count)
+          pattern: (distribution|summary|breakdown|tally|table|total|trait|count)
       - type: prompt
     rubric:
       - Tagged the happy-path PlaceOrder tests (ValidInput, MultipleItems, SendsConfirmationEmail) as positive
@@ -99,13 +99,10 @@ stimuli:
           value: "[Category("
       - type: output-matches
         config:
-          pattern: \[Category\b
-      - type: output-matches
-        config:
           pattern: positive|negative
       - type: output-matches
         config:
-          pattern: (distribution|summary|trait|count)
+          pattern: (distribution|summary|breakdown|tally|table|total|trait|count)
       - type: prompt
     rubric:
       - Tagged the happy-path PlaceOrder tests (ValidInput, MultipleItems, SendsConfirmationEmail) as positive
@@ -200,7 +197,7 @@ stimuli:
           pattern: (positive|negative)
       - type: output-matches
         config:
-          pattern: (distribution|summary|trait|count)
+          pattern: (distribution|summary|breakdown|tally|table|total|trait|count)
       - type: prompt
     rubric:
       - Preserved the existing [TestCategory("positive")] and [TestCategory("critical-path")] on
@@ -241,7 +238,7 @@ stimuli:
           pattern: (positive|negative)
       - type: output-matches
         config:
-          pattern: (distribution|summary|trait|count)
+          pattern: (distribution|summary|breakdown|tally|table|total|trait|count)
       - type: prompt
     rubric:
       - Classified DeleteTask_Success as negative (and/or security) because the body asserts UnauthorizedAccessException,

--- a/tests/dotnet-test/test-tagging/eval.yaml
+++ b/tests/dotnet-test/test-tagging/eval.yaml
@@ -99,6 +99,9 @@ stimuli:
           value: "[Category("
       - type: output-matches
         config:
+          pattern: \[Category\b
+      - type: output-matches
+        config:
           pattern: positive|negative
       - type: output-matches
         config:
@@ -321,7 +324,9 @@ stimuli:
       - Classified TestDivide_ByZero_ReturnsError as the error/negative-path test
       - Classified the remaining three tests as happy-path/positive coverage
       - Reported the distribution between the two groups
-      - Did not modify calculator_test.go — the user asked for analysis only
+      - Treated Go as a report-only framework — delivered the classification as a report and modified no source
+        files, leaving calculator_test.go byte-for-byte unchanged with no build tags, t.Skip calls, or comment
+        markers injected
       - Did not invent a C#-style attribute such as [TestCategory] or [Trait]; recognised that Go expresses this
         through naming, build tags, or testing.Short rather than attributes, or reported without proposing a
         mechanism at all

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService.Tests/OrderService.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="3.8.0" />

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderService.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-partially-tagged/OrderService/OrderService.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-untagged/OrderService.Tests/OrderService.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-untagged/OrderService.Tests/OrderService.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="3.8.0" />

--- a/tests/dotnet-test/test-tagging/fixtures/mstest-untagged/OrderService/OrderService.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/mstest-untagged/OrderService/OrderService.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager.Tests/TaskManager.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-misleading-names/TaskManager/TaskManager.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-untagged/OrderService.Tests/OrderService.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-untagged/OrderService.Tests/OrderService.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/tests/dotnet-test/test-tagging/fixtures/nunit-untagged/OrderService/OrderService.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/nunit-untagged/OrderService/OrderService.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/tests/dotnet-test/test-tagging/fixtures/xunit-untagged/OrderService.Tests/OrderService.Tests.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/xunit-untagged/OrderService.Tests/OrderService.Tests.csproj
@@ -1,9 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!--
+      This fixture exists to be tagged, not to model xUnit cancellation style.
+      xUnit1051 fires on every async call in the suite; left on, it buries the
+      build output in 26 warnings that tempt the agent away from the tagging
+      task it was actually asked to do.
+    -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="2.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/dotnet-test/test-tagging/fixtures/xunit-untagged/OrderService/OrderService.csproj
+++ b/tests/dotnet-test/test-tagging/fixtures/xunit-untagged/OrderService/OrderService.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

The skill coverage report on #945 flagged roughly 190 uncovered teaching points across 9 `dotnet-test` skills, 7 of them at 0%. Reproducing it locally showed those skills all report `Evidence items: 0`, so most of that number was a measurement artifact rather than a real gap.

`eng/skill-coverage/Measure-SkillCoverage.ps1` parses an eval schema this repo does not use. It looks for `assertions:` blocks with sibling `pattern:`/`value:` keys, but all `tests/**/eval.yaml` files use `graders:` with a nested `config:` map. It also only captured rubric entries written as single-line quoted scalars, while nearly every rubric item here is an unquoted plain scalar wrapped across lines. The tool therefore found no evidence at all and reported every teaching point as uncovered. Writing ~190 assertions to satisfy that would have produced exactly the overfitting `eng/skill-validator/src/docs/OverfittingDetection.md` warns about.

**1. Fix the measurement.** `Get-EvalEvidence` is rewritten as an indentation-driven parser that reads the real spec shape: graders with nested config (`pattern`, `substring`, `value`, `command`, `stdout_contains`, `stdout_matches`, and `path` for file-exists graders), plus block and folded scalars for both grader values and rubric items. Literal values are regex-escaped before code-pattern matching so a substring is not mistakenly treated as a regex. This alone moved the 9 skills from 0-33% to 82-100%.

**2. Close the points that were genuinely uncovered.** All 9 skills now sit at 100%:

- `detect-static-dependencies`: new accounting-discipline stimulus for `file:line` locations, one authoritative total, and pure helpers such as `Path.Combine` excluded from the needs-wrapping total.
- `migrate-static-to-wrapper`: new `with-tests` fixture (a custom `IClock` seam plus an MSTest project) and a stimulus covering the required `using` directive, test doubles in the updated tests, scope discipline, and the Step 7 migration summary; plus the pitfall that static classes cannot take constructors, so the ambient context seam is used instead of converting the type.
- `test-smell-detection`: wires up the orphaned `skip-and-magic` fixture, which was committed but had no stimulus referencing it and was missing its production class. Covers reasoned vs bare skips, contextually obvious numbers, justified severities, and concrete fix examples.
- `test-tagging`: the report-only "no source files were modified" rule folded into the existing Go stimulus, and the `[Category]` attribute pattern credited from the existing `file-contains` grader.
- `assertion-quality`, `test-anti-patterns`, `test-gap-analysis`: rubric items for metric arithmetic, per-finding locations, severity prioritisation, empirical survivor confirmation, mutation category labels, and settled verdicts.

**3. Address the review feedback on the parser** (commit 2). Three correctness fixes, none of which move any number:

- `Remove-YamlQuoting` now applies each quoting style's escape rules — single-quoted `''` collapses to `'` (the corpus has `user''s` and `xUnit''s`), and double-quoted scalars honour `\"`, `\\`, `\n`, `\t`, `\r` rather than only `\\`.
- `Read-YamlScalar` switches to indentation-only consumption once a `|`/`>` header is seen, instead of applying the plain-scalar structural breaks that would truncate a block scalar at its first blank, `#`, `- ` or `key:`-shaped line. The same treatment now applies to a quoted scalar until its closing quote is reached, which fixes the one real truncation in the corpus today: the double-quoted rubric item in `dotnet-upgrade/migrate-nullable-references` whose continuation line starts with `#nullable disable`.
- The stimulus boundary is anchored to the indent of the first `- name:` seen and only fires outside a graders/rubric block, so a deeper rubric bullet starting with `name:` can no longer be mistaken for a new scenario and reset the section.

**4. Repair the broken eval fixtures the eval run exposed** (commit 3). An eval run over `test-gap-analysis`, `test-smell-detection` and `test-tagging` failed 6 scenarios. Three were the intended baseline signal — an unskilled agent picks domain categories (`Validation`, `BusinessLogic`) instead of the positive/negative taxonomy — and one was a harness flake where the agent could not read the file at all. The other two were eval defects, and chasing them surfaced a much larger problem: **every C# fixture behind these three skills failed to compile before the agent touched it.**

- All 5 `test-tagging` and all 4 `test-gap-analysis` fixtures omit `ImplicitUsings`/`Nullable` while their sources use `List<>`, `Task<>`, `CancellationToken`, `Dictionary<,>`, `DateTime`, `ArgumentOutOfRangeException` and `string?` with no `using` directives.
- All 4 `test-gap-analysis` test projects pin **MSTest 4.1.0** but call `Assert.ThrowsException<T>`, which v4 removed. Renamed to `ThrowsExactly<T>`, the exact-type-match equivalent this repo's own `migrate-mstest-v3-to-v4` skill prescribes.

This mattered most for `test-gap-analysis`, whose entire method is *inject a mutation, run the suite, see whether it fails*. On a project that does not build, every mutation looks the same. The judges recorded the cost directly: *"proactively fixed pre-existing build issues (missing ImplicitUsings)"* and *"the build couldn't be verified due to pre-existing errors in the source project"*. The `test-tagging` build grader was likewise measuring whether the agent noticed and repaired an unrelated csproj bug, not whether tagging preserved buildability.

Two brittle graders that produced false negatives on runs the judge scored as correct are also fixed: `output-matches /\[Category\b/` only tested whether the agent echoed attribute syntax in prose (removed — `file-contains "[Category("` already proves it), and `/(distribution|summary|trait|count)/` missed a run the judge called *"a clear distribution summary"* (widened with `breakdown|tally|table|total`).

### Worth a careful look

- The parser rewrite is the load-bearing change. It is cross-checked against a real YAML parser rather than eyeballed, but it is trusted tooling that runs from the base branch in CI, so a second opinion on `Read-YamlScalar` and the section-tracking loop is welcome.
- The `Get-CodePatterns` change (emitting the open bracket form of an attribute pattern) moves coverage on 5 of 75 skills. Each was verified to be a genuine pre-existing false negative — the rubrics literally name `[CascadingParameter]`, `[FromForm]` and `[TestMethod]`.
- `test-smell-detection` fixtures are deliberately standalone test files with no production class and no build grader, so they are intentionally left alone.
- This was originally stacked on `dev/amauryleve/dotnet-test-eval-followups` (#945). Now that #945 has merged, the branch is rebased onto `main`. In the conflicting files, main's versions supersede this PR's, which is why the `.gitignore` negation and the Cobertura fixture no longer appear in the diff — #945 landed better versions of both.

### Known pre-existing defect, deliberately not fixed here

The PyYAML cross-check surfaces one file where a real YAML parser and this parser legitimately disagree: `tests/dotnet-test-migration/migrate-mstest-v3-to-v4/eval.yaml` has two rubric items written as unquoted `Shows the correct syntax: ...` strings, which YAML parses as maps rather than strings. A map rubric item will not deserialize into the `List<string>` the eval runner expects. It is pre-existing on `main` and in a different skill family, so it belongs in its own change.

## Related issue

Follows up the coverage report on #945.

## Validation

- `Measure-SkillCoverage.ps1 -All -Format Json` cross-checked against a real YAML parser (PyYAML): **1 mismatch across all 98 `eval.yaml` files**, and that one is the pre-existing `migrate-mstest-v3-to-v4` map-rubric defect described above.
- All 628 fixture `src:` references resolve.
- Coverage is unchanged across all 75 skills for the commit-2 parser fixes, confirming they close latent foot-guns without moving numbers.
- **All 9 repaired fixtures build and pass**, run outside the repo so the root `global.json` MTP setting does not interfere: `test-gap-analysis` 11 / 9 / 2 / 15 tests, `test-tagging` 23 / 23 / 23 / 15 / 10 tests. Every one of them failed to compile beforehand.
- **The intended mutation behaviour is confirmed empirically, not assumed.** Applying real mutations to the repaired `boundary-gaps` fixture: all four survivors its rubric names still survive (discount tiers `>= 1000`→`>`, `>= 500`→`>`, free shipping `> 250`→`>=`, heavy item `> 10.0`→`>=`). Applying four mutations to `well-tested`: all four are killed, matching its "acknowledge well-tested code" premise.
- `dotnet test Billing.Tests` on the `with-tests` fixture: 3 passed. `dotnet build Inventory.Tests` on `skip-and-magic`: succeeded, 0 warnings.
- Unit-checked the three parser fixes directly: `''`/`\"`/`\\` unquoting round-trips, a block scalar containing a blank line, a `#` line, a `- ` bullet and a `key:` line is captured whole, and a synthetic rubric bullet with a nested `- name:` no longer opens a second scenario.
- Final coverage for the 9 reported skills: all 100%.
- `skill-validator check` could not run: building it downloads `@github/copilot-win32-x64` from npmjs and the sandbox blocks that TLS handshake. No `plugins/**` content changed in this PR, so its checks are unaffected.

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content. (N/A - no owned content moved)
- [x] I updated all marketplace manifests when plugin metadata changed. (N/A - no plugin metadata changed)
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content. (N/A - no new external domains)