### PR TITLE
Update CODEOWNERS for msbuild paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 /.github/workflows/ @AbhitejJohn @JanKrivanek
 
 # msbuild
-/plugins/dotnet-msbuild/ @ViktorHofer @JanKrivanek @dotnet/skills-msbuild-reviewers
-/tests/dotnet-msbuild/ @ViktorHofer @JanKrivanek @dotnet/skills-msbuild-reviewers
+/plugins/dotnet-msbuild/ @dotnet/skills-msbuild-reviewers
+/tests/dotnet-msbuild/ @dotnet/skills-msbuild-reviewers
 
 # dotnet (common everyday C#/.NET)
 /plugins/dotnet/skills/setup-local-sdk/ @dotnet/roslyn-ide @dotnet/skills-csharp-language-reviewers


### PR DESCRIPTION
Removed specific users from CODEOWNERS for msbuild paths.

## Summary

<!-- Describe the change and why it is needed. Keep the scope focused. -->

## Related issue

<!-- Link the issue this addresses, for example: Fixes #123. Use N/A for small fixes. -->

## Validation

<!-- List the commands you ran and their results, or explain why validation is not applicable. -->

## Checklist

- [ ] I searched existing issues and pull requests to avoid duplicates.
- [ ] I kept this pull request focused and avoided unrelated refactors.
- [ ] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [ ] I updated CODEOWNERS when adding or moving owned content.
- [ ] I updated all marketplace manifests when plugin metadata changed.
- [ ] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.
