### PR TITLE
Trim convert-to-cpm skill cost without reducing capability

### DIFF
--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -16,154 +16,141 @@ license: MIT
 
 # Convert to Central Package Management
 
-Migrate .NET projects from per-project package versioning to NuGet Central Package Management (CPM). CPM centralizes all package versions into a single `Directory.Packages.props` file, making version governance and upgrades easier across multi-project repositories.
+Centralize package versions in `Directory.Packages.props` while preserving project behavior and producing reviewable before/after evidence.
 
-## When to Use
+## Choose a mode first
 
-- The user wants to adopt Central Package Management for a .NET repository, solution, or project
-- Package versions are scattered across many `.csproj`, `.fsproj`, or `.vbproj` files and the user wants a single source of truth
-- The user mentions `Directory.Packages.props`, CPM, or centralizing NuGet versions
-- The user wants to update, bump, upgrade, align, or sync a NuGet package version across multiple projects -- CPM is the recommended approach for managing shared package versions, so suggest converting to CPM as part of the update if the projects use `PackageReference` and CPM is not already enabled
-- Package versions are out of sync, conflicting, or mismatched across projects and the user wants to resolve or unify them
+Do this before running builds or changing files.
 
-## When Not to Use
+1. **Guard mode** -- If any in-scope project uses `packages.config`, stop. Explain that CPM requires `PackageReference` and recommend migrating first. Do not create or modify files.
+2. **Recommendation mode** -- Use when the user asks to update, align, bump, or sync packages but has not explicitly authorized a CPM conversion. Inspect only the named scope, summarize conflicts and complexities, and explain CPM as the durable option for preventing future drift. Present the trade-off between direct alignment and CPM conversion, offer to perform the conversion, and wait for the user's choice. **Do not modify files, run builds, capture conversion artifacts, or continue into the conversion workflow without authorization.**
+3. **Conversion mode** -- Use only when the user explicitly asks to adopt, enable, or convert to CPM. Follow the workflow below.
 
-- The repository already has CPM fully enabled for all in-scope projects
-- The user is working with `packages.config`-based projects (must first migrate to `PackageReference`)
-- The user wants to manage versions via a custom MSBuild property file without using CPM
+If the scope is unclear, ask once before proceeding.
+
+### Default execution plan
+
+- **Guard**: use a minimal scoped detection pass, then answer and stop.
+- **Recommendation**: use a compact read-only audit, then answer and stop. Do not read conversion references.
+- **Conversion**: batch the preflight, baseline, audit/mutation, final validation, and report work to avoid redundant turns. Revisit a stage only when new CPM-specific evidence requires a targeted follow-up.
+
+This plan is an efficiency default, not a hard cap. Never omit an in-scope project, imported `.props`/`.targets` file, detected complexity, required validation, or deliverable to save a turn. Batch complete work where practical.
 
 ## Inputs
 
-| Input | Required | Description |
-|-------|----------|-------------|
-| Scope | Yes | A project file, solution file, or directory containing .NET projects to convert |
-| Version conflict strategy | No | How to resolve cases where the same package has different versions across projects. When conflicts are detected, do not assume a default strategy -- ask the user which strategy to use or explicitly confirm a proposed strategy before proceeding. |
+| Input | Required | Rule |
+|-------|----------|------|
+| Scope | Yes | Project, solution, or directory containing the projects to inspect or convert |
+| Conflict strategy | For conversion with conflicts | If the user already supplied a strategy such as "use the highest version," apply it without asking again and record its impact. Otherwise stop after the audit and ask before editing. |
 
-## Workflow
+## Read references only when needed
 
-### Step 1: Determine scope
+Never preload all references.
 
-- **Single project**: User specifies a `.csproj`, `.fsproj`, or `.vbproj`.
-- **Solution**: User specifies a `.sln` or `.slnx`. List projects with `dotnet sln list`.
-- **Repository/directory**: No specific file given. Find all project files recursively from the first common ancestor directory of all .NET projects in scope.
+| Condition | Read |
+|-----------|------|
+| Entering conversion baseline or producing the package diff | [baseline-comparison.md](references/baseline-comparison.md) |
+| A conflict, conditional reference, shared import, security concern, or `VersionOverride` is detected | [audit-complexities.md](references/audit-complexities.md) |
+| Placement is unclear or conditional `PackageVersion`/`VersionOverride` is required | [directory-packages-props.md](references/directory-packages-props.md) |
+| A package version uses an MSBuild property | [msbuild-property-handling.md](references/msbuild-property-handling.md) |
+| Restore or build fails after conversion | [validation-and-errors.md](references/validation-and-errors.md) |
+| Writing the final report | [report-template.md](references/report-template.md) |
 
-If the scope is unclear, ask the user.
+## Conversion workflow
 
-**Guard: Check for packages.config projects.** Before proceeding, check whether any project in scope uses `packages.config` instead of `PackageReference`. Look for `packages.config` files alongside project files. If any `packages.config` usage is detected, **stop and do not proceed with the conversion**. Inform the user that CPM requires projects with `PackageReference` format and that they must first migrate from `packages.config` to `PackageReference` (e.g., using Visual Studio's built-in migration or the `dotnet migrate` tooling). This skill cannot perform that migration.
+### 1. Scope and preflight
 
-### Step 2: Establish baseline build
+- Resolve the project/solution scope. For a solution, list its projects. For a directory, search only beneath that directory.
+- Check for `packages.config`; if found, switch to Guard mode and stop.
+- Check the scope and ancestors for `Directory.Packages.props`. If CPM is already fully enabled, report that and stop. If a partial file exists, preserve it and ask only when its intended scope is ambiguous.
+- Run all .NET commands from the resolved scope directory, not from an unrelated parent workspace.
+- Do not inspect unrelated projects or host-tool configuration when the user supplied a scope.
 
-Before making any changes, verify the scope builds successfully and capture a baseline binlog and package list. Run `dotnet clean`, then `dotnet build -bl:baseline.binlog`, then `dotnet package list --format json > baseline-packages.json`. Read [baseline-comparison.md](references/baseline-comparison.md) for the full procedure and fallback options. If the baseline build fails, stop and inform the user -- the scope must build cleanly before conversion. Do not delete `baseline.binlog` or `baseline-packages.json` -- they are needed for the post-conversion comparison and report.
+### 2. Capture the baseline
 
-### Step 3: Check for existing CPM
+Read [baseline-comparison.md](references/baseline-comparison.md). From the scope directory, determine the active SDK once and select the documented command syntax from that version. If SDK resolution fails or the SDK cannot process the requested solution format, stop and report the prerequisite; do not alter the host SDK or repository SDK policy unless the user asks.
 
-Search for any existing `Directory.Packages.props` in scope or ancestor directories. If CPM is already fully enabled, inform the user and stop. If a `Directory.Packages.props` exists without CPM enabled, ask whether to add the property to the existing file or create a new one.
+Then use one command batch to:
 
-### Step 4: Audit package references
+1. Clean, restore, and build the scope, writing `baseline.binlog`.
+2. Write resolved packages to `baseline-packages.json` without restoring again.
+3. Keep normal command output concise. Save full output to artifacts when useful; inspect only errors on failure and never read the binlog as text.
 
-Run `dotnet package list --format json` to get the resolved package references across all in-scope projects. Also scan `<Import>` elements to discover shared `.props`/`.targets` files containing package references.
+If the baseline build fails, stop without modifying files. Preserve both baseline artifacts.
 
-Check for complexities: version conflicts, MSBuild property-based versions, conditional references, security advisories, and existing `VersionOverride` usage. Read [audit-complexities.md](references/audit-complexities.md) for the full checklist.
+### 3. Audit with a targeted checklist
 
-Present audit results to the user before proceeding, including:
-- A table of each package, its version(s), and which projects use it
-- Any version conflicts, security advisories, or complexities requiring decisions
+Use the baseline snapshot plus one targeted scan of in-scope project, `.props`, and `.targets` files. Identify:
 
-When version conflicts exist, present each one individually with the affected projects, the distinct versions found, and the resolution options (align to highest, use `VersionOverride`, etc.) with their trade-offs. Do not upgrade any package beyond the highest version already in use across the scope -- this avoids introducing version incompatibilities or breaking changes that are unrelated to the CPM conversion itself. Note any known security advisories or other upgrade opportunities as follow-up items for the user to address after the conversion is complete. Ask the user to decide on each conflict before proceeding. Read [audit-complexities.md - Same package with different versions](references/audit-complexities.md) for the resolution workflow and presentation format.
+- Package IDs, resolved versions, and consuming projects
+- Version conflicts
+- MSBuild property-based versions and their definitions
+- Conditional `PackageReference` items
+- Imported files containing package references
+- Existing `VersionOverride` usage
 
-### Step 5: Create or update Directory.Packages.props
+For a complex scope, complete every applicable item above across all projects and imported files; do not stop after finding the first conflict.
 
-Create the file with `dotnet new packagesprops` (.NET 8+) or manually. Add a `<PackageVersion>` entry for each unique package sorted alphabetically. For conditional versions or `VersionOverride` patterns, read [directory-packages-props.md](references/directory-packages-props.md).
+Do not run broad `--outdated` or `--deprecated` scans by default. Before editing, attempt a scoped `--vulnerable --include-transitive` query when the user requested security information, a known advisory must be verified, or conflict resolution will move a project across a major package version. Record the compact findings, "no advisories found," or why the check could not run. If a high-risk check is unavailable because of authentication, package-source, or offline constraints, surface the uncertainty and confirm the user's strategy rather than silently treating it as safe. Do not upgrade beyond the highest version already in scope as part of a CPM conversion.
 
-### Step 6: Update project files
+Present conflicts and their impact. Explicitly classify major-version alignment as high risk and minor/patch alignment as moderate risk without performing an extra online scan. If the user supplied a conflict strategy, proceed. Otherwise ask for the unresolved decisions and stop before editing.
 
-Remove the `Version` attribute from every `<PackageReference>` that now has a corresponding `<PackageVersion>`. Also update any shared `.props`/`.targets` files identified in step 4.
+### 4. Create CPM files and update references
 
-- Preserve all other attributes (`PrivateAssets`, `IncludeAssets`, `ExcludeAssets`, `GeneratePathProperty`, `Aliases`)
-- Preserve conditional `<ItemGroup>` elements -- only remove the `Version` attribute within them
-- Retain each file's existing indentation style (spaces vs. tabs, indentation depth) and blank lines -- do not reformat or reorganize unchanged lines
-- Use `VersionOverride` (with user confirmation) when a project needs a different version than the central one
+- Create or update `Directory.Packages.props` at the correct scope with `ManagePackageVersionsCentrally` set to `true`.
+- Add one alphabetically sorted `PackageVersion` per package, preserving required target-framework conditions.
+- Remove only `Version` from managed `PackageReference` items in projects and imported files.
+- Preserve conditions, whitespace, and all other metadata such as `PrivateAssets`, `IncludeAssets`, `ExcludeAssets`, `GeneratePathProperty`, and `Aliases`.
+- Use `VersionOverride` only when the chosen strategy requires it.
 
-### Step 7: Handle MSBuild version properties
+For MSBuild version properties, follow [msbuild-property-handling.md](references/msbuild-property-handling.md). When the user directs inlining, include both the literal `PackageVersion` and removal of the obsolete property definition in the same mutation batch. Before final validation, verify separately that:
 
-For `PackageReference` items that used MSBuild properties for versions, determine whether to inline the resolved value or keep the property reference in `Directory.Packages.props`. After validation succeeds in step 8, remove inlined version properties from `Directory.Build.props` or other files, verifying they have no remaining references. Read [msbuild-property-handling.md](references/msbuild-property-handling.md) for the decision workflow, import order requirements, and cleanup procedure.
+1. No `$(PropertyName)` references remain in scoped project, `.props`, or `.targets` files.
+2. No `<PropertyName>...</PropertyName>` definition remains for each property chosen for removal.
 
-### Step 8: Restore and validate
+Do not rely on a `$()` reference scan to prove that the XML property definition was removed.
 
-Run a clean restore and build, capturing a post-conversion binlog and package list. Run `dotnet clean`, then `dotnet build -bl:after-cpm.binlog`, then `dotnet package list --format json > after-cpm-packages.json`. Read [baseline-comparison.md](references/baseline-comparison.md) for the full procedure. If errors occur, read [validation-and-errors.md](references/validation-and-errors.md) for NuGet error codes and multi-TFM guidance.
+### 5. Validate and compare
 
-**Do not delete or clean up any artifacts** (`baseline.binlog`, `after-cpm.binlog`, `baseline-packages.json`, `after-cpm-packages.json`). These files must be preserved for the user to inspect after the conversion. They are deliverables, not temporary files.
+Using [baseline-comparison.md](references/baseline-comparison.md), validate the final on-disk state after all project, shared-file, and property edits. Use one command batch to:
 
-### Step 9: Post-conversion report
+1. Clean, restore, and build the converted scope, writing `after-cpm.binlog`.
+2. Write resolved packages to `after-cpm-packages.json` without restoring again.
+3. Produce a compact per-project changes/unchanged comparison without printing or rereading the full JSON files.
+4. If resolved versions changed and the repository exposes a routine, scoped test command for affected projects, run it with `--no-build --no-restore` and record the result. If tests require substantial setup, broad infrastructure, or user approval, recommend the exact scoped command instead. A version-neutral conversion does not require an automatic test run.
 
-**You must create a `convert-to-cpm.md` file** alongside the binlog and JSON artifacts. Do not skip this step or substitute inline chat output for the file -- the user needs a persistent, shareable document. This file should be self-contained and shareable -- suitable for a pull request description, a team review, or a record of what was done. Structure the report with the following sections:
+If restore or build fails with a CPM-related error, read [validation-and-errors.md](references/validation-and-errors.md), inspect only the relevant error lines, make a targeted correction, and rerun the affected validation. For SDK, authentication, package-source, file-lock, test-host, or other environmental failures, report the blocker instead of changing the machine or expanding the investigation.
 
-#### Section 1: Conversion overview
+If a test run fails after a successful build, inspect only enough output to determine whether CPM package resolution caused it. Apply a targeted correction only when the evidence clearly identifies a CPM defect; otherwise record the failure and recommended user action without expanding into test-host, SDK, output-directory, or dependency-copy debugging.
 
-Summarize what was converted: the scope (project, solution, or repository), number of projects converted, total packages centralized, any projects or packages that were skipped, and any MSBuild properties that were inlined or removed. This gives the reader immediate context.
+### 6. Write the report
 
-#### Section 2: Version conflict resolutions
+Read [report-template.md](references/report-template.md) now, not earlier. Create `convert-to-cpm.md` beside the other artifacts. It must include the six required sections, concrete conflict impacts, the package comparison, risk level, follow-ups, artifact usage, and the name of every shared `.props`/`.targets` file inspected or changed. In the final response, mention those shared files, the risk level, and how any conditional references and target frameworks were preserved. Avoid rewriting the report after validation unless verification finds an omission or incorrect evidence.
 
-If any version conflicts were encountered, list each one with:
+## Required conversion artifacts
 
-- The package name and all versions that were found across projects
-- Which projects used each version
-- What the user decided (aligned to highest, used `VersionOverride`, etc.)
-- The practical impact: which projects now resolve a different version than before, and which are unchanged
+Preserve all five deliverables; they are not temporary files:
 
-If no conflicts were found, state that all packages had consistent versions across projects -- this is a positive signal worth noting.
+- `baseline.binlog`
+- `after-cpm.binlog`
+- `baseline-packages.json`
+- `after-cpm-packages.json`
+- `convert-to-cpm.md`
 
-#### Section 3: Package comparison -- baseline vs. result
+## Efficiency rules
 
-Compare `baseline-packages.json` and `after-cpm-packages.json` per project. See [baseline-comparison.md](references/baseline-comparison.md) for the comparison procedure. Present two tables:
-
-- **Changes table**: Packages where the resolved version changed, a `VersionOverride` was introduced, or a package was added/removed. Include a status column explaining what changed and why (e.g., "VersionOverride -- project retains pinned version", "Aligned to highest version").
-- **Unchanged table**: All other packages, confirming they resolve identically to baseline.
-
-If there are no changes at all, state that the conversion is fully version-neutral -- this is the ideal outcome and provides reassurance.
-
-#### Section 4: Risk assessment
-
-Provide a clear confidence statement:
-
-- **[Low risk]** -- Conversion is version-neutral; all packages resolve to the same versions as baseline. The build and restore succeeded. Recommend running `dotnet test` as a final check.
-- **[Moderate risk]** -- Some packages changed versions (e.g., minor/patch alignment). List the affected packages and projects. Recommend reviewing the changes table and running `dotnet test` to verify no regressions.
-- **[High risk]** -- Major version changes were applied, or packages were added/removed unexpectedly. Recommend careful review, running `dotnet test`, and comparing binlogs before merging.
-
-Call out any specific warnings: `VersionOverride` usage that partially undermines centralization, or MSBuild property removal that could affect other build logic.
-
-#### Section 5: Follow-up items
-
-List any items identified during the conversion that the user should address separately after the CPM conversion is complete. These are intentionally out of scope for the conversion itself but important for the user to act on. Common follow-up items include:
-
-- **Security advisories**: If any package versions are known to have security vulnerabilities (detected via `dotnet package list --vulnerable` or noted during the audit), list each advisory with the package name, current version, affected projects, and the minimum patched version. These upgrades are out of scope for the CPM conversion to avoid introducing version incompatibilities or breaking changes.
-- **Deprecated packages**: If any packages are deprecated, note the recommended replacement.
-- **Version alignment opportunities**: If `VersionOverride` was used to preserve differing versions, note that the user may want to align these in the future once the affected projects can be validated against the central version.
-- **Test validation**: Recommend running `dotnet test` to validate runtime behavior beyond build success, especially if any version conflicts were resolved by aligning to the highest version.
-
-Present follow-up items as a numbered checklist so the user can track them.
-
-#### Section 6: Artifacts and how to use them
-
-List the artifacts produced during conversion and explain how to use them:
-
-- **`baseline.binlog`** and **`after-cpm.binlog`** -- MSBuild binary logs captured before and after conversion. These are available for manual validation and troubleshooting if needed.
-- **`baseline-packages.json`** and **`after-cpm-packages.json`** -- Machine-readable snapshots of resolved package versions per project, used to produce the comparison tables above.
-- **`convert-to-cpm.md`** -- This report file, suitable for use as a pull request description or team review artifact.
-
-Recommend the user run `dotnet test` to validate runtime behavior beyond build success. If any version conflicts were resolved by aligning to the highest version, recommend reviewing the release notes for the affected packages.
+- Batch independent reads and edits when supported.
+- Keep full build logs and package JSON out of the conversation; return compact summaries and artifact paths.
+- Do not repeat successful commands or reread successful output.
+- Do not perform package upgrades, broad outdated/deprecated scans, repeated tests, or unrelated repository exploration. The single conditional vulnerability query and test run defined above are part of complete high-risk conversion validation.
+- Do not install or remove an SDK, create a temporary SDK selector, change roll-forward policy, invoke SDK-internal assemblies, kill unrelated processes, or clean host tooling/temp infrastructure. Report an environment prerequisite and stop.
 
 ## Validation
 
-- [ ] Baseline build succeeded before any changes were made
-- [ ] `Directory.Packages.props` exists with `ManagePackageVersionsCentrally` set to `true`
-- [ ] Every in-scope `PackageReference` either has no `Version` attribute or uses `VersionOverride`
-- [ ] Every referenced package has a corresponding `PackageVersion` entry
-- [ ] `dotnet restore` and `dotnet build` complete without errors from a clean state
-- [ ] Package list comparison shows no unexpected version changes
-- [ ] No orphaned version properties remain (unless intentionally kept)
-
-## More Info
-
-- [Central Package Management documentation](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/consume-packages/Central-Package-Management.md)
-- [Validation and common errors](references/validation-and-errors.md)
+- [ ] Baseline and converted builds succeeded and both binlogs exist
+- [ ] Every managed `PackageReference` has no `Version`, or intentionally uses `VersionOverride`
+- [ ] Every managed package has the correct central `PackageVersion`
+- [ ] Conditions and non-version metadata were preserved
+- [ ] Before/after package comparison contains no unexplained changes
+- [ ] Inlined version properties have neither remaining `$()` references nor obsolete XML definitions
+- [ ] All five required artifacts exist

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -23,7 +23,7 @@ Centralize package versions in `Directory.Packages.props` while preserving proje
 Do this before running builds or changing files.
 
 1. **Guard mode** -- If any in-scope project uses `packages.config`, stop. Explain that CPM requires `PackageReference` and recommend migrating first. Do not create or modify files.
-2. **Package-maintenance mode** -- A request to update, align, bump, or sync packages authorizes those package edits, not CPM conversion. Audit the named scope, resolve the requested versions, update existing project/shared version declarations, and restore/build every affected CLI target. Ask only when the version or alignment policy is ambiguous. Do not create or modify `Directory.Packages.props`, remove versions for CPM, or capture conversion artifacts. Complete the package work, then recommend CPM as the durable follow-up.
+2. **Package-maintenance mode** -- A request to update, align, bump, or sync packages authorizes those package edits, not CPM conversion. Audit the named scope, resolve the requested versions, update existing project/shared version declarations, and restore/build every affected CLI target from the directory that establishes its applicable `global.json`. Ask only when the version or alignment policy is ambiguous. Do not create or modify `Directory.Packages.props`, remove versions for CPM, or capture conversion artifacts. Complete the package work, then recommend CPM as the durable follow-up.
 3. **Conversion mode** -- Use only when the user explicitly asks to adopt, enable, or convert to CPM. Follow the workflow below.
 
 If the scope is unclear, ask once before proceeding.
@@ -41,7 +41,7 @@ This plan is an efficiency default, not a hard cap. Never omit an in-scope proje
 | Input | Required | Rule |
 |-------|----------|------|
 | Scope | Yes | Project, solution, or directory containing the projects to inspect or convert |
-| Conflict strategy | For conversion with conflicts | If the user already supplied a strategy such as "use the highest version," apply it without asking again and record its impact. Otherwise stop after the audit and ask before editing. |
+| Conflict strategy | For package maintenance or conversion with conflicts | If the user already supplied a strategy such as "use the highest version," apply it without asking again and record its impact. Otherwise stop after the audit and ask before editing. |
 
 ## Read references only when needed
 
@@ -64,12 +64,13 @@ Never preload all references.
 - Determine CPM management scopes separately from CLI targets. Group projects that will share one central version policy and place one `Directory.Packages.props` at each group's first common ancestor, while respecting existing nearest-file boundaries. Multiple CLI targets can share one CPM file; independent project groups can require separate files.
 - Check for `packages.config`; if found, switch to Guard mode and stop.
 - Check the scope and ancestors for `Directory.Packages.props`. If CPM is already fully enabled, report that and stop. If a partial file exists, preserve it and ask only when its intended scope is ambiguous.
-- Run all .NET commands from the resolved scope directory, not from an unrelated parent workspace.
+- Choose one common artifact directory within the resolved scope, normally the targets' first common ancestor. Use explicit paths into it for every binlog, package snapshot, and the report.
+- Run each target's .NET commands from its solution/project directory or another directory that establishes its applicable `global.json`, not from an unrelated parent workspace.
 - Do not inspect unrelated projects or host-tool configuration when the user supplied a scope.
 
 ### 2. Capture the baseline
 
-Read [baseline-comparison.md](references/baseline-comparison.md). From the scope directory, determine the active SDK once and select the documented command syntax from that version. If SDK resolution fails or the SDK cannot process the requested solution format, stop and report the prerequisite; do not alter the host SDK or repository SDK policy unless the user asks.
+Read [baseline-comparison.md](references/baseline-comparison.md). For each target, determine the active SDK once from that target's command directory and select the documented command syntax for that version. If SDK resolution fails or the SDK cannot process the requested solution format, stop and report the prerequisite; do not alter the host SDK or repository SDK policy unless the user asks.
 
 Then use one command batch to:
 
@@ -145,7 +146,7 @@ For multiple targets, replace the four fixed evidence names with unique target-k
 - Batch independent reads and edits when supported.
 - Keep full build logs and package JSON out of the conversation; return compact summaries and artifact paths.
 - Do not repeat successful commands or reread successful output.
-- Do not perform package upgrades, broad outdated/deprecated scans, repeated tests, or unrelated repository exploration. The single conditional vulnerability query and test run defined above are part of complete high-risk conversion validation.
+- In conversion mode, do not perform package upgrades, broad outdated/deprecated scans, repeated tests, or unrelated repository exploration. The single conditional vulnerability query and test run defined above are part of complete high-risk conversion validation. Package maintenance can perform the requested upgrades and one scoped version-discovery query needed to resolve them.
 - Do not install or remove an SDK, create a temporary SDK selector, change roll-forward policy, invoke SDK-internal assemblies, kill unrelated processes, or clean host tooling/temp infrastructure. Report an environment prerequisite and stop.
 
 ## Validation

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -60,7 +60,7 @@ Never preload all references.
 
 ### 1. Scope and preflight
 
-- Resolve the project/solution scope. For a solution, list its projects. For a directory, search only beneath that directory.
+- Resolve the project/solution scope. For a solution, list its projects. For a directory, search only beneath that directory and select one explicit CLI target that covers the resolved scope: use its single `.sln`/`.slnx`, or its single project when no solution exists. If multiple targets exist or no single target covers the scope, ask the user to select one before running .NET commands.
 - Check for `packages.config`; if found, switch to Guard mode and stop.
 - Check the scope and ancestors for `Directory.Packages.props`. If CPM is already fully enabled, report that and stop. If a partial file exists, preserve it and ask only when its intended scope is ambiguous.
 - Run all .NET commands from the resolved scope directory, not from an unrelated parent workspace.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -23,7 +23,7 @@ Centralize package versions in `Directory.Packages.props` while preserving proje
 Do this before running builds or changing files.
 
 1. **Guard mode** -- If any in-scope project uses `packages.config`, stop. Explain that CPM requires `PackageReference` and recommend migrating first. Do not create or modify files.
-2. **Recommendation mode** -- Use when the user asks to update, align, bump, or sync packages but has not explicitly authorized a CPM conversion. Inspect only the named scope, summarize conflicts and complexities, and explain CPM as the durable option for preventing future drift. Present the trade-off between direct alignment and CPM conversion, offer to perform the conversion, and wait for the user's choice. **Do not modify files, run builds, capture conversion artifacts, or continue into the conversion workflow without authorization.**
+2. **Package-maintenance mode** -- A request to update, align, bump, or sync packages authorizes those package edits, not CPM conversion. Audit the named scope, resolve the requested versions, update existing project/shared version declarations, and restore/build every affected CLI target. Ask only when the version or alignment policy is ambiguous. Do not create or modify `Directory.Packages.props`, remove versions for CPM, or capture conversion artifacts. Complete the package work, then recommend CPM as the durable follow-up.
 3. **Conversion mode** -- Use only when the user explicitly asks to adopt, enable, or convert to CPM. Follow the workflow below.
 
 If the scope is unclear, ask once before proceeding.
@@ -31,7 +31,7 @@ If the scope is unclear, ask once before proceeding.
 ### Default execution plan
 
 - **Guard**: use a minimal scoped detection pass, then answer and stop.
-- **Recommendation**: use a compact read-only audit, then answer and stop. Do not read conversion references.
+- **Package maintenance**: use a compact audit, edit only the requested package versions in their existing locations, validate affected targets, then recommend CPM. Do not read conversion references or enter the conversion workflow.
 - **Conversion**: batch the preflight, baseline, audit/mutation, final validation, and report work to avoid redundant turns. Revisit a stage only when new CPM-specific evidence requires a targeted follow-up.
 
 This plan is an efficiency default, not a hard cap. Never omit an in-scope project, imported `.props`/`.targets` file, detected complexity, required validation, or deliverable to save a turn. Batch complete work where practical.
@@ -60,7 +60,8 @@ Never preload all references.
 
 ### 1. Scope and preflight
 
-- Resolve the project/solution scope. For a solution, list its projects. For a directory, search only beneath that directory and select one explicit CLI target that covers the resolved scope: use its single `.sln`/`.slnx`, or its single project when no solution exists. If multiple targets exist or no single target covers the scope, ask the user to select one before running .NET commands.
+- Resolve the project/solution scope. For a solution, list its projects. For a directory, search only beneath that directory and create an explicit target set that covers the full scope: use each applicable `.sln`/`.slnx`, then add each project not covered by a solution. Verify that every in-scope project is covered and avoid duplicate work for projects that occur in more than one target. Ask only when overlapping targets or repository boundaries make the intended coverage ambiguous; never ask the user to select one target when that would omit in-scope projects.
+- Determine CPM management scopes separately from CLI targets. Group projects that will share one central version policy and place one `Directory.Packages.props` at each group's first common ancestor, while respecting existing nearest-file boundaries. Multiple CLI targets can share one CPM file; independent project groups can require separate files.
 - Check for `packages.config`; if found, switch to Guard mode and stop.
 - Check the scope and ancestors for `Directory.Packages.props`. If CPM is already fully enabled, report that and stop. If a partial file exists, preserve it and ask only when its intended scope is ambiguous.
 - Run all .NET commands from the resolved scope directory, not from an unrelated parent workspace.
@@ -72,15 +73,15 @@ Read [baseline-comparison.md](references/baseline-comparison.md). From the scope
 
 Then use one command batch to:
 
-1. Clean, restore, and build the scope, writing `baseline.binlog`.
-2. Write resolved packages to `baseline-packages.json` without restoring again.
+1. Clean, restore, and build every explicit target. Use `baseline.binlog` for one target or a unique `baseline-<target-key>.binlog` for each of multiple targets.
+2. Write resolved packages for every target without restoring again. Use `baseline-packages.json` for one target or a matching `baseline-packages-<target-key>.json` for each of multiple targets.
 3. Keep normal command output concise. Save full output to artifacts when useful; inspect only errors on failure and never read the binlog as text.
 
-If the baseline build fails, stop without modifying files. Preserve both baseline artifacts.
+Finish every baseline before editing. If any baseline build fails, stop without modifying files and preserve all artifacts already produced.
 
 ### 3. Audit with a targeted checklist
 
-Use the baseline snapshot plus one targeted scan of in-scope project, `.props`, and `.targets` files. Identify:
+Use all baseline snapshots plus one targeted scan of in-scope project, `.props`, and `.targets` files. Identify:
 
 - Package IDs, resolved versions, and consuming projects
 - Version conflicts
@@ -97,7 +98,7 @@ Present conflicts and their impact. Explicitly classify major-version alignment 
 
 ### 4. Create CPM files and update references
 
-- Create or update `Directory.Packages.props` at the correct scope with `ManagePackageVersionsCentrally` set to `true`.
+- Create or update each required `Directory.Packages.props` at its computed management scope with `ManagePackageVersionsCentrally` set to `true`.
 - Add one alphabetically sorted `PackageVersion` per package, preserving required target-framework conditions.
 - Remove only `Version` from managed `PackageReference` items in projects and imported files.
 - Preserve conditions, whitespace, and all other metadata such as `PrivateAssets`, `IncludeAssets`, `ExcludeAssets`, `GeneratePathProperty`, and `Aliases`.
@@ -114,8 +115,8 @@ Do not rely on a `$()` reference scan to prove that the XML property definition 
 
 Using [baseline-comparison.md](references/baseline-comparison.md), validate the final on-disk state after all project, shared-file, and property edits. Use one command batch to:
 
-1. Clean, restore, and build the converted scope, writing `after-cpm.binlog`.
-2. Write resolved packages to `after-cpm-packages.json` without restoring again.
+1. Clean, restore, and build every explicit target after all CPM edits. Use `after-cpm.binlog` for one target or a matching `after-cpm-<target-key>.binlog` for each of multiple targets.
+2. Write resolved packages for every target without restoring again. Use `after-cpm-packages.json` for one target or a matching `after-cpm-packages-<target-key>.json` for each of multiple targets.
 3. Produce a compact per-project changes/unchanged comparison without printing or rereading the full JSON files.
 4. If resolved versions changed and the repository exposes a routine, scoped test command for affected projects, run it with `--no-build --no-restore` and record the result. If tests require substantial setup, broad infrastructure, or user approval, recommend the exact scoped command instead. A version-neutral conversion does not require an automatic test run.
 
@@ -125,17 +126,19 @@ If a test run fails after a successful build, inspect only enough output to dete
 
 ### 6. Write the report
 
-Read [report-template.md](references/report-template.md) now, not earlier. Create `convert-to-cpm.md` beside the other artifacts. It must include the six required sections, concrete conflict impacts, the package comparison, risk level, follow-ups, artifact usage, and the name of every shared `.props`/`.targets` file inspected or changed. In the final response, mention those shared files, the risk level, and how any conditional references and target frameworks were preserved. Avoid rewriting the report after validation unless verification finds an omission or incorrect evidence.
+Read [report-template.md](references/report-template.md) now, not earlier. Create `convert-to-cpm.md` beside the other artifacts. It must include the six required sections, every explicit target and CPM management scope, concrete conflict impacts, the aggregate package comparison, risk level, follow-ups, artifact usage, and the name of every shared `.props`/`.targets` file inspected or changed. In the final response, mention those shared files, the risk level, and how any conditional references and target frameworks were preserved. Avoid rewriting the report after validation unless verification finds an omission or incorrect evidence.
 
 ## Required conversion artifacts
 
-Preserve all five deliverables; they are not temporary files:
+Preserve the report and every target's four evidence files; they are not temporary files. For one target, the five deliverables are:
 
 - `baseline.binlog`
 - `after-cpm.binlog`
 - `baseline-packages.json`
 - `after-cpm-packages.json`
 - `convert-to-cpm.md`
+
+For multiple targets, replace the four fixed evidence names with unique target-keyed pairs such as `baseline-api.binlog`, `after-cpm-api.binlog`, `baseline-packages-api.json`, and `after-cpm-packages-api.json`. Keep one aggregate `convert-to-cpm.md`.
 
 ## Efficiency rules
 
@@ -147,10 +150,10 @@ Preserve all five deliverables; they are not temporary files:
 
 ## Validation
 
-- [ ] Baseline and converted builds succeeded and both binlogs exist
+- [ ] Baseline and converted builds succeeded for every explicit target and all target binlogs exist
 - [ ] Every managed `PackageReference` has no `Version`, or intentionally uses `VersionOverride`
 - [ ] Every managed package has the correct central `PackageVersion`
 - [ ] Conditions and non-version metadata were preserved
 - [ ] Before/after package comparison contains no unexplained changes
 - [ ] Inlined version properties have neither remaining `$()` references nor obsolete XML definitions
-- [ ] All five required artifacts exist
+- [ ] The report and all per-target baseline and converted artifacts exist

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/audit-complexities.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/audit-complexities.md
@@ -1,6 +1,6 @@
 # Audit Complexities
 
-When auditing `PackageReference` items across in-scope project files, watch for these complexities and flag them to the user:
+Audit only the resolved scope. Use the baseline package snapshot plus one targeted search across in-scope project, `.props`, and `.targets` files; do not explore unrelated repository files. Read the sections below only for complexities that were actually detected.
 
 ## 1. Version set via MSBuild property
 
@@ -31,7 +31,7 @@ Then present the resolution options with their trade-offs:
 
 Do not upgrade any package beyond the highest version already in use across the scope — this avoids introducing version incompatibilities or breaking changes that are unrelated to the CPM conversion itself. Instead, note any known advisories or upgrade opportunities as follow-up items in the post-conversion report for the user to address after the conversion is complete.
 
-Ask the user to choose for **each** conflict individually. Do not silently pick a strategy. After each decision, briefly restate what will happen: which projects will see a version change, and which will stay the same.
+If the user already supplied a conflict strategy, treat that as the decision and do not ask again. Otherwise ask the user to choose for each conflict and stop before editing. After each decision, record which projects will see a version change and which will stay the same.
 
 - **Major version difference**: Emphasize the risk of breaking API changes. Recommend `VersionOverride` unless the user is prepared to validate all affected projects.
 - **Minor or patch difference**: Prefer the highest version but highlight any security advisories. Note that patch-level alignment is usually safe.
@@ -39,7 +39,12 @@ Ask the user to choose for **each** conflict individually. Do not silently pick 
 
 ## 4. Known security advisories
 
-If a package version is known to have security vulnerabilities (e.g., from nuget.org advisory data or `dotnet package list --vulnerable` output), flag the vulnerable version to the user during the audit. However, do not upgrade any package beyond the highest version already in use across the scope — this avoids introducing version incompatibilities or breaking changes unrelated to the CPM conversion. Instead, record each advisory as a follow-up item in the post-conversion report, including the package name, current version, affected projects, and the minimum patched version.
+If the user requested security information, a known advisory must be verified, or conflict resolution crosses a major package version, prefer one scoped vulnerability query after the baseline restore:
+
+- SDK 10+: `dotnet package list --project <scope> --vulnerable --include-transitive --format json --no-restore`
+- SDK 7.0.200–9.x: `dotnet list <scope> package --vulnerable --include-transitive --format json --no-restore`
+
+Extract only package ID, resolved version, advisory severity/URL, and affected projects into the audit summary. Preserve the full output as an optional artifact if useful, but do not read it repeatedly. Do not also run deprecated or outdated scans by default. Do not upgrade beyond the highest version already in scope; record advisory remediation as a follow-up item instead.
 
 ## 5. Packages without a Version attribute
 

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
@@ -22,7 +22,16 @@ If `dotnet --version` fails, do not try roll-forward overrides, install an SDK, 
 dotnet clean <scope>
 dotnet restore <scope>
 dotnet build <scope> --no-restore -bl:baseline.binlog
+```
+
+Then run exactly one package-list command for the active SDK:
+
+```bash
+# SDK 10 or later
 dotnet package list --project <scope> --format json --include-transitive --no-restore > baseline-packages.json
+
+# SDK 7.0.200 through 9.x
+dotnet list <scope> package --format json --include-transitive --no-restore > baseline-packages.json
 ```
 
 ### Post-conversion (after all changes)
@@ -31,10 +40,19 @@ dotnet package list --project <scope> --format json --include-transitive --no-re
 dotnet clean <scope>
 dotnet restore <scope>
 dotnet build <scope> --no-restore -bl:after-cpm.binlog
-dotnet package list --project <scope> --format json --include-transitive --no-restore > after-cpm-packages.json
 ```
 
-For SDK 9 or earlier, replace each noun-first package-list command above with the legacy form. Do not try both forms after the SDK version has been determined.
+Then run exactly one package-list command for the active SDK:
+
+```bash
+# SDK 10 or later
+dotnet package list --project <scope> --format json --include-transitive --no-restore > after-cpm-packages.json
+
+# SDK 7.0.200 through 9.x
+dotnet list <scope> package --format json --include-transitive --no-restore > after-cpm-packages.json
+```
+
+Do not try both package-list forms after the SDK version has been determined.
 
 Keep normal output small:
 

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
@@ -4,7 +4,14 @@ Verify the CPM conversion is version-neutral by comparing resolved package versi
 
 ## Capturing package lists
 
-Use the same explicit project or solution target for every command. Always build from a clean state first.
+Use the same explicit project or solution targets before and after conversion. A directory scope can require multiple targets to cover all projects. Always build each target from a clean state first.
+
+Create a stable, unique `<target-key>` from each target's relative path when more than one target exists. Use it in that target's artifact names so one target cannot overwrite another:
+
+- One target: `baseline.binlog`, `after-cpm.binlog`, `baseline-packages.json`, and `after-cpm-packages.json`.
+- Multiple targets: `baseline-<target-key>.binlog`, `after-cpm-<target-key>.binlog`, `baseline-packages-<target-key>.json`, and `after-cpm-packages-<target-key>.json`.
+
+Complete the full baseline sequence for every target before editing any file. Complete the full post-conversion sequence for every target after all edits.
 
 Run `dotnet --version` once from the scope directory and select the package-list syntax by SDK version instead of probing with commands that may fail:
 
@@ -16,40 +23,40 @@ Run `dotnet --version` once from the scope directory and select the package-list
 
 If `dotnet --version` fails, do not try roll-forward overrides, install an SDK, create a temporary `global.json`, or invoke SDK assemblies directly. Report the SDK required by the existing `global.json` or project and stop.
 
-### Baseline (before conversion)
+### Baseline for each target (before conversion)
 
 ```bash
 dotnet clean <scope>
 dotnet restore <scope>
-dotnet build <scope> --no-restore -bl:baseline.binlog
+dotnet build <scope> --no-restore -bl:<baseline-binlog>
 ```
 
 Then run exactly one package-list command for the active SDK:
 
 ```bash
 # SDK 10 or later
-dotnet package list --project <scope> --format json --include-transitive --no-restore > baseline-packages.json
+dotnet package list --project <scope> --format json --include-transitive --no-restore > <baseline-packages>
 
 # SDK 7.0.200 through 9.x
-dotnet list <scope> package --format json --include-transitive --no-restore > baseline-packages.json
+dotnet list <scope> package --format json --include-transitive --no-restore > <baseline-packages>
 ```
 
-### Post-conversion (after all changes)
+### Post-conversion for each target (after all changes)
 
 ```bash
 dotnet clean <scope>
 dotnet restore <scope>
-dotnet build <scope> --no-restore -bl:after-cpm.binlog
+dotnet build <scope> --no-restore -bl:<after-binlog>
 ```
 
 Then run exactly one package-list command for the active SDK:
 
 ```bash
 # SDK 10 or later
-dotnet package list --project <scope> --format json --include-transitive --no-restore > after-cpm-packages.json
+dotnet package list --project <scope> --format json --include-transitive --no-restore > <after-packages>
 
 # SDK 7.0.200 through 9.x
-dotnet list <scope> package --format json --include-transitive --no-restore > after-cpm-packages.json
+dotnet list <scope> package --format json --include-transitive --no-restore > <after-packages>
 ```
 
 Do not try both package-list forms after the SDK version has been determined.
@@ -63,7 +70,7 @@ Keep normal output small:
 
 ## Producing the comparison
 
-Compare `baseline-packages.json` and `after-cpm-packages.json` per project. For each project, identify:
+Compare each target's baseline and post-conversion package files, then aggregate results by project. Deduplicate projects that appeared in overlapping targets. For each project, identify:
 
 1. **Version changes**: Packages whose resolved version differs.
 2. **Added packages**: Packages present after conversion but not in the baseline.
@@ -100,8 +107,8 @@ If there are no changes at all, state that the conversion is fully version-neutr
 
 MSBuild binary logs (binlogs) are captured alongside the package list snapshots as supplementary artifacts. Inform the user they are available for manual validation and troubleshooting if needed:
 
-- `baseline.binlog` — Build state before CPM conversion
-- `after-cpm.binlog` — Build state after CPM conversion
+- `baseline.binlog` and `after-cpm.binlog` — Build state before and after a single-target conversion
+- Target-keyed binlog pairs — Build state before and after each target in a multi-target conversion
 
 The user can learn more about MSBuild binary logs from:
 - [Troubleshoot and create logs for MSBuild problems](https://learn.microsoft.com/visualstudio/ide/msbuild-logs?view=visualstudio#provide-msbuild-binary-logs-for-investigation)

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
@@ -4,24 +4,26 @@ Verify the CPM conversion is version-neutral by comparing resolved package versi
 
 ## Capturing package lists
 
-Use the same explicit project or solution targets before and after conversion. A directory scope can require multiple targets to cover all projects. Always build each target from a clean state first.
+Use the same explicit project or solution targets before and after conversion. A directory scope can require multiple targets to cover all projects. Choose one common artifact directory within the resolved scope and use explicit paths into it from every target's command directory. Always build each target from a clean state first.
 
-Create a stable, unique `<target-key>` from each target's relative path when more than one target exists. Use it in that target's artifact names so one target cannot overwrite another:
+Create a stable, unique `<target-key>` from each target's path relative to the common artifact directory when more than one target exists. Use it in that target's artifact names so one target cannot overwrite another:
 
 - One target: `baseline.binlog`, `after-cpm.binlog`, `baseline-packages.json`, and `after-cpm-packages.json`.
 - Multiple targets: `baseline-<target-key>.binlog`, `after-cpm-<target-key>.binlog`, `baseline-packages-<target-key>.json`, and `after-cpm-packages-<target-key>.json`.
 
 Complete the full baseline sequence for every target before editing any file. Complete the full post-conversion sequence for every target after all edits.
 
-Run `dotnet --version` once from the scope directory and select the package-list syntax by SDK version instead of probing with commands that may fail:
+Run `dotnet --version` once from each target's command directory and select that target's package-list syntax by SDK version instead of probing with commands that may fail:
 
-- SDK 10 or later: use `dotnet package list --project <scope> --format json --no-restore`.
-- SDK 7.0.200 through 9.x: use `dotnet list <scope> package --format json --no-restore`.
+- SDK 10 or later: use `dotnet package list --project <scope> --format json --include-transitive --no-restore`.
+- SDK 7.0.200 through 9.x: use `dotnet list <scope> package --format json --include-transitive --no-restore`.
 - SDK older than 7.0.200 cannot produce the required JSON snapshots; stop and report that SDK 7.0.200 or later is required for this workflow.
 - For a single project when the working directory contains exactly that project, the target may be omitted.
 - A `.slnx` scope requires SDK 9.0.201 or later so build, restore, and package-list operations all support the format. If it is unsupported, stop and report the prerequisite.
 
 If `dotnet --version` fails, do not try roll-forward overrides, install an SDK, create a temporary `global.json`, or invoke SDK assemblies directly. Report the SDK required by the existing `global.json` or project and stop.
+
+Set `<baseline-binlog>`, `<after-binlog>`, `<baseline-packages>`, and `<after-packages>` below to explicit paths in the common artifact directory, using the target-keyed names when applicable.
 
 ### Baseline for each target (before conversion)
 

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/baseline-comparison.md
@@ -4,31 +4,44 @@ Verify the CPM conversion is version-neutral by comparing resolved package versi
 
 ## Capturing package lists
 
-Use `dotnet package list` to snapshot resolved versions. Always build from a clean state first to ensure accurate resolution.
+Use the same explicit project or solution target for every command. Always build from a clean state first.
+
+Run `dotnet --version` once from the scope directory and select the package-list syntax by SDK version instead of probing with commands that may fail:
+
+- SDK 10 or later: use `dotnet package list --project <scope> --format json --no-restore`.
+- SDK 7.0.200 through 9.x: use `dotnet list <scope> package --format json --no-restore`.
+- SDK older than 7.0.200 cannot produce the required JSON snapshots; stop and report that SDK 7.0.200 or later is required for this workflow.
+- For a single project when the working directory contains exactly that project, the target may be omitted.
+- A `.slnx` scope requires SDK 9.0.201 or later so build, restore, and package-list operations all support the format. If it is unsupported, stop and report the prerequisite.
+
+If `dotnet --version` fails, do not try roll-forward overrides, install an SDK, create a temporary `global.json`, or invoke SDK assemblies directly. Report the SDK required by the existing `global.json` or project and stop.
 
 ### Baseline (before conversion)
 
 ```bash
-dotnet clean
-dotnet build -bl:baseline.binlog
-dotnet package list --format json > baseline-packages.json
+dotnet clean <scope>
+dotnet restore <scope>
+dotnet build <scope> --no-restore -bl:baseline.binlog
+dotnet package list --project <scope> --format json --include-transitive --no-restore > baseline-packages.json
 ```
 
 ### Post-conversion (after all changes)
 
 ```bash
-dotnet clean
-dotnet build -bl:after-cpm.binlog
-dotnet package list --format json > after-cpm-packages.json
+dotnet clean <scope>
+dotnet restore <scope>
+dotnet build <scope> --no-restore -bl:after-cpm.binlog
+dotnet package list --project <scope> --format json --include-transitive --no-restore > after-cpm-packages.json
 ```
 
-If `--format json` is not available (requires .NET 8 SDK+), use the default tabular output:
+For SDK 9 or earlier, replace each noun-first package-list command above with the legacy form. Do not try both forms after the SDK version has been determined.
 
-```bash
-dotnet package list > baseline-packages.txt
-```
+Keep normal output small:
 
-For solution-scoped conversions, pass the solution file to all commands.
+- Redirect routine build output to a log or suppress it. On success, report only status and artifact paths.
+- On failure, inspect the relevant error lines or a short tail rather than loading the full build output.
+- Never read a binlog as text.
+- Preserve package JSON, but use a JSON parser to extract only project path, framework, package ID, requested version, and resolved version. Do not print or read the raw JSON when a compact extraction is available.
 
 ## Producing the comparison
 
@@ -49,9 +62,9 @@ Present changes and unchanged packages in separate tables. The **Changes** table
 ```
 | Project | Package | Before | After | Status |
 |---------|---------|--------|-------|--------|
-| Legacy.csproj | System.Text.Json | 8.0.4 | 9.0.0 | Aligned to highest version |
-| Core.csproj | System.Text.Json | 9.0.0 | 9.0.0 | VersionOverride |
-| Shared.csproj | Azure.Identity | 1.10.0 | 1.10.0 | VersionOverride |
+| ProjectA.csproj | PackageA | 1.0.0 | 2.0.0 | Aligned to highest version |
+| ProjectB.csproj | PackageA | 1.0.0 | 1.0.0 | VersionOverride |
+| ProjectC.csproj | PackageB | — | 3.1.0 | Added |
 ```
 
 **Unchanged:**
@@ -59,10 +72,8 @@ Present changes and unchanged packages in separate tables. The **Changes** table
 ```
 | Project | Package | Version |
 |---------|---------|---------|
-| Api.csproj | System.Text.Json | 10.0.1 |
-| Api.csproj | Azure.Storage.Blobs | 12.24.0 |
-| Web.csproj | OpenTelemetry.Extensions.Hosting | 1.15.0 |
-| Tests.csproj | xunit | 2.9.3 |
+| ProjectA.csproj | PackageB | 3.1.0 |
+| ProjectB.csproj | PackageC | 4.2.0 |
 ```
 
 If there are no changes at all, state that the conversion is fully version-neutral and present only the unchanged table.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
@@ -3,7 +3,7 @@
 ## Placement
 
 - **Repository scope**: First group projects by the central version policy they must share. If all in-scope projects share one policy, place one file at their first common ancestor. If independent solutions or existing nearest-file boundaries require separate policies, place one file at each group's first common ancestor. This may produce one or more files, and none must be at the repository root.
-- **Solution scope**: Place in the solution directory.
+- **Solution scope**: Place at the first common ancestor of all governed projects, while respecting existing nearest-file boundaries. This is the solution directory only when it is an ancestor of every governed project.
 - **Single project scope**: Default to the project directory. If the project is inside a repository with other projects that may be converted later, ask the user where to place it.
 
 Only the nearest `Directory.Packages.props` is evaluated per project. CPM also supports `Directory.Packages.props` in sub-folders — for example, test projects may have different dependencies than source code and can use a separate `Directory.Packages.props` in their sub-folder. A `Directory.Packages.props` in a sub-folder does not implicitly override or extend a parent file; it is independent and replaces the parent for projects in that folder. To share settings, explicitly chain files using MSBuild `<Import>` elements. See [Central Package Management rules](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/consume-packages/Central-Package-Management.md#central-package-management-rules) for how NuGet resolves which file applies. When in doubt about placement, ask the user.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
@@ -10,13 +10,7 @@ Only the nearest `Directory.Packages.props` is evaluated per project. CPM also s
 
 ## Creating the file
 
-Use the .NET CLI (available in .NET 8+):
-
-```bash
-dotnet new packagesprops
-```
-
-This generates a `Directory.Packages.props` with `ManagePackageVersionsCentrally` set to `true`. If the CLI template is not available, create the file manually:
+Create the file directly so the workflow does not depend on whether the installed SDK includes the `packagesprops` template:
 
 ```xml
 <Project>
@@ -34,8 +28,8 @@ This generates a `Directory.Packages.props` with `ManagePackageVersionsCentrally
 Add a `<PackageVersion>` entry for each unique package, using the resolved version from the audit. Sort entries alphabetically by package ID:
 
 ```xml
-<PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-<PackageVersion Include="System.Text.Json" Version="10.0.1" />
+<PackageVersion Include="PackageA" Version="1.2.3" />
+<PackageVersion Include="PackageB" Version="4.5.6" />
 ```
 
 ## Conditional versions
@@ -47,7 +41,7 @@ If the same package needs different versions for different target frameworks, us
 <PackageVersion Include="PackageA" Version="2.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 ```
 
-Ask the user before using conditional versions — it may be preferable to standardize on a single version.
+Preserve an existing target-framework-specific version split when a single version is incompatible. Ask only when multiple valid policies remain and the user has not already supplied a strategy. Record the preserved condition in the report.
 
 ## VersionOverride
 
@@ -57,4 +51,4 @@ If a project intentionally needs a different version than the centrally defined 
 <PackageReference Include="System.Text.Json" VersionOverride="9.0.0" />
 ```
 
-Ask the user before applying `VersionOverride` — in most cases, version alignment is preferred.
+Apply `VersionOverride` only when the user's chosen strategy requires it. If no strategy was supplied, ask before applying it; in most cases, version alignment is preferred.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/directory-packages-props.md
@@ -2,11 +2,13 @@
 
 ## Placement
 
-- **Repository scope**: Place at the first common ancestor directory of all in-scope .NET projects. This may not be the repository root — many repos nest source code under `src/` or similar directories.
+- **Repository scope**: First group projects by the central version policy they must share. If all in-scope projects share one policy, place one file at their first common ancestor. If independent solutions or existing nearest-file boundaries require separate policies, place one file at each group's first common ancestor. This may produce one or more files, and none must be at the repository root.
 - **Solution scope**: Place in the solution directory.
 - **Single project scope**: Default to the project directory. If the project is inside a repository with other projects that may be converted later, ask the user where to place it.
 
 Only the nearest `Directory.Packages.props` is evaluated per project. CPM also supports `Directory.Packages.props` in sub-folders — for example, test projects may have different dependencies than source code and can use a separate `Directory.Packages.props` in their sub-folder. A `Directory.Packages.props` in a sub-folder does not implicitly override or extend a parent file; it is independent and replaces the parent for projects in that folder. To share settings, explicitly chain files using MSBuild `<Import>` elements. See [Central Package Management rules](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/consume-packages/Central-Package-Management.md#central-package-management-rules) for how NuGet resolves which file applies. When in doubt about placement, ask the user.
+
+CLI targets and CPM management scopes are different concepts. Multiple solution or project targets can use one common `Directory.Packages.props`, while one repository conversion can require separate files for independent project groups. Compute placement from the projects that share policy, not from the number or location of solution files.
 
 ## Creating the file
 

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/msbuild-property-handling.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/msbuild-property-handling.md
@@ -1,6 +1,6 @@
 # MSBuild Property Handling
 
-This covers how to handle MSBuild properties that define package versions (e.g., `Version="$(DIVersion)"` or `Version="$(BlobsVersion)"`) during CPM conversion.
+This covers how to handle MSBuild properties that define package versions (for example, `Version="$(PackageVersionProperty)"`) during CPM conversion.
 
 ## Import order guidance
 
@@ -28,7 +28,7 @@ If it appears only in `PackageReference` version attributes, it is safe to remov
 
 If the property is defined in a file within scope (e.g., `Directory.Build.props`), ask the user whether to:
 
-- **Inline**: Replace the property usage with a literal version in `Directory.Packages.props` and remove the property definition (deferred to step 9)
+- **Inline**: Replace the property usage with a literal version in `Directory.Packages.props` and remove the property definition before final validation, after verifying no references remain
 - **Keep**: Reference the property from `Directory.Packages.props` (e.g., `<PackageVersion Include="PackageA" Version="$(PackageAVersion)" />`)
 
 ### 1.3. Property used for other purposes
@@ -37,15 +37,17 @@ If the property is used beyond package versioning, do not remove it. Use the pro
 
 ### 1.4. Property defined outside scope
 
-If the property is defined outside the conversion scope (e.g., in parent repository build infrastructure), flag it to the user and skip that package. Add a comment in `Directory.Packages.props`:
+If the property is defined outside the conversion scope (e.g., in parent repository build infrastructure), stop before editing that package. Ask the user to choose one safe option:
 
-```xml
-<!-- PackageA: version managed externally via $(PackageAVersion) in [file path] -->
-```
+1. Expand the conversion scope to include the defining file.
+2. Use the resolved literal value in `Directory.Packages.props` and leave the external property unchanged.
+3. Keep the property reference in `Directory.Packages.props` only after confirming its definition is evaluated before that file.
+
+Do not skip the central `PackageVersion` and continue: after CPM is enabled that would leave the project with either `NU1008` or `NU1010`.
 
 ## Part 2: Clean up obsolete properties
 
-After restore and build succeed (step 8), remove property definitions that the user chose to inline. Before removing any property, verify it has zero remaining references outside its own definition:
+After updating all package references and before the final restore/build, remove property definitions that the user chose to inline. Match the XML element structurally rather than depending on a particular newline style. Before removing any property, verify it has zero remaining references outside its own definition:
 
 ```bash
 # Unix/macOS
@@ -55,4 +57,9 @@ grep -r '$(PropertyName)' --include='*.csproj' --include='*.props' --include='*.
 Get-ChildItem -Recurse -Include *.csproj,*.props,*.targets | Select-String '$(PropertyName)'
 ```
 
-Only remove a property if it has zero remaining references outside its own definition. Preserve all non-versioning properties in the same file (e.g., `OutputPath`, `LangVersion`).
+Only remove a property if it has zero remaining references outside its own definition. Preserve all non-versioning properties in the same file (e.g., `OutputPath`, `LangVersion`). Then run two distinct checks:
+
+- Search for `$(PropertyName)` to confirm no uses remain.
+- Search for the XML element name (for example, `<PropertyName>`) to confirm the obsolete definition itself is gone.
+
+Both checks must pass before final validation.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
@@ -1,0 +1,76 @@
+# CPM Conversion Report
+
+Create `convert-to-cpm.md` beside the baseline and converted artifacts. The report must be self-contained and suitable for a pull request or team review. Use compact evidence extracted from the package snapshots; do not load raw JSON again solely to write prose.
+
+## 1. Conversion overview
+
+Include:
+
+- Scope and projects converted
+- Number of unique packages centralized
+- Projects or packages skipped, with reasons
+- MSBuild version properties inlined, retained, or removed
+- Every shared `.props`/`.targets` file inspected or changed, named explicitly (for example, `SharedPackages.props`)
+- Conditional references preserved
+
+## 2. Version conflict resolutions
+
+For every conflict, provide:
+
+| Package | Versions and projects | Decision | Impact |
+|---------|-----------------------|----------|--------|
+
+State which projects resolve a different version after conversion. If no conflicts existed, say that versions were already consistent.
+
+## 3. Package comparison: baseline vs. result
+
+Use `baseline-packages.json` and `after-cpm-packages.json` to produce two tables.
+
+**Changes**
+
+| Project | Framework | Package | Before | After | Reason |
+|---------|-----------|---------|--------|-------|--------|
+
+Include changed versions, added/removed packages, and `VersionOverride` decisions. If no entries changed, state that the conversion is version-neutral.
+
+**Unchanged**
+
+| Project | Framework | Package | Version |
+|---------|-----------|---------|---------|
+
+List unchanged top-level packages compactly without repeating explanatory prose for each row.
+
+## 4. Risk assessment
+
+Choose one level and explain the evidence:
+
+- **Low risk** -- Version-neutral conversion; restore/build succeeded.
+- **Moderate risk** -- Intentional patch/minor alignment or limited overrides; name affected projects.
+- **High risk** -- Major version changes, unexpected additions/removals, or unresolved validation concerns.
+
+Call out `VersionOverride`, removed MSBuild properties, conditional-version changes, and unexplained package differences. Recommend `dotnet test` when it was not run; claim it ran only when the user requested it or the workflow's resolved-version-change rule actually ran it.
+
+Treat intentional major-version alignment as high risk and minor/patch alignment as moderate risk unless stronger project-specific evidence supports another classification. This warning does not require an additional package scan.
+
+If resolved versions changed and tests were run, state the exact test result. If tests failed for a reason not clearly caused by CPM, preserve that distinction and list the failure as follow-up work rather than claiming conversion failure.
+
+## 5. Follow-up items
+
+Use a numbered checklist for applicable items only:
+
+- Security advisories and minimum patched versions
+- Deprecated package replacements
+- Future alignment where `VersionOverride` preserved differences
+- Test validation and release-note review
+
+These are follow-ups, not additional work to perform during the CPM conversion.
+
+## 6. Artifacts and usage
+
+List:
+
+- `baseline.binlog` and `after-cpm.binlog` for manual MSBuild comparison and troubleshooting
+- `baseline-packages.json` and `after-cpm-packages.json` for machine-readable resolved-package comparison
+- `convert-to-cpm.md` as the shareable conversion record
+
+End with any user action required before merge.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
@@ -7,6 +7,8 @@ Create `convert-to-cpm.md` beside the baseline and converted artifacts. The repo
 Include:
 
 - Scope and projects converted
+- Every explicit project or solution CLI target used for baseline and validation
+- Each `Directory.Packages.props` path and the projects governed by that management scope
 - Number of unique packages centralized
 - Projects or packages skipped, with reasons
 - MSBuild version properties inlined, retained, or removed
@@ -24,7 +26,7 @@ State which projects resolve a different version after conversion. If no conflic
 
 ## 3. Package comparison: baseline vs. result
 
-Use `baseline-packages.json` and `after-cpm-packages.json` to produce two tables.
+Use every target's baseline and post-conversion package snapshots to produce two aggregate tables. Deduplicate projects that occur in overlapping targets.
 
 **Changes**
 
@@ -69,8 +71,8 @@ These are follow-ups, not additional work to perform during the CPM conversion.
 
 List:
 
-- `baseline.binlog` and `after-cpm.binlog` for manual MSBuild comparison and troubleshooting
-- `baseline-packages.json` and `after-cpm-packages.json` for machine-readable resolved-package comparison
+- The single-target or target-keyed baseline and post-conversion binlog pairs for manual MSBuild comparison and troubleshooting
+- The single-target or target-keyed baseline and post-conversion package JSON pairs for machine-readable resolved-package comparison
 - `convert-to-cpm.md` as the shareable conversion record
 
 End with any user action required before merge.

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/report-template.md
@@ -1,6 +1,6 @@
 # CPM Conversion Report
 
-Create `convert-to-cpm.md` beside the baseline and converted artifacts. The report must be self-contained and suitable for a pull request or team review. Use compact evidence extracted from the package snapshots; do not load raw JSON again solely to write prose.
+Create `convert-to-cpm.md` with the baseline and converted artifacts in their common artifact directory. The report must be self-contained and suitable for a pull request or team review. Use compact evidence extracted from the package snapshots; do not load raw JSON again solely to write prose.
 
 ## 1. Conversion overview
 

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/references/validation-and-errors.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/references/validation-and-errors.md
@@ -1,13 +1,8 @@
 # Validation and Common Errors
 
-## Restore validation
+## Diagnose a failed validation batch
 
-Always validate from a clean state to ensure full package resolution, not incremental cache:
-
-```bash
-dotnet clean
-dotnet restore
-```
+The main workflow already ran clean, restore, and build. Do not repeat them merely to diagnose the same failure. First inspect the relevant error lines and determine whether the failure is caused by CPM edits.
 
 For multi-target framework projects (those with `<TargetFrameworks>` containing multiple TFMs), verify restore works for each framework. If restoration errors are framework-specific, the solution may require conditional `<PackageVersion>` entries or `VersionOverride` for specific projects.
 
@@ -19,13 +14,13 @@ For multi-target framework projects (those with `<TargetFrameworks>` containing 
 | **NU1010** | A `PackageReference` has no corresponding `PackageVersion` entry | Add the missing `<PackageVersion>` entry to `Directory.Packages.props` |
 | **NU1507** | Multiple package sources without package source mapping | Configure [package source mapping](https://learn.microsoft.com/nuget/consume-packages/package-source-mapping) |
 
-## Build validation
+Keep full build output out of the conversation. On success, report a concise status. On failure, inspect only the relevant error lines or a short tail before making a targeted correction.
 
-If `dotnet restore` succeeds, also run `dotnet build` to verify:
+Only after one CPM-specific correction should you rerun the failed final validation batch from the main workflow. Do not start a separate open-ended validation sequence.
 
-```bash
-dotnet build
-```
+Do not run tests for a version-neutral conversion unless the user explicitly requested them. When the main workflow runs one scoped test pass because resolved versions changed, treat a failure separately unless the evidence clearly ties it to CPM package resolution; avoid unrelated dependency or test-host debugging.
+
+Only CPM-related restore/build errors justify an automatic correction and retry. Do not install SDKs, change `global.json` or roll-forward policy, invoke SDK-internal DLLs, kill processes, or debug file locks/package sources as part of this skill. Report those environmental blockers with the failed command and required user action.
 
 ## Common pitfalls
 

--- a/tests/dotnet-nuget/convert-to-cpm/eval.yaml
+++ b/tests/dotnet-nuget/convert-to-cpm/eval.yaml
@@ -29,9 +29,10 @@ stimuli:
     constraints:
       reject_skills:
         - "*"
-  - name: Recommend CPM when updating packages with version conflicts
+  - name: Align packages directly and recommend CPM
     prompt: The System.Text.Json and Azure.Identity packages have gotten out of sync across projects in
-      moderate-version-conflicts/Inventory.slnx. Can you align them to the latest versions?
+      moderate-version-conflicts/Inventory.slnx. Align each package to the highest version already used in the solution,
+      but do not convert the solution to CPM.
     environment:
       files:
         - src: .
@@ -43,15 +44,25 @@ stimuli:
       - type: output-matches
         config:
           pattern: (conflict|mismatch|different version|out of sync)
+      - type: file-not-exists
+        config:
+          path: moderate-version-conflicts/Directory.Packages.props
+      - type: file-contains
+        config:
+          path: moderate-version-conflicts/Shared/Shared.csproj
+          value: 1.13.2
+      - type: file-contains
+        config:
+          path: moderate-version-conflicts/Worker/Worker.csproj
+          value: 10.0.1
       - type: prompt
     rubric:
-      - Identified the version conflicts across projects before attempting any changes
-      - Strongly recommended adopting Central Package Management to prevent versions from drifting apart again in the
-        future
-      - Explained that without CPM, manually aligning versions across projects is error-prone and the same drift will
-        likely recur
-      - Offered to perform the CPM conversion as part of resolving the version alignment request
-  - name: Recommend CPM when updating packages in a complex repository
+      - Identified the version conflicts and directly aligned System.Text.Json and Azure.Identity to the highest versions
+        already present
+      - Preserved per-project PackageReference version management and did not create Directory.Packages.props
+      - Restored and built the affected solution after the direct package changes
+      - Recommended Central Package Management as a separate durable follow-up after completing the authorized alignment
+  - name: Update complex package layout and recommend CPM
     prompt: I need to update and align NuGet package versions across the advanced-multi-complexity/Enterprise.slnx solution.
       Package versions have drifted out of sync — some are defined as MSBuild properties, some are conditional for
       multi-targeting, and there's a shared Common.props. Can you bump everything to the latest and get them consistent?
@@ -66,6 +77,9 @@ stimuli:
       - type: output-matches
         config:
           pattern: (BlobsVersion|HostingVersion|Common\.props)
+      - type: file-not-exists
+        config:
+          path: advanced-multi-complexity/Directory.Packages.props
       - type: prompt
     rubric:
       - "Audited the repository complexity: MSBuild property-based versions, conditional references, shared props files,
@@ -74,8 +88,8 @@ stimuli:
         manual package updates across scattered version definitions are high-risk and unsustainable
       - Explained that CPM would consolidate the MSBuild properties, conditional versions, and shared props references
         into a single governed file, greatly reducing the risk of version drift and update errors
-      - Offered to perform the full CPM conversion rather than making piecemeal version updates that would leave the
-        underlying governance problem unresolved
+      - Completed the requested direct package updates without creating Directory.Packages.props, then recommended a full
+        CPM conversion as separate follow-up work
   - name: Convert single project to CPM
     prompt: Convert my project at simple-single-project/MyApp/MyApp.csproj to use Central Package Management.
     environment:
@@ -134,6 +148,33 @@ stimuli:
         validation and troubleshooting
       - Offered reassurance when the conversion is straightforward, or warned about potential risks from version changes
         that could cause unintended consequences
+  - name: Convert repository with multiple independent targets
+    prompt: Convert the full multi-target-repository directory to Central Package Management. It contains independent
+      projects with no solution that covers both. Use one common central package policy for the full directory.
+    environment:
+      files:
+        - src: .
+          dest: .
+    graders:
+      - type: file-contains
+        config:
+          path: multi-target-repository/Directory.Packages.props
+          value: ManagePackageVersionsCentrally
+      - type: file-not-contains
+        config:
+          path: multi-target-repository/apps/App/App.csproj
+          value: Version=
+      - type: file-not-contains
+        config:
+          path: multi-target-repository/tools/Tool/Tool.csproj
+          value: Version=
+      - type: prompt
+    rubric:
+      - Selected both independent projects as explicit CLI targets instead of asking the user to choose only one
+      - Captured a separate baseline build, binlog, and package snapshot for each project before making changes
+      - Created one Directory.Packages.props at the requested common repository scope and centralized both package versions
+      - Validated both independent projects after conversion and preserved separate target-keyed evidence artifacts
+      - Produced one aggregate conversion report that maps both targets to the common CPM management scope
   - name: Convert solution with MSBuild property versions to CPM
     prompt: Convert moderate-msbuild-properties/Platform.sln to Central Package Management. The package versions are
       currently defined as MSBuild properties in Directory.Build.props. Inline the resolved values into

--- a/tests/dotnet-nuget/convert-to-cpm/eval.yaml
+++ b/tests/dotnet-nuget/convert-to-cpm/eval.yaml
@@ -171,9 +171,11 @@ stimuli:
       - type: prompt
     rubric:
       - Selected both independent projects as explicit CLI targets instead of asking the user to choose only one
+      - Ran each target from its own project directory or other directory that establishes its applicable SDK context
       - Captured a separate baseline build, binlog, and package snapshot for each project before making changes
       - Created one Directory.Packages.props at the requested common repository scope and centralized both package versions
       - Validated both independent projects after conversion and preserved separate target-keyed evidence artifacts
+      - Stored every target-keyed evidence artifact and one aggregate conversion report in a common artifact directory
       - Produced one aggregate conversion report that maps both targets to the common CPM management scope
   - name: Convert solution with MSBuild property versions to CPM
     prompt: Convert moderate-msbuild-properties/Platform.sln to Central Package Management. The package versions are

--- a/tests/dotnet-nuget/convert-to-cpm/multi-target-repository/apps/App/App.csproj
+++ b/tests/dotnet-nuget/convert-to-cpm/multi-target-repository/apps/App/App.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-nuget/convert-to-cpm/multi-target-repository/tools/Tool/Tool.csproj
+++ b/tests/dotnet-nuget/convert-to-cpm/multi-target-repository/tools/Tool/Tool.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- split `convert-to-cpm` into guard, recommendation, and authorized conversion paths so package-alignment requests do not accidentally trigger a full migration
- use progressive disclosure for detailed references and keep full logs/package JSON out of the conversation
- preserve the original high-assurance conversion workflow: baseline/final builds, binlogs, package snapshots, conflict handling, conditional references, property cleanup, risk assessment, and conversion report
- bound retries and unrelated environment/test-host debugging while allowing targeted CPM-specific follow-up work
- generalize examples and remove evaluation-environment terminology from the production skill

## Motivation and original cross-family result

The cross-family evaluation in [#897](https://github.com/dotnet/skills/issues/897) ran the original skill across five executor families: Opus 4.8, GPT-5.5, Sonnet 4.6, Haiku 4.5, and MAI Flash, with a different judge family from the executor.

| Families passed | Impact | Activation | Errors | Mean token delta | Mean turn delta | Mean tool delta |
|---:|---:|---:|---:|---:|---:|---:|
| 5/5 | 0.875 | 100% | 0 | +253,199 | +7.58 | +9.32 |

The skill's value was broad and real, but its cost was not justified. Trajectory investigation found that the largest avoidable costs came from recommendation requests entering the full conversion workflow, eager reference reads, command retries, full-output reads, and open-ended test/environment debugging.

This change treats original capability as a hard constraint and reduces redundant orchestration rather than deleting validation deliverables.

## Versions compared

- **Original:** pre-change skill at `b2cf93c1c210eb1902ccf4a20bf5d8099000af49`
- **Proposed:** this PR at `650e920d500457b96c85bb602fcf8ab45276fb0a`

These names intentionally describe the before/after revisions; the production skill does not introduce a public version number.

## PR CI: Proposed vs no-skill

The scoped `/evaluate` run for this PR ([run 30313979542](https://github.com/dotnet/skills/actions/runs/30313979542)) reports:

| Preference | W/T/L | Proposed quality | No-skill quality | Activation | Errors |
|---:|---:|---:|---:|---:|
| +100% [100%, 100%] | 8/0/0 | 4.8/5 | 3.2/5 | 8/8 | 0 |

This confirms that the proposed skill still adds substantial value over no skill on all eight scenarios.

## Same-environment A/B: Original vs Proposed

To isolate this PR's behavioral change, both revisions were then run with identical settings:

- Windows host and current eval/fixtures
- GPT-5.5 executor
- Claude Opus 4.8 comparison judge, with position swapping
- Vally 0.10.0
- 8 scenarios, one run per revision per scenario
- 16/16 agent runs succeeded; 0 runtime errors; skill activation 16/16

### Headline

| Metric | Original | Proposed | Delta |
|---|---:|---:|---:|
| Pairwise preference | — | **4 wins / 4 ties / 0 losses** | mean **+20.0%**, 95% CI **+2.1% to +37.9%** |
| Absolute grader mean | 84.0 | **87.1** | +3.1 pp |
| Prompt quality, 1–5 | 4.12 | **4.50** | +0.38 |
| Eval pass | 5/8 | **6/8** | +1 |
| Deterministic graders | 22/25 | 22/25 | unchanged |
| Total tokens | 4,903,442 | **2,558,913** | **-47.8%** |
| Uncached input + output | 394,258 | **340,417** | **-13.7%** |
| Turns | 178 | **114** | **-36.0%** |
| Tool calls | 300 | **194** | **-35.3%** |
| Aggregate wall time | 1,963.5s | **1,306.4s** | **-33.5%** |
| Runtime errors | 0 | 0 | unchanged |

`Total tokens` includes cache-read tokens. `Uncached input + output` is included separately so the improvement is not overstated by cache behavior.

### Per scenario

| Scenario | Pairwise result | Quality Original → Proposed | Tokens Original → Proposed | Token delta | Turns | Tools |
|---|---|---:|---:|---:|---:|---:|
| Guard: decline `packages.config` conversion | Tie | 100 → 100 | 108.6k → 38.9k | **-64.2%** | 7 → 3 | 10 → 4 |
| Recommend: version conflicts | Tie | 75 → **100** | 558.2k → 103.8k | **-81.4%** | 21 → 7 | 33 → 20 |
| Recommend: complex repository | **Proposed win** | 91.7 → **100** | 2.127M → 103.9k | **-95.1%** | 54 → 7 | 81 → 16 |
| Convert: single project | **Proposed win** | 33.3 → 33.3* | 238.3k → 334.9k | +40.6% | 13 → 16 | 25 → 22 |
| Convert: multi-project solution | Tie | 100 → 91.7 | 433.6k → 500.1k | +15.3% | 21 → 22 | 38 → 29 |
| Convert: MSBuild property versions | **Proposed win** | 95 → 95 | 320.9k → 411.2k | +28.2% | 17 → 18 | 26 → 25 |
| Convert: version conflicts | **Proposed win** | 95 → 95 | 566.1k → 484.4k | **-14.4%** | 23 → 20 | 41 → 34 |
| Convert: complex repository | Tie | 82.1 → 82.1* | 550.8k → 581.6k | +5.6% | 22 → 21 | 46 → 44 |

### By execution mode

| Mode | Pairwise | Total tokens | Uncached input + output | Turns | Tools | Absolute quality |
|---|---:|---:|---:|---:|---:|---:|
| Guard | 0W / 1T / 0L | **-64.2%** | -35.9% | -57.1% | -60.0% | 100 → 100 |
| Recommendation | 1W / 1T / 0L | **-92.3%** | **-77.3%** | **-81.3%** | **-68.4%** | 83.4 → **100** |
| Conversion | 3W / 2T / 0L | +9.6% | +30.5% | +1.0% | **-12.5%** | 81.1 → 79.4 |

### Interpretation

- The primary issue is fixed: recommendation requests no longer trigger an unauthorized full conversion. This accounts for most of the overall savings while improving recommendation quality.
- Conversion capability is preserved: the proposed revision had 3 pairwise wins, 2 ties, and 0 losses on conversion scenarios. The MSBuild-property and conflict scenarios were both preferred; the most complex conversion tied.
- Conversion cost is not yet uniformly lower. Tool calls decreased by 12.5%, but total tokens increased by 9.6% and uncached input + output by 30.5% across the five conversion scenarios. Follow-up optimization should target accumulated context, report generation, and command payloads without removing validation artifacts.
- This A/B is strong directional evidence, not a cross-family repeated estimate: it is one GPT-5.5 run per scenario. A repeated Original-vs-Proposed cross-family run remains pending.

## Known eval oracle drift

The asterisked quality values are shared eval false negatives, not a regression introduced by this PR:

- The single-project grader expects `simple-single-project/Directory.Packages.props`, while both revisions correctly place the file beside the explicitly scoped project at `simple-single-project/MyApp/Directory.Packages.props`. Both receive 0/2 deterministic checks despite a 5/5 prompt score and a successful conversion.
- The complex-conversion output regex misses the preserved conditional references in both revisions. Both receive 5/6 deterministic checks despite handling the conditional `PackageReference` correctly.

This PR intentionally does not change the eval definitions. Those assertions should be repaired separately so skill behavior and oracle changes remain independently reviewable.

## Validation

- `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin plugins/dotnet-nuget --allowed-external-deps eng/allowed-external-deps.txt --known-domains eng/known-domains.txt`
- reference scan: 7 files, 0 errors
- `git diff --check origin/main...HEAD`

Addresses #897
