### PR TITLE
Own CI/CD CODEOWNERS paths instead of auto-requesting Viktor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 * @webreidi @AbhitejJohn
 
 # Engineering and CI/CD
-/eng/ @ViktorHofer @JanKrivanek
-/.github/workflows/ @ViktorHofer @JanKrivanek
+/eng/ @AbhitejJohn @JanKrivanek
+/.github/workflows/ @AbhitejJohn @JanKrivanek
 
 # msbuild
 /plugins/dotnet-msbuild/ @ViktorHofer @JanKrivanek @dotnet/skills-msbuild-reviewers


### PR DESCRIPTION
Replace `@ViktorHofer` with `@AbhitejJohn` on the `/eng/` and `/.github/workflows/` CODEOWNERS rules, keeping `@JanKrivanek`.

Routine engineering and CI/CD workflow PRs currently auto-request Viktor as a reviewer via CODEOWNERS. This takes him off those two lines so he is no longer auto-assigned, and puts me on them instead. All other ownership rules (msbuild, experimental, etc.) are unchanged.