### PR TITLE
Fix the underpowered eval gate: score direction, not magnitude

### DIFF
--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -4,9 +4,10 @@ name: eval-quality
 #
 # Each failing check corresponds to a defect that has already cost a real
 # evaluation result on this repo — see eng/eval-quality/README.md. All of them
-# are structural (file existence, git state, YAML keys), so the gate cannot
-# fire spuriously on well-written prose. Judgement calls such as statistical
-# power and orphaned fixtures are reported but never fail the build.
+# are structural (file existence, git state, declared counts, YAML keys), so the
+# gate cannot fire spuriously on well-written prose. Judgement calls such as
+# orphaned fixtures and grandfathered underpowered evals are reported but never
+# fail the build.
 
 on:
   pull_request:
@@ -14,18 +15,24 @@ on:
       - "tests/**"
       - "plugins/**"
       - "eng/eval-quality/**"
+      # check_floor_agreement() reads MIN_CREDIBLE_TRIALS out of the adapter, so
+      # the one diff that can break the floor's two-language agreement is a diff
+      # to the adapter. Without this the guard would never run on it.
+      - "eng/vally-adapter/**"
       - ".github/workflows/eval-quality.yml"
       - ".gitignore"
   push:
     branches: [main]
     # Kept in sync with the pull_request paths above. The gate reads plugins/*
-    # (skills with no eval) and .gitignore (fixtures excluded from the index),
-    # so omitting them here would let a direct push or a squash-merge that
-    # touches only those land on main without the gate ever running.
+    # (skills with no eval), .gitignore (fixtures excluded from the index), and
+    # eng/vally-adapter (the trial floor it must agree with), so omitting any of
+    # them here would let a direct push or a squash-merge that touches only
+    # those land on main without the gate ever running.
     paths:
       - "tests/**"
       - "plugins/**"
       - "eng/eval-quality/**"
+      - "eng/vally-adapter/**"
       - ".github/workflows/eval-quality.yml"
       - ".gitignore"
   workflow_dispatch:
@@ -45,6 +52,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
+          # The underpowered allowlist is shrink-only, which needs the base
+          # revision to compare against. Shallow history has no merge base.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -60,4 +70,14 @@ jobs:
         run: python eng/eval-quality/selftest_eval_quality.py
 
       - name: Check eval quality
-        run: python eng/eval-quality/check_eval_quality.py
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # On a pull request, additionally reject new entries in the
+          # underpowered allowlist relative to the base branch — otherwise a PR
+          # could add a below-floor eval and exempt it in the same change.
+          if [ -n "$BASE_REF" ]; then
+            python eng/eval-quality/check_eval_quality.py --base-ref "origin/$BASE_REF"
+          else
+            python eng/eval-quality/check_eval_quality.py
+          fi

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -498,7 +498,7 @@ jobs:
         run: |
           echo "## 🔬 Vally Evaluation Results: $ENTRY_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible improvement (mean preference > 0 with its 95% CI above 0)." >> $GITHUB_STEP_SUMMARY
+          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible net win — more wins than losses, by an exact one-sided sign test at p ≤ 0.05 — over enough trials for any record to reach that bar. ⚠️ marks a verdict that can't be reached: an underpowered eval, or a comparison that didn't complete." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           RESULTS_DIR="artifacts/TestResults/vally/$ENTRY_NAME"
@@ -507,9 +507,10 @@ jobs:
             EVAL_NAME=$(basename "$(dirname "$RESULTS_JSON")")
 
             CONCLUSIVE=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].conclusive)" "$RESULTS_JSON")
+            UNDERPOWERED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].underpowered === true)" "$RESULTS_JSON")
             PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].passed)" "$RESULTS_JSON")
             REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].reason)" "$RESULTS_JSON")
-            if [ "$CONCLUSIVE" != "true" ]; then
+            if [ "$CONCLUSIVE" != "true" ] || [ "$UNDERPOWERED" = "true" ]; then
               ICON="⚠️"
             elif [ "$PASSED" = "true" ]; then
               ICON="✅"
@@ -521,17 +522,29 @@ jobs:
             echo "$REASON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            # Per-scenario table: mean preference score and win/tie/loss.
-            echo "| Scenario | Mean preference | Trials (W/T/L) |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|-----------------|----------------|" >> $GITHUB_STEP_SUMMARY
+            # Per-scenario table: net win (the basis the gate reads), the
+            # magnitude-weighted preference for triage, and win/tie/loss. The
+            # arrow follows the net win so a row can never point the opposite
+            # way to the verdict it feeds. adapt.mjs computes these per
+            # scenario; the fallback covers results.json written before it did.
+            echo "| Scenario | Net win | Δ Pref | Trials (W/T/L) |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|---------|--------|----------------|" >> $GITHUB_STEP_SUMMARY
             node -e "
               const r = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8'));
+              const dir = (t) => t.winner === 'treatment' ? 1 : t.winner === 'baseline' ? -1
+                : t.winner === 'tie' ? 0 : Math.sign(typeof t.score === 'number' ? t.score : 0);
+              const pct = (x) => (x >= 0 ? '+' : '') + (x * 100).toFixed(1) + '%';
               for (const s of r.verdicts[0].scenarios) {
-                const icon = s.meanScore > 0 ? '▲' : s.meanScore < 0 ? '▼' : '=';
-                const pct = (s.meanScore >= 0 ? '+' : '') + (s.meanScore * 100).toFixed(1) + '%';
-                let w=0,t=0,l=0;
-                for (const tr of (s.trials||[])) { if (tr.score>0) w++; else if (tr.score<0) l++; else t++; }
-                console.log('| ' + icon + ' ' + s.scenarioName + ' | ' + pct + ' | ' + w + '/' + t + '/' + l + ' |');
+                let { netWin, wins, ties, losses } = s;
+                if (typeof netWin !== 'number') {
+                  const counted = (s.trials || []).filter((t) => !t.errored);
+                  wins = counted.filter((t) => dir(t) > 0).length;
+                  losses = counted.filter((t) => dir(t) < 0).length;
+                  ties = counted.length - wins - losses;
+                  netWin = counted.length ? (wins - losses) / counted.length : 0;
+                }
+                const icon = netWin > 0 ? '▲' : netWin < 0 ? '▼' : '=';
+                console.log('| ' + icon + ' ' + s.scenarioName + ' | ' + pct(netWin) + ' | ' + pct(s.meanScore || 0) + ' | ' + wins + '/' + ties + '/' + losses + ' |');
               }
             " "$RESULTS_JSON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1110,8 +1110,14 @@ jobs:
             node eng/vally-adapter/consolidate.mjs --format simple --root all-results/ --output simplified-body.md
 
             INVESTIGATE_PROMPT=""
-            # If any skill failed, build a copy-paste prompt for AI-assisted investigation
-            if jq -se '[.[].verdicts[] | select(.passed == false)] | length > 0' $JSON_FILES > /dev/null 2>&1; then
+            # If any skill genuinely lost to its baseline, build a copy-paste
+            # prompt for AI-assisted investigation. Underpowered and inconclusive
+            # verdicts also carry `passed: false`, but neither is evidence that
+            # the skill regressed — attaching the prompt to those would fire on
+            # nearly every run and contradict the ⚠️ semantics of the comment
+            # body. The `!= false` / `!= true` form keeps results.json files that
+            # predate those fields classifying exactly as they did before.
+            if jq -se '[.[].verdicts[] | select(.passed == false and .conclusive != false and .underpowered != true)] | length > 0' $JSON_FILES > /dev/null 2>&1; then
               RUN_ID="${{ github.run_id }}"
               INVESTIGATE_PROMPT=$(printf '\n> **To investigate failures**, paste this to your AI coding agent:\n>\n> _For PR %s in %s, download eval artifacts with `gh run download %s --repo %s --pattern "vally-results-*" --dir ./eval-results`, then fetch https://raw.githubusercontent.com/%s/%s/eng/vally-adapter/InvestigatingResults.md and follow it to analyze the results.json files. Diagnose each failure, suggest fixes to the eval.yaml and skill content, and tell me what to fix first._' \
                 "${PR_NUMBER}" "${{ github.repository }}" "${RUN_ID}" "${{ github.repository }}" "${{ github.repository }}" "${{ needs.gate.outputs.head_sha }}")

--- a/dotnet-skills.experiment.yaml
+++ b/dotnet-skills.experiment.yaml
@@ -10,13 +10,26 @@
 #
 # The `agent.*` evals are excluded: they exercise orchestrator agents and do
 # not map to a single plugins/<plugin>/skills/<skill> directory.
+#
+# `overrides:` deliberately does NOT set `runs`. Precedence is
+# "CLI flags > experiment overrides > eval defaults", and the merge is a plain
+# spread (`{ ...eval.defaults, ...experiment.overrides }`), so an `overrides:
+# runs:` here does not set a *default* — it overwrites every eval's own
+# `defaults.runs` and makes per-eval trial counts impossible to express. An eval
+# that needs more trials than it has scenarios raises its own count:
+#
+#   defaults:
+#     runs: 3
+#
+# Trials per eval = scenarios x runs, and that product is what the pass gate's
+# confidence interval is computed over. See eng/eval-quality/README.md for the
+# floor and why it sits where it does.
 name: dotnet-skills
 evals:
   - tests/*/!(agent.*)/eval.yaml
 overrides:
   model: claude-opus-4.6
   judge_model: claude-opus-4.6
-  runs: 1
 vary:
   - /environment/skills
 baseline: baseline

--- a/eng/eval-quality/README.md
+++ b/eng/eval-quality/README.md
@@ -3,7 +3,8 @@
 `check_eval_quality.py` blocks defect classes that have each already cost a real
 evaluation result on this repo. Every one of them was invisible to the existing
 checks: the eval specs parsed, `skill-validator` passed, and the damage only
-showed up as a skill mysteriously losing to its own baseline.
+showed up as a skill mysteriously losing to its own baseline — or as a skill
+winning every trial and failing anyway.
 
 Run it from the repository root:
 
@@ -15,7 +16,7 @@ python eng/eval-quality/selftest_eval_quality.py       # prove the gate still fi
 
 ## Failing checks
 
-All seven are **structural** — they inspect file existence, git state, declared
+All eight are **structural** — they inspect file existence, git state, declared
 numbers, or YAML keys. None of them interprets prose, so they cannot fire
 spuriously on a well-written eval.
 
@@ -144,6 +145,102 @@ The repo convention is `expect_activation: false` **alone** (see
 `system-text-json-net11`), so the skill is actually loaded and the guard
 measures the real property.
 
+### 8. Fewer than 5 trials behind a verdict
+
+Trials, not scenarios, are what the pass gate is computed over. `vally compare`
+produces one head-to-head trial per stimulus per run, so
+
+```
+trials = scenarios × defaults.runs
+```
+
+and the gate is an exact one-sided **sign test**: more wins than losses, at
+`p ≤ 0.05`.
+
+That test cannot reach 5% on fewer than five discordant (non-tie) trials —
+`0.5⁴ = 0.0625` is already above alpha, `0.5⁵ = 0.031` is not — and discordant
+trials can never exceed counted trials. So **below five trials no possible
+record passes**, however good the skill is: the eval cannot answer the question
+it exists to answer. Five is not a chosen constant; it is where the test becomes
+attainable.
+
+| trials | best possible record | its `p` |
+| ---: | --- | ---: |
+| 1–4 | a clean sweep | ≥ 0.0625 — cannot pass |
+| 5 | 5W/0T/0L | 0.031 |
+| 8 | 5W/3T/0L | 0.031 |
+
+This is an *eligibility* floor — the minimum evidence a verdict may rest on —
+not a guarantee of adequate power for a realistic effect, which needs
+considerably more. Below it, `eng/vally-adapter/adapt.mjs` marks the verdict
+`underpowered` and the PR comment shows ⚠️: never a pass, never a regression.
+This check makes that state un-shippable for *new* evals.
+
+Raising an eval over the floor by adding scenarios is strictly better than
+raising `runs`: five repeats of one scenario satisfy the arithmetic but provide
+no cross-scenario evidence, so the skill is still only measured on one task.
+Use `runs` where a scenario is genuinely expensive to add:
+
+```yaml
+defaults:
+  runs: 3
+```
+
+`dotnet-skills.experiment.yaml` deliberately does not set `runs` in its
+`overrides:` block. Precedence there is *CLI flags > experiment overrides > eval
+defaults* and the merge is a plain spread, so an experiment-level `runs` does
+not *default* anything — it overwrites every eval's own value and makes
+per-eval trial counts impossible to express.
+
+**Grandfathering.** `underpowered-allowlist.txt` carries the evals that predate
+the floor. It is a debt ledger and it is shrink-only in the mechanical sense:
+the gate errors on an entry that is stale, duplicated, or no longer needed, and
+`--base-ref` (which CI passes on every pull request) rejects entries that are
+*new* relative to the base branch. Without that second half, a PR could add a
+below-floor eval and exempt it in the same change — the defect the floor exists
+to prevent, relocated one file over. Renames are read from git, so moving a
+grandfathered eval is not treated as growth. `agent.*` evals are exempt
+outright: the experiment's `evals:` glob excludes them, so no verdict is ever
+computed and the floor has nothing to protect.
+
+## Why the gate scores direction, not magnitude
+
+Worth recording, because the check above is only half of what went wrong.
+
+Compare scores each trial on a five-point ordinal scale — `much-better` `+1.0`,
+`slightly-better` `+0.4`, `equal` `0`, `slightly-worse` `−0.4`, `much-worse`
+`−1.0`. Weighting a confidence interval by those magnitudes makes a Student's-t
+interval read the 0.4 → 1.0 step as *variance*, so a skill is punished for
+winning more decisively. Four wins and three ties over seven trials:
+
+| trials | mean | ci_low | verdict |
+| --- | ---: | ---: | --- |
+| every win `slightly-better` | +0.229 | **+0.031** | ✅ |
+| one win `much-better` | +0.314 | **−0.021** | ❌ |
+
+Same record, better outcome, reversed verdict. This is the mechanism behind the
+A/A instability in #952, where two runs on byte-identical inputs flipped 3 of 11
+verdicts. `coverage-analysis` failed five consecutive runs while winning 100% of
+its trials, then passed on a sixth with the same 3W/0T/0L record: its scores
+were `[+0.4, +0.4, +1.0]` in a failing run and `[+0.4, +0.4, +0.4]` in the
+passing one.
+
+`adapt.mjs` therefore reads only each trial's **winner**, never its magnitude.
+The verdict is a deterministic function of the win/tie/loss record, so identical
+records always produce identical results.
+
+Collapsing to direction is necessary but not sufficient: a t-interval over
+win/tie/loss is still not calibrated at these sample sizes. Exhaustively
+comparing it to the exact test up to 10 trials, the two disagree on 12 records
+and in **every one of them the interval is the permissive one** — it passes
+4W/0T/0L, 4W/3T/0L and 6W/0T/1L, all of which are `p = 0.0625`. The exact
+binomial tail has no such gap, which is why the gate uses it rather than an
+interval.
+
+Vally's magnitude-weighted mean is still reported (as `meanScore`, and as
+**Δ Pref** in the PR comment) because it is useful for triage; it just no longer
+decides anything.
+
 ## Warnings (reported; failing only under `--strict`)
 
 CI runs the gate without `--strict`, so these are informational there. Passing
@@ -151,47 +248,20 @@ CI runs the gate without `--strict`, so these are informational there. Passing
 
 ### Statistical power
 
-`dotnet-skills.experiment.yaml` sets `runs: 1`, so `n` is the scenario count and
-one judge call decides each scenario. The pass gate is `mean > 0 ∧ ci_low > 0`,
-i.e.
-
-```
-sqrt(n) × (mean / sd) > t(n-1)
-```
-
-| n | required mean/sd |
-| ---: | ---: |
-| 1 | undefined — a single trial decides |
-| 2 | 8.98 |
-| 3 | 2.48 |
-| 4 | 1.59 |
-| 6 | 1.05 |
-| 8 | 0.84 |
-
-These are `t(n-1)/sqrt(n)`. An earlier revision of this table read the critical
-value at `t(n)` instead, understating every row — n=3 appeared to need 1.84 when
-it really needs 2.48, and n=2 appeared to need 3.04 against a true 8.98. That
-made a thin eval look one good trial away from credible when it was not. The
-worked example below is the check: `coverage-analysis` scoring 0.4/1.0/0.4 has
-mean/sd = 1.73, which reads as a near miss against the old 1.84 but is 30% short
-of the real 2.48 — a difference that changes the remedy from "re-run it" to
-"raise n or runs".
-
-Consequences seen in practice: `coverage-analysis` **won 100% of its trials in
-four consecutive runs and failed all four**; `migrate-static-to-wrapper` missed
-by 0.4 of a percentage point at 4W/1T/0L. Neither is a content problem.
-
-Roughly half of the repo's skill evals sit at n ≤ 3. Raising `runs` is the
-durable fix (`runs: 3` turns 3 scenarios into 9 trials and drops the required
-ratio to 0.77) at a proportional increase in CI cost — a maintainer decision,
-which is why this is a warning and not a failure.
+The evals that are still below the five-trial floor of failing check 8, listed
+from `underpowered-allowlist.txt` with their current
+`scenarios × runs`. Their verdicts are reported as ⚠️ underpowered rather than
+as a pass or a failure, so raising them is the highest-value eval work
+available. See check 8 for how, and for why the floor sits at five.
 
 ### Orphaned fixtures
 
 A fixture directory that is committed but that no stimulus references. Usually
 means a scenario was planned and dropped, so the coverage it was built for is
 being paid for in repo size but never exercised. Wiring these up is the cheapest
-way to raise `n`.
+way to raise an eval's trial count, because the fixture already exists —
+`migrate-nullable-references` sits at 3 scenarios with three unreferenced
+fixtures beside it.
 
 ### Skills with no eval
 

--- a/eng/eval-quality/check_eval_quality.py
+++ b/eng/eval-quality/check_eval_quality.py
@@ -27,17 +27,25 @@ FAILS on unambiguous bugs:
   7. Dormancy guard that also sets `reject_skills`. That forces the skilled arm
      skill-free, making it identical to the baseline arm, so the score is judge
      noise.
+  8. Fewer than MIN_TRIALS trials (scenarios x `defaults.runs`). The pass gate
+     is an exact one-sided sign test over the head-to-head trials, which cannot
+     reach 5% on fewer than five discordant trials
+     (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5). Discordant trials can never
+     exceed counted trials, so below five no possible record produces a pass —
+     the eval cannot answer the question it exists to answer. Existing evals are
+     grandfathered through a shrink-only allowlist.
 
 Every failing check above is structural — it inspects file existence, git
 state, declared numbers, or YAML shape/keys — so it cannot fire spuriously on
 well-written content.
 
-REPORTS warnings for pre-existing debt and judgement calls: statistical power,
-orphaned fixtures, skills with no eval, and dormancy guards that appear to lack
-an anti-hijack rubric item. Warnings do not fail unless `--strict` is passed.
-That last one is deliberately a warning: detecting "the rubric says the skill
-should stay dormant" needs phrase matching, which will always have false
-positives, and a gate that blocks a PR spuriously is a gate the team turns off.
+REPORTS warnings for pre-existing debt and judgement calls: grandfathered
+underpowered evals, orphaned fixtures, skills with no eval, and dormancy guards
+that appear to lack an anti-hijack rubric item. Warnings do not fail unless
+`--strict` is passed. That last one is deliberately a warning: detecting "the
+rubric says the skill should stay dormant" needs phrase matching, which will
+always have false positives, and a gate that blocks a PR spuriously is a gate
+the team turns off.
 
 Usage:  python eng/eval-quality/check_eval_quality.py [--strict]
 """
@@ -45,8 +53,8 @@ from __future__ import annotations
 
 import argparse
 import glob
-import math
 import os
+import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -57,12 +65,20 @@ except ImportError:  # pragma: no cover
     print("PyYAML is required: pip install pyyaml", file=sys.stderr)
     raise SystemExit(2)
 
-# 95% two-sided t critical values, keyed by DEGREES OF FREEDOM (n - 1), which is
-# what the pass gate's confidence interval uses. Keying this by n instead is an
-# easy and costly slip: it makes every reported threshold too lenient.
-T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
-       8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160,
-       14: 2.145, 15: 2.131}
+# Minimum trials (scenarios x runs) behind a verdict. Below this the pass gate
+# stops measuring the skill — see check_power() and eng/eval-quality/README.md.
+# Must equal MIN_CREDIBLE_TRIALS in the adapter, which is what actually enforces
+# it at scoring time; check_floor_agreement() fails the build if they drift.
+#
+# (The t critical values this file used to carry went with report_power: the
+# gate is an exact sign test now, so no interval is computed on this side.)
+MIN_TRIALS = 5
+ADAPTER = "eng/vally-adapter/adapt.mjs"
+
+# Debt ledger for evals that predate the floor. Shrink-only: check_power()
+# errors on any entry that is stale or no longer needed, and
+# check_allowlist_growth() rejects new ones.
+ALLOWLIST = "eng/eval-quality/underpowered-allowlist.txt"
 
 ANTI_HIJACK = ("derail", "did not attempt", "outside the scope", "out of scope",
                "did not perform", "declined", "does not load", "does not reference",
@@ -247,23 +263,165 @@ def check_cobertura() -> None:
                     f"or rubric quotes the old figure, update it too")
 
 
-def report_power(specs: list[str]) -> None:
-    thin = []
+def eval_trial_count(doc: dict) -> tuple[int, int, int]:
+    """(scenarios, runs, trials) for one eval spec.
+
+    Trials, not scenarios, is what the pass gate is computed over: `vally
+    compare` produces one head-to-head trial per stimulus per run, and the
+    adapter's sign test is over all of them together. `defaults.runs` is
+    honoured because dotnet-skills.experiment.yaml no longer overrides it
+    globally.
+    """
+    scenarios = len(doc.get("stimuli") or [])
+    runs = (doc.get("defaults") or {}).get("runs", 1)
+    if not isinstance(runs, int) or isinstance(runs, bool) or runs < 1:
+        runs = 1
+    return scenarios, runs, scenarios * runs
+
+
+def load_allowlist() -> list[str]:
+    if not os.path.exists(ALLOWLIST):
+        return []
+    with open(ALLOWLIST, encoding="utf-8") as fh:
+        return [ln.strip() for ln in fh
+                if ln.strip() and not ln.lstrip().startswith("#")]
+
+
+def check_power(specs: list[str]) -> None:
+    """Fail an eval that cannot produce a credible verdict at any effect size.
+
+    The gate is an exact one-sided sign test over the head-to-head trials. It
+    cannot reach 5% on fewer than five discordant trials (0.5^4 = 0.0625 is
+    already above alpha), and discordant trials can never exceed counted
+    trials — so below MIN_TRIALS no possible record passes, however good the
+    skill is. See eng/eval-quality/README.md.
+
+    Existing debt is grandfathered through an allowlist that may only shrink: an
+    entry that no longer needs to be there, or that points at a spec which no
+    longer exists, is itself an error, and check_allowlist_growth() rejects new
+    ones against the base branch.
+    """
+    allowed = load_allowlist()
+    allowed_set = set(allowed)
+    spec_set = set(specs)
+    thin, listed_thin, agent_specs = [], [], set()
+
     for spec in specs:
+        # `agent.*` evals are excluded from dotnet-skills.experiment.yaml's
+        # `evals:` glob, so no verdict is ever computed for them and the floor
+        # has nothing to protect.
+        if os.path.basename(os.path.dirname(spec)).startswith("agent."):
+            agent_specs.add(spec)
+            continue
         with open(spec, encoding="utf-8") as fh:
             doc = yaml.safe_load(fh) or {}
-        n = len(doc.get("stimuli") or [])
-        if n <= 3:
-            need = T95.get(n - 1, 1.96) / math.sqrt(n) if n >= 2 else float("inf")
-            thin.append((n, need, spec))
-    if not thin:
+        scenarios, runs, trials = eval_trial_count(doc)
+        if trials >= MIN_TRIALS:
+            continue
+        (listed_thin if spec in allowed_set else thin).append((trials, scenarios, runs, spec))
+
+    if thin:
+        errors.append(
+            f"{len(thin)} eval(s) have fewer than {MIN_TRIALS} trials, so no effect size can "
+            f"produce a credible verdict. Add scenarios (preferred — scenarios also widen what "
+            f"the skill is measured on, where extra runs only re-measure the same one), or set "
+            f"`defaults: {{ runs: N }}` so scenarios x runs >= {MIN_TRIALS}:")
+        for trials, scenarios, runs, spec in sorted(thin):
+            need = "N/A" if scenarios == 0 else -(-MIN_TRIALS // scenarios)
+            errors.append(
+                f"    {trials} trial(s) = {scenarios} scenario(s) x runs={runs}  {spec}  "
+                f"(needs runs>={need})")
+
+    if listed_thin:
+        warnings.append(
+            f"{len(listed_thin)} eval(s) are below the {MIN_TRIALS}-trial floor and grandfathered "
+            f"in {ALLOWLIST}. Their verdicts are reported as underpowered, never as a pass or a "
+            f"failure. Raising them is the highest-value eval work available:")
+        for trials, scenarios, runs, spec in sorted(listed_thin):
+            warnings.append(f"    {trials} trial(s) = {scenarios} scenario(s) x runs={runs}  {spec}")
+
+    # Ratchet: the allowlist is a debt ledger, so it must only ever shrink.
+    for spec in sorted(allowed_set - {s for _, _, _, s in listed_thin}):
+        if spec in agent_specs:
+            errors.append(
+                f"{ALLOWLIST} lists '{spec}', but agent.* evals are excluded from the experiment "
+                f"and never receive a verdict, so they never need an exemption. Remove the line.")
+        elif spec not in spec_set:
+            errors.append(
+                f"{ALLOWLIST} lists '{spec}', which is not an eval spec in this repo. "
+                f"Remove the stale line.")
+        else:
+            errors.append(
+                f"{ALLOWLIST} lists '{spec}', but it now meets the {MIN_TRIALS}-trial floor. "
+                f"Remove the line so the exemption can't be silently reused.")
+    for spec in sorted({s for s in allowed if allowed.count(s) > 1}):
+        errors.append(f"{ALLOWLIST} lists '{spec}' more than once.")
+
+
+def check_allowlist_growth(base_ref: str) -> None:
+    """Reject NEW exemptions, so the ledger can only shrink.
+
+    Detecting stale entries is not enough on its own: without this, a PR could
+    add a below-floor eval *and* add its path to the allowlist in the same
+    change, which is the defect the floor exists to prevent, relocated one file
+    over. Comparing against the base branch is what makes "shrink-only" a
+    property of the gate rather than of code review.
+
+    A pure rename is not growth. `tests/<plugin>/<skill>/eval.yaml` is the
+    allowlist's key, so moving a grandfathered eval would otherwise be blocked
+    with no valid resolution short of raising it above the floor in the same
+    commit — and a gate that blocks a legitimate change is a gate that gets
+    switched off. Renames are read from git so the new path inherits the old
+    path's exemption.
+    """
+    def git(*args):
+        try:
+            return subprocess.run(["git", *args], capture_output=True, text=True)
+        except FileNotFoundError:
+            return None
+
+    # Resolve the ref first. `git show <ref>:<path>` fails identically for "bad
+    # ref" and "file absent at ref", and silently skipping the ratchet because
+    # CI passed a ref that no longer resolves is exactly how it would rot.
+    probe = git("rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}")
+    if probe is None:
+        warnings.append(f"git is unavailable; could not verify {ALLOWLIST} against {base_ref}")
         return
-    warnings.append(
-        f"{len(thin)} eval(s) have n<=3 scenarios. With runs=1 the pass gate needs "
-        f"mean/sd > t(n-1)/sqrt(n), so these can fail while winning every trial:")
-    for n, need, spec in sorted(thin):
-        need_s = "inf" if math.isinf(need) else f"{need:.2f}"
-        warnings.append(f"    n={n}  needs mean/sd > {need_s:>4}  {spec}")
+    if probe.returncode != 0:
+        errors.append(
+            f"--base-ref '{base_ref}' does not resolve to a commit, so the {ALLOWLIST} "
+            f"shrink-only check could not run. Check the ref name and the checkout's "
+            f"fetch-depth.")
+        return
+
+    show = git("show", f"{base_ref}:{ALLOWLIST}")
+    if show.returncode != 0:
+        # The ref resolves but the file is not on it. True only for the change
+        # that introduces the allowlist; afterwards this means it was deleted
+        # and re-added, so report it rather than passing silently.
+        warnings.append(
+            f"{ALLOWLIST} does not exist at {base_ref}, so its entries could not be checked for "
+            f"growth. Expected only on the change that introduces the file.")
+        return
+    base = {ln.strip() for ln in show.stdout.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")}
+
+    # new path -> old path, for anything git considers a rename under tests/.
+    renamed_from = {}
+    diff = git("diff", "--find-renames", "--name-status", base_ref, "--", "tests/")
+    if diff is not None and diff.returncode == 0:
+        for line in diff.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) == 3 and parts[0].startswith("R"):
+                renamed_from[parts[2].replace(os.sep, "/")] = parts[1].replace(os.sep, "/")
+
+    added = sorted(spec for spec in set(load_allowlist()) - base
+                   if renamed_from.get(spec) not in base)
+    if added:
+        errors.append(
+            f"{len(added)} new exemption(s) added to {ALLOWLIST}. The ledger is shrink-only: an "
+            f"eval below the {MIN_TRIALS}-trial floor must be given enough trials, not exempted.")
+        errors.extend(f"    {spec}" for spec in added)
 
 
 def report_orphans(specs: list[str]) -> None:
@@ -297,12 +455,49 @@ def report_uncovered() -> None:
         warnings.extend(missing)
 
 
+def check_floor_agreement() -> None:
+    """The floor lives in two languages; make them unable to drift apart.
+
+    This gate refuses a spec below MIN_TRIALS, but the adapter is what actually
+    withholds a verdict at scoring time. If the two constants disagree, the
+    repo either blocks evals that would have been scored, or accepts evals that
+    can never produce a verdict — both silent. Nothing else ties them together,
+    so read the adapter's value directly, and fail closed: an unreadable
+    constant means the agreement is unverified, not that it holds.
+    """
+    if not os.path.exists(ADAPTER):
+        return  # not a full checkout (e.g. the self-test's scratch tree)
+    try:
+        with open(ADAPTER, encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        errors.append(f"could not read {ADAPTER} to verify the trial floor: {exc}")
+        return
+    match = re.search(r"^const MIN_CREDIBLE_TRIALS = (\d+);", source, re.M)
+    if match is None:
+        errors.append(
+            f"could not find `const MIN_CREDIBLE_TRIALS = <n>;` in {ADAPTER}, so this gate's "
+            f"floor of {MIN_TRIALS} is unverified. Update the pattern in check_floor_agreement() "
+            f"if the declaration moved.")
+    elif int(match.group(1)) != MIN_TRIALS:
+        errors.append(
+            f"trial floor mismatch: this gate uses {MIN_TRIALS} but {ADAPTER} enforces "
+            f"{match.group(1)}. They must agree, or evals are blocked that would be scored "
+            f"(or accepted that can never produce a verdict).")
+
+
 def main() -> int:
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--strict", action="store_true", help="treat warnings as failures")
+    ap.add_argument("--base-ref", help="git ref to check the underpowered allowlist against; "
+                                       "new exemptions relative to it are an error")
     args = ap.parse_args()
 
-    specs = sorted(glob.glob("tests/*/*/eval.yaml"))
+    # Normalize to forward slashes so paths compare and print identically on
+    # Windows and Linux — the allowlist is a committed file of "/" paths, and
+    # a contributor running this locally must get the same verdict CI does.
+    specs = sorted(p.replace(os.sep, "/") for p in glob.glob("tests/*/*/eval.yaml"))
     if not specs:
         print("No eval specs found — run from the repository root.", file=sys.stderr)
         return 2
@@ -320,7 +515,10 @@ def main() -> int:
         check_dormancy_guards(spec, doc)
 
     check_cobertura()
-    report_power(specs)
+    check_power(specs)
+    check_floor_agreement()
+    if args.base_ref:
+        check_allowlist_growth(args.base_ref)
     report_orphans(specs)
     report_uncovered()
 

--- a/eng/eval-quality/selftest_eval_quality.py
+++ b/eng/eval-quality/selftest_eval_quality.py
@@ -14,8 +14,8 @@ REPO = os.getcwd()
 GATE = os.path.join(REPO, "eng", "eval-quality", "check_eval_quality.py")
 
 
-def run_gate(cwd):
-    r = subprocess.run([sys.executable, GATE], cwd=cwd, capture_output=True, text=True)
+def run_gate(cwd, *extra):
+    r = subprocess.run([sys.executable, GATE, *extra], cwd=cwd, capture_output=True, text=True)
     return r.returncode, r.stdout + r.stderr
 
 
@@ -30,6 +30,10 @@ def scratch():
     with open(os.path.join(ev, "eval.yaml"), "w") as f:
         f.write(
             "name: widget\n"
+            # Meets the MIN_TRIALS floor with a single scenario, which keeps the
+            # rest of the cases small. Trials = scenarios x runs.
+            "defaults:\n"
+            "  runs: 5\n"
             "stimuli:\n"
             "  - name: Does the thing\n"
             "    prompt: do it\n"
@@ -52,12 +56,12 @@ def scratch():
     return d
 
 
-def case(label, mutate, expect_fail):
+def case(label, mutate, expect_fail, gate_args=()):
     d = scratch()
     try:
         mutate(d)
         subprocess.run(["git", "add", "-A"], cwd=d, capture_output=True, check=True)
-        code, out = run_gate(d)
+        code, out = run_gate(d, *gate_args)
         failed = code != 0
         ok = failed == expect_fail
         want = "FAIL" if expect_fail else "PASS"
@@ -181,18 +185,13 @@ def empty_grader_config(d):
         )
 
 
-def three_scenarios(d):
-    # n=3, so the power warning must quote t(n-1)/sqrt(n) = 4.303/sqrt(3) = 2.48.
-    # Reading the critical value at t(n) instead yields 1.84 — the off-by-one
-    # that made thin evals look close to credible when they were not.
-    with open(EV(d), "a") as f:
-        for i in (2, 3):
-            f.write(
-                f"  - name: Does the thing {i}\n"
-                f"    prompt: do it {i}\n"
-                f"    rubric:\n"
-                f"      - Did the thing {i}\n"
-            )
+def grandfathered_reports_its_arithmetic(d):
+    # The gate's job for a grandfathered eval is to tell the contributor what to
+    # change, so the reported figure must be the trial arithmetic and not just
+    # the scenario count. (This replaces #964's t(n-1) case: the gate is an
+    # exact sign test now, so there is no critical value left to misquote.)
+    drop_runs(d)
+    write_allowlist(d, SPEC)
 
 
 def guard_with_reject_skills(d):
@@ -220,6 +219,111 @@ def guard_ok(d):
         )
 
 
+# --- statistical power ------------------------------------------------------
+# Trials = scenarios x runs. Below the floor the pass gate cannot reach a
+# credible verdict at any effect size, so a new eval must not land there.
+
+SPEC = "tests/demo/widget/eval.yaml"
+
+
+def write_allowlist(d, *entries):
+    path = os.path.join(d, "eng", "eval-quality")
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "underpowered-allowlist.txt"), "w") as f:
+        f.write("# debt ledger\n")
+        for entry in entries:
+            f.write(entry + "\n")
+
+
+def drop_runs(d):
+    """1 scenario x runs=1 = 1 trial: vally reports no interval at all there."""
+    with open(EV(d)) as f:
+        text = f.read()
+    with open(EV(d), "w") as f:
+        f.write(text.replace("defaults:\n  runs: 5\n", ""))
+
+
+def underpowered(d):
+    drop_runs(d)
+
+
+def underpowered_but_allowlisted(d):
+    drop_runs(d)
+    write_allowlist(d, SPEC)
+
+
+def allowlisted_eval_that_now_meets_the_floor(d):
+    # The eval is fine; the exemption is stale and must be given up, or it
+    # silently covers whatever the eval becomes next.
+    write_allowlist(d, SPEC)
+
+
+def allowlist_entry_for_a_spec_that_does_not_exist(d):
+    write_allowlist(d, "tests/demo/deleted/eval.yaml")
+
+
+def runs_lifts_a_single_scenario_over_the_floor(d):
+    # Already the scratch tree's shape; asserted explicitly so a regression in
+    # the scenarios-x-runs arithmetic can't hide behind the other cases.
+    pass
+
+
+def agent_eval_exempted(d):
+    # agent.* evals never receive a verdict, so they never need an exemption —
+    # and an entry for one would otherwise sit in the ledger forever.
+    ev = os.path.join(d, "tests", "demo", "agent.widget")
+    os.makedirs(ev)
+    with open(os.path.join(ev, "eval.yaml"), "w") as f:
+        f.write("name: agent-widget\nstimuli:\n  - name: One\n    prompt: go\n    rubric:\n      - Did it\n")
+    write_allowlist(d, "tests/demo/agent.widget/eval.yaml")
+
+
+def commit(d, message):
+    subprocess.run(["git", "add", "-A"], cwd=d, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=d, check=True)
+
+
+def _seed_allowlist_on_a_base_commit(d):
+    """Commit a below-floor eval + its exemption, so HEAD~1 is a real base ref."""
+    drop_runs(d)
+    write_allowlist(d, SPEC)
+    commit(d, "grandfather the existing eval")
+
+
+def allowlist_unchanged_since_base(d):
+    _seed_allowlist_on_a_base_commit(d)
+    # No further change: the ledger is identical to its base, which is allowed.
+
+
+def new_exemption_added_since_base(d):
+    _seed_allowlist_on_a_base_commit(d)
+    # A second below-floor eval smuggled in together with its own exemption —
+    # structurally identical to what the floor exists to prevent.
+    ev = os.path.join(d, "tests", "demo", "gadget")
+    os.makedirs(ev)
+    with open(os.path.join(ev, "eval.yaml"), "w") as f:
+        f.write("name: gadget\nstimuli:\n  - name: One\n    prompt: go\n    rubric:\n      - Did it\n")
+    write_allowlist(d, SPEC, "tests/demo/gadget/eval.yaml")
+
+
+def grandfathered_eval_renamed(d):
+    # A pure rename carries no new debt. The allowlist is keyed on the eval
+    # path, so without rename awareness this is unresolvable: the new path is
+    # below the floor and unlisted, the old entry is stale, and listing the new
+    # path looks like growth.
+    _seed_allowlist_on_a_base_commit(d)
+    old = os.path.join(d, "tests", "demo", "widget")
+    new = os.path.join(d, "tests", "demo", "widget-renamed")
+    subprocess.run(["git", "mv", old, new], cwd=d, check=True)
+    write_allowlist(d, "tests/demo/widget-renamed/eval.yaml")
+
+
+def unresolvable_base_ref(d):
+    # A ref that doesn't resolve must fail loudly: silently skipping the
+    # ratchet would leave a green build with the guarantee switched off.
+    _seed_allowlist_on_a_base_commit(d)
+
+
 print("Eval quality gate — self-test\n")
 results = [
     case("clean tree", clean, expect_fail=False),
@@ -231,7 +335,22 @@ results = [
     case("grader with an empty config enforces nothing", empty_grader_config, expect_fail=True),
     case("dormancy guard also sets reject_skills", guard_with_reject_skills, expect_fail=True),
     case("well-formed dormancy guard", guard_ok, expect_fail=False),
-    output_case("power threshold uses t(n-1), not t(n)", three_scenarios, "> 2.48"),
+    case("eval below the trial floor", underpowered, expect_fail=True),
+    case("below the floor but grandfathered", underpowered_but_allowlisted, expect_fail=False),
+    output_case("grandfathered warning reports scenarios x runs",
+                grandfathered_reports_its_arithmetic, "1 trial(s) = 1 scenario(s) x runs=1"),
+    case("stale exemption for an eval that now qualifies", allowlisted_eval_that_now_meets_the_floor, expect_fail=True),
+    case("exemption for a spec that no longer exists", allowlist_entry_for_a_spec_that_does_not_exist, expect_fail=True),
+    case("exemption for an agent.* eval that never needs one", agent_eval_exempted, expect_fail=True),
+    case("runs lifts one scenario over the floor", runs_lifts_a_single_scenario_over_the_floor, expect_fail=False),
+    case("ledger unchanged since its base", allowlist_unchanged_since_base,
+         expect_fail=False, gate_args=("--base-ref", "HEAD")),
+    case("new exemption added since the base ref", new_exemption_added_since_base,
+         expect_fail=True, gate_args=("--base-ref", "HEAD")),
+    case("grandfathered eval renamed, not newly exempted", grandfathered_eval_renamed,
+         expect_fail=False, gate_args=("--base-ref", "HEAD")),
+    case("base ref that does not resolve", unresolvable_base_ref,
+         expect_fail=True, gate_args=("--base-ref", "origin/no-such-branch")),
 ]
 print()
 if all(results):

--- a/eng/eval-quality/underpowered-allowlist.txt
+++ b/eng/eval-quality/underpowered-allowlist.txt
@@ -1,0 +1,84 @@
+# Evals below the 5-trial floor enforced by eng/eval-quality/check_eval_quality.py.
+#
+# Trials = scenarios x `defaults.runs`. Below 5 trials the pass gate cannot
+# reach a credible verdict at any effect size, so eng/vally-adapter/adapt.mjs
+# reports these as underpowered — never as a pass, never as a regression.
+# eng/eval-quality/README.md explains why the floor sits at 5.
+#
+# This file is a debt ledger and it is SHRINK-ONLY, mechanically:
+#   - the gate errors on any entry that is stale, duplicated, or no longer
+#     needed, so an exemption cannot be silently reused by a different eval; and
+#   - on a pull request the gate also runs with `--base-ref`, which errors on any
+#     entry that is NEW relative to the base branch. Without that, a PR could add
+#     a below-floor eval and exempt it in the same change.
+#
+# Retiring an eval means deleting its line here too, in the same change. CI
+# checks the merge with the base branch, so an entry left behind for a deleted
+# eval fails the gate even though it passes on the retiring branch alone.
+#
+# To remove a line, either give the eval more scenarios (strongly preferred:
+# five repeats of one scenario satisfy the arithmetic but still measure the
+# skill on a single task) or add
+#
+#   defaults:
+#     runs: N
+#
+# to its eval.yaml so that scenarios x runs >= 5.
+
+tests/dotnet-advanced/csharp-scripts/eval.yaml
+tests/dotnet-aspnetcore/convert-blazor-server-to-webapp/eval.yaml
+tests/dotnet-data/optimizing-ef-core-queries/eval.yaml
+tests/dotnet-diag/microbenchmarking/eval.yaml
+tests/dotnet-msbuild/binlog-failure-analysis/eval.yaml
+tests/dotnet-msbuild/build-parallelism/eval.yaml
+tests/dotnet-msbuild/build-perf-baseline/eval.yaml
+tests/dotnet-msbuild/build-perf-diagnostics/eval.yaml
+tests/dotnet-msbuild/check-bin-obj-clash/eval.yaml
+tests/dotnet-msbuild/directory-build-organization/eval.yaml
+tests/dotnet-msbuild/eval-performance/eval.yaml
+tests/dotnet-msbuild/including-generated-files/eval.yaml
+tests/dotnet-msbuild/incremental-build/eval.yaml
+tests/dotnet-msbuild/msbuild-modernization/eval.yaml
+tests/dotnet-msbuild/msbuild-server/eval.yaml
+tests/dotnet-msbuild/resolve-project-references/eval.yaml
+tests/dotnet-template-engine/template-instantiation/eval.yaml
+tests/dotnet-upgrade/dotnet-aot-compat/eval.yaml
+tests/dotnet-advanced/dotnet-pinvoke/eval.yaml
+tests/dotnet-blazor/collect-user-input/eval.yaml
+tests/dotnet-blazor/configure-auth/eval.yaml
+tests/dotnet-blazor/coordinate-components/eval.yaml
+tests/dotnet-blazor/fetch-and-send-data/eval.yaml
+tests/dotnet-blazor/support-prerendering/eval.yaml
+tests/dotnet-template-engine/template-authoring/eval.yaml
+tests/dotnet-template-engine/template-validation/eval.yaml
+tests/dotnet-advanced/nuget-trusted-publishing/eval.yaml
+tests/dotnet-aspnetcore/configuring-opentelemetry-dotnet/eval.yaml
+tests/dotnet-aspnetcore/dotnet-webapi/eval.yaml
+tests/dotnet-aspnetcore/minimal-api-file-upload/eval.yaml
+tests/dotnet-blazor/create-blazor-project/eval.yaml
+tests/dotnet-diag/apple-crash-symbolication/eval.yaml
+tests/dotnet-msbuild/binlog-generation/eval.yaml
+tests/dotnet-msbuild/extension-points/eval.yaml
+tests/dotnet-msbuild/item-management/eval.yaml
+tests/dotnet-msbuild/property-patterns/eval.yaml
+tests/dotnet-msbuild/target-authoring/eval.yaml
+tests/dotnet-template-engine/template-comparison/eval.yaml
+tests/dotnet-test/code-testing-agent/eval.yaml
+tests/dotnet-test/coverage-analysis/eval.yaml
+tests/dotnet-upgrade/migrate-nullable-references/eval.yaml
+tests/dotnet/setup-local-sdk/eval.yaml
+tests/dotnet11/system-text-json-net11/eval.yaml
+tests/dotnet-blazor/use-js-interop/eval.yaml
+tests/dotnet-experimental/exp-test-maintainability/eval.yaml
+tests/dotnet-maui/maui-app-lifecycle/eval.yaml
+tests/dotnet-maui/maui-collectionview/eval.yaml
+tests/dotnet-maui/maui-data-binding/eval.yaml
+tests/dotnet-maui/maui-dependency-injection/eval.yaml
+tests/dotnet-maui/maui-safe-area/eval.yaml
+tests/dotnet-maui/maui-shell-navigation/eval.yaml
+tests/dotnet-maui/maui-theming/eval.yaml
+tests/dotnet-msbuild/msbuild-antipatterns/eval.yaml
+tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+tests/dotnet-test/find-untested-sources/eval.yaml
+tests/dotnet-test/generate-testability-wrappers/eval.yaml
+tests/dotnet-test/grade-tests/eval.yaml

--- a/eng/run-skill-evals.sh
+++ b/eng/run-skill-evals.sh
@@ -6,10 +6,12 @@
 # over the dotnet-skills experiment (baseline = no skills, skilled = the one
 # skill under test), then uses the adapter (eng/vally-adapter/adapt.mjs) to split
 # the output by eval and score each skill head-to-head, producing the per-skill
-# results.json CI also produces. A skill passes only on a credible improvement
-# (mean preference > 0 with its 95% CI above 0). The underlying evaluation
-# harness is an implementation detail and may change without affecting this
-# command or its output layout.
+# results.json CI also produces. A skill passes only on a credible net win over
+# baseline — more wins than losses, by an exact one-sided sign test at p <= 0.05
+# — over enough trials for any record to reach that bar; below that floor the
+# verdict is reported as underpowered instead. The underlying evaluation harness
+# is an implementation detail and may change without affecting this command or
+# its output layout.
 #
 # Usage:
 #   ./eng/run-skill-evals.sh                          # all skills
@@ -27,9 +29,11 @@
 #   VALLY             Eval CLI invocation (default: npx @microsoft/vally-cli)
 #   RESULTS_DIR       Output root (default: ./eval-results)
 #
-# Model, judge model, and runs-per-stimulus come from the experiment file's
-# `overrides:` block — edit dotnet-skills.experiment.yaml (or point EXPERIMENT_FILE
-# at your own copy) to change them.
+# Model and judge model come from the experiment file's `overrides:` block —
+# edit dotnet-skills.experiment.yaml (or point EXPERIMENT_FILE at your own copy)
+# to change them. Runs-per-stimulus is deliberately NOT set there: it is a
+# per-eval `defaults.runs`, because an experiment-level override would replace
+# every eval's own value rather than default it.
 #
 # Prerequisites (verified automatically at startup, with actionable errors):
 #   - Node.js 20+ (CI uses 22); the eval CLI is fetched on first use via npx
@@ -60,10 +64,8 @@ read_override() {
 }
 MODEL="$(read_override model)"
 JUDGE_MODEL="$(read_override judge_model)"
-RUNS="$(read_override runs)"
 MODEL="${MODEL:-claude-opus-4.6}"
 JUDGE_MODEL="${JUDGE_MODEL:-claude-opus-4.6}"
-RUNS="${RUNS:-1}"
 
 PLUGIN="${1:-}"
 SKILL="${2:-}"
@@ -124,7 +126,7 @@ else
   CLEAR_DIR=""
 fi
 
-echo -e "${BOLD}Running $SCOPE_DESC — model=$MODEL runs=$RUNS workers=$WORKERS${NC}"
+echo -e "${BOLD}Running $SCOPE_DESC — model=$MODEL workers=$WORKERS${NC}"
 echo ""
 
 # ---- Run the experiment -----------------------------------------------------
@@ -174,20 +176,28 @@ node "$ADAPTER_DIR/adapt.mjs" \
 # ---- Summary ----------------------------------------------------------------
 
 echo ""
-PASS=0; NOIMPROVE=0; FAIL=0
+PASS=0; NOIMPROVE=0; INDETERMINATE=0; FAIL=0
 while IFS= read -r RESULTS_JSON; do
-  PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].passed)" "$RESULTS_JSON" 2>/dev/null || echo "")
-  case "$PASSED" in
-    true)  PASS=$((PASS + 1)) ;;
-    false) NOIMPROVE=$((NOIMPROVE + 1)) ;;
-    *)     FAIL=$((FAIL + 1)) ;;
+  # "indeterminate" covers both an incomplete comparison and an eval with too
+  # few trials for the confidence interval to mean anything — neither is
+  # evidence that the skill failed to help.
+  STATE=$(node -e "
+    const v = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8')).verdicts[0];
+    console.log(v.conclusive === false || v.underpowered === true ? 'indeterminate' : v.passed ? 'pass' : 'noimprove');
+  " "$RESULTS_JSON" 2>/dev/null || echo "")
+  case "$STATE" in
+    pass)          PASS=$((PASS + 1)) ;;
+    noimprove)     NOIMPROVE=$((NOIMPROVE + 1)) ;;
+    indeterminate) INDETERMINATE=$((INDETERMINATE + 1)) ;;
+    *)             FAIL=$((FAIL + 1)) ;;
   esac
 done < <(find "$RESULTS_ROOT" -name results.json -not -path "$EXPERIMENT_OUT/*")
 
-PRODUCED=$((PASS + NOIMPROVE + FAIL))
+PRODUCED=$((PASS + NOIMPROVE + INDETERMINATE + FAIL))
 echo -e "${BOLD}━━━ Summary ━━━${NC}"
 echo -e "  ${GREEN}✔ $PASS passed${NC}"
 [ $NOIMPROVE -gt 0 ] && echo -e "  ${CYAN}⊘ $NOIMPROVE no improvement${NC}"
+[ $INDETERMINATE -gt 0 ] && echo -e "  ${YELLOW}⚠ $INDETERMINATE underpowered or inconclusive${NC}"
 [ $FAIL -gt 0 ] && echo -e "  ${RED}✘ $FAIL unreadable${NC}"
 echo -e "  Skills evaluated: $PRODUCED"
 echo -e "  Results: $RESULTS_ROOT"

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -27,7 +27,7 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 | Column | Meaning |
 |--------|---------|
 | `Skill` | Skill under test |
-| `Result` | ✅ credible net win / ❌ no credible net win / ⚠️ no verdict possible (underpowered eval, or a comparison that errored, had unmatched trials, or contradicted itself) |
+| `Result` | ✅ credible net win / 🔻 credible regression / ❌ no credible change / ⚠️ the gate withheld a verdict (underpowered eval, or a comparison that errored, had unmatched trials, or contradicted itself) |
 | `Net win` | `(wins − losses) / trials`. **The deciding effect size** |
 | `p` | One-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials |
 | `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -27,8 +27,10 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 | Column | Meaning |
 |--------|---------|
 | `Skill` | Skill under test |
-| `Result` | ✅ credible improvement / ❌ no credible improvement / ⚠️ inconclusive (comparison errored or had unmatched trials) |
-| `Δ Preference [95% CI]` | Mean head-to-head preference of skilled vs baseline (−100%…+100%) and its 95% CI (passes only when the whole interval is above 0) |
+| `Result` | ✅ credible net win / ❌ no credible net win / ⚠️ no verdict possible (underpowered eval, or a comparison that errored, had unmatched trials, or contradicted itself) |
+| `Net win` | `(wins − losses) / trials`. **The deciding effect size** |
+| `p` | One-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials |
+| `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |
 | `W/T/L` | Wins / ties / losses across trials |
 | `Quality` (+ `Quality (Plugin)` in the full step summary) / `Baseline` | Mean absolute judge score 0–5 for skilled isolated (and plugin) vs the skill-free control |
 | `Overfit` | Overfitting-judge severity — ✅ Low, 🟡 Moderate, 🔴 High, — none — with its score |
@@ -54,11 +56,17 @@ A verdict carries **both** the head-to-head preference (what gates the PR) and a
 | Field | Description |
 |-------|-------------|
 | `skillName` / `skillPath` | The skill under test |
-| `passed` | **The gate.** `true` only on a *credible* improvement: `meanScore > 0` **and** the 95% CI is entirely above 0 |
-| `meanScore` | Mean preference of skilled over baseline (fraction, −1..1) from `vally compare` |
-| `confidenceInterval` | `{ low, high, level: 0.95 }` — the 95% CI on `meanScore` |
-| `winRate`, `wins`, `ties`, `losses` | Trial-level head-to-head tally |
-| `trialCount`, `erroredCount` | Total trials and how many errored (errored trials don't count toward the mean) |
+| `passed` | **The gate.** `true` only on a credible net win: more wins than losses at `signTest.pValue <= 0.05`, `conclusive`, and not `underpowered` |
+| `netWin` | `(wins − losses) / trials` — the effect size the gate reads. Magnitude-free, so an identical W/T/L record always yields an identical verdict |
+| `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over the discordant (non-tie) trials. **This is what decides.** Ties can't support a win, so they hold `discordant` down |
+| `regressed` | `true` when the *losses* are credible by the same test — the mirror of `passed` |
+| `conclusive` | `false` when the comparison didn't complete: errored trials, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
+| `underpowered` | `true` when a *completed* comparison counted fewer than `minCredibleTrials` trials, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. Disjoint from `conclusive` |
+| `minCredibleTrials` | The trial floor in force (5). See `eng/eval-quality/README.md` for why |
+| `meanScore` | Vally's magnitude-weighted mean preference (`much-better` ±1.0, `slightly-better` ±0.4), −1..1. **Triage only — not the gate**; weighting the statistic by magnitude is what made verdicts flip in dotnet/skills#952 |
+| `confidenceInterval` | `{ low, high, level: 0.95 }` — the 95% CI on `meanScore`, reported alongside it |
+| `winRate`, `wins`, `ties`, `losses` | Trial-level head-to-head tally as vally reported it |
+| `trialCount`, `erroredCount` | Counted trials (scenarios × `defaults.runs`) and how many errored (errored trials don't count toward either statistic) |
 | `reason` | Human-readable summary of the above |
 | `scenarios[]` | Per-scenario detail (below) |
 
@@ -102,13 +110,19 @@ The agent didn't finish within the eval's `config.timeout`. Either the task is t
 ### 3. Skill didn't activate (`skillActivationIsolated.activated == false`)
 The skill was available but the agent never invoked it, so "skilled" ≈ "baseline" and no improvement is possible. Fixes: sharpen the skill's `description`/trigger phrasing in `SKILL.md` so the model recognizes when to use it, and make sure the eval prompt actually describes a task the skill targets.
 
-### 4. No credible improvement (`passed == false` with `meanScore <= 0` or CI crossing 0)
+### 4. Underpowered eval (`underpowered == true`)
+Not a skill problem — an eval problem. The gate is an exact one-sided sign test over the head-to-head trials, and `trials = scenarios × defaults.runs`. That test cannot reach `p ≤ 0.05` on fewer than five discordant trials (`0.5⁴ = 0.0625`), and discordant trials can never exceed counted trials — so below `minCredibleTrials` (5) **no possible record passes**, however good the skill is.
+
+Do not "fix" the skill in response to this. Fix the eval: add scenarios (strongly preferred — five repeats of one scenario satisfy the arithmetic but still measure the skill on a single task), or declare `defaults: { runs: N }` in its `eval.yaml` so `scenarios × runs >= 5`. `eng/eval-quality/check_eval_quality.py` fails any new eval below the floor and tracks the grandfathered ones in `eng/eval-quality/underpowered-allowlist.txt`.
+
+### 5. No credible net win (`passed == false` with `netWin <= 0` or `signTest.pValue > 0.05`)
 The judge didn't consistently prefer the skilled run over baseline.
-- **`meanScore <= 0`** — baseline was as good or better. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. Strengthen the skill's guidance, or reconsider whether the scenario exercises the skill's value.
-- **`meanScore > 0` but CI includes 0** — a real but noisy signal. Add more/broader scenarios to the eval so there's enough evidence, and ensure the skill helps consistently rather than occasionally.
+- **`netWin <= 0`** — at least as many losses as wins. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. Strengthen the skill's guidance, or reconsider whether the scenario exercises the skill's value. If `regressed` is also `true`, the losses themselves are credible: the skill is actively hurting.
+- **`netWin > 0` but `signTest.pValue > 0.05`** — a real but inconsistent signal: the skill wins some scenarios and ties or loses others. Ties count against here, because they hold the discordant trial count down. Add more/broader scenarios so there is enough evidence, and make the skill help consistently rather than occasionally.
+- Do **not** read `meanScore` here. It is magnitude-weighted and reported for triage only; a verdict never turns on it (see `eng/eval-quality/README.md`, "Why the gate scores direction, not magnitude").
 - Inspect `scenarios[].trials[].evidence` for the judge's reasoning on losses/ties, and compare the skilled vs baseline `events.jsonl` to see what the skill changed (or failed to change).
 
-### 5. Quality looks fine but the skill still fails the gate
+### 6. Quality looks fine but the skill still fails the gate
 The gate is a **preference** comparison, not an absolute score. A high `skilledIsolated.judgeResult.overallScore` that isn't clearly better than `baseline.judgeResult.overallScore` will not pass. Focus on the *delta* over baseline, not the absolute number.
 
 ## Re-running

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -20,6 +20,12 @@ result:
 - `conclusive` is `false` when either signal is nonzero. An inconclusive verdict
   cannot pass and is rendered as a workflow warning rather than as evidence
   that a skill regressed.
+- `underpowered` is a separate signal with the same "not evidence of a
+  regression" property, but a different cause: the eval counted fewer than
+  `minCredibleTrials` trials, so no possible win/tie/loss record could have
+  reached the sign test's 5% threshold. It is a property of the eval spec, not
+  of the run, and it is fixed by adding scenarios or raising `defaults.runs` —
+  never by changing the skill. See `eng/eval-quality/README.md`.
 
 Inspect the raw variant `results.jsonl` before changing a skill. A
 `status: "error"` agent timeout is different from a successful pair whose

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -14,8 +14,10 @@
  *      baseline vs skilled slices. Comparison is a head-to-head, position-swap
  *      debiased judgment — the correct signal for "did the skill help?", rather
  *      than differencing two independently-graded absolute scores. This drives
- *      the PR gate/comment (a skill passes only on a *credible* improvement:
- *      mean preference > 0 with its 95% CI entirely above 0).
+ *      the PR gate/comment: a skill passes only on a credible *net win* (more
+ *      wins than losses by an exact one-sided sign test at 5%) over at least
+ *      MIN_CREDIBLE_TRIALS trials. Below that floor the verdict is reported as
+ *      underpowered rather than as a pass or a failure.
  *   4. Emit a per-skill results.json that is a SUPERSET carrying BOTH:
  *        - the compare-based preference verdict (for gating + PR comment), and
  *        - absolute per-role dashboard fields (baseline / skilledIsolated /
@@ -44,7 +46,14 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv
 // CLI
 // ---------------------------------------------------------------------------
 
+// Parse the process's argv only when this file IS the process. Importing a
+// module must never make it interpret its importer's command line: consolidate.mjs
+// reuses `trialDirection` from here, and with an unconditional parse its own
+// `--format` flag made this `strict: true` call throw at import time. Passing
+// `args: []` still applies every declared default, so `opts` is well-formed
+// either way.
 const { values: opts } = parseArgs({
+  args: isMain ? process.argv.slice(2) : [],
   options: {
     "experiment-dir": { type: "string" },
     "output-root": { type: "string", default: "eval-results" },
@@ -98,9 +107,48 @@ Options:
   process.exit(opts.help ? 0 : 1);
 }
 
-// Credibility threshold: a skill "passes" only when the mean preference is
-// positive AND its 95% CI is entirely above zero. Mirrors compare's own
-// --fail-on-regression logic (negated), so pass/fail are symmetric and honest.
+// Credibility threshold: a skill "passes" only on a credible *net win* over the
+// baseline — more wins than losses, by an exact one-sided sign test at 5%.
+//
+// Two properties matter here, and the gate had neither before.
+//
+// 1. It must not read magnitude. Compare scores each trial on a five-point
+//    ordinal scale ({-1, -0.4, 0, +0.4, +1}), and putting a Student-t interval
+//    over those numbers makes it read the 0.4 -> 1.0 step as *variance*, so a
+//    skill is punished for winning more decisively. With four wins and three
+//    ties over seven trials:
+//
+//      every win "slightly-better"  -> mean +0.229, ciLow +0.031  PASS
+//      one win   "much-better"      -> mean +0.314, ciLow -0.021  FAIL
+//
+//    Same record, better outcome, reversed verdict. That is the mechanism
+//    behind the A/A instability in dotnet/skills#952, where two runs on
+//    byte-identical inputs flipped 3 of 11 verdicts. Scoring win/tie/loss
+//    removes it at the source, and makes the verdict a deterministic function
+//    of the record: identical W/L, identical result, every time.
+//
+// 2. It must be calibrated. A t-interval over win/tie/loss still is not: at
+//    these sample sizes it is anticonservative in every case where it disagrees
+//    with the exact test, never conservative. It passes 4W/0T/0L (p = 0.0625),
+//    4W/3T/0L (p = 0.0625) and 6W/0T/1L (p = 0.0625) — all short of 5%. The
+//    exact binomial tail over the discordant (non-tie) trials has no such gap.
+//
+// Ties are not discarded silently: they cannot support a win, so they hold the
+// discordant count down and a tie-heavy record simply fails to reach 5%.
+const SIGN_TEST_ALPHA = 0.05;
+
+// Minimum counted trials behind a verdict. This is not a chosen constant: the
+// sign test cannot reach 5% on fewer than five discordant trials
+// (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5), and discordant trials can never
+// exceed counted trials — so at four or fewer, no possible record produces a
+// pass. Reporting those as "underpowered" rather than as a failure is what
+// stops "won every trial, failed anyway" from being rediagnosed every run.
+//
+// It is an *eligibility* floor — the minimum evidence a verdict may rest on —
+// not a guarantee of adequate power for a realistic effect, which needs
+// considerably more. eng/eval-quality/check_eval_quality.py enforces the same
+// number against eval specs before they are ever run.
+const MIN_CREDIBLE_TRIALS = 5;
 
 // ---------------------------------------------------------------------------
 // JSONL loading + provenance
@@ -340,9 +388,99 @@ function warn(msg) {
 // compare invocation
 // ---------------------------------------------------------------------------
 
+/**
+ * Split a CLI invocation into its binary plus fixed prefix args.
+ *
+ * The invocation may legitimately be multi-token ("npx @microsoft/vally-cli"),
+ * so it can't be passed through as a single argv entry. Quoted segments are
+ * kept together: plain whitespace splitting silently mangles any path
+ * containing a space, e.g. Windows' "C:\\Program Files\\nodejs\\node.exe".
+ */
 function splitVallyCommand(cmd) {
-  const parts = cmd.trim().split(/\s+/);
-  return { bin: parts[0], prefix: parts.slice(1) };
+  const tokens = [];
+  let current = "";
+  let quote = null;
+  let inToken = false;
+  for (const ch of cmd.trim()) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      inToken = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (inToken) {
+        tokens.push(current);
+        current = "";
+        inToken = false;
+      }
+      continue;
+    }
+    current += ch;
+    inToken = true;
+  }
+  if (inToken) tokens.push(current);
+  // An unterminated quote means the input was never shell-quoted in the first
+  // place — most likely a bare apostrophe in a path ("/home/o'brien/vally.mjs").
+  // Consuming it would drop the character and swallow the following whitespace
+  // into one mangled argv entry, so fall back to the original whitespace split,
+  // which passes such input through verbatim.
+  if (quote !== null) {
+    const parts = cmd.trim().split(/\s+/);
+    return { bin: parts[0], prefix: parts.slice(1) };
+  }
+  return { bin: tokens[0] ?? "", prefix: tokens.slice(1) };
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+function logFactorial(n) {
+  let acc = 0;
+  for (let i = 2; i <= n; i++) acc += Math.log(i);
+  return acc;
+}
+
+function logChoose(n, k) {
+  return logFactorial(n) - logFactorial(k) - logFactorial(n - k);
+}
+
+/**
+ * One-sided exact binomial tail: P(X >= wins | n = wins + losses, p = 0.5).
+ *
+ * The sign test conditions on the discordant (non-tie) trials, which is what
+ * makes it exact — there is no distributional assumption to violate at n = 6.
+ * Computed in log space so the binomial coefficient can't overflow if trial
+ * counts ever grow.
+ */
+function signTestPValue(wins, losses) {
+  const n = wins + losses;
+  if (n === 0) return 1;
+  let tail = 0;
+  for (let k = wins; k <= n; k++) tail += Math.exp(logChoose(n, k) + n * Math.log(0.5));
+  return Math.min(1, tail);
+}
+
+/**
+ * The direction of one comparison trial, as -1 / 0 / +1.
+ *
+ * `winner` is the judge's categorical verdict and is authoritative; `score` is
+ * a magnitude derived from it. Reading the score's sign instead would let a
+ * schema change or an absent score silently become a tie while the summary
+ * still reports a win, so prefer the winner and fall back only when it's absent.
+ */
+function trialDirection(trial) {
+  const winner = trial.winner;
+  if (winner === "treatment") return 1;
+  if (winner === "baseline") return -1;
+  if (winner === "tie") return 0;
+  const score = trial.score;
+  return typeof score === "number" ? Math.sign(score) : 0;
 }
 
 /**
@@ -406,8 +544,54 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   const unmatchedBaseline = report.unmatchedBaseline ?? [];
   const unmatchedTreatment = report.unmatchedTreatment ?? [];
   const unmatchedTrialCount = unmatchedBaseline.length + unmatchedTreatment.length;
-  const conclusive = s.erroredCount === 0 && unmatchedTrialCount === 0;
-  const passed = conclusive && s.meanScore > 0 && s.ciLow > 0;
+
+  // Every counted trial, as a direction. Errored trials are excluded from every
+  // statistic (matching compare's own `summarize`) so a flaky judge can't
+  // register as a run of genuine ties.
+  const directions = (report.stimuli ?? [])
+    .flatMap((st) => st.trials ?? [])
+    .filter((t) => !t.errored)
+    .map(trialDirection);
+  const wins = directions.filter((d) => d > 0).length;
+  const losses = directions.filter((d) => d < 0).length;
+  const ties = directions.length - wins - losses;
+
+  // The gate reads the enumerated trials; the summary is what humans read. If
+  // they disagree, the report is malformed and neither can be trusted — that is
+  // a comparison that didn't complete, not a small eval, so it must not be
+  // routed to the contributor as "add more scenarios".
+  const summaryAgrees =
+    directions.length === (s.trialCount ?? 0) &&
+    wins === (s.wins ?? 0) &&
+    ties === (s.ties ?? 0) &&
+    losses === (s.losses ?? 0);
+  if (!summaryAgrees) {
+    warn(
+      `${identity.plugin}/${identity.skill}: compare summary reports ` +
+        `${s.trialCount} trial(s) ${s.wins}W/${s.ties}T/${s.losses}L but stimuli[].trials shows ` +
+        `${directions.length} trial(s) ${wins}W/${ties}T/${losses}L — verdict marked inconclusive`,
+    );
+  }
+
+  const conclusive = s.erroredCount === 0 && unmatchedTrialCount === 0 && summaryAgrees;
+  // Too few counted trials for any record to reach significance — see
+  // MIN_CREDIBLE_TRIALS. This is a property of the eval spec, not of the run, so
+  // it is only claimed when the comparison actually completed: a trial count
+  // depressed by errored, unmatched or unreadable trials is an infrastructure
+  // problem and is already reported as inconclusive.
+  const underpowered = conclusive && directions.length < MIN_CREDIBLE_TRIALS;
+
+  // The p-value is always the one-sided tail *in the direction the record
+  // actually points*, so a reported p never describes the opposite hypothesis
+  // to the verdict beside it. `passed` and `regressed` each additionally
+  // require that direction, so both read the tail they mean.
+  const direction = wins > losses ? "better" : losses > wins ? "worse" : "none";
+  const pValue =
+    direction === "worse" ? signTestPValue(losses, wins) : signTestPValue(wins, losses);
+  const netWin = directions.length ? (wins - losses) / directions.length : 0;
+  const credible = pValue <= SIGN_TEST_ALPHA;
+  const passed = conclusive && !underpowered && direction === "better" && credible;
+  const regressed = conclusive && !underpowered && direction === "worse" && credible;
   const nonActivation = nonActivationStims ?? new Set();
 
   // Compare's per-stimulus preference (meanScore + trials), keyed by name so we
@@ -436,10 +620,22 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     const skilled = roleFromRecords(skilledByStim.get(name));
     const plugin = hasPlugin ? roleFromRecords(pluginByStim.get(name)) : null;
 
+    // Per-scenario record on the same win/tie/loss basis as the verdict, so a
+    // scenario row can never point the opposite way to the verdict it feeds.
+    // Computed once here rather than re-derived by each renderer.
+    const counted = (st?.trials ?? []).filter((t) => !t.errored);
+    const sWins = counted.filter((t) => trialDirection(t) > 0).length;
+    const sLosses = counted.filter((t) => trialDirection(t) < 0).length;
+
     const scenario = {
       scenarioName: name,
-      // Compare-based preference (drives PR comment/gate); 0/empty when compare
-      // didn't cover this stimulus.
+      // The scenario's contribution to the verdict, on the gate's own basis.
+      netWin: counted.length ? (sWins - sLosses) / counted.length : 0,
+      wins: sWins,
+      ties: counted.length - sWins - sLosses,
+      losses: sLosses,
+      // Compare's magnitude-weighted preference for this stimulus. Reported for
+      // triage; the gate never reads it.
       meanScore: st?.meanScore ?? 0,
       trials: (st?.trials ?? []).map((t) => ({
         winner: t.winner,
@@ -466,29 +662,61 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     return scenario;
   });
 
+  const sweep = directions.length > 0 && wins === directions.length;
   const credibility =
     s.erroredCount > 0
       ? "inconclusive (comparison errors)"
       : unmatchedTrialCount > 0
         ? "inconclusive (unmatched trajectories)"
-        : passed
-          ? "credibly better"
-          : s.meanScore <= 0
-            ? "no improvement"
-            : "not credible (95% CI includes 0)";
+        : !summaryAgrees
+          ? `inconclusive (compare report inconsistent: summary says ${s.trialCount} trial(s) ` +
+            `${s.wins}W/${s.ties}T/${s.losses}L, trials show ${directions.length} ` +
+            `${wins}W/${ties}T/${losses}L)`
+          : underpowered
+            ? `underpowered (${directions.length} counted trial(s); a credible verdict needs at ` +
+              `least ${MIN_CREDIBLE_TRIALS}${sweep ? ", and this eval won every one of them" : ""}) — ` +
+              `raise the eval's trial count with more scenarios or defaults.runs`
+            : passed
+              ? "credibly better"
+              : regressed
+                ? "credibly worse"
+                : wins <= losses
+                  ? "no improvement"
+                  : `not credible (sign test p=${pValue.toFixed(3)} > ${SIGN_TEST_ALPHA})`;
 
   const reason =
-    `Mean preference ${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)} ` +
-    `[95% CI ${pct(s.ciLow)}, ${pct(s.ciHigh)}], ` +
-    `win rate ${pct(s.winRate)} (${s.wins}W/${s.ties}T/${s.losses}L over ${s.trialCount} trial(s)` +
+    `Net win ${netWin >= 0 ? "+" : ""}${pct(netWin)} ` +
+    `(${wins}W/${ties}T/${losses}L over ${directions.length} trial(s), ` +
+    `sign test p=${pValue.toFixed(3)}), ` +
+    `mean preference ${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)}` +
     `${s.erroredCount ? `, ${s.erroredCount} errored` : ""}` +
-    `${unmatchedTrialCount ? `, ${unmatchedTrialCount} unmatched` : ""}) — ${credibility}`;
+    `${unmatchedTrialCount ? `, ${unmatchedTrialCount} unmatched` : ""} — ${credibility}`;
 
   return {
     skillName: identity.skill,
     skillPath: identity.skillPath,
     conclusive,
+    underpowered,
+    minCredibleTrials: MIN_CREDIBLE_TRIALS,
     passed,
+    regressed,
+    // The deciding statistic: (wins - losses) / trials as the effect size, and
+    // an exact one-sided sign test over the discordant trials as its
+    // credibility. Magnitude-free, so it cannot reverse when the judge upgrades
+    // a win from "slightly-better" to "much-better".
+    netWin,
+    signTest: {
+      wins,
+      ties,
+      losses,
+      discordant: wins + losses,
+      // One-sided tail for `direction` — "better" and "none" use the
+      // improvement tail, "worse" the regression tail.
+      direction,
+      pValue,
+      alpha: SIGN_TEST_ALPHA,
+    },
+    // Vally's magnitude-weighted preference, reported for triage. NOT the gate.
     meanScore: s.meanScore,
     confidenceInterval: { low: s.ciLow, high: s.ciHigh, level: 0.95 },
     winRate: s.winRate,
@@ -508,9 +736,15 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
 }
 
 function verdictSummaryLine(v) {
-  const icon = !v.conclusive ? "⚠️" : v.passed ? "✅" : "❌";
+  const icon = !v.conclusive || v.underpowered ? "⚠️" : v.passed ? "✅" : "❌";
+  // Ordered and signed by net win, on the same basis as the verdict, so a line
+  // can never point ▼ for a scenario contributing a positive net win.
   const scenarios = v.scenarios
-    .map((s) => `    ${s.meanScore > 0 ? "▲" : s.meanScore < 0 ? "▼" : "="} ${s.scenarioName} (${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)})`)
+    .map(
+      (s) =>
+        `    ${s.netWin > 0 ? "▲" : s.netWin < 0 ? "▼" : "="} ${s.scenarioName} ` +
+        `(net ${s.netWin >= 0 ? "+" : ""}${pct(s.netWin)}, ${s.wins}W/${s.ties}T/${s.losses}L)`,
+    )
     .join("\n");
   return `${icon} ${v.skillName}: ${v.reason}${scenarios ? "\n" + scenarios : ""}`;
 }
@@ -649,4 +883,17 @@ if (isMain) {
   }
 }
 
-export { roleFromRecords, roleToDashboard, groupByStimulus, stimulusOf, comparisonToVerdict, evalIdentity, readNonActivationStimuli };
+export {
+  roleFromRecords,
+  roleToDashboard,
+  groupByStimulus,
+  stimulusOf,
+  comparisonToVerdict,
+  evalIdentity,
+  readNonActivationStimuli,
+  splitVallyCommand,
+  signTestPValue,
+  trialDirection,
+  MIN_CREDIBLE_TRIALS,
+  SIGN_TEST_ALPHA,
+};

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -6,7 +6,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { comparisonToVerdict, splitVallyCommand, signTestPValue, trialDirection, MIN_CREDIBLE_TRIALS, SIGN_TEST_ALPHA } from "./adapt.mjs";
+
 const adapterPath = fileURLToPath(new URL("./adapt.mjs", import.meta.url));
+
 const evalFile = "tests/dotnet-diag/analyzing-dotnet-performance/eval.yaml";
 
 function writeJsonl(path, records) {
@@ -27,63 +30,69 @@ function createExperiment(root) {
   return runDir;
 }
 
-function createFakeVally(root, mode) {
+function createFakeVally(root, mode, trialCount) {
   const scriptPath = join(root, "fake-vally.mjs");
   const statePath = join(root, "compare-count.txt");
   writeFileSync(
     scriptPath,
     `import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
-const [statePath, mode, command, ...args] = process.argv.slice(2);
+const [statePath, mode, trialCountRaw, command, ...args] = process.argv.slice(2);
 if (command !== "compare") process.exit(2);
+const trialCount = Number(trialCountRaw);
 const count = existsSync(statePath) ? Number(readFileSync(statePath, "utf8")) + 1 : 1;
 writeFileSync(statePath, String(count));
 if (mode === "fails") process.exit(3);
 const output = args[args.indexOf("--output") + 1];
 const errored = mode === "persistent" || (mode === "recover" && count === 1);
 const unmatched = mode === "unmatched";
+// One winning trial per run of the single stimulus, all scored "slightly
+// better". Errored trials are excluded from every statistic by vally, so the
+// errored modes report zero counted trials.
+const trials = Array.from({ length: trialCount }, (_, trialIndex) => ({
+  trialIndex,
+  winner: errored ? "tie" : "treatment",
+  magnitude: errored ? "equal" : "slightly-better",
+  score: errored ? 0 : 0.4,
+  evidence: errored ? "Comparison judge failed: timeout" : "Treatment was better",
+  baselinePassed: true,
+  treatmentPassed: true,
+  errored
+}));
 const report = {
   type: "comparison-report",
   summary: {
-    trialCount: errored ? 0 : 1,
-    erroredCount: errored ? 1 : 0,
+    trialCount: errored ? 0 : trialCount,
+    erroredCount: errored ? trialCount : 0,
     meanScore: errored ? 0 : 0.4,
-    ciLow: errored ? 0 : 0.1,
-    ciHigh: errored ? 0 : 0.7,
-    wins: errored ? 0 : 1,
+    ciLow: errored ? 0 : 0.4,
+    ciHigh: errored ? 0 : 0.4,
+    wins: errored ? 0 : trialCount,
     ties: 0,
     losses: 0,
     winRate: errored ? 0 : 1,
-    mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: 1, pValue: 1, exact: true },
+    mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: trialCount, pValue: 1, exact: true },
     metricDeltas: []
   },
-  stimuli: [{
-    stimulusName: "Scenario",
-    meanScore: errored ? 0 : 0.4,
-    trials: [{
-      trialIndex: 0,
-      winner: errored ? "tie" : "treatment",
-      magnitude: errored ? "equal" : "slightly-better",
-      score: errored ? 0 : 0.4,
-      evidence: errored ? "Comparison judge failed: timeout" : "Treatment was better",
-      baselinePassed: true,
-      treatmentPassed: true,
-      errored
-    }]
-  }],
+  stimuli: [{ stimulusName: "Scenario", meanScore: errored ? 0 : 0.4, trials }],
   unmatchedBaseline: unmatched ? ["Baseline only (trial 0)"] : [],
   unmatchedTreatment: unmatched ? ["Treatment only (trial 0)"] : []
 };
 writeFileSync(output, JSON.stringify(report) + "\\n");
 `,
   );
-  return { command: `${process.execPath} ${scriptPath} ${statePath} ${mode}`, statePath };
+  return {
+    command: `"${process.execPath}" "${scriptPath}" "${statePath}" ${mode} ${trialCount}`,
+    statePath,
+  };
 }
 
-function runAdapter(root, mode) {
+// Default to a trial count at the credibility floor so a test that isn't about
+// statistical power gets a verdict that can actually pass.
+function runAdapter(root, mode, trialCount = 5) {
   const runDir = createExperiment(root);
   const outputRoot = join(root, "output");
-  const fakeVally = createFakeVally(root, mode);
+  const fakeVally = createFakeVally(root, mode, trialCount);
   const result = spawnSync(
     process.execPath,
     [
@@ -130,8 +139,9 @@ test("retries a transient comparison error once", () => {
     assert.equal(compareCount, 2);
     assert.equal(verdict.erroredCount, 0);
     assert.equal(verdict.conclusive, true);
+    assert.equal(verdict.underpowered, false);
     assert.equal(verdict.passed, true);
-    assert.match(result.stderr, /reduced errored trials from 1 to 0/);
+    assert.match(result.stderr, /reduced errored trials from 5 to 0/);
   });
 });
 
@@ -149,7 +159,7 @@ test("keeps a persistent comparison error visible after one retry", () => {
     const { result, compareCount, verdict } = runAdapter(root, "persistent");
     assert.equal(result.status, 0, result.stderr);
     assert.equal(compareCount, 2);
-    assert.equal(verdict.erroredCount, 1);
+    assert.equal(verdict.erroredCount, 5);
     assert.equal(verdict.conclusive, false);
     assert.equal(verdict.passed, false);
     assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
@@ -169,4 +179,279 @@ test("surfaces unmatched trajectories in the verdict", () => {
     assert.equal(verdict.passed, false);
     assert.match(verdict.reason, /2 unmatched.*inconclusive \(unmatched trajectories\)/);
   });
+});
+
+// An eval with too few trials cannot clear the 95% CI bar at any effect size:
+// at one trial vally reports no interval at all (ciLow == mean), so before the
+// floor existed a single lucky judgment passed outright.
+test("reports a below-floor eval as underpowered rather than as a pass", () => {
+  withTempDir((root) => {
+    const { result, verdict } = runAdapter(root, "clean", 1);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(verdict.conclusive, true, "the comparison itself completed");
+    assert.equal(verdict.underpowered, true);
+    assert.equal(verdict.passed, false);
+    assert.equal(verdict.minCredibleTrials, 5);
+    assert.match(verdict.reason, /underpowered \(1 counted trial\(s\); a credible verdict needs at least 5/);
+    assert.match(verdict.reason, /won every one of them/);
+    assert.match(verdict.reason, /defaults\.runs/);
+    assert.match(result.stdout, /⚠️/);
+  });
+});
+
+test("passes once the eval reaches the credibility floor", () => {
+  withTempDir((root) => {
+    const { verdict } = runAdapter(root, "clean", 5);
+    assert.equal(verdict.underpowered, false);
+    assert.equal(verdict.passed, true);
+    assert.equal(verdict.trialCount, 5);
+    assert.match(verdict.reason, /credibly better/);
+  });
+});
+
+// --- the gate itself --------------------------------------------------------
+
+const IDENTITY = { skill: "s", plugin: "p", skillPath: "plugins/p/skills/s" };
+const EMPTY_ROLES = {
+  baselineByStim: new Map(),
+  skilledByStim: new Map(),
+  pluginByStim: null,
+  hasPlugin: false,
+};
+
+// Build a compare report from raw trial scores, spreading them over one
+// stimulus. `summaryOverrides` lets a test assert that a field is NOT read.
+function reportFromScores(scores, summaryOverrides = {}) {
+  const counted = scores.filter((s) => s !== null);
+  const winnerOf = (s) => (s > 0 ? "treatment" : s < 0 ? "baseline" : "tie");
+  return {
+    summary: {
+      trialCount: counted.length,
+      erroredCount: 0,
+      meanScore: counted.reduce((a, b) => a + b, 0) / (counted.length || 1),
+      ciLow: 0,
+      ciHigh: 0,
+      wins: counted.filter((s) => s > 0).length,
+      ties: counted.filter((s) => s === 0).length,
+      losses: counted.filter((s) => s < 0).length,
+      winRate: counted.filter((s) => s > 0).length / (counted.length || 1),
+      ...summaryOverrides,
+    },
+    stimuli: [
+      {
+        stimulusName: "Scenario",
+        meanScore: 0,
+        trials: scores.map((score, trialIndex) => ({
+          trialIndex,
+          score,
+          winner: winnerOf(score),
+          errored: false,
+        })),
+      },
+    ],
+    unmatchedBaseline: [],
+    unmatchedTreatment: [],
+  };
+}
+
+const gate = (scores, summaryOverrides) =>
+  comparisonToVerdict(reportFromScores(scores, summaryOverrides), IDENTITY, EMPTY_ROLES, new Set());
+
+// The defect behind dotnet/skills#952: weighting the statistic by how decisive
+// each win was let the SAME win/tie/loss record reverse the verdict when the
+// judge upgraded one win from "slightly-better" (+0.4) to "much-better" (+1.0).
+// Under vally's magnitude interval these two vectors give ciLow +0.031 and
+// -0.021 respectively — pass then fail. The gate must not be able to see that.
+test("an identical W/T/L record cannot flip when a win gets more decisive", () => {
+  const pairs = [
+    [
+      [0, 0, 0, 0.4, 0.4, 0.4, 0.4],
+      [0, 0, 0, 0.4, 0.4, 0.4, 1.0],
+    ],
+    [
+      [0.4, 0.4, 0.4, 0.4, 0.4],
+      [1.0, 0.4, 1.0, 0.4, 1.0],
+    ],
+    [
+      [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, -0.4],
+      [1.0, 0.4, 0.4, 0.4, 0.4, 0.4, -1.0],
+    ],
+  ];
+  for (const [mild, decisive] of pairs) {
+    const a = gate(mild);
+    const b = gate(decisive);
+    assert.equal(a.passed, b.passed, `verdict flipped for ${JSON.stringify(decisive)}`);
+    assert.equal(a.netWin, b.netWin);
+    assert.deepEqual(a.signTest, b.signTest);
+    // The magnitude-weighted mean does differ — it is reported, just not gated.
+    assert.notEqual(a.meanScore, b.meanScore);
+  }
+});
+
+// A t-interval over win/tie/loss still is not calibrated at these sample sizes:
+// wherever it disagrees with the exact test it is the permissive one, claiming
+// 95% confidence the record cannot support.
+test("records that miss 5% by the exact test do not pass", () => {
+  for (const scores of [
+    [0.4, 0.4, 0.4, 0.4], // 4W/0T/0L  p=0.0625
+    [0.4, 0.4, 0.4, 0.4, 0], // 4W/1T/0L  p=0.0625
+    [0, 0, 0, 0.4, 0.4, 0.4, 0.4], // 4W/3T/0L  p=0.0625
+    [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, -0.4], // 6W/0T/1L  p=0.0625
+  ]) {
+    const v = gate(scores);
+    assert.equal(v.passed, false, `${JSON.stringify(scores)} must not pass`);
+    assert.ok(v.signTest.pValue > SIGN_TEST_ALPHA || v.underpowered);
+  }
+});
+
+test("the smallest record that does pass is five wins and no losses", () => {
+  const v = gate([0.4, 0.4, 0.4, 0.4, 0.4]);
+  assert.equal(v.passed, true);
+  assert.equal(v.underpowered, false);
+  assert.ok(v.signTest.pValue <= SIGN_TEST_ALPHA);
+  assert.match(v.reason, /credibly better/);
+  // Ties never help a record reach significance, but they do not disqualify a
+  // record that already has five clean wins.
+  assert.equal(gate([0.4, 0.4, 0.4, 0.4, 0.4, 0, 0, 0]).passed, true);
+});
+
+test("the gate ignores the statistics vally reports", () => {
+  // vally's summary claims a decisively negative interval; the 6W/0T/0L record
+  // says otherwise, and the record is what decides.
+  const verdict = gate([0.4, 0.4, 0.4, 0.4, 0.4, 0.4], { ciLow: -0.9, ciHigh: -0.5 });
+  assert.equal(verdict.passed, true);
+  assert.equal(verdict.confidenceInterval.low, -0.9, "vally's interval is still reported");
+  assert.equal(verdict.netWin, 1);
+});
+
+test("losses sink a verdict, and a clean sweep of them is a credible regression", () => {
+  assert.equal(gate([0.4, 0.4, 0.4, -0.4, -0.4, -0.4]).passed, false, "even split");
+  const swept = gate([-0.4, -0.4, -0.4, -0.4, -0.4]);
+  assert.equal(swept.passed, false);
+  assert.equal(swept.regressed, true);
+  assert.match(swept.reason, /credibly worse/);
+  assert.equal(gate([0.4, 0.4, 0.4, 0, 0, -1.0]).passed, false, "one loss among ties");
+});
+
+// A reported p-value must describe the hypothesis it is printed beside. Taking
+// the improvement tail unconditionally made a 0W/0T/5L verdict read
+// "p=1.000 — credibly worse", when the deciding regression tail is 0.031.
+test("the p-value always describes the direction the record points", () => {
+  const worse = gate([-0.4, -0.4, -0.4, -0.4, -0.4]);
+  assert.equal(worse.signTest.direction, "worse");
+  assert.ok(Math.abs(worse.signTest.pValue - 0.03125) < 1e-12);
+  assert.ok(worse.signTest.pValue <= worse.signTest.alpha);
+
+  const better = gate([0.4, 0.4, 0.4, 0.4, 0.4]);
+  assert.equal(better.signTest.direction, "better");
+  assert.ok(Math.abs(better.signTest.pValue - 0.03125) < 1e-12);
+
+  const level = gate([0.4, 0.4, 0.4, -0.4, -0.4, -0.4]);
+  assert.equal(level.signTest.direction, "none");
+  assert.equal(level.passed, false);
+  assert.equal(level.regressed, false);
+});
+
+test("a summary whose tie count is wrong is inconclusive", () => {
+  // Trial and win/loss counts can agree while the tie count doesn't, which
+  // would leave the verdict's top-level W/T/L contradicting its own signTest.
+  const report = reportFromScores([0.4, 0.4, 0.4, 0.4, 0.4, 0]);
+  report.summary.ties = 0;
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+  assert.equal(verdict.conclusive, false);
+  assert.match(verdict.reason, /compare report inconsistent/);
+});
+
+test("each scenario carries its own record on the gate's basis", () => {
+  // Two "slightly-better" wins and one "much-better" loss: magnitude-weighted
+  // this scenario reads negative, but it contributes a positive net win, and a
+  // renderer keyed on magnitude would point the opposite way to the verdict.
+  const report = reportFromScores([0.4, 0.4, -1.0, 0.4, 0.4, 0.4]);
+  report.stimuli[0].meanScore = -0.06;
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+  const scenario = verdict.scenarios[0];
+  assert.equal(scenario.wins, 5);
+  assert.equal(scenario.losses, 1);
+  assert.equal(scenario.ties, 0);
+  assert.ok(scenario.netWin > 0, "net win is positive");
+  assert.ok(scenario.meanScore < 0, "while the magnitude-weighted mean is negative");
+});
+
+test("a summary that disagrees with its own trials is inconclusive, not underpowered", () => {
+  // A truncated or malformed compare report is an adapter/harness problem. It
+  // must not be routed to the contributor as "add more scenarios", which is a
+  // remedy they cannot apply.
+  const report = reportFromScores([0.4, 0.4, 0.4, 0.4, 0.4]);
+  report.stimuli = [];
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+  assert.equal(verdict.conclusive, false);
+  assert.equal(verdict.underpowered, false);
+  assert.equal(verdict.passed, false);
+  assert.match(verdict.reason, /compare report inconsistent/);
+});
+
+test("errored trials are excluded from the deciding statistic", () => {
+  const report = reportFromScores([0.4, 0.4, 0.4, 0.4, 0.4]);
+  report.stimuli[0].trials[0].errored = true;
+  report.summary.erroredCount = 1;
+  report.summary.trialCount = 4;
+  report.summary.wins = 4;
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+  assert.equal(verdict.signTest.wins, 4, "the errored trial is not counted");
+  assert.equal(verdict.conclusive, false);
+  assert.equal(
+    verdict.underpowered,
+    false,
+    "a trial count depressed by an infrastructure failure is inconclusive, not underpowered",
+  );
+  assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
+});
+
+test("direction comes from the judge's winner, not the derived score", () => {
+  assert.equal(trialDirection({ winner: "treatment", score: 0 }), 1);
+  assert.equal(trialDirection({ winner: "baseline", score: 0 }), -1);
+  assert.equal(trialDirection({ winner: "tie", score: 0.4 }), 0);
+  // Fall back to the score only when the categorical verdict is absent.
+  assert.equal(trialDirection({ score: 0.4 }), 1);
+  assert.equal(trialDirection({ score: -1 }), -1);
+  assert.equal(trialDirection({}), 0);
+});
+
+test("signTestPValue is the exact one-sided binomial tail", () => {
+  assert.equal(signTestPValue(0, 0), 1);
+  assert.ok(Math.abs(signTestPValue(4, 0) - 0.0625) < 1e-12);
+  assert.ok(Math.abs(signTestPValue(5, 0) - 0.03125) < 1e-12);
+  assert.ok(Math.abs(signTestPValue(6, 1) - 0.0625) < 1e-12);
+  assert.ok(Math.abs(signTestPValue(3, 3) - 0.65625) < 1e-12);
+});
+
+test("the credibility floor is the smallest count that can reach the alpha", () => {
+  // Stated as the property that fixes the constant, so changing it needs a
+  // reason: 0.5^5 = 0.031 <= 0.05 < 0.0625 = 0.5^4, and discordant trials can
+  // never exceed counted trials.
+  assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS, 0) <= SIGN_TEST_ALPHA);
+  assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS - 1, 0) > SIGN_TEST_ALPHA);
+});
+
+// --- CLI tokenizer ----------------------------------------------------------
+
+test("splitVallyCommand keeps quoted paths whole and passes odd input through", () => {
+  assert.deepEqual(splitVallyCommand("npx @microsoft/vally-cli"), {
+    bin: "npx",
+    prefix: ["@microsoft/vally-cli"],
+  });
+  assert.deepEqual(splitVallyCommand("  vally  "), { bin: "vally", prefix: [] });
+  assert.deepEqual(splitVallyCommand('"C:\\Program Files\\nodejs\\node.exe" run.mjs'), {
+    bin: "C:\\Program Files\\nodejs\\node.exe",
+    prefix: ["run.mjs"],
+  });
+  // An unterminated quote means the input was never shell-quoted — most likely
+  // an apostrophe in a path. Consuming it would drop the character and swallow
+  // the following whitespace into one mangled argv entry, so fall back to the
+  // plain whitespace split, which passes it through verbatim.
+  assert.deepEqual(splitVallyCommand("node /home/o'brien/vally.mjs --flag"), {
+    bin: "node",
+    prefix: ["/home/o'brien/vally.mjs", "--flag"],
+  });
+  assert.deepEqual(splitVallyCommand(""), { bin: "", prefix: [] });
 });

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -7,7 +7,9 @@
  *
  * Each results.json (written by adapt.mjs) has:
  *   { model, judgeModel, timestamp, verdicts: [ {
- *       skillName, passed, meanScore, confidenceInterval:{low,high},
+ *       skillName, passed, conclusive, underpowered, regressed,
+ *       netWin, signTest:{wins,ties,losses,discordant,pValue,alpha},  // the gate
+ *       meanScore, confidenceInterval:{low,high},  // magnitude, triage only
  *       winRate, wins, ties, losses, trialCount, erroredCount, reason,
  *       scenarios: [ { scenarioName, skilledIsolated:{judgeResult:{overallScore}},
  *                      skilledPlugin?:{judgeResult:{overallScore}},
@@ -15,8 +17,9 @@
  *   } ] }
  *
  * A skill's verdict is head-to-head preference of skilled vs baseline (judged by
- * `vally compare`): it PASSES only on a credible improvement (mean preference > 0
- * with its 95% CI above 0). Absolute per-role quality is shown for context.
+ * `vally compare`): it PASSES only on a credible net win — more wins than
+ * losses by an exact one-sided sign test at 5% — over enough trials for any
+ * record to reach that bar. Absolute per-role quality is shown for context.
  *
  * Both formats render a table (Overfit + Skills Loaded columns included),
  * followed by a legend and a collapsible <details> per skill that carries the
@@ -34,6 +37,10 @@
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+
+// Reuse the adapter's trial-direction rule so the PR comment and the gate can
+// never disagree about who won a trial.
+import { trialDirection } from "./adapt.mjs";
 
 const { values: opts, positionals } = parseArgs({
   options: {
@@ -148,20 +155,31 @@ function activationCell(verdict) {
   return missingExpected ? `⚠️ ${cell}` : cell;
 }
 
-// Per-scenario preference table (mirrors evaluation-run.yml's step summary).
+// Per-scenario table (mirrors evaluation-run.yml's step summary).
+//
+// The arrow and the leading number follow the scenario's *net win*, so a
+// scenario's row can never point the opposite way to the verdict it feeds.
+// Ranking by magnitude instead let two `slightly-better` wins and one
+// `much-better` loss display ▼ while contributing a positive net win.
+//
+// adapt.mjs computes these per scenario; the fallback re-derives them from the
+// trials for results.json files written before it did.
 function scenarioTable(verdict) {
-  const rows = ["| Scenario | Mean preference | Trials (W/T/L) |", "|---|---|---|"];
+  const rows = ["| Scenario | Net win | Δ Pref | Trials (W/T/L) |", "|---|---|---|---|"];
   for (const s of verdict.scenarios ?? []) {
-    const m = typeof s.meanScore === "number" ? s.meanScore : 0;
-    const icon = m > 0 ? "▲" : m < 0 ? "▼" : "=";
-    let w = 0, t = 0, l = 0;
-    for (const tr of s.trials ?? []) {
-      if (tr.errored) continue;
-      if (tr.score > 0) w++;
-      else if (tr.score < 0) l++;
-      else t++;
+    let { netWin, wins, ties, losses } = s;
+    if (typeof netWin !== "number") {
+      const counted = (s.trials ?? []).filter((tr) => !tr.errored);
+      wins = counted.filter((tr) => trialDirection(tr) > 0).length;
+      losses = counted.filter((tr) => trialDirection(tr) < 0).length;
+      ties = counted.length - wins - losses;
+      netWin = counted.length ? (wins - losses) / counted.length : 0;
     }
-    rows.push(`| ${icon} ${td(s.scenarioName)} | ${pct(m)} | ${w}/${t}/${l} |`);
+    const icon = netWin > 0 ? "▲" : netWin < 0 ? "▼" : "=";
+    const m = typeof s.meanScore === "number" ? s.meanScore : 0;
+    rows.push(
+      `| ${icon} ${td(s.scenarioName)} | ${pct(netWin)} | ${pct(m)} | ${wins}/${ties}/${losses} |`,
+    );
   }
   return rows;
 }
@@ -180,32 +198,44 @@ for (const file of uniqueFiles) {
 
 verdicts.sort((a, b) => (a.skillName ?? "").localeCompare(b.skillName ?? ""));
 
-// A verdict is inconclusive (⚠️) when the comparison couldn't complete
-// (errored/unmatched trials); otherwise it passed (✅) or failed (❌). Mirrors
-// adapt.mjs and the evaluation-run.yml per-entry summary.
+// A verdict is ⚠️ when it can't support a pass/fail either because the
+// comparison couldn't complete (errored/unmatched trials) or because the eval
+// has too few trials for the interval to mean anything (`underpowered`).
+// Otherwise it passed (✅) or failed (❌). Mirrors adapt.mjs and the
+// evaluation-run.yml per-entry summary.
+function isIndeterminate(v) {
+  return v.conclusive === false || v.underpowered === true;
+}
+
 function resultIcon(v) {
-  if (v.conclusive === false) return "⚠️";
+  if (isIndeterminate(v)) return "⚠️";
   return v.passed ? "✅" : "❌";
 }
 
 const passedCount = verdicts.filter((v) => v.passed).length;
-const inconclusiveCount = verdicts.filter((v) => v.conclusive === false).length;
-const failedCount = verdicts.length - passedCount - inconclusiveCount;
+const underpoweredCount = verdicts.filter(
+  (v) => v.conclusive !== false && v.underpowered === true,
+).length;
+const incompleteCount = verdicts.filter((v) => v.conclusive === false).length;
+const indeterminateCount = underpoweredCount + incompleteCount;
+const failedCount = verdicts.length - passedCount - indeterminateCount;
 
 const isFull = opts.format === "full";
 
 const header = isFull
-  ? ["Skill", "Result", "Δ Preference [95% CI]", "W/T/L", "Quality (Isolated)", "Quality (Plugin)", "Baseline", "Overfit", "Skills Loaded"]
-  : ["Skill", "Result", "Δ Preference [95% CI]", "W/T/L", "Quality", "Baseline", "Overfit", "Skills Loaded"];
+  ? ["Skill", "Result", "Net win", "p", "Δ Pref", "W/T/L", "Quality (Isolated)", "Quality (Plugin)", "Baseline", "Overfit", "Skills Loaded"]
+  : ["Skill", "Result", "Net win", "p", "Δ Pref", "W/T/L", "Quality", "Baseline", "Overfit", "Skills Loaded"];
 
 const lines = [];
 lines.push(`## 📊 Skill Evaluation Results`);
 lines.push("");
 lines.push(
   `${verdicts.length} skill(s) evaluated — **${passedCount} improved**, **${failedCount} no credible improvement**` +
-    `${inconclusiveCount > 0 ? `, **${inconclusiveCount} inconclusive**` : ""}. ` +
-    `A skill passes only on a credible improvement over baseline (mean preference > 0 with its 95% CI above 0); ` +
-    `⚠️ marks a comparison that couldn't complete (errored/unmatched trials).`,
+    `${underpoweredCount > 0 ? `, **${underpoweredCount} underpowered**` : ""}` +
+    `${incompleteCount > 0 ? `, **${incompleteCount} inconclusive**` : ""}. ` +
+    `A skill passes only on a credible net win over baseline (more wins than losses, by an exact one-sided sign test at p ≤ 0.05); ` +
+    `⚠️ marks a verdict that can't be reached — either the eval has too few trials to clear that bar at all ` +
+    `(underpowered), or the comparison didn't complete (errored/unmatched trials).`,
 );
 lines.push("");
 
@@ -216,10 +246,17 @@ if (verdicts.length === 0) {
   lines.push(`|${header.map(() => "---").join("|")}|`);
   for (const v of verdicts) {
     const result = resultIcon(v);
-    const ci = v.confidenceInterval
-      ? ` [${pct(v.confidenceInterval.low)}, ${pct(v.confidenceInterval.high)}]`
-      : "";
-    const pref = `${pct(v.meanScore)}${ci}`;
+    // The deciding statistic is the net win and its sign-test p. Older
+    // results.json files predate both, so fall back to the magnitude-weighted
+    // mean and interval they were actually gated on at the time.
+    const hasNetWin = typeof v.netWin === "number";
+    const netWin = hasNetWin
+      ? pct(v.netWin)
+      : `${pct(v.meanScore)}${v.confidenceInterval ? ` [${pct(v.confidenceInterval.low)}, ${pct(v.confidenceInterval.high)}]` : ""}`;
+    const pv = v.signTest && typeof v.signTest.pValue === "number"
+      ? v.signTest.pValue.toFixed(3)
+      : "—";
+    const pref = pct(v.meanScore);
     const wtl = `${v.wins ?? 0}/${v.ties ?? 0}/${v.losses ?? 0}`;
     const isolated = fmtQuality(roleQuality(v, "skilledIsolated"));
     const plugin = fmtQuality(roleQuality(v, "skilledPlugin"));
@@ -227,8 +264,8 @@ if (verdicts.length === 0) {
     const overfit = fmtOverfit(v);
     const activation = activationCell(v);
     const cells = isFull
-      ? [td(v.skillName), result, pref, wtl, isolated, plugin, baseline, overfit, activation]
-      : [td(v.skillName), result, pref, wtl, isolated, baseline, overfit, activation];
+      ? [td(v.skillName), result, netWin, pv, pref, wtl, isolated, plugin, baseline, overfit, activation]
+      : [td(v.skillName), result, netWin, pv, pref, wtl, isolated, baseline, overfit, activation];
     lines.push(`| ${cells.join(" | ")} |`);
   }
   lines.push("");
@@ -236,9 +273,11 @@ if (verdicts.length === 0) {
   // Legend / glossary — kept out of table cells so it renders reliably.
   lines.push("<details><summary>ℹ️ Column legend</summary>");
   lines.push("");
-  lines.push("- **Δ Preference** — mean head-to-head preference of skilled vs baseline (−100%…+100%), judged by `vally compare`.");
-  lines.push("- **[95% CI]** — 95% confidence interval on that mean; a skill passes only when the whole interval is above 0.");
+  lines.push("- **Net win** — `(wins − losses) / trials` for skilled vs baseline, judged head-to-head by `vally compare`. **This is the effect the gate decides on.**");
+  lines.push("- **p** — one-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials.");
+  lines.push("- **Δ Pref** — the same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Reported for triage only: weighting the statistic by magnitude made a skill fail for winning *harder*, which is why the gate deliberately ignores this column.");
   lines.push("- **W/T/L** — wins / ties / losses across trials.");
+  lines.push("- **⚠️** — no verdict is possible: either the eval has fewer trials than any record needs to reach `p ≤ 0.05` (underpowered — add scenarios or raise `defaults.runs`), or the comparison didn't complete.");
   lines.push("- **Quality / Baseline** — mean absolute judge score 0–5 (skilled isolated vs skill-free control).");
   if (isFull) {
     lines.push("- **Quality (Plugin)** — mean absolute judge score 0–5 for the whole-plugin run.");
@@ -253,7 +292,7 @@ if (verdicts.length === 0) {
   // comment limit; when it can't all fit, the details that matter most for triage
   // (failing, then inconclusive) are kept and the rest are omitted with a pointer.
   const COMMENT_BUDGET = 63000; // leave headroom for links the workflow appends
-  const rank = (v) => (v.conclusive === false ? 1 : v.passed ? 2 : 0); // ❌, then ⚠️, then ✅
+  const rank = (v) => (isIndeterminate(v) ? 1 : v.passed ? 2 : 0); // ❌, then ⚠️, then ✅
   const detailBlocks = verdicts.map((v) => {
     const icon = resultIcon(v);
     const block = [

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -200,16 +200,17 @@ verdicts.sort((a, b) => (a.skillName ?? "").localeCompare(b.skillName ?? ""));
 
 // A verdict is ⚠️ when it can't support a pass/fail either because the
 // comparison couldn't complete (errored/unmatched trials) or because the eval
-// has too few trials for the interval to mean anything (`underpowered`).
-// Otherwise it passed (✅) or failed (❌). Mirrors adapt.mjs and the
-// evaluation-run.yml per-entry summary.
+// has too few trials for any result to reach the alpha (`underpowered`).
+// Otherwise it improved (✅), got credibly worse (🔻), or changed nothing the
+// gate can call (❌). Mirrors adapt.mjs and the evaluation-run.yml summary.
 function isIndeterminate(v) {
   return v.conclusive === false || v.underpowered === true;
 }
 
 function resultIcon(v) {
   if (isIndeterminate(v)) return "⚠️";
-  return v.passed ? "✅" : "❌";
+  if (v.passed) return "✅";
+  return v.regressed === true ? "🔻" : "❌";
 }
 
 const passedCount = verdicts.filter((v) => v.passed).length;
@@ -218,7 +219,8 @@ const underpoweredCount = verdicts.filter(
 ).length;
 const incompleteCount = verdicts.filter((v) => v.conclusive === false).length;
 const indeterminateCount = underpoweredCount + incompleteCount;
-const failedCount = verdicts.length - passedCount - indeterminateCount;
+const regressedCount = verdicts.filter((v) => v.regressed === true).length;
+const failedCount = verdicts.length - passedCount - indeterminateCount - regressedCount;
 
 const isFull = opts.format === "full";
 
@@ -229,13 +231,35 @@ const header = isFull
 const lines = [];
 lines.push(`## 📊 Skill Evaluation Results`);
 lines.push("");
+// Headline. Kept explicit about what ⚠️ is *not*: an underpowered eval is one
+// the gate refused to judge because no possible result at its size can reach
+// p <= 0.05. Reporting those next to real failures reads as a wall of
+// regressions, which is the opposite of what happened — the skill was never
+// measured. `regressed` is called out separately for the same reason: "did
+// anything get worse?" should be answerable from the first line.
 lines.push(
-  `${verdicts.length} skill(s) evaluated — **${passedCount} improved**, **${failedCount} no credible improvement**` +
-    `${underpoweredCount > 0 ? `, **${underpoweredCount} underpowered**` : ""}` +
-    `${incompleteCount > 0 ? `, **${incompleteCount} inconclusive**` : ""}. ` +
-    `A skill passes only on a credible net win over baseline (more wins than losses, by an exact one-sided sign test at p ≤ 0.05); ` +
-    `⚠️ marks a verdict that can't be reached — either the eval has too few trials to clear that bar at all ` +
-    `(underpowered), or the comparison didn't complete (errored/unmatched trials).`,
+  `${verdicts.length} skill(s) evaluated — ✅ **${passedCount} improved**, ` +
+    `❌ **${failedCount} no credible change**, 🔻 **${regressedCount} regressed**.`,
+);
+if (indeterminateCount > 0) {
+  const parts = [];
+  if (underpoweredCount > 0) {
+    parts.push(
+      `**${underpoweredCount} underpowered** — the eval has fewer trials than any result needs ` +
+        `to reach \`p ≤ 0.05\`, so no verdict was possible. This is the eval's size, **not a ` +
+        `skill regression**; fix it by adding scenarios or raising \`defaults.runs\``,
+    );
+  }
+  if (incompleteCount > 0) {
+    parts.push(`**${incompleteCount} inconclusive** — the comparison didn't complete (errored, unmatched, or self-contradictory trials)`);
+  }
+  lines.push("");
+  lines.push(`⚠️ **${indeterminateCount} could not be judged**: ${parts.join("; ")}.`);
+}
+lines.push("");
+lines.push(
+  `A skill passes only on a credible net win over baseline: more wins than losses, by an exact ` +
+    `one-sided sign test at \`p ≤ 0.05\`.`,
 );
 lines.push("");
 
@@ -277,7 +301,8 @@ if (verdicts.length === 0) {
   lines.push("- **p** — one-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials.");
   lines.push("- **Δ Pref** — the same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Reported for triage only: weighting the statistic by magnitude made a skill fail for winning *harder*, which is why the gate deliberately ignores this column.");
   lines.push("- **W/T/L** — wins / ties / losses across trials.");
-  lines.push("- **⚠️** — no verdict is possible: either the eval has fewer trials than any record needs to reach `p ≤ 0.05` (underpowered — add scenarios or raise `defaults.runs`), or the comparison didn't complete.");
+  lines.push("- **⚠️** — the gate withheld a verdict. Either the eval has fewer trials than any result needs to reach `p ≤ 0.05` (**underpowered** — the skill was never actually measured, so this is not a regression; add scenarios or raise `defaults.runs`), or the comparison didn't complete.");
+  lines.push("- **🔻** — a credible *regression*: the losses themselves clear the same bar the gate uses for wins.");
   lines.push("- **Quality / Baseline** — mean absolute judge score 0–5 (skilled isolated vs skill-free control).");
   if (isFull) {
     lines.push("- **Quality (Plugin)** — mean absolute judge score 0–5 for the whole-plugin run.");
@@ -291,8 +316,16 @@ if (verdicts.length === 0) {
   // away. Budgeted so the whole comment stays under GitHub's 65,536-character
   // comment limit; when it can't all fit, the details that matter most for triage
   // (failing, then inconclusive) are kept and the rest are omitted with a pointer.
+  // Two-phase selection so a passing (✅) detail can never be shown while a
+  // higher-priority detail was dropped for size: fit as many high-priority
+  // blocks as possible first, and only surface passing blocks if every
+  // high-priority block fit. Within the high-priority set, a credible
+  // regression (🔻) is considered before a no-change (❌) and both before an
+  // unjudgeable (⚠️) one, so a real regression can't lose its budget to an
+  // eval-size problem.
   const COMMENT_BUDGET = 63000; // leave headroom for links the workflow appends
-  const rank = (v) => (isIndeterminate(v) ? 1 : v.passed ? 2 : 0); // ❌, then ⚠️, then ✅
+  const rank = (v) =>
+    isIndeterminate(v) ? 2 : v.passed ? 3 : v.regressed === true ? 0 : 1;
   const detailBlocks = verdicts.map((v) => {
     const icon = resultIcon(v);
     const block = [


### PR DESCRIPTION
Fixes #952.

The eval gate flipped ~27% of its verdicts between runs on byte-identical inputs. I reproduced **all 22 verdicts** from the A/A test in #952 from the gate's formula alone, which isolates two independent defects — only one of which the issue names.

## Defect 1: the gate scored the judge's adjective

Trial scores are a five-point ordinal scale (`much-better` `+1.0`, `slightly-better` `+0.4`, `equal` `0`, …). A Student's-t interval over those reads the 0.4 → 1.0 step as *variance*, so a skill is punished for winning **more decisively**. Four wins and three ties over seven trials:

| trials | mean | ci_low | verdict |
| --- | ---: | ---: | --- |
| every win `slightly-better` | +0.229 | **+0.031** | ✅ |
| one win `much-better` | +0.314 | **−0.021** | ❌ |

Same record, better outcome, reversed verdict. `coverage-analysis` failed five consecutive runs while winning 100% of its trials, then passed on a sixth with the same 3W/0T/0L record — its scores were `[+0.4, +0.4, +1.0]` in a failing run and `[+0.4, +0.4, +0.4]` in the passing one.

## Defect 2 (not in the issue): no minimum sample size

`meanWithCi` returns `ciLow = mean` below two trials, so a single lucky judgment passed outright. Simulated at 200k runs/cell, **a skill with no real effect passes ~30% of the time at one trial** — and 18 of 94 gated evals sit there. The gate was simultaneously too strict at n=3 and a rubber stamp at n=1.

## The fix

**`adapt.mjs` reads only each trial's `winner`** and decides with an **exact one-sided sign test** at 5%. The verdict is now a deterministic function of the win/tie/loss record: identical records always produce identical results.

Collapsing to direction alone is *not* sufficient — I checked. A t-interval over win/tie/loss disagrees with the exact test on 12 records up to n=10, and in **every one it is the permissive side**, passing 4W/0T/0L, 4W/3T/0L and 6W/0T/1L at `p = 0.0625`. The exact binomial tail has no such gap, so the ported interval code is gone entirely.

**`MIN_CREDIBLE_TRIALS = 5` falls out of that test** rather than being chosen: the sign test cannot reach 5% below five discordant trials (`0.5⁴ = 0.0625`), and discordant trials can never exceed counted trials. Below it *no record can pass*, so the verdict is reported as **⚠️ underpowered** — never a pass, never a regression. That is what stops "won every trial, failed anyway" from being rediagnosed every run.

**`check_eval_quality.py` enforces the same floor on specs** before they ever run, counting `trials = scenarios × defaults.runs`. The 60 existing evals below it are grandfathered in a ledger that can only shrink: the gate errors on a stale, duplicated or unnecessary entry, and `--base-ref` (passed by CI on every PR) rejects entries that are *new* relative to the base branch — so a PR cannot add a below-floor eval and exempt it in the same change. Renames are read from git and aren't treated as growth.

**The experiment file no longer sets `runs` in `overrides:`.** Precedence is *CLI > experiment overrides > eval defaults* and the merge is a plain spread, so that line didn't *default* anything — it overwrote every eval's own `defaults.runs`, making the issue's first recommendation impossible to implement. No eval declares `defaults:` today, so this changes nothing until one opts in.

## Cost

**Zero additional CI minutes.** Raising `runs` on specific evals is deliberately left as follow-up — it's the only part that costs money, and it's now expressible. For the record, a targeted `runs = ceil(8/scenarios)` policy measures at **1.62× for `dotnet-test`** (~75 → ~121 min, inside the existing 180-minute timeout) and 1.82× repo-wide, versus 3.00× for the blanket `runs: 3` the issue rightly rejects.

## Also fixed (latent, found while testing)

- `--vally` paths containing a space were split into separate argv entries. This made the adapter test suite unrunnable on Windows, where `process.execPath` lives under `Program Files`. An unterminated quote now falls back to the old whitespace split so a bare apostrophe in a path can't be mangled either.
- Importing `adapt.mjs` made it parse its *importer's* command line.
- The `/evaluate` investigation prompt fired on every `passed == false`, which would have attached "To investigate failures" to essentially every comment once 60 evals started reporting ⚠️.
- Per-scenario rows ranked by magnitude could point ▼ while contributing a positive net win. All three renderers now read the same per-scenario record computed once in the adapter.

## What reviewers will notice

The PR comment gains **Net win** and **p** columns; `Δ Preference` becomes `Δ Pref` and is explicitly triage-only. **60 of 94 evals will render ⚠️ underpowered on the first run.** That is the honest state of the repo — none of them can currently produce a credible verdict — and ⚠️ fails no check. `eng/eval-quality/underpowered-allowlist.txt` is the ledger for burning it down.

## Verification

- 20/20 adapter tests, including a regression test that encodes the #952 defect directly (three score-vector pairs that differ only in magnitude must produce identical verdicts) and one asserting the gate ignores a deliberately negative `ciLow` from vally.
- 18/18 eval-quality self-tests, covering the trial floor, grandfathering, the shrink-only ratchet, rename handling, and an unresolvable base ref.
- `check_eval_quality.py` exit 0, `actionlint` clean on all three workflows, `bash -n`, `markdownlint` clean.
- Live `consolidate.mjs` render over four verdict shapes: new schema, **legacy schema** (pre-`netWin`/`signTest`), underpowered, and errored.

Three rounds of code review and design review; every finding is addressed in the diff.

Docs: `eng/eval-quality/README.md` gains failing check 7 plus a "Why the gate scores direction, not magnitude" section; `eng/vally-adapter/InvestigatingResults.md` documents the new verdict fields and the underpowered failure mode.