### PR TITLE
Fix invalid XML in version-tooling nuget.config (unblocks automated version bumps)

### DIFF
--- a/eng/version/nuget.config
+++ b/eng/version/nuget.config
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  Trusted, locked-down NuGet configuration for the version-stamping tooling.
-
-  The versioning workflows run `dotnet tool restore` to fetch nbgv. In the
-  /version-bump command this restore happens with a PR branch checked out, so
-  without an explicit --configfile dotnet would honor a nuget.config the PR
-  author added to remap the nbgv package source to a malicious feed and achieve
-  code execution in the privileged context. Passing --configfile <this file>
-  makes NuGet use ONLY these settings (no hierarchical discovery), and source
-  mapping pins every package to nuget.org.
--->
 <configuration>
+  <!--
+    Trusted, locked-down NuGet configuration for the version-stamping tooling.
+
+    The versioning workflows run `dotnet tool restore` to fetch nbgv. In the
+    /version-bump command this restore happens with a PR branch checked out, so
+    without an explicit configfile argument dotnet would honor a nuget.config the
+    PR author added to remap the nbgv package source to a malicious feed and
+    achieve code execution in the privileged context. Pointing `dotnet` at this
+    file with its configfile option makes NuGet use ONLY these settings (no
+    hierarchical discovery), and source mapping pins every package to nuget.org.
+
+    IMPORTANT: keep this comment free of a doubled hyphen. XML forbids the two
+    hyphen sequence inside a comment, so a phrase like the configfile flag written
+    with its leading hyphens made the whole file invalid XML. NuGet then failed
+    every restore with "NuGet.Config is not valid XML", which silently broke
+    `dotnet tool restore` in both versioning workflows.
+  -->
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
## Problem

The automated per-plugin versioning infra (added in #813) has **never produced a version bump**. Both `weekly-version-sync` and `version-bump-command` fail at their `dotnet tool restore` step with:

> `NuGet.Config is not valid XML. Path: 'eng/version/nuget.config'`

**Root cause:** the header comment in `eng/version/nuget.config` contained `--configfile` — a doubled hyphen `--`, which XML forbids *inside a comment*. That makes the entire file invalid XML, so NuGet rejects it before any restore can run. This has been broken since the file first landed.

Evidence:
- `weekly-version-sync` scheduled runs on 2026-07-20 and 2026-07-27 both **failed** at `Restore tools`.
- Reproduced locally: `[xml]` load fails with *"An XML comment cannot contain '--'"*; `dotnet tool restore --configfile eng/version/nuget.config` fails with the same NuGet error.

## Fix

Reword the comment to avoid any doubled-hyphen sequence (and move it inside `<configuration>`). No functional NuGet settings changed — the locked-down single-source pinning to nuget.org is preserved.

## Verification

- `[xml]` parse of the fixed file: **valid**.
- `dotnet tool restore --configfile eng/version/nuget.config`: **Restore was successful**.
- `nbgv get-version` against repo plugins computes correctly with canonical `pathFilters`.
- Drift check across all 16 plugins: **15 have drifted** from their stamped `x.y.0` and will be reconciled by the first successful `weekly-version-sync` run (e.g. `dotnet` 0.2.0→0.2.3, `dotnet-maui` 0.1.0→0.1.16, `dotnet-test` 0.2.0→0.2.10).

This one file unblocks both versioning workflows (they share this config).