### PR TITLE
Add golden end-to-end test generation scenarios

### DIFF
--- a/plugins/dotnet-test/README.md
+++ b/plugins/dotnet-test/README.md
@@ -62,25 +62,28 @@ For non-.NET languages, use the native coverage tool: `coverage.py`/`pytest-cov`
 | **detect-static-dependencies** | Scan C# code for hard-to-test statics (DateTime.Now, File.*, HttpClient, etc.) |
 | **generate-testability-wrappers** | Generate wrapper interfaces or guide adoption of built-in abstractions (TimeProvider, IFileSystem) |
 | **migrate-static-to-wrapper** | Bulk-replace static call sites with injected wrapper calls and add constructor injection |
+| **testability-obstacle** | Resolve one concrete ambient-dependency blocker and test the behavior through fixed/in-memory dependencies |
 
 ### Reference data (loaded by other skills)
 
 | Skill | Description |
 |---|---|
 | **code-testing-extensions** | Language-specific guidance loaded by the code-testing pipeline (test generation) |
+| **scaffold-dotnet-test-project** *(.NET)* | Create and register a missing test project when the code-testing pipeline starts from zero |
 | **test-analysis-extensions** | Language-specific guidance loaded by the polyglot analysis skills (test markers, assertion APIs, sleeps, skips, mystery-guest indicators, integration markers, tag-support capability) |
 | **platform-detection** *(.NET)* | Detect VSTest vs MTP and identify the test framework from project files |
 | **filter-syntax** *(.NET)* | Test filter syntax reference for VSTest and MTP across all frameworks |
 
-These four set `disable-model-invocation: true`, so the CLI keeps them out of the
-model-facing skill menu and a consumer loads them by name. Two of them
-(`code-testing-extensions`, `test-analysis-extensions`) deliberately have no
+These five set `disable-model-invocation: true`, so the CLI keeps them out of the
+model-facing skill menu and a consumer loads them by name. Three of them
+(`code-testing-extensions`, `scaffold-dotnet-test-project`,
+`test-analysis-extensions`) deliberately have no
 `tests/dotnet-test/<skill>/eval.yaml`: the experiment's skilled arm loads a
 single skill, which the model could never invoke here, so such an eval would
 compare two identical arms and score judge noise. They are measured through the
 evals of the skills that load them — the polyglot analysis skills and
 `grade-tests` for `test-analysis-extensions`, and `code-testing-agent` for
-`code-testing-extensions`.
+`code-testing-extensions` and `scaffold-dotnet-test-project`.
 
 `platform-detection` (#974) and `filter-syntax` (#976) are the exceptions: both
 were given a direct eval built from ordinary user requests, so the answer is
@@ -100,7 +103,7 @@ These are the entry-point agents you invoke directly:
 | Agent | Purpose |
 |---|---|
 | **test-quality-auditor** | Runs multi-skill audit pipelines for comprehensive test suite assessment |
-| **testability-migration** | End-to-end testability improvement: detect → generate wrappers → migrate call sites |
+| **testability-migration** | End-to-end testability improvement: detect → generate wrappers → migrate call sites → add deterministic tests when requested |
 
 > **Test framework/platform migration** is handled by the `test-migration` agent in the separate [`dotnet-test-migration`](../dotnet-test-migration/) plugin.
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -45,6 +45,18 @@ and "cover pagination boundaries" are three independently verifiable
 requirements. Direct strategy keeps this checklist in context; delegated
 strategies record it in `.testagent/research.md`.
 
+For .NET, resolve two prerequisites before choosing a strategy:
+
+1. If no compatible test project references the target production project,
+   invoke `scaffold-dotnet-test-project` and use the project it creates. If that
+   helper is unavailable, apply its workflow inline: preserve framework/CPM
+   conventions, create one bounded project, add required project references,
+   register it with the real solution/filter, and verify solution discovery.
+2. If a deterministic test is blocked by direct ambient time, filesystem,
+   environment, randomness, or similar dependencies and the user permits the
+   smallest production seam, invoke `testability-obstacle` before generating
+   tests. Do not substitute real I/O or wall-clock sleeps.
+
 ### Step 2: Choose Execution Strategy
 
 Based on the request scope, pick exactly one strategy and follow it:
@@ -56,6 +68,15 @@ Based on the request scope, pick exactly one strategy and follow it:
 | **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's `.testagent/` documents (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
 
 **Default to Direct** unless the request explicitly mentions multiple files, modules, or an entire project. Most test generation requests — including "generate tests for function X", "add tests covering these scenarios", and "write unit tests for this class" — should use Direct strategy. The full Research → Plan → Implement pipeline is only needed when the scope spans multiple unrelated source files. **Choosing Direct trades away only the sub-agent pipeline (Steps 3-5); it never trades away the Step 7 pre-completion gate.** When a request enumerates specific behaviors/scenarios (e.g., "add 1 test for each of these scenarios"), treat that list as the spec: target the exact symbol named, cover every enumerated scenario, and run the Step 7 gate before reporting completion.
+
+When the request is to discover and close gaps in an existing suite, first invoke
+`test-gap-analysis` against the bounded source/test pair. Treat only empirically
+verified survivors and no-coverage paths as the implementation checklist. Add
+new tests without rewriting existing test files unless the user explicitly asks
+to strengthen one, and do not add a case for behavior the existing suite already
+kills. If the skill is unavailable, perform the same pseudo-mutation reasoning
+and narrow-test verification inline. Re-run the gap analysis after implementation
+as the Step 7 gate.
 
 **Strategy decision examples:**
 
@@ -212,3 +233,5 @@ All state is stored in `.testagent/` folder:
 12. **Preserve existing tests** — never delete or overwrite existing test files; create new files or append to existing ones
 13. **Never mutate version control** — your only outputs are additive test files plus minimal build-manifest edits to register a new test project. Any command that reverts, restores, resets, stashes, or cleans the tree, or deletes tracked files, is out of scope — even when the workspace looks broken or incomplete.
 14. **Bound context and reuse findings** — scope every search to the user's requested files/modules, read only the source and existing tests needed for the next implementation phase, and reuse `.testagent/research.md` instead of repeating workspace discovery.
+15. **Scaffold once** — when a .NET target has no suitable test project, use `scaffold-dotnet-test-project`, then keep every generated test in that project. Never create a second project during implementation.
+16. **Close only demonstrated gaps** — on partial-suite requests, preserve existing tests and add only cases that exercise a verified missing behavior. A higher test count is not evidence of a better result.

--- a/plugins/dotnet-test/agents/testability-migration.agent.md
+++ b/plugins/dotnet-test/agents/testability-migration.agent.md
@@ -2,7 +2,8 @@
 description: >-
   Orchestrates end-to-end testability migration for .NET codebases: detects
   untestable static dependencies, generates wrapper abstractions or guides
-  built-in adoption, and performs mechanical bulk migration of call sites.
+  built-in adoption, performs mechanical migration of call sites, and writes
+  deterministic tests when the request includes testing the migrated behavior.
   Use when asked to make code testable, remove static coupling, migrate to
   TimeProvider, adopt IFileSystem, or improve testability of a legacy codebase.
 name: testability-migration
@@ -23,19 +24,17 @@ You are a testability migration agent for .NET codebases. Your mission is to hel
 
 ## Pipeline Overview
 
-You operate a three-phase pipeline: **Detect → Generate → Migrate**. Each phase uses a specialized skill. You orchestrate them in order, confirming with the user between phases.
+You operate a four-phase pipeline: **Detect → Generate → Migrate → Test**. Each
+phase uses a specialized skill. When the user asks only for analysis, stop after
+Detect. When the user explicitly asks you to make the code testable or add tests,
+that is authorization to complete the requested phases without pausing for
+confirmation between them.
 
-```
-┌─────────────────────┐     ┌──────────────────────────┐     ┌─────────────────────────┐
-│  1. DETECT           │ ──▶ │  2. GENERATE              │ ──▶ │  3. MIGRATE              │
-│                      │     │                           │     │                          │
-│  Scan for statics    │     │  Create wrappers or       │     │  Bulk-replace call sites │
-│  Rank by frequency   │     │  adopt built-in abstractions│   │  Add constructor injection│
-│  Identify scope      │     │  Register in DI            │     │  Update tests            │
-│                      │     │                           │     │                          │
-│  detect-static-      │     │  generate-testability-     │     │  migrate-static-to-      │
-│  dependencies        │     │  wrappers                  │     │  wrapper                 │
-└─────────────────────┘     └──────────────────────────┘     └─────────────────────────┘
+```text
+Detect ambient dependencies
+  -> Generate or adopt the smallest seam
+  -> Migrate the bounded call sites
+  -> Test through fixed/in-memory dependencies
 ```
 
 ## Workflow
@@ -48,9 +47,9 @@ Use the `detect-static-dependencies` skill to:
 3. Rank by frequency and group by category
 4. Present the report to the user
 
-After presenting results, ask the user:
-- Which category to tackle first (recommend the highest-frequency one with best built-in support)
-- What scope to migrate (single project? namespace? whole solution?)
+If the request is ambiguous or analysis-only, ask which category and scope to
+migrate. If it names the target behavior/dependencies and requests implementation,
+use that bounded scope and continue.
 
 ### Phase 2: Generate
 
@@ -61,7 +60,8 @@ Use the `generate-testability-wrappers` skill to:
 4. Add DI registration or ambient context setup
 5. Verify the project builds with the new abstraction
 
-Present the generated code to the user and confirm before proceeding to migration.
+For advice-only requests, present the proposed seam and stop. For implementation
+requests, continue after the affected production project builds.
 
 ### Phase 3: Migrate
 
@@ -72,6 +72,21 @@ Use the `migrate-static-to-wrapper` skill to:
 4. Update existing test files with test doubles
 5. Verify the project builds
 6. Report what was changed and what remains
+
+### Phase 4: Test
+
+When the request includes tests, use `testability-obstacle` or
+`code-testing-agent` to:
+
+1. Reuse the migrated seam rather than introducing another abstraction.
+2. Use `FakeTimeProvider`, an in-memory filesystem, or a hand-rolled fake.
+3. Test the requested business behavior without real I/O, wall-clock sleeps,
+   environment mutation, process execution, or network access.
+4. Run the targeted test project and the repository-level test command.
+5. Map each requested behavior and seam to an exact test name.
+
+Do not call the migration complete merely because production builds. The tests
+are part of the requested outcome.
 
 ## Decision Rules
 
@@ -101,10 +116,11 @@ Use the ambient context pattern when:
 ### Full pipeline request
 
 When the user asks something like "make my code testable" or "help me get rid of static dependencies":
-1. Start with Phase 1 (detection)
-2. Present the report
-3. Ask for confirmation on scope and priority
-4. Proceed through Phase 2 and Phase 3
+1. Start with Phase 1 (detection).
+2. If the user asked only for analysis, present the report and stop.
+3. If the user explicitly requested implementation, infer the narrowest safe
+   scope from the named behavior and proceed through the required phases.
+4. If the request also asks for tests, complete Phase 4 before reporting.
 
 ### Targeted request
 
@@ -127,3 +143,5 @@ Always respect scope boundaries:
 3. **Always build after changes** — run `dotnet build` and fix any errors before reporting success
 4. **Preserve behavior** — the wrapper must delegate directly to the static; no logic changes
 5. **Incremental only** — migrate one scope at a time, never the entire solution in one pass unless it's small (< 20 files)
+6. **No real ambient resources in new tests** — use fixed or in-memory dependencies
+7. **Honor explicit implementation intent** — do not pause for confirmation when the user already asked for the bounded migration and tests

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -1,19 +1,10 @@
 ---
 name: code-testing-agent
 description: >-
-  MANDATORY ENTRY POINT for generating or writing tests. Invoke this skill
-  before editing files whenever the user asks to generate tests, write/add unit
-  tests, scaffold a test project or suite, improve/achieve coverage, extend an
-  existing suite to cover an untested method, or test an app, API, service,
-  module, library, or package. Applies to a single function, method or file as
-  much as to a whole project — scope changes how much of the workflow runs,
-  never whether the skill applies. Invoke it when the workspace looks sparse,
-  gutted or partially deleted — then test only the source that remains and
-  never restore missing source.
-  Polyglot: C#/.NET, Python, TypeScript/JavaScript, Go, Rust, Java, Ruby.
-  DO NOT USE FOR: running existing tests (use run-tests); analyzing coverage
-  reports (use coverage-analysis or crap-score); MSTest-specific test authoring
-  or modernization (use writing-mstest-tests).
+  Generate or add tests. MANDATORY FOR: write tests, scaffold a test project,
+  improve coverage, fill suite gaps, or test a function/file/module/app/API.
+  DO NOT USE FOR: only running tests (run-tests), analyzing reports
+  (coverage-analysis/crap-score), or MSTest authoring (writing-mstest-tests).
 license: MIT
 ---
 
@@ -113,10 +104,13 @@ For multi-file requests:
 2. Research only the requested module or project and write the checklist plus a compact target inventory to `.testagent/research.md`.
 3. Reuse manifests, symbol references, and deterministic pairing tools instead of reading every source and test file.
 4. For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, or Ruby, run `find-untested-sources` once and consume its pairing and suggested-path output; do not repeat that discovery manually.
-5. Plan each target file once, then implement phases sequentially. Map every checklist item to at least one concrete test or explain why it is blocked.
-6. Build and test the narrow target during fix cycles; run workspace-level validation once at the end.
-7. Before reporting success, re-open the generated tests and verify every checklist item against concrete test names and assertions. Coverage alone is not evidence that a requested mock seam, boundary, state transition, or property combination was tested.
-8. Read a language example from `code-testing-extensions` only when the repository has no representative tests and the base extension is insufficient.
+5. For .NET, if no suitable test project references the target production project, invoke `scaffold-dotnet-test-project` before planning test cases. If unavailable, perform its essential workflow inline: infer framework/CPM conventions, create one bounded project, add only required project references, register it with the real solution/filter, replace template boilerplate with a real smoke test, and verify solution-level discovery. Reuse that scaffold; do not create a competing project.
+6. When the user asks to find and fill gaps in an existing suite, run `test-gap-analysis` before implementation. If unavailable, perform the equivalent pseudo-mutation review inline and verify candidate gaps against the narrow existing tests. Add tests only for verified survived/no-coverage behavior, keep existing test files byte-for-byte unchanged unless the user explicitly asks to strengthen one, and do not duplicate behavior already killed by existing tests.
+7. If a requested deterministic test is blocked by direct time, filesystem, environment, randomness, or similar ambient dependencies and the user permits a minimal production seam, invoke `testability-obstacle`. Otherwise report the blocker; do not silently add real-I/O tests.
+8. Plan each target file once, then implement phases sequentially. Map every checklist item to at least one concrete test or explain why it is blocked.
+9. Build and test the narrow target during fix cycles; run workspace-level validation once at the end.
+10. Before reporting success, re-open the generated tests and verify every checklist item against concrete test names and assertions. Coverage alone is not evidence that a requested mock seam, boundary, state transition, or property combination was tested.
+11. Read a language example from `code-testing-extensions` only when the repository has no representative tests and the base extension is insufficient.
 
 ### Completion contract
 
@@ -144,6 +138,10 @@ Do not report completion until all of these are true:
    record the findings and fixes in `.testagent/status.md`. On a focused scope,
    do the equivalent review inline — re-read each generated assertion against
    the source — without spawning extra passes.
+6. For gap-closing requests, every added test maps to a verified pre-existing
+   gap, existing tests remain unchanged unless modification was explicitly
+   requested, and no added case duplicates behavior an existing assertion
+   already pins down.
 
 The final response MUST include a compact `Requirement | Evidence` table.
 Behavioral rows cite exact generated test names. Non-behavioral rows cite the

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: scaffold-dotnet-test-project
+description: >-
+  Wire a missing .NET test project. USE FOR: no test project, add Tests.csproj,
+  register it in a solution/filter, add ProjectReference, or fix CI discovery.
+  DO NOT USE FOR: an existing test project (code-testing-agent) or migration.
+disable-model-invocation: true
+license: MIT
+---
+
+# Scaffold a .NET Test Project
+
+Create the smallest test project that fits the repository's existing build and
+test conventions, wire it to the correct production project and build entry
+point, and prove solution-level test discovery sees it. This skill scaffolds the
+container for tests; it does not invent a solution-wide test architecture.
+
+## When to Use
+
+- A .NET solution or project has production code but no suitable test project.
+- A user asks to "set up tests" or "add a test project" from a vague starting point.
+- Tests pass when the new `.csproj` is targeted directly but CI cannot discover it.
+- A multi-project solution needs a bounded test project for one production project.
+
+## When Not to Use
+
+- A compatible test project already references the target production project.
+  Reuse it and continue with `code-testing-agent`.
+- The request is specifically about authoring or modernizing MSTest test code.
+  Use `writing-mstest-tests` after the project exists.
+- The repository's current build is broken for an unrelated reason. Report that
+  blocker; do not redesign project structure to hide it.
+- The user asks to migrate xUnit, NUnit, MSTest, TUnit, VSTest, or MTP.
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Repository or solution path | No | Discover from the current workspace when omitted |
+| Production project | No | Infer the narrowest project in the requested scope |
+| Test framework | No | Use an explicit choice; otherwise infer repository convention |
+| Build entry point | No | Existing `.sln`, `.slnx`, `.slnf`, or project graph used by CI |
+
+## Workflow
+
+### Step 1: Establish the repository contract
+
+Inspect only the files needed to answer these questions:
+
+1. Which production project is in scope?
+2. What command does CI or the repository use to build and test?
+3. Does a suitable test project already reference that production project?
+4. Which test framework and runner do neighboring test projects use?
+5. Are package versions centrally managed by `Directory.Packages.props`,
+   `Directory.Build.props`, `global.json`, or an MSBuild SDK declaration?
+6. Which target framework(s) must the test project compile against?
+
+Treat a test project as suitable only when its target framework can reference the
+production project and its purpose matches the requested layer. Do not create a
+second test project merely because its name differs from your preferred name.
+
+### Step 2: Choose one bounded project
+
+Default to one test project per production project, named according to repository
+convention (`Foo.Tests`, `Foo.UnitTests`, and so on). For a vague multi-project
+request, start with the project that owns the user-visible behavior or has the
+highest-value untested logic; do not create one test project per source project
+without evidence that the repository wants that layout.
+
+Match, in order:
+
+1. The user's explicit framework choice.
+2. Existing test projects in the same repository.
+3. Repository-wide package/SDK conventions.
+4. A standard SDK template only when the repository provides no convention.
+
+Never mix frameworks in one test project. Never add package versions directly
+when central package management supplies them.
+
+### Step 3: Scaffold and reference the target
+
+Use the matching `dotnet new` template (`xunit`, `nunit`, or `mstest`) rather than
+hand-writing template boilerplate. Then make only the repository-specific edits:
+
+1. Align target framework, nullable, implicit-usings, runner, and package style.
+2. Add a `ProjectReference` to each production project directly exercised by
+   the planned tests. Do not reference every project in the solution.
+3. Remove template sample tests that do not test repository behavior.
+
+Prefer `dotnet add <test-project> reference <production-project>` for project
+references. Inspect the resulting project file before continuing.
+
+### Step 4: Register with the real build entry point
+
+Creating a `.csproj` is not enough. Add it to the exact solution artifact used by
+the repository:
+
+- `.sln` or `.slnx`: `dotnet sln <solution> add <test-project>`
+- `.slnf`: add the project to the underlying solution and include it in the
+  filter used by the requested/CI test command.
+- No solution artifact: keep the existing project-oriented workflow. Do not
+  create a solution solely for aesthetics unless the user asked for one.
+
+Do not substitute a different solution file because it is easier to edit.
+
+### Step 5: Add a real smoke test
+
+Replace template examples with at least one deterministic test of production
+behavior. The test must:
+
+- instantiate or invoke a real symbol from the referenced production project;
+- assert a concrete result, not only non-null/truthiness;
+- avoid network, wall-clock, process, and real filesystem dependencies.
+
+This smoke test proves the project reference and discovery path. Broader test
+generation belongs to `code-testing-agent`.
+
+### Step 6: Verify direct and harness-level execution
+
+Run, in this order:
+
+1. `dotnet test <test-project>` to isolate scaffolding failures.
+2. The repository's solution/root test command to prove CI discovery.
+3. A solution/project listing command to confirm the new project is registered.
+
+If the direct command passes but the harness-level command discovers no new
+test, the scaffolding is incomplete. Fix registration before reporting success.
+Do not claim success from `dotnet build` alone.
+
+## Output Contract
+
+Report a compact table:
+
+| Requirement | Evidence |
+|-------------|----------|
+| Test project created/reused | Project path |
+| Production reference | Referenced `.csproj` path |
+| Build registration | `.sln`/`.slnx`/`.slnf` entry or project-oriented command |
+| Test discovery | Passing harness-level command and discovered test |
+
+If validation is blocked, report the exact failing command and first actionable
+error. Do not describe an unrun command as successful.
+
+## Validation
+
+- [ ] A suitable existing test project was ruled out before creating another.
+- [ ] Framework, runner, target framework, and package style match the repository.
+- [ ] Project references cover only the production projects under test.
+- [ ] Central package management was preserved.
+- [ ] Template sample tests were removed.
+- [ ] At least one real deterministic test asserts a concrete behavior.
+- [ ] The test project passes directly.
+- [ ] The repository's solution/root command discovers and runs the new test.
+
+## Common Pitfalls
+
+| Pitfall | Corrective action |
+|---------|-------------------|
+| Creating a project that CI never sees | Register it with the exact solution/filter used by CI and run that command |
+| Picking a favorite framework | Infer the repository convention before using a default |
+| Adding package versions under CPM | Add versionless references and keep versions in `Directory.Packages.props` |
+| Referencing the whole solution | Reference only projects whose APIs the tests compile against |
+| Keeping `UnitTest1` | Replace it with a concrete test of repository behavior |
+| Creating parallel unit/integration projects from a vague ask | Start with one bounded project; expand only for a demonstrated boundary |
+| Treating a green build as test discovery | Run the harness-level test command and observe the test |

--- a/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
+++ b/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: testability-obstacle
+description: >-
+  Add a minimal C# seam and deterministic tests for DateTime/File dependencies
+  without real I/O. DO NOT USE FOR: audits (detect-static-dependencies),
+  wrapper-only work (generate-testability-wrappers), bulk migration
+  (migrate-static-to-wrapper), or an existing seam (code-testing-agent).
+license: MIT
+---
+
+# Resolve a Testability Obstacle
+
+Introduce the smallest behavior-preserving seam needed to test a specific C#
+behavior, then add deterministic tests that prove both the behavior and the seam.
+The production edit is a means to the requested test, not an invitation to
+redesign adjacent code.
+
+## When to Use
+
+- A requested test would otherwise read/write the real filesystem.
+- Behavior depends on the current time, delay, random value, environment, console,
+  process, or another ambient dependency.
+- The user explicitly permits or requests a safe production seam.
+- Existing tests cannot control a dependency without process-global mutation.
+
+## When Not to Use
+
+- The dependency is already injected or passed as an argument. Write tests with
+  a fake through the existing seam using `code-testing-agent`.
+- The user wants a repository-wide testability audit. Use
+  `detect-static-dependencies`.
+- The user wants wrappers generated but not call sites/tests changed. Use
+  `generate-testability-wrappers`.
+- The user requests a broad mechanical migration. Use
+  `migrate-static-to-wrapper`, then generate tests separately.
+- The code is not C#/.NET.
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Behavior to test | Yes | The method/workflow and expected observable behavior |
+| Target scope | No | Discover the narrowest relevant file/project when omitted |
+| Allowed production changes | No | Default to the minimum internal/constructor seam |
+
+## Workflow
+
+### Step 1: Prove the obstacle
+
+Read the target production path and its existing tests. Identify the exact ambient
+operation preventing a deterministic test and the behavior that must remain
+unchanged. Do not run a repository-wide static scan for a single-class request.
+
+If an adequate seam already exists, stop refactoring and use it. This skill adds
+no value when a fake can already be supplied.
+
+### Step 2: Select the smallest safe seam
+
+Choose by dependency and repository constraints:
+
+| Dependency | Preferred seam |
+|------------|----------------|
+| Current time / timers | Inject `TimeProvider`; use `FakeTimeProvider` in tests |
+| Filesystem | Existing repository file abstraction; otherwise the smallest interface or `System.IO.Abstractions` when already used/accepted |
+| HTTP | Existing typed `HttpClient`/handler or `IHttpClientFactory` seam |
+| Randomness | Inject `Random` or a minimal generator interface |
+| Environment/console/process | Minimal interface containing only members used by the target |
+
+Constructor injection is the default for instance classes. Reuse the repository's
+DI and naming conventions, but do not add a DI container to a class library just
+to satisfy this workflow.
+
+For a static class or a public API that cannot change, use a scoped ambient seam
+only when constructor/parameter injection is impossible. The override must:
+
+- flow across `await` (`AsyncLocal<T>`, not `[ThreadStatic]`);
+- return `IDisposable` and restore the previous value, including nested scopes;
+- default to the real production dependency;
+- avoid a process-global mutable fake that makes tests non-parallel.
+
+### Step 3: Preserve behavior and API shape
+
+Keep the production change mechanical:
+
+- Wrap only members used by the target behavior.
+- Default implementations delegate directly to the original API.
+- Preserve exceptions, path handling, time zone, and `DateTime.Kind`.
+- Keep existing public signatures unless the user explicitly permits an API change.
+- Do not move business logic into the wrapper or fix unrelated production bugs.
+
+For time replacements:
+
+- `DateTime.UtcNow` -> `timeProvider.GetUtcNow().UtcDateTime`
+- `DateTime.Now` -> `timeProvider.GetLocalNow().LocalDateTime`
+- `DateTimeOffset.UtcNow` -> `timeProvider.GetUtcNow()`
+- `DateTimeOffset.Now` -> `timeProvider.GetLocalNow()`
+
+### Step 4: Keep production defaults wired
+
+Update every composition root or constructor call affected by the seam. Production
+must still use real time/filesystem/etc. by default. If the project uses DI,
+register the default implementation with the lifetime matching repository
+conventions. If it does not use DI, compose explicitly; do not introduce a
+container.
+
+Build the affected production project before writing tests. A compile failure here
+is a seam problem, not a test problem.
+
+### Step 5: Write deterministic tests
+
+Use the repository's existing test project. If none exists, invoke
+`scaffold-dotnet-test-project` first.
+
+Tests must supply controlled dependencies:
+
+- fixed/advanced time rather than wall-clock waiting;
+- an in-memory fake filesystem or hand-rolled fake rather than temp/real files;
+- no environment mutation, external process, console input, or network.
+
+Assert the requested business result and at least one interaction/state observable
+that proves the fake dependency drove the path. Include a production-default test
+only when it can remain deterministic; never touch the real filesystem merely to
+prove the adapter delegates.
+
+### Step 6: Verify the complete path
+
+Run the affected production build, targeted test project, and repository-level
+test command. Re-read the diff and confirm:
+
+1. every production change is required by the seam;
+2. no real ambient resource is used by the new tests;
+3. current-time semantics and public behavior are preserved;
+4. existing tests were not replaced or duplicated.
+
+## Output Contract
+
+Provide a compact `Requirement | Evidence` table. Cite the production seam,
+production default wiring, exact test names, and passing commands. If a package
+restore or build blocks validation, report that blocker rather than claiming the
+tests pass.
+
+## Validation
+
+- [ ] The original obstacle was concrete and in the requested path.
+- [ ] An existing seam was reused when available.
+- [ ] The new abstraction exposes only members required by the target behavior.
+- [ ] Production defaults still delegate to the original dependency.
+- [ ] Time conversions preserve local/UTC and `DateTime.Kind` semantics.
+- [ ] Static ambient overrides are async-safe, scoped, nested, and reversible.
+- [ ] New tests use fixed/in-memory dependencies and no real I/O or wall clock.
+- [ ] Production build and targeted/repository tests pass.
+
+## Common Pitfalls
+
+| Pitfall | Corrective action |
+|---------|-------------------|
+| Refactoring before proving a blocker | Reuse an existing seam and write the test directly |
+| Wrapping an entire static API | Expose only members exercised by the target |
+| Converting `UtcNow` with `.DateTime` | Use `.UtcDateTime` to preserve `DateTimeKind.Utc` |
+| Mutable static fake shared by tests | Use constructor injection or a scoped `AsyncLocal<T>` override |
+| Adding DI to a library with no container | Compose the dependency explicitly |
+| Using temp files as a shortcut | Supply an in-memory fake; the scenario requires no real I/O |
+| Stopping after the refactor builds | Write and run the behavior tests that justified the seam |

--- a/tests/dotnet-test/agent.testability-migration/eval.yaml
+++ b/tests/dotnet-test/agent.testability-migration/eval.yaml
@@ -1,15 +1,15 @@
 name: agent.testability-migration
 description: Evaluates the dotnet-test/agent.testability-migration orchestrator agent
 type: capability
-config:
-  timeout: 5m
+defaults:
+  timeout: 20m
 stimuli:
   - name: "Full pipeline: detect statics and recommend migration plan"
     prompt: >
       I have a SubscriptionManager class that's impossible to unit test
       because it uses DateTime.UtcNow, File.*, Directory.*, Environment.*,
-      and Console.* all directly. Can you analyze it and help me make it
-      testable?
+      and Console.* all directly. Analyze it and give me a bounded migration
+      plan, but do not change files yet.
     environment:
       files:
         - src: ./fixtures/full-pipeline

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -4,29 +4,52 @@ type: capability
 # `defaults:` replaces the deprecated `config:` — vally's loader throws on a
 # spec declaring both (eng/eval-quality check 10).
 #
-# runs: 2 for two independent reasons, reached separately on this branch and in
-# #974.
-#
-# It is necessary: at runs: 1 this eval could not produce a passing verdict at
-# any effect size. The sign test conditions on the discordant (non-tie) trials,
-# and one of the five scenarios is a dormancy guard whose correct outcome IS a
-# tie — both arms diagnose the failing suite and the skill rightly stays
-# dormant. That caps discordant trials at 4, one short of the 5 the test needs,
-# so the eval was unwinnable before a single trial ran (run 30631489464:
-# 1W/4T/0L, p=0.500). Two runs give ~8 discordant-capable trials, which a
-# genuinely-helping skill can clear and luck cannot.
-#
-# And runs is the right lever here rather than more scenarios, which is normally
-# preferred because it widens what the skill is measured on: every scenario here
-# drives the full multi-file generate-build-test pipeline end to end — `npm ci`
-# plus two Vitest runs, `pip install` plus pytest, and a `dotnet test` build.
-# Another scenario of that shape costs more than it informs. This is also the
-# plugin's most expensive eval and its token cost is the open P1 on #899, so 2
-# is the smallest count that makes a verdict reachable at all.
+# Seven scenarios now cover seven distinct behaviors. One is a dormancy guard whose
+# correct result is likely a tie, leaving six discordant-capable trials at
+# runs: 1 — enough to make a passing verdict reachable without repeating every
+# expensive end-to-end generation task.
 defaults:
   timeout: 60m
-  runs: 2
+  runs: 1
 stimuli:
+  - name: Create and wire the first test project for a Csharp solution
+    prompt: |
+      The Commerce solution under
+      fixtures/csharp-zero-to-one-scaffolding/ has two production projects and
+      no tests. Set up a sensible initial test project, wire it into the
+      solution, and add useful tests for the pricing behavior. The normal
+      solution-level test command must discover and run them.
+    environment:
+      files:
+        - src: fixtures/csharp-zero-to-one-scaffolding
+          dest: fixtures/csharp-zero-to-one-scaffolding
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "test $(find fixtures/csharp-zero-to-one-scaffolding/tests -name '*.csproj' | wc -l) -eq 1"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: sh -c "dotnet sln fixtures/csharp-zero-to-one-scaffolding/Commerce.sln list | grep -q 'Tests.csproj' && dotnet test fixtures/csharp-zero-to-one-scaffolding/Commerce.sln"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "grep -R 'Commerce.Pricing.csproj' fixtures/csharp-zero-to-one-scaffolding/tests --include='*.csproj' && grep -R 'PriceCalculator' fixtures/csharp-zero-to-one-scaffolding/tests --include='*.cs' | grep -q ."
+          expected_exit_code: 0
+          timeout: 1m
+      - type: output-matches
+        config:
+          pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
+      - type: prompt
+    rubric:
+      - Created one bounded test project rather than scaffolding a project for every production assembly
+      - Matched the repository's xUnit v3, central package management, target framework, and tests-directory conventions
+      - Referenced Commerce.Pricing and added concrete PriceCalculator behavior tests
+      - Registered the project in Commerce.sln so the solution-level command discovers it
+      - Produced a passing solution-level test run and mapped scaffolding plus behaviors to evidence
+
   - name: Generate Vitest tests for the shopping-cart library (TypeScript polyglot)
     prompt: |
       I have a TypeScript shopping-cart library under
@@ -237,6 +260,50 @@ stimuli:
         generated test rather than to a general statement that the method is covered
       - Once every requested behaviour is covered, judged on meaningful, nonredundant cases; a smaller focused suite
         is not penalized merely for containing fewer tests than another passing suite
+
+  # The suite already covers the two happy paths. The agent must discover the
+  # boundaries from source and existing assertions, then add only missing cases
+  # in a new file without being handed a checklist in the prompt.
+  - name: Discover and close edge gaps in a partial suite
+    prompt: |
+      DiscountRules under fixtures/csharp-partial-discount-suite/ already has a
+      small passing xUnit suite. Review the production behavior and current
+      assertions, identify the meaningful edge cases the suite misses, and add
+      focused tests for those gaps. Keep DiscountRulesTests.cs byte-for-byte
+      unchanged and do not duplicate behavior it already covers.
+    environment:
+      files:
+        - src: fixtures/csharp-partial-discount-suite
+          dest: fixtures/csharp-partial-discount-suite
+      commands:
+        - mkdir -p .eval-baseline && cp fixtures/csharp-partial-discount-suite/tests/DiscountRulesTests.cs .eval-baseline/DiscountRulesTests.cs
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/csharp-partial-discount-suite/tests/DiscountRules.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "diff -u .eval-baseline/DiscountRulesTests.cs fixtures/csharp-partial-discount-suite/tests/DiscountRulesTests.cs"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: sh -c "test $(find fixtures/csharp-partial-discount-suite/tests -name '*.cs' | wc -l) -gt 1"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: output-matches
+        config:
+          pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
+      - type: prompt
+    rubric:
+      - Read the production code and existing suite to identify gaps rather than blindly adding more happy-path examples
+      - Left DiscountRulesTests.cs byte-for-byte unchanged and placed additions in a new test file
+      - Did not duplicate the existing null-code no-discount case or the standard uppercase SAVE10 calculation
+      - Covered whitespace codes, case-insensitive SAVE10, FLAT5 below five dollars, negative subtotal rejection, and unknown-code rejection
+      - Used concrete decimal results and exact exception types rather than truthiness or exception-anything assertions
+      - Produced a passing test run and mapped each discovered gap to an exact added test
 
   # Focused single-function request. The pipeline ceremony (research/plan
   # artifacts, sub-agent fan-out, repeated whole-repo discovery) is what makes

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.cs
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.cs
@@ -20,7 +20,7 @@ public sealed class DiscountRules
                 subtotal * 0.9m,
                 2,
                 MidpointRounding.AwayFromZero),
-            "FLAT5" => Math.Max(0, subtotal - 5m),
+            "FLAT5" => Math.Max(0m, subtotal - 5m),
             _ => throw new ArgumentException("Unknown discount code.", nameof(code)),
         };
     }

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.cs
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.cs
@@ -1,0 +1,27 @@
+namespace Discounts;
+
+public sealed class DiscountRules
+{
+    public decimal Apply(decimal subtotal, string? code)
+    {
+        if (subtotal < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(subtotal));
+        }
+
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return subtotal;
+        }
+
+        return code.ToUpperInvariant() switch
+        {
+            "SAVE10" => decimal.Round(
+                subtotal * 0.9m,
+                2,
+                MidpointRounding.AwayFromZero),
+            "FLAT5" => Math.Max(0, subtotal - 5m),
+            _ => throw new ArgumentException("Unknown discount code.", nameof(code)),
+        };
+    }
+}

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.csproj
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/src/DiscountRules.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/tests/DiscountRules.Tests.csproj
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/tests/DiscountRules.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\DiscountRules.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/tests/DiscountRulesTests.cs
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-partial-discount-suite/tests/DiscountRulesTests.cs
@@ -1,0 +1,21 @@
+using Discounts;
+using Xunit;
+
+namespace Discounts.Tests;
+
+public sealed class DiscountRulesTests
+{
+    private readonly DiscountRules _rules = new();
+
+    [Fact]
+    public void Apply_WithNoCode_ReturnsSubtotal()
+    {
+        Assert.Equal(25m, _rules.Apply(25m, null));
+    }
+
+    [Fact]
+    public void Apply_WithSave10_ReturnsTenPercentReduction()
+    {
+        Assert.Equal(90m, _rules.Apply(100m, "SAVE10"));
+    }
+}

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Commerce.sln
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Commerce.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commerce.Domain", "src\Commerce.Domain\Commerce.Domain.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commerce.Pricing", "src\Commerce.Pricing\Commerce.Pricing.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Commerce.sln
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Commerce.sln
@@ -2,9 +2,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commerce.Domain", "src\Commerce.Domain\Commerce.Domain.csproj", "{11111111-1111-1111-1111-111111111111}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Commerce.Domain", "src\Commerce.Domain\Commerce.Domain.csproj", "{11111111-1111-1111-1111-111111111111}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commerce.Pricing", "src\Commerce.Pricing\Commerce.Pricing.csproj", "{22222222-2222-2222-2222-222222222222}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Commerce.Pricing", "src\Commerce.Pricing\Commerce.Pricing.csproj", "{22222222-2222-2222-2222-222222222222}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Directory.Build.props
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Directory.Packages.props
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="xunit.v3" Version="1.1.0" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/README.md
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/README.md
@@ -1,0 +1,7 @@
+# Commerce
+
+Production projects live under `src/`; test projects live under `tests/` and use
+the `{ProductionProject}.Tests` naming pattern. New tests use xUnit v3. Package
+versions belong in `Directory.Packages.props`, not individual project files.
+
+The repository build and test entry point is `Commerce.sln`.

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Domain/Commerce.Domain.csproj
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Domain/Commerce.Domain.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Domain/Money.cs
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Domain/Money.cs
@@ -1,0 +1,6 @@
+namespace Commerce.Domain;
+
+public readonly record struct Money(decimal Amount)
+{
+    public Money Add(Money other) => new(Amount + other.Amount);
+}

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Pricing/Commerce.Pricing.csproj
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Pricing/Commerce.Pricing.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Commerce.Domain\Commerce.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Pricing/PriceCalculator.cs
+++ b/tests/dotnet-test/code-testing-agent/fixtures/csharp-zero-to-one-scaffolding/src/Commerce.Pricing/PriceCalculator.cs
@@ -1,0 +1,19 @@
+using Commerce.Domain;
+
+namespace Commerce.Pricing;
+
+public sealed class PriceCalculator
+{
+    public Money ApplyPercentageDiscount(Money subtotal, decimal percentage)
+    {
+        if (percentage is < 0 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(percentage));
+        }
+
+        return new Money(decimal.Round(
+            subtotal.Amount * (1 - (percentage / 100)),
+            2,
+            MidpointRounding.AwayFromZero));
+    }
+}

--- a/tests/dotnet-test/testability-obstacle/eval.yaml
+++ b/tests/dotnet-test/testability-obstacle/eval.yaml
@@ -1,0 +1,183 @@
+name: testability-obstacle
+description: Evaluates the dotnet-test/testability-obstacle skill
+type: capability
+defaults:
+  timeout: 20m
+  runs: 1
+stimuli:
+  - name: Make time and filesystem behavior deterministic end to end
+    prompt: |
+      ArchiveWriter currently stamps a filename with the current UTC time and
+      writes through File directly. Introduce the smallest safe seams needed to
+      test Archive without touching the real filesystem or wall clock, then add
+      tests for the timestamped path and written content. Keep production
+      behavior unchanged.
+    environment:
+      files:
+        - src: fixtures/archive-writer
+          dest: fixtures/archive-writer
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/archive-writer/tests/ArchiveWriter.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "! grep -q 'DateTimeOffset.UtcNow\\|File.WriteAllText' fixtures/archive-writer/src/ArchiveWriter.cs"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: sh -c "grep -R 'TimeProvider' fixtures/archive-writer/tests --include='*.cs' | grep -q . && grep -R 'Fake\\|Stub\\|InMemory\\|Recording' fixtures/archive-writer/tests --include='*.cs' | grep -q ."
+          expected_exit_code: 0
+          timeout: 1m
+      - type: prompt
+    rubric:
+      - Introduced bounded seams for current time and the file write without moving business logic into adapters
+      - Kept production defaults wired to system time and the real filesystem
+      - Added passing tests that control the instant and capture writes entirely in memory
+      - Asserted the exact timestamped archive path and content written
+      - Did not use temporary files, wall-clock waiting, environment mutation, or process-global fakes
+
+  - name: Preserve UTC DateTime semantics when replacing the clock
+    prompt: |
+      ExpirationPolicy is impossible to test at the exact expiry boundary because
+      it calls DateTime.UtcNow. Refactor only that dependency to TimeProvider and
+      add deterministic tests for just-before, exactly-at, and just-after expiry.
+      CurrentUtc must continue returning a DateTime whose Kind is Utc.
+    environment:
+      files:
+        - src: fixtures/expiration-policy
+          dest: fixtures/expiration-policy
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/expiration-policy/tests/ExpirationPolicy.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "! grep -q 'DateTime.UtcNow' fixtures/expiration-policy/src/ExpirationPolicy.cs && grep -q 'UtcDateTime' fixtures/expiration-policy/src/ExpirationPolicy.cs"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: prompt
+    rubric:
+      - Replaced the ambient clock with an injected TimeProvider and did not add unrelated abstractions
+      - Preserved DateTimeKind.Utc by converting with UtcDateTime rather than DateTime
+      - Added distinct deterministic boundary tests for before, exactly at, and after expiry
+      - Included a test that verifies CurrentUtc returns a UTC DateTime
+      - Kept the existing expiry comparison semantics rather than changing production behavior
+
+  - name: Add only the filesystem seam requested
+    prompt: |
+      ConfigLoader reads a config file directly. Make Load testable without real
+      disk access and add tests for a present config and a missing config. This
+      class library has no DI container; do not add one.
+    environment:
+      files:
+        - src: fixtures/config-loader
+          dest: fixtures/config-loader
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/config-loader/tests/ConfigLoader.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "! grep -q 'File.ReadAllText\\|File.Exists' fixtures/config-loader/src/ConfigLoader.cs && ! grep -R 'IServiceCollection\\|ServiceCollection' fixtures/config-loader --include='*.cs'"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: prompt
+    rubric:
+      - Added a minimal filesystem seam containing only the operations ConfigLoader needs
+      - Used explicit construction or constructor injection without introducing a DI container
+      - Kept a real production adapter that delegates to System.IO
+      - Added passing in-memory tests for present and missing config behavior
+      - Did not access temporary or real files from tests
+
+  - name: Reuse a seam that already exists
+    prompt: |
+      SnapshotExporter already accepts TimeProvider and ITextStore. Add
+      deterministic tests for Export that verify the UTC timestamp, generated
+      path, and stored content. Change production code only if a seam is actually
+      missing.
+    environment:
+      files:
+        - src: fixtures/already-seamed
+          dest: fixtures/already-seamed
+      commands:
+        - mkdir -p .eval-baseline && cp fixtures/already-seamed/src/SnapshotExporter.cs .eval-baseline/SnapshotExporter.cs
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "diff -u .eval-baseline/SnapshotExporter.cs fixtures/already-seamed/src/SnapshotExporter.cs"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/already-seamed/tests/SnapshotExporter.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: prompt
+    rubric:
+      - Recognized that production already has adequate time and storage seams
+      - Left SnapshotExporter.cs byte-for-byte unchanged
+      - Added deterministic tests using a controlled TimeProvider and in-memory ITextStore fake
+      - Asserted the exact generated path and stored content
+      - Did not add a second wrapper or abstraction around existing dependencies
+
+  - name: Keep a static API while making its clock override parallel-safe
+    prompt: |
+      ReceiptNamer is a public static utility, so its Create signature and static
+      shape cannot change. Add a safe scoped clock seam that allows deterministic
+      async tests without leaking state between parallel tests, then test the
+      generated name. Production must still use system time by default.
+    environment:
+      files:
+        - src: fixtures/static-receipt-namer
+          dest: fixtures/static-receipt-namer
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "dotnet test fixtures/static-receipt-namer/tests/ReceiptNamer.Tests.csproj"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: run-command
+        config:
+          command: sh -c "grep -q 'static class ReceiptNamer' fixtures/static-receipt-namer/src/ReceiptNamer.cs && grep -q 'AsyncLocal' fixtures/static-receipt-namer/src/ReceiptNamer.cs && grep -q 'IDisposable' fixtures/static-receipt-namer/src/ReceiptNamer.cs"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: prompt
+    rubric:
+      - Preserved ReceiptNamer as a public static class with the existing Create signature
+      - Added a scoped async-flowing override that restores the previous value on disposal
+      - Supported nested or concurrent async scopes without a process-global mutable fake
+      - Kept system time as the production default
+      - Added a passing deterministic test that restores the seam even when assertions fail
+
+  - name: Leave a non-dotnet testability request to its language workflow
+    prompt: |
+      This Python report writer calls datetime.now() and open() directly. Refactor
+      it so I can test timestamps and file output without real I/O, then add
+      pytest coverage.
+    expect_activation: false
+    environment:
+      files:
+        - src: fixtures/python-report-writer
+          dest: fixtures/python-report-writer
+      commands:
+        - mkdir -p .eval-baseline && cp -R fixtures/python-report-writer .eval-baseline/python-report-writer
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "diff -ru .eval-baseline/python-report-writer fixtures/python-report-writer"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: prompt
+    rubric:
+      - Recognized that this C#/.NET-specific workflow does not apply to Python
+      - Did not modify the Python fixture or attempt to introduce .NET abstractions
+      - Stayed dormant instead of applying the C# seam-migration workflow to Python
+      - Redirected the request to the normal Python test-generation/refactoring workflow

--- a/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/src/SnapshotExporter.cs
+++ b/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/src/SnapshotExporter.cs
@@ -1,0 +1,16 @@
+namespace Snapshots;
+
+public interface ITextStore
+{
+    void Write(string path, string content);
+}
+
+public sealed class SnapshotExporter(TimeProvider timeProvider, ITextStore store)
+{
+    public string Export(string content)
+    {
+        var path = $"snapshot-{timeProvider.GetUtcNow():yyyyMMdd-HHmmss}.txt";
+        store.Write(path, content);
+        return path;
+    }
+}

--- a/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/src/SnapshotExporter.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/src/SnapshotExporter.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/tests/SnapshotExporter.Tests.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/already-seamed/tests/SnapshotExporter.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\SnapshotExporter.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/src/ArchiveWriter.cs
+++ b/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/src/ArchiveWriter.cs
@@ -1,0 +1,15 @@
+namespace Reports;
+
+public sealed class ArchiveWriter(string archiveDirectory)
+{
+    public string Archive(string content)
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        var path = Path.Combine(
+            archiveDirectory,
+            $"report-{timestamp:yyyyMMdd-HHmmss}.txt");
+
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/src/ArchiveWriter.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/src/ArchiveWriter.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/tests/ArchiveWriter.Tests.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/archive-writer/tests/ArchiveWriter.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\ArchiveWriter.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/config-loader/src/ConfigLoader.cs
+++ b/tests/dotnet-test/testability-obstacle/fixtures/config-loader/src/ConfigLoader.cs
@@ -1,0 +1,9 @@
+namespace Configuration;
+
+public sealed class ConfigLoader
+{
+    public string? Load(string path)
+    {
+        return File.Exists(path) ? File.ReadAllText(path) : null;
+    }
+}

--- a/tests/dotnet-test/testability-obstacle/fixtures/config-loader/src/ConfigLoader.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/config-loader/src/ConfigLoader.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/config-loader/tests/ConfigLoader.Tests.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/config-loader/tests/ConfigLoader.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\ConfigLoader.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/src/ExpirationPolicy.cs
+++ b/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/src/ExpirationPolicy.cs
@@ -1,0 +1,8 @@
+namespace Licensing;
+
+public sealed class ExpirationPolicy
+{
+    public bool IsExpired(DateTime expiresAtUtc) => DateTime.UtcNow >= expiresAtUtc;
+
+    public DateTime CurrentUtc() => DateTime.UtcNow;
+}

--- a/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/src/ExpirationPolicy.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/src/ExpirationPolicy.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/tests/ExpirationPolicy.Tests.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/expiration-policy/tests/ExpirationPolicy.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\ExpirationPolicy.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/python-report-writer/report_writer.py
+++ b/tests/dotnet-test/testability-obstacle/fixtures/python-report-writer/report_writer.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+
+def write_report(path: str, content: str) -> str:
+    timestamped = f"{path}-{datetime.now():%Y%m%d-%H%M%S}.txt"
+    with open(timestamped, "w", encoding="utf-8") as stream:
+        stream.write(content)
+    return timestamped

--- a/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/src/ReceiptNamer.cs
+++ b/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/src/ReceiptNamer.cs
@@ -1,0 +1,7 @@
+namespace Receipts;
+
+public static class ReceiptNamer
+{
+    public static string Create(int orderId) =>
+        $"receipt-{orderId}-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.txt";
+}

--- a/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/src/ReceiptNamer.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/src/ReceiptNamer.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/tests/ReceiptNamer.Tests.csproj
+++ b/tests/dotnet-test/testability-obstacle/fixtures/static-receipt-namer/tests/ReceiptNamer.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <ProjectReference Include="..\src\ReceiptNamer.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Why

The test-generation plugin needs stable end-to-end scenarios that exercise more than isolated test authoring: starting from an untested .NET solution, extending a partial suite without duplication, and safely testing code blocked by ambient time or filesystem dependencies.

## What changed

- Add an internal `scaffold-dotnet-test-project` helper and route zero-to-one .NET test setup through `code-testing-agent`.
- Add a public `testability-obstacle` skill that introduces the smallest behavior-preserving seam and completes the work with deterministic tests.
- Extend the test generator and testability migration agent with explicit scaffolding, gap-discovery, and migrate-through-tests behavior.
- Add self-contained Vally fixtures and powered scenarios for multi-project scaffolding, partial-suite edge discovery, time/filesystem seams, existing seams, static APIs, and off-target routing.

## Design note

`scaffold-dotnet-test-project` is intentionally hidden from direct model invocation. `code-testing-agent` owns user-facing test-generation requests and invokes the helper by name, avoiding a routing collision and keeping the plugin skill menu within its runtime budget. Its behavior is covered through the consumer eval.

## Validation

- `skill-validator check --plugin ./plugins/dotnet-test`
- `python eng/eval-quality/check_eval_quality.py`
- Built all new .NET fixtures and ran the populated xUnit baseline suites