### PR TITLE
Make BinlogMcp feed-neutral and configure eval NuGet source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,8 @@
           "args": [
             "dnx",
             "Microsoft.AITools.BinlogMcp",
-            "--yes"
+            "--yes",
+            "--prerelease"
           ],
           "tools": ["*"]
         }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,9 +35,7 @@
           "args": [
             "dnx",
             "Microsoft.AITools.BinlogMcp",
-            "--yes",
-            "--source",
-            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+            "--yes"
           ],
           "tools": ["*"]
         }

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -190,6 +190,11 @@ jobs:
           ref: ${{ inputs.head_sha || '' }}
           persist-credentials: false
 
+      - name: Configure NuGet for evaluations
+        run: |
+          mkdir -p "$HOME/.nuget/NuGet"
+          cp eng/evaluation/nuget.config "$HOME/.nuget/NuGet/NuGet.Config"
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/eng/allowed-external-deps.txt
+++ b/eng/allowed-external-deps.txt
@@ -24,5 +24,5 @@ script:migrate-nullable-references:scripts/Get-NullableReadiness.ps1
 tool-ref:msbuild:#tool:web/fetch
 tool-ref:msbuild:#tool:agent/runSubagent
 
-# dotnet-msbuild plugin: Microsoft.AITools.BinlogMcp server (binlog analysis MCP from dotnet-public feed)
+# dotnet-msbuild plugin: Microsoft.AITools.BinlogMcp server (binlog analysis MCP from dotnet-eng feed)
 mcp-server:dotnet-msbuild:binlog

--- a/eng/allowed-external-deps.txt
+++ b/eng/allowed-external-deps.txt
@@ -24,5 +24,5 @@ script:migrate-nullable-references:scripts/Get-NullableReadiness.ps1
 tool-ref:msbuild:#tool:web/fetch
 tool-ref:msbuild:#tool:agent/runSubagent
 
-# dotnet-msbuild plugin: Microsoft.AITools.BinlogMcp server (binlog analysis MCP from dotnet-eng feed)
+# dotnet-msbuild plugin: Microsoft.AITools.BinlogMcp server (binlog analysis MCP)
 mcp-server:dotnet-msbuild:binlog

--- a/eng/evaluation/nuget.config
+++ b/eng/evaluation/nuget.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Evaluation workspaces are created outside the repository, so the workflow
+       installs this as the runner's user-level configuration. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/eng/evaluation/nuget.config
+++ b/eng/evaluation/nuget.config
@@ -4,10 +4,10 @@
        installs this as the runner's user-level configuration. -->
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
+    <packageSource key="dotnet-public">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>

--- a/eng/version/nuget.config
+++ b/eng/version/nuget.config
@@ -9,7 +9,7 @@
     PR author added to remap the nbgv package source to a malicious feed and
     achieve code execution in the privileged context. Pointing `dotnet` at this
     file with its configfile option makes NuGet use ONLY these settings (no
-    hierarchical discovery), and source mapping pins every package to nuget.org.
+    hierarchical discovery), and source mapping pins every package to dotnet-public.
 
     IMPORTANT: keep this comment free of a doubled hyphen. XML forbids the two
     hyphen sequence inside a comment, so a phrase like the configfile flag written
@@ -19,10 +19,10 @@
   -->
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
+    <packageSource key="dotnet-public">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>

--- a/plugins/dotnet-msbuild/.claude-plugin/plugin.json
+++ b/plugins/dotnet-msbuild/.claude-plugin/plugin.json
@@ -15,7 +15,8 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes"
+        "--yes",
+        "--prerelease"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/.claude-plugin/plugin.json
+++ b/plugins/dotnet-msbuild/.claude-plugin/plugin.json
@@ -15,9 +15,7 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+        "--yes"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
@@ -6,9 +6,7 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+        "--yes"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
+++ b/plugins/dotnet-msbuild/.codex-plugin/.mcp.json
@@ -6,7 +6,8 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes"
+        "--yes",
+        "--prerelease"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/plugin.json
+++ b/plugins/dotnet-msbuild/plugin.json
@@ -15,7 +15,8 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes"
+        "--yes",
+        "--prerelease"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/plugin.json
+++ b/plugins/dotnet-msbuild/plugin.json
@@ -15,9 +15,7 @@
       "args": [
         "dnx",
         "Microsoft.AITools.BinlogMcp",
-        "--yes",
-        "--source",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+        "--yes"
       ],
       "tools": ["*"]
     }

--- a/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
@@ -33,7 +33,7 @@ Use the available MCP server tools to query the binary log for:
 ## Fallback workflow — text-log replay (when MCP is unavailable)
 
 Use this only when the MCP server cannot be started (for example, on an older
-SDK or in an offline environment without access to the `dotnet-public` NuGet feed).
+SDK or in an offline environment without access to the `dotnet-tools` NuGet feed).
 
 ### Replay the binlog to text logs
 

--- a/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
+++ b/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md
@@ -33,7 +33,7 @@ Use the available MCP server tools to query the binary log for:
 ## Fallback workflow — text-log replay (when MCP is unavailable)
 
 Use this only when the MCP server cannot be started (for example, on an older
-SDK or in an offline environment without access to the `dotnet-tools` NuGet feed).
+SDK or in an offline environment).
 
 ### Replay the binlog to text logs
 


### PR DESCRIPTION
Reverts #969 while keeping package-source ownership in the evaluation environment.

## Summary

- Removes the explicit `dotnet-public` source from every `Microsoft.AITools.BinlogMcp` plugin manifest.
- Adds a repository-owned NuGet configuration for evaluation runs that clears ambient sources and maps all packages to `dotnet-public`.
- Installs that configuration at the runner user level so Vally's temporary workspaces discover it.
- Makes related documentation source-neutral.

## Validation

- Installed `Microsoft.AITools.BinlogMcp` 2.0.1 with `--no-cache` from `dotnet-public` using only `eng/evaluation/nuget.config`.
- Confirmed user-level NuGet discovery from an unrelated temporary work directory.
- Parsed all changed JSON and XML files successfully.
- `actionlint` and `git diff --check` pass.
- The full skill-validator publish restored through the explicit NuGet configuration, then was blocked by an external npm TLS handshake failure while downloading `@github/copilot-win32-x64`.
