### PR TITLE
[dummy] Validate hardened /evaluate gates (do not merge)

### DIFF
--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -167,3 +167,4 @@ Recommend the user run `dotnet test` to validate runtime behavior beyond build s
 
 - [Central Package Management documentation](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/consume-packages/Central-Package-Management.md)
 - [Validation and common errors](references/validation-and-errors.md)
+

--- a/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
+++ b/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md
@@ -16,7 +16,7 @@ license: MIT
 
 # Convert to Central Package Management
 
-Migrate .NET projects from per-project package versioning to NuGet Central Package Management (CPM). CPM centralizes all package versions into a single `Directory.Packages.props` file, making version governance and upgrades easier across multi-project repositories.
+Migrate .NET projects from per-project package versioning to NuGet Central Package Management (CPM). CPM centralizes all package versions into a single `Directory.Packages.props` file, which makes version governance and upgrades easier across multi-project repositories.
 
 ## When to Use
 


### PR DESCRIPTION
**Throwaway PR — do not merge.**

Purpose: validate the hardened valuation.yml gates that could only be exercised after #956 merged to `main` (the comment / review / label entry points load their workflow YAML from the default branch).

Contains a single trivial wording tweak to the `convert-to-cpm` skill so there is a changed skill for the pipeline to pick up.

Will be closed once validation is complete.