### PR TITLE
Fix malformed criteria

### DIFF
--- a/tests/dotnet-test-migration/migrate-mstest-v3-to-v4/eval.yaml
+++ b/tests/dotnet-test-migration/migrate-mstest-v3-to-v4/eval.yaml
@@ -348,7 +348,7 @@ stimuli:
       - type: prompt
     rubric:
       - Identifies that TestMethodAttribute constructor now uses CallerInfo parameters
-      - Shows the correct syntax: [TestMethod(DisplayName = "...")]
+      - 'Shows the correct syntax: [TestMethod(DisplayName = "...")]'
       - Applies the fix to both [TestMethod("...")] and [TestMethodAttribute("...")] usages
       - Provides corrected code for all three test methods in the fixture
 
@@ -375,7 +375,7 @@ stimuli:
       - type: prompt
     rubric:
       - Identifies that Assert.IsInstanceOfType<T> no longer uses an out parameter in MSTest v4
-      - Shows the new pattern: var typed = Assert.IsInstanceOfType<T>(obj) using the return value
+      - 'Shows the new pattern: var typed = Assert.IsInstanceOfType<T>(obj) using the return value'
       - Provides corrected code for all three test methods using IsInstanceOfType
       - Explains the typed variable is now assigned from the return value instead of an out parameter
 


### PR DESCRIPTION
Caught these two rubric criteria that included `: ` which was being incorrectly parsed, so judges weren't actually getting the correct input and improvising around it. Looks like they were fine originally but the quotes were stripped inadvertently in #877.

Note that Vally 0.13.0 or later will catch this sort of thing and fail during lint.