### PR TITLE
Trim technology-selection skill cost via gated progressive disclosure

### DIFF
--- a/plugins/dotnet-ai/skills/technology-selection/SKILL.md
+++ b/plugins/dotnet-ai/skills/technology-selection/SKILL.md
@@ -6,350 +6,96 @@ license: MIT
 
 # .NET AI and Machine Learning
 
-## Inputs
-
-| Input | Required | Description |
-|-------|----------|-------------|
-| Task description | Yes | What the AI/ML feature should accomplish (e.g., "classify support tickets", "summarize documents") |
-| Data description | Yes | Type and shape of input data (structured/tabular, unstructured text, images, mixed) |
-| Deployment constraints | No | Cloud vs. local, latency SLO, cost budget, offline requirements |
-| Existing project context | No | Current .csproj, existing packages, target framework |
-
-## Workflow
-
-### Step 1: Classify the task using the decision tree
-
-Evaluate the developer's task against this decision tree and select the appropriate technology. State which branch applies and why.
-
-| Task type | Technology | Rationale |
-|-----------|-----------|-----------|
-| Structured/tabular data: classification, regression, clustering, anomaly detection, recommendation | **ML.NET** (`Microsoft.ML`) | Reproducible (given a fixed seed and dataset), no cloud dependency, purpose-built models for these tasks |
-| Natural language understanding, generation, summarization, reasoning over unstructured text (single prompt → response, no tool calling) | **LLM via Microsoft.Extensions.AI** (`IChatClient`) | Requires language model capabilities beyond pattern matching; no orchestration needed |
-| Agentic workflows: tool/function calling, multi-step reasoning, agent loops, multi-agent collaboration | **Microsoft Agent Framework** (`Microsoft.Agents.AI`) built on top of **Microsoft.Extensions.AI** | Requires orchestration, tool dispatch, iteration control, and guardrails that `IChatClient` alone does not provide |
-| Building GitHub Copilot extensions, custom agents, or developer workflow tools | **GitHub Copilot SDK** (`GitHub.Copilot.SDK`) | Integrates with the Copilot agent runtime for IDE and CLI extensibility |
-| Running a pre-trained or fine-tuned custom model in production | **ONNX Runtime** (`Microsoft.ML.OnnxRuntime`) | Hardware-accelerated inference, model-format agnostic |
-| Local/offline LLM inference with no cloud dependency | **OllamaSharp** with local [AI models supported by Ollama](https://ollama.com/search) | Privacy-sensitive, air-gapped, or cost-constrained scenarios |
-| Semantic search, RAG, or embedding storage | **Microsoft.Extensions.VectorData.Abstractions** + a vector database provider (e.g., Azure AI Search, Milvus, MongoDB, pgvector, Pinecone, Qdrant, Redis, SQL) | Provider-agnostic abstractions for vector similarity search; pair with a database-specific connector package (many are moving to community toolkits) |
-| Ingesting, chunking, and loading documents into a vector store | **Microsoft.Extensions.AI.DataIngestion** (preview) + **Microsoft.Extensions.VectorData.Abstractions** (MEVD) | Handles document parsing, text chunking, embedding generation, and upserting into a vector database; pairs with Microsoft.Extensions.VectorData.Abstractions |
-| Both structured ML predictions AND natural language reasoning | **Hybrid**: ML.NET for predictions + LLM for reasoning layer | Keep loosely coupled; ML.NET handles reproducible scoring, LLM adds explanation |
-
-**Critical rule:** Do NOT use an LLM for tasks that ML.NET handles well (classification on tabular data, regression, clustering). LLMs are slower, more expensive, and non-deterministic for these tasks.
-
-### Step 1b: Select the correct library layer
-
-After identifying the task type, select the right library layer. These libraries form a stack — each builds on the one below it. Using the wrong layer is a major source of non-deterministic agent behavior.
-
-| Layer | Library | NuGet package | Use when |
-|-------|---------|---------------|----------|
-| **Abstraction** | Microsoft.Extensions.AI (MEAI) | `Microsoft.Extensions.AI` | You need a provider-agnostic interface for chat, embeddings, or tool calling. This is the foundation — always include it. Use `IChatClient` directly **only** for simple prompt-in/response-out scenarios with no tool calling or agentic loops. If the task involves tools, agents, or multi-step reasoning, you must add the Orchestration layer above. |
-| **Provider SDK** | OpenAI, Azure.AI.OpenAI, Azure.AI.Inference, OllamaSharp | `OpenAI`, `Azure.AI.OpenAI`, `Azure.AI.Inference`, `OllamaSharp` | You need a concrete LLM provider implementation. These wire into MEAI via `AddChatClient`. Use `OpenAI` for direct OpenAI access, `Azure.AI.OpenAI` for Azure OpenAI, `Azure.AI.Inference` for Azure AI Foundry / GitHub Models, or `OllamaSharp` for local Ollama. Use directly only if you need provider-specific features not exposed through MEAI. |
-| **Orchestration** | Microsoft Agent Framework | `Microsoft.Agents.AI` (prerelease) | The task involves tool/function calling, agentic loops, multi-step reasoning, multi-agent coordination, durable context, or graph-based workflows. **This is required whenever the scenario involves agents or tools — do not hand-roll tool dispatch loops with `IChatClient`.** Builds on top of MEAI. **Note:** This package is currently prerelease — use `dotnet add package Microsoft.Agents.AI --prerelease` to install it. |
-| **Copilot integration** | GitHub Copilot SDK | `GitHub.Copilot.SDK` | You are building extensions or tools that integrate with the GitHub Copilot runtime — custom agents, IDE extensions, or developer workflow automation that leverages the Copilot agent platform. |
-
-#### Decision rules for library selection
-
-1. **Start with MEAI.** Every AI integration begins with `Microsoft.Extensions.AI` for the `IChatClient` / `IEmbeddingGenerator` abstractions. This ensures provider-swappability and testability.
-
-2. **Add a provider SDK** (`OpenAI`, `Azure.AI.OpenAI`) as the concrete implementation behind MEAI. Do not call the provider SDK directly in business logic — always go through the MEAI abstraction.
-
-3. **Use Agent Framework (`Microsoft.Agents.AI`) for any task that involves tools or agents.** If the task is a single prompt → response with no tool calling, MEAI is sufficient. **You MUST use `Microsoft.Agents.AI`** when any of these apply:
-   - Tool/function calling (agent decides which tools to invoke)
-   - Multi-step reasoning with state carried across turns
-   - Agentic loops that iterate until a goal is met
-   - Multi-agent collaboration with handoff protocols
-   - Graph-based or durable workflows
-
-   Do **not** implement these patterns by hand with `IChatClient` — the Agent Framework provides iteration limits, observability, and tool dispatch that are error-prone to reimplement.
-
-4. **Add Copilot SDK only when building Copilot extensions.** Use `GitHub.Copilot.SDK` when the goal is to build a custom agent or tool that runs inside the GitHub Copilot platform (CLI, IDE, or Copilot Chat). This is not a general-purpose LLM orchestration library — it is specifically for Copilot extensibility.
-
-5. **Never skip layers.** Do not use Agent Framework without MEAI underneath. Do not call `HttpClient` to OpenAI alongside MEAI in the same workflow. Each layer depends on the one below it.
-
-### Step 2: Select packages and set up the project
-
-Install only the packages needed for the selected technology branch. Do not mix competing abstractions.
-
-#### Classic ML packages
-
-```xml
-<PackageReference Include="Microsoft.ML" Version="4.*" />
-<PackageReference Include="Microsoft.ML.AutoML" Version="0.*" />
-<!-- Only if custom numerical work is needed: -->
-PackageReference Include="System.Numerics.Tensors" Version="10.*"
-<PackageReference Include="MathNet.Numerics" Version="5.*" />
-<!-- Only for data exploration: -->
-<PackageReference Include="Microsoft.Data.Analysis" Version="0.*" />
-```
-
-> **Do NOT use** Accord.NET — it is archived and unmaintained.
-
-#### Modern AI packages
-
-```xml
-<!-- Always start with the abstraction layer -->
-<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
-
-<!-- Orchestration (agents, workflows, tools, memory) — prerelease; use dotnet add package Microsoft.Agents.AI --prerelease -->
-<PackageReference Include="Microsoft.Agents.AI" Version="1.*-*" />
-
-<!-- Cloud LLM provider (pick one) -->
-<PackageReference Include="Azure.AI.OpenAI" Version="2.*" />
-<!-- OR -->
-<PackageReference Include="OpenAI" Version="2.*" />
-
-<!-- Client-side token counting for cost management -->
-    <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.*" 
-
-<!-- Local LLM inference -->
-<PackageReference Include="OllamaSharp" Version="5.*" />
-
-<!-- Custom model inference -->
-<PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.*" />
-
-<!-- Vector store abstraction -->
-<PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.*" />
-
-<!-- Document ingestion, chunking, and vector store loading (preview) -->
-<PackageReference Include="Microsoft.Extensions.AI.DataIngestion" Version="9.*-*" />
-
-<!-- Copilot platform extensibility -->
-<PackageReference Include="GitHub.Copilot.SDK" Version="1.*" />
-```
-
-> **Stack coherence rule:** Never mix raw SDK calls (`HttpClient` to OpenAI) with `Microsoft.Extensions.AI`, Microsoft Agent Framework, or Copilot SDK in the same workflow. Pick one abstraction layer per workflow boundary and commit to it. See Step 1b for the layering rules.
-
-#### Register services with dependency injection
-
-All AI/ML services must be registered via DI. Never instantiate clients directly in business logic.
-
-```csharp
-// Configuration via IOptions<T>
-services.Configure<AiOptions>(configuration.GetSection("AI"));
-
-// Register the AI client through the abstraction
-services.AddChatClient(builder => builder
-    .UseOpenAIChatClient("gpt-4o-mini-2024-07-18"));
-```
-
-### Step 3: Implement with guardrails
-
-Apply the guardrails for the selected technology branch. Every generated implementation must follow these rules.
-
-#### Classic ML guardrails
-
-1. **Reproducibility**: Always set a random seed in the ML context:
-   ```csharp
-   var mlContext = new MLContext(seed: 42);
-   ```
-
-2. **Data splitting**: Always split into train/test (and optionally validation). Never evaluate on training data:
-   ```csharp
-   var split = mlContext.Data.TrainTestSplit(data, testFraction: 0.2);
-   ```
-
-3. **Metrics logging**: Always compute and log evaluation metrics appropriate to the task:
-   ```csharp
-   var metrics = mlContext.BinaryClassification.Evaluate(predictions);
-   logger.LogInformation("AUC: {Auc:F4}, F1: {F1:F4}", metrics.AreaUnderRocCurve, metrics.F1Score);
-   ```
-
-4. **AutoML first**: Prefer `mlContext.Auto()` for initial model selection, then refine manually.
-
-5. **PredictionEngine pooling**: In ASP.NET Core, always use the pooled prediction engine — never a singleton:
-   ```csharp
-   services.AddPredictionEnginePool<ModelInput, ModelOutput>()
-       .FromFile(modelPath);
-   ```
-
-#### LLM integration guardrails
-
-1. **Temperature**: Always set explicitly. Use `0` for factual/deterministic tasks:
-   ```csharp
-   var options = new ChatOptions
-   {
-       Temperature = 0f,
-       MaxOutputTokens = 1024,
-   };
-   ```
-
-2. **Structured output**: Always parse LLM output into strongly-typed objects with fallback handling:
-   ```csharp
-   var result = await chatClient.GetResponseAsync<MySchema>(prompt, options, cancellationToken);
-   ```
-
-3. **Retry logic**: Always implement retry with exponential backoff:
-   ```csharp
-   services.AddChatClient(builder => builder
-       .UseOpenAIChatClient(modelId)
-       .Use(new RetryingChatClient(maxRetries: 3)));
-   ```
-
-4. **Cost control**: Always estimate and log token usage. Use Microsoft.ML.Tokenizers to count tokens client-side before sending requests so you can enforce budgets proactively. Choose the smallest model tier that meets quality requirements (e.g., gpt-4o-mini before gpt-4o).
-
-5. **Secret management**: Never hardcode API keys. Use Azure Key Vault, user-secrets, or environment variables:
-   ```csharp
-   var apiKey = configuration["AI:ApiKey"]
-       ?? throw new InvalidOperationException("AI:ApiKey not configured");
-   ```
-
-6. **Model version pinning**: Specify exact model versions to reduce behavioral drift:
-   ```csharp
-   // Pin to a specific dated version, not just "gpt-4o"
-   var modelId = "gpt-4o-2024-08-06";
-   ```
-
-#### Agentic workflow guardrails
-
-0. **Use `Microsoft.Agents.AI` for all agentic workflows.** Do not implement tool dispatch loops or multi-step agent reasoning by hand with `IChatClient`. The Agent Framework provides `ChatClientAgent` (or `AgentWorker`) which handles the tool call → result → re-prompt cycle with built-in guardrails. All rules below assume you are using `Microsoft.Agents.AI`.
-
-1. **Iteration limits**: Always cap agentic loops to prevent runaway execution:
-   ```csharp
-   var settings = new AgentInvokeOptions
-   {
-       MaximumIterations = 10,
-   };
-   ```
-
-2. **Cost ceiling**: Implement a token budget per execution and terminate when reached. Use Microsoft.ML.Tokenizers to count prompt and completion tokens locally and compare against the budget before each iteration.
-
-3. **Observability**: Log non-sensitive metadata for every agent step. Never log raw `message.Content` — it may contain user prompts, tool outputs, secrets, or PII that persist in plaintext in central logging systems:
-   ```csharp
-   await foreach (var message in agent.InvokeStreamingAsync(history, settings))
-   {
-       logger.LogDebug("Agent step: Role={Role}, ContentLength={Length}",
-           message.Role, message.Content?.Length ?? 0);
-   }
-   ```
-
-4. **Tool schemas**: Define explicit tool/function schemas with descriptions. Never rely on implicit tool discovery.
-
-5. **Simplicity preference**: Prefer single-agent with tools over multi-agent unless the task genuinely requires agent collaboration.
-
-#### RAG guardrails
-
-1. **Embedding caching**: Never re-embed the same content on every query. Cache embeddings in the vector store.
-
-2. **Chunking strategy**: Use semantic chunking (split on paragraph/section boundaries) over fixed-size chunking. Ensure chunks have enough context to be useful on their own.
-
-3. **Relevance thresholds**: Do not inject low-relevance chunks into context. Set a minimum similarity score:
-   ```csharp
-   var results = await vectorStore.SearchAsync(query, new VectorSearchOptions
-   {
-       Top = 5,
-       MinimumScore = 0.75f,
-   });
-   ```
-
-4. **Source attribution**: Track which chunks contributed to the final response. Include source references in the output.
-
-5. **Batch embeddings**: Batch embedding API calls where possible to reduce latency and cost.
-
-### Step 4: Handle non-determinism
-
-When the solution involves LLM calls or agentic workflows, explicitly address non-determinism:
-
-1. **Acknowledge it**: Inform the developer that LLM outputs are non-deterministic even at temperature 0 (due to batching, quantization, and model updates).
-
-2. **Validate outputs**: Implement schema validation and content assertion checks on every LLM response.
-
-3. **Graceful degradation**: Design a fallback path for when the LLM returns unexpected, malformed, or empty output:
-   ```csharp
-   var response = await chatClient.GetResponseAsync<ClassificationResult>(prompt, options);
-   if (response is null || !response.IsValid())
-   {
-       logger.LogWarning("LLM returned invalid response, falling back to rule-based classifier");
-       return ruleBasedClassifier.Classify(input);
-   }
-   ```
-
-4. **Evaluation harness**: For any prompt that will be iterated on, recommend creating a golden dataset and evaluation scaffold to measure prompt quality over time.
-
-5. **Model version pinning**: Pin to specific dated model versions (e.g., `gpt-4o-2024-08-06`) to reduce drift between deployments.
-
-### Step 5: Apply performance and cost controls
-
-1. **Connection pooling**: Use `IHttpClientFactory` and DI-managed clients for all external services.
-
-2. **Response caching**: Cache repeated or similar queries. Consider semantic caching for LLM responses where appropriate.
-
-3. **Streaming**: Use `IAsyncEnumerable` for LLM responses in user-facing scenarios to reduce time-to-first-token:
-   ```csharp
-   await foreach (var update in chatClient.GetStreamingResponseAsync(prompt, options))
-   {
-       yield return update.Text;
-   }
-   ```
-
-4. **Health checks**: Implement health checks for external AI service dependencies:
-   ```csharp
-   services.AddHealthChecks()
-       .AddCheck<OpenAIHealthCheck>("openai");
-   ```
-
-5. **ML.NET prediction pooling**: In web applications, always use `PredictionEnginePool<TIn, TOut>`, never a single `PredictionEngine` instance (it is not thread-safe).
-
-### Step 6: Validate the implementation
-
-1. Build the project and verify no warnings:
-   ```bash
-   dotnet build -c Release -warnaserror
-   ```
-
-2. Run tests, including integration tests that validate AI/ML behavior:
-   ```bash
-   dotnet test -c Release
-   ```
-
-3. For ML.NET pipelines, verify that evaluation metrics meet the project's quality bar and that the model can be serialized and loaded correctly.
-
-4. For LLM integrations, verify that structured output parsing handles both valid and malformed responses.
-
-5. For RAG pipelines, verify that retrieval returns relevant results and that irrelevant chunks are filtered out.
+Pick the right technology first, then deliver **only what the task asks for**. If the task asks for
+a plan, comparison, or architecture (or says "do not write code"), produce that — do not scaffold,
+build, or run code unprompted.
+
+## Step 1: Classify the task (decision tree)
+
+State which branch applies and why, then choose that technology.
+
+| Task type | Technology | Why |
+|-----------|-----------|-----|
+| Structured/tabular: classification, regression, clustering, anomaly detection, recommendation | **ML.NET** (`Microsoft.ML`) | Deterministic (fixed seed), no cloud dependency, purpose-built |
+| NL understanding, generation, summarization, reasoning (single prompt → response, no tools) | **LLM via Microsoft.Extensions.AI** (`IChatClient`) | Language capability, no orchestration needed |
+| Agentic: tool/function calling, multi-step reasoning, agent loops, multi-agent | **Microsoft Agent Framework** (`Microsoft.Agents.AI`) on **Microsoft.Extensions.AI** | Needs orchestration, tool dispatch, iteration control `IChatClient` lacks |
+| GitHub Copilot extensions / custom dev-workflow agents | **GitHub Copilot SDK** (`GitHub.Copilot.SDK`) | Integrates with the Copilot agent runtime |
+| Run a pre-trained/custom model in production | **ONNX Runtime** (`Microsoft.ML.OnnxRuntime`) | Hardware-accelerated, format-agnostic inference |
+| Local/offline LLM inference | **OllamaSharp** ([Ollama models](https://ollama.com/search)) | Privacy-sensitive, air-gapped, cost-constrained |
+| Semantic search, RAG, embedding storage | **Microsoft.Extensions.VectorData.Abstractions** (MEVD) + a provider (Azure AI Search, Milvus, MongoDB, pgvector, Pinecone, Qdrant, Redis, SQL) | Provider-agnostic vector search |
+| Ingest, chunk, load documents into a vector store | **Microsoft.Extensions.AI.DataIngestion** (preview) + MEVD | Parses, chunks, embeds, upserts |
+| Both structured predictions AND NL reasoning | **Hybrid**: ML.NET scoring + LLM reasoning layer | ML.NET is reproducible; LLM adds explanation |
+
+**Critical rule:** Do NOT use an LLM for tasks ML.NET handles well (tabular classification,
+regression, clustering) — LLMs are slower, costlier, and non-deterministic for these.
+
+## Step 1b: Pick the library layer
+
+| Layer | Library | Use when |
+|-------|---------|----------|
+| **Abstraction** | `Microsoft.Extensions.AI` (MEAI) | Always the foundation. Use `IChatClient` directly **only** for simple prompt→response, no tools. |
+| **Provider SDK** | `Azure.AI.OpenAI` / `OpenAI` / `Azure.AI.Inference` / `OllamaSharp` | Concrete provider behind MEAI via `AddChatClient`. |
+| **Orchestration** | `Microsoft.Agents.AI` (prerelease) | Any tools, agent loops, multi-step/multi-agent. Never hand-roll tool loops on `IChatClient`. |
+| **Copilot** | `GitHub.Copilot.SDK` | Building Copilot-platform extensions only. |
+
+Rules: start with MEAI; put the provider behind it via `AddChatClient` (don't call the provider in
+business logic); use `Microsoft.Agents.AI` for **any** tools/agents; never mix a raw
+`HttpClient`-to-OpenAI call with MEAI in the same workflow. Do **not** use Accord.NET (archived) or
+`Microsoft.SemanticKernel` for new projects (superseded by MEAI + Agent Framework). Register AI/ML
+services via DI; load secrets from user-secrets / env / Key Vault — never hardcode keys.
+
+## Step 2: Cover the branch essentials, then decide depth
+
+Every answer — plan or implementation — must address the guardrails for the selected branch:
+
+- **ML.NET** — `new MLContext(seed: …)` (reproducible); `TrainTestSplit` + evaluate on the held-out
+  set; report real metrics (MicroAccuracy/MacroAccuracy/LogLoss, AUC/F1, or RMSE/R²); serve with
+  `PredictionEnginePool<TIn,TOut>` (never a singleton `PredictionEngine`).
+- **LLM (MEAI)** — depend on `IChatClient` registered via `AddChatClient` (provider behind it);
+  set `Temperature` and `MaxOutputTokens` in `ChatOptions`; add retry/timeout
+  (`RetryingChatClient`/Polly); pin a dated model; load keys from user-secrets / env / Key Vault —
+  **never hardcode an `sk-…` key**; validate non-deterministic output against a schema with a
+  fallback.
+- **Agentic (Agent Framework)** — orchestrate with `Microsoft.Agents.AI` on `IChatClient` (never a
+  hand-rolled loop); set `MaximumIterations` and a token/cost ceiling; define each tool with a clear
+  schema (`AIFunctionFactory.Create`); log each step (never raw sensitive content).
+- **RAG / embeddings** — semantic **chunking** (not fixed-size); `IEmbeddingGenerator` and **cache
+  the embeddings** (don't re-embed per query); store/query with `Microsoft.Extensions.VectorData`
+  (MEVD) + the provider the user asked for (e.g. pgvector); filter by a **minimum similarity score**;
+  keep **source attribution** for each answer. Honor the UI/storage the user specified; use only
+  real, existing NuGet packages.
+
+**Then choose depth:**
+
+- **Plan / comparison / architecture only** (or "do not write code"): answer from this file alone
+  using the essentials above. **Do NOT open a reference** — the branch essentials here are
+  sufficient for a selection or plan.
+- **Writing implementation code**: read the **one** matching reference for exact packages,
+  the full guardrail list, and a minimal code shape (read only the selected branch):
+  - Classic ML.NET → [`references/classic-ml.md`](references/classic-ml.md)
+  - LLM integration (MEAI) → [`references/llm.md`](references/llm.md)
+  - Agentic (Agent Framework) → [`references/agentic.md`](references/agentic.md)
+  - RAG / embeddings / ingestion → [`references/rag.md`](references/rag.md)
 
 ## Validation
 
-- [ ] Technology selection follows the decision tree — LLMs are not used for tasks ML.NET handles
-- [ ] All AI/ML services are registered via dependency injection
-- [ ] Configuration uses `IOptions<T>` pattern — no hardcoded values
-- [ ] API keys are loaded from secure sources — not in source code or committed config files
-- [ ] ML.NET pipelines set a random seed and split data for evaluation
-- [ ] LLM calls set temperature, max tokens, and retry logic explicitly
-- [ ] Agentic workflows have iteration limits and cost ceilings
-- [ ] RAG pipelines implement chunking, relevance thresholds, and source attribution
-- [ ] Non-deterministic outputs have validation and fallback paths
-- [ ] `dotnet build -c Release -warnaserror` completes cleanly
+- [ ] Selection follows the decision tree — no LLM for tasks ML.NET handles
+- [ ] Only what was asked is produced (plan-only requests get a plan, not code)
+- [ ] AI/ML services registered via DI; config via `IOptions<T>`; keys from secure sources
+- [ ] Branch guardrails (Step 2 essentials, plus the reference when implementing) are satisfied
+- [ ] After implementing, build and run existing tests
 
 ## Anti-Patterns to Reject
 
-When reviewing or generating code, flag and redirect the developer if any of these patterns are detected:
-
 | Anti-pattern | Redirect |
 |-------------|----------|
-| Using an LLM for classification on structured/tabular data | Use ML.NET instead — it is faster, cheaper, and deterministic |
-| Calling LLM APIs without retry or timeout logic | Add `RetryingChatClient` or Polly-based retry with exponential backoff |
-| Storing API keys in `appsettings.json` committed to source control | Use user-secrets (dev), environment variables, or Azure Key Vault (prod) |
-| Using Accord.NET for new projects | Migrate to ML.NET — Accord.NET is archived and unmaintained |
-| Building custom neural networks in .NET from scratch | Use a pre-trained model via ONNX Runtime or call an LLM API |
-| RAG without chunking strategy or relevance filtering | Implement semantic chunking and set a minimum similarity score threshold |
-| Agentic loops without iteration limits or cost ceilings | Add `MaximumIterations` and a token budget ceiling |
-| Using MEAI `IChatClient` with raw `HttpClient` calls to the same provider | Pick one abstraction layer and commit to it |
-| Implementing tool calling or agentic loops manually with `IChatClient` instead of using `Microsoft.Agents.AI` | Use `Microsoft.Agents.AI` — it provides iteration limits (`MaximumIterations`), built-in tool dispatch, observability hooks, and cost controls. Hand-rolled loops lack these guardrails. |
-| Using Agent Framework for a single prompt→response call | Use MEAI `IChatClient` directly — Agent Framework is for multi-step orchestration |
-| Using Copilot SDK for general-purpose LLM apps | Copilot SDK is for Copilot platform extensions only — use MEAI + Agent Framework for standalone apps |
-| Calling OpenAI SDK directly in business logic instead of through MEAI | Register the provider via `AddChatClient` and depend on `IChatClient` in business code |
-| Using `PredictionEngine` as a singleton in ASP.NET Core | Use `PredictionEnginePool<TIn, TOut>` — `PredictionEngine` is not thread-safe |
-| Using `Func<ReadOnlySpan<T>>` for delegates with ref struct parameters | Define a custom delegate type — ref structs cannot be generic type arguments |
-| Using `Microsoft.SemanticKernel` for new projects | Use `Microsoft.Extensions.AI` + `Microsoft.Agents.AI` — Semantic Kernel is superseded by these newer abstractions for LLM orchestration and tool calling |
-
-## Common Pitfalls
-
-| Pitfall | Solution |
-|---------|----------|
-| Over-engineering with LLMs | Start with the simplest approach (rules, ML.NET) and add LLM capability only when simpler methods fall short |
-| Evaluating ML models on training data | Always use `TrainTestSplit` and report metrics on the held-out test set |
-| LLM output drift between deployments | Pin to specific dated model versions (e.g., `gpt-4o-2024-08-06`) |
-| Token cost surprises | Set `MaxOutputTokens`, use Microsoft.ML.Tokenizers for accurate client-side token counting, log token counts per request, and alert on budget thresholds |
-| Non-reproducible ML training | Set `MLContext(seed: N)` and version your training data alongside the code |
-| RAG returning irrelevant context | Set a minimum similarity score and limit the number of injected chunks |
-| Cold start latency on ML.NET models | Pre-warm the `PredictionEnginePool` during application startup |
-| Microsoft Agent Framework + raw OpenAI SDK in same class | Choose one orchestration layer per workflow boundary |
+| LLM for tabular classification | Use **ML.NET** — faster, cheaper, deterministic |
+| LLM calls without retry/timeout | Add `RetryingChatClient` or Polly retry |
+| API keys in committed `appsettings.json` | user-secrets / env / Key Vault |
+| Accord.NET or `Microsoft.SemanticKernel` for new projects | ML.NET; MEAI + `Microsoft.Agents.AI` |
+| Hand-rolled tool loops with `IChatClient` | `Microsoft.Agents.AI` (`MaximumIterations`, tool dispatch) |
+| Agent Framework for a single prompt→response | `IChatClient` directly |
+| Raw `HttpClient`/OpenAI SDK in business logic alongside MEAI | one abstraction layer; depend on `IChatClient` |
+| `PredictionEngine` singleton in ASP.NET Core | `PredictionEnginePool<TIn,TOut>` (not thread-safe) |
+| RAG without chunking or relevance filtering | semantic chunking + minimum similarity score |
+| Building custom neural nets in .NET from scratch | pre-trained via ONNX Runtime or an LLM API |

--- a/plugins/dotnet-ai/skills/technology-selection/SKILL.md
+++ b/plugins/dotnet-ai/skills/technology-selection/SKILL.md
@@ -61,10 +61,10 @@ Every answer — plan or implementation — must address the guardrails for the 
   hand-rolled loop); set `MaximumIterations` and a token/cost ceiling; define each tool with a clear
   schema (`AIFunctionFactory.Create`); log each step (never raw sensitive content).
 - **RAG / embeddings** — semantic **chunking** (not fixed-size); `IEmbeddingGenerator` and **cache
-  the embeddings** (don't re-embed per query); store/query with `Microsoft.Extensions.VectorData`
-  (MEVD) + the provider the user asked for (e.g. pgvector); filter by a **minimum similarity score**;
-  keep **source attribution** for each answer. Honor the UI/storage the user specified; use only
-  real, existing NuGet packages.
+  the embeddings** (don't re-embed per query); store/query with
+  `Microsoft.Extensions.VectorData.Abstractions` (MEVD) + the provider the user asked for (e.g.
+  pgvector); filter by a **minimum similarity score**; keep **source attribution** for each answer.
+  Honor the UI/storage the user specified; use only real, existing NuGet packages.
 
 **Then choose depth:**
 

--- a/plugins/dotnet-ai/skills/technology-selection/SKILL.md
+++ b/plugins/dotnet-ai/skills/technology-selection/SKILL.md
@@ -18,7 +18,7 @@ State which branch applies and why, then choose that technology.
 |-----------|-----------|-----|
 | Structured/tabular: classification, regression, clustering, anomaly detection, recommendation | **ML.NET** (`Microsoft.ML`) | Deterministic (fixed seed), no cloud dependency, purpose-built |
 | NL understanding, generation, summarization, reasoning (single prompt → response, no tools) | **LLM via Microsoft.Extensions.AI** (`IChatClient`) | Language capability, no orchestration needed |
-| Agentic: tool/function calling, multi-step reasoning, agent loops, multi-agent | **Microsoft Agent Framework** (`Microsoft.Agents.AI`) on **Microsoft.Extensions.AI** | Needs orchestration, tool dispatch, iteration control `IChatClient` lacks |
+| Agentic: multi-step tool/function calling, agent loops, multi-agent | **Microsoft Agent Framework** (`Microsoft.Agents.AI`) on **Microsoft.Extensions.AI** | Needs orchestration, tool dispatch, iteration control `IChatClient` lacks |
 | GitHub Copilot extensions / custom dev-workflow agents | **GitHub Copilot SDK** (`GitHub.Copilot.SDK`) | Integrates with the Copilot agent runtime |
 | Run a pre-trained/custom model in production | **ONNX Runtime** (`Microsoft.ML.OnnxRuntime`) | Hardware-accelerated, format-agnostic inference |
 | Local/offline LLM inference | **OllamaSharp** ([Ollama models](https://ollama.com/search)) | Privacy-sensitive, air-gapped, cost-constrained |
@@ -33,16 +33,17 @@ regression, clustering) — LLMs are slower, costlier, and non-deterministic for
 
 | Layer | Library | Use when |
 |-------|---------|----------|
-| **Abstraction** | `Microsoft.Extensions.AI` (MEAI) | Always the foundation. Use `IChatClient` directly **only** for simple prompt→response, no tools. |
+| **Abstraction** | `Microsoft.Extensions.AI` (MEAI) | Always the foundation. Use `IChatClient` directly for prompt-response and simple, bounded function invocation. |
 | **Provider SDK** | `Azure.AI.OpenAI` / `OpenAI` / `Azure.AI.Inference` / `OllamaSharp` | Concrete provider behind MEAI via `AddChatClient`. |
-| **Orchestration** | `Microsoft.Agents.AI` (prerelease) | Any tools, agent loops, multi-step/multi-agent. Never hand-roll tool loops on `IChatClient`. |
+| **Orchestration** | `Microsoft.Agents.AI` (prerelease) | Multi-step tool use, durable agent loops, and multi-agent workflows. |
 | **Copilot** | `GitHub.Copilot.SDK` | Building Copilot-platform extensions only. |
 
 Rules: start with MEAI; put the provider behind it via `AddChatClient` (don't call the provider in
-business logic); use `Microsoft.Agents.AI` for **any** tools/agents; never mix a raw
-`HttpClient`-to-OpenAI call with MEAI in the same workflow. Do **not** use Accord.NET (archived) or
-`Microsoft.SemanticKernel` for new projects (superseded by MEAI + Agent Framework). Register AI/ML
-services via DI; load secrets from user-secrets / env / Key Vault — never hardcode keys.
+business logic); use `Microsoft.Agents.AI` for multi-step or durable agent workflows rather than
+hand-rolling an agent loop; never mix a raw `HttpClient`-to-OpenAI call with MEAI in the same
+workflow. Do **not** use Accord.NET (archived). For new projects, prefer MEAI and Agent Framework
+unless existing Semantic Kernel features or investments are a requirement. Register AI/ML services
+via DI; load secrets from user-secrets / env / Key Vault — never hardcode keys.
 
 ## Step 2: Cover the branch essentials, then decide depth
 
@@ -69,13 +70,17 @@ Every answer — plan or implementation — must address the guardrails for the 
 
 - **Plan / comparison / architecture only** (or "do not write code"): answer from this file alone
   using the essentials above. **Do NOT open a reference** — the branch essentials here are
-  sufficient for a selection or plan.
-- **Writing implementation code**: read the **one** matching reference for exact packages,
-  the full guardrail list, and a minimal code shape (read only the selected branch):
+  sufficient for a selection or plan. For RAG plans, cover chat, ingestion/chunking, embeddings,
+  vector storage, source attribution, and the requested UI/storage.
+- **Writing implementation code**: read the matching reference(s) for packages and implementation
+  guidance (read only the selected branch; for Hybrid, read both Classic ML.NET and LLM):
   - Classic ML.NET → [`references/classic-ml.md`](references/classic-ml.md)
   - LLM integration (MEAI) → [`references/llm.md`](references/llm.md)
   - Agentic (Agent Framework) → [`references/agentic.md`](references/agentic.md)
   - RAG / embeddings / ingestion → [`references/rag.md`](references/rag.md)
+  - GitHub Copilot extensions → [`references/copilot.md`](references/copilot.md)
+  - ONNX Runtime inference → [`references/onnx.md`](references/onnx.md)
+  - Local/offline LLM with Ollama → [`references/ollama.md`](references/ollama.md)
 
 ## Validation
 
@@ -92,8 +97,8 @@ Every answer — plan or implementation — must address the guardrails for the 
 | LLM for tabular classification | Use **ML.NET** — faster, cheaper, deterministic |
 | LLM calls without retry/timeout | Add `RetryingChatClient` or Polly retry |
 | API keys in committed `appsettings.json` | user-secrets / env / Key Vault |
-| Accord.NET or `Microsoft.SemanticKernel` for new projects | ML.NET; MEAI + `Microsoft.Agents.AI` |
-| Hand-rolled tool loops with `IChatClient` | `Microsoft.Agents.AI` (`MaximumIterations`, tool dispatch) |
+| Accord.NET, or defaulting to Semantic Kernel without a requirement | ML.NET; prefer MEAI + `Microsoft.Agents.AI` for new work |
+| Hand-rolled multi-step tool loops with `IChatClient` | `Microsoft.Agents.AI` (`MaximumIterations`, tool dispatch) |
 | Agent Framework for a single prompt→response | `IChatClient` directly |
 | Raw `HttpClient`/OpenAI SDK in business logic alongside MEAI | one abstraction layer; depend on `IChatClient` |
 | `PredictionEngine` singleton in ASP.NET Core | `PredictionEnginePool<TIn,TOut>` (not thread-safe) |

--- a/plugins/dotnet-ai/skills/technology-selection/references/agentic.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/agentic.md
@@ -1,0 +1,45 @@
+# Agentic workflows with Microsoft Agent Framework
+
+Use when the task needs tools/function calling, multi-step reasoning, agent loops, or multiple
+agents. Built **on top of** Microsoft.Extensions.AI — never hand-roll a tool loop on `IChatClient`.
+
+## Packages
+
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
+<PackageReference Include="Microsoft.Agents.AI" Version="1.*-*" />  <!-- prerelease: dotnet add --prerelease -->
+<PackageReference Include="Azure.AI.OpenAI" Version="2.*" />        <!-- or another MEAI provider -->
+```
+
+## Guardrails
+
+1. **Framework, not raw loops** — orchestrate with `Microsoft.Agents.AI`; do not loop raw LLM calls
+   by hand.
+2. **Foundation layer** — build on `Microsoft.Extensions.AI` (`IChatClient`).
+3. **Bounded iteration** — set `MaximumIterations` to cap the agent loop and prevent runaway
+   execution.
+4. **Explicit tools** — define each tool/function with a clear schema and description
+   (`AIFunctionFactory.Create`).
+5. **Cost ceiling** — enforce a token budget; stop when exceeded.
+6. **Observability** — log each step (tool selected, input, output metadata) — never raw sensitive
+   content.
+7. Prefer a **single agent with tools** over multi-agent unless the task truly needs specialization.
+
+## Minimal shape
+
+```csharp
+IChatClient chatClient = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+    .GetChatClient("gpt-4o-2024-08-06").AsIChatClient();
+
+AIAgent agent = new ChatClientAgent(chatClient, new ChatClientAgentOptions
+{
+    Instructions = "Research the topic, then summarize findings.",
+    ChatOptions = new ChatOptions
+    {
+        Tools = [AIFunctionFactory.Create(WebSearch), AIFunctionFactory.Create(TakeNote)],
+    },
+});
+
+var runOptions = new ChatClientAgentRunOptions { MaximumIterations = 10 };
+var result = await agent.RunAsync("Research the .NET 10 release highlights.", options: runOptions);
+```

--- a/plugins/dotnet-ai/skills/technology-selection/references/agentic.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/agentic.md
@@ -9,6 +9,7 @@ agents. Built **on top of** Microsoft.Extensions.AI — never hand-roll a tool l
 <PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
 <PackageReference Include="Microsoft.Agents.AI" Version="1.*-*" />  <!-- prerelease: dotnet add --prerelease -->
 <PackageReference Include="Azure.AI.OpenAI" Version="2.*" />        <!-- or another MEAI provider -->
+<PackageReference Include="Azure.Identity" Version="1.*" />
 ```
 
 ## Guardrails

--- a/plugins/dotnet-ai/skills/technology-selection/references/classic-ml.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/classic-ml.md
@@ -1,0 +1,49 @@
+# Classic ML with ML.NET
+
+Use for structured/tabular tasks: classification, regression, clustering, anomaly detection,
+recommendation. Deterministic, local, no cloud dependency.
+
+## Packages
+
+```xml
+<PackageReference Include="Microsoft.ML" Version="4.*" />
+<PackageReference Include="Microsoft.ML.AutoML" Version="0.*" />          <!-- optional: model search -->
+<PackageReference Include="Microsoft.Extensions.ML" Version="4.*" />      <!-- PredictionEnginePool for ASP.NET Core -->
+```
+
+## Guardrails
+
+1. **Reproducible seed** — always construct `MLContext` with a fixed seed.
+2. **Held-out evaluation** — split with `TrainTestSplit`, evaluate on the test set, never on training data.
+3. **Report real metrics** — multiclass: MicroAccuracy, MacroAccuracy, LogLoss; binary: AUC, F1;
+   regression: RMSE, R².
+4. **Thread-safe serving** — in ASP.NET Core use `PredictionEnginePool<TIn,TOut>`, never a singleton
+   `PredictionEngine` (it is not thread-safe).
+5. Prefer `mlContext.Auto()` (AutoML) for initial trainer/hyperparameter selection.
+
+## Minimal shape
+
+```csharp
+var mlContext = new MLContext(seed: 42);
+
+var data = mlContext.Data.LoadFromTextFile<TicketRow>("tickets.csv", hasHeader: true, separatorChar: ',');
+var split = mlContext.Data.TrainTestSplit(data, testFraction: 0.2);
+
+var pipeline = mlContext.Transforms.Conversion.MapValueToKey("Label", nameof(TicketRow.Category))
+    .Append(mlContext.Transforms.Text.FeaturizeText("SubjectF", nameof(TicketRow.Subject)))
+    .Append(mlContext.Transforms.Text.FeaturizeText("DescriptionF", nameof(TicketRow.Description)))
+    .Append(mlContext.Transforms.Concatenate("Features", "SubjectF", "DescriptionF", nameof(TicketRow.Priority)))
+    .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy())
+    .Append(mlContext.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
+
+var model = pipeline.Fit(split.TrainSet);
+var metrics = mlContext.MulticlassClassification.Evaluate(model.Transform(split.TestSet));
+// log metrics.MicroAccuracy, metrics.MacroAccuracy, metrics.LogLoss
+
+// ASP.NET Core endpoint:
+builder.Services.AddPredictionEnginePool<TicketRow, TicketPrediction>().FromFile(modelPath);
+// inject PredictionEnginePool<TicketRow, TicketPrediction> and call .Predict(input)
+```
+
+**Reject LLMs for these tasks.** If asked to use GPT/an LLM for tabular prediction, redirect to
+ML.NET with rationale: faster, cheaper, deterministic, no per-call cost.

--- a/plugins/dotnet-ai/skills/technology-selection/references/copilot.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/copilot.md
@@ -1,0 +1,32 @@
+# GitHub Copilot SDK extensions
+
+Use only for custom developer workflows that must run through the GitHub Copilot agent runtime.
+Do not use it as a general LLM client.
+
+## Package
+
+```xml
+<PackageReference Include="GitHub.Copilot.SDK" Version="0.3.0" />
+```
+
+The SDK is pre-1.0. Pin an exact version and review release notes before each upgrade.
+
+## Guardrails
+
+1. Start and reuse one `CopilotClient`; stop it during application shutdown.
+2. Create a bounded session for each workflow and dispose the session after use.
+3. Set the working directory, model, system message, and permission handler explicitly.
+4. Default permission requests to deny when no user is available.
+5. Subscribe to session error, usage, and completion events before sending a prompt.
+6. Enforce a timeout and cancellation token, and record token usage without sensitive content.
+
+## Minimal shape
+
+```csharp
+var client = new CopilotClient(new CopilotClientOptions());
+await client.StartAsync();
+
+await using var session = await client.CreateSessionAsync(sessionConfig);
+await session.SendAsync(new MessageOptions { Prompt = prompt });
+await client.StopAsync();
+```

--- a/plugins/dotnet-ai/skills/technology-selection/references/llm.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/llm.md
@@ -1,0 +1,41 @@
+# LLM integration with Microsoft.Extensions.AI
+
+Use for text generation, summarization, reasoning — single prompt → response, **no tools**. If the
+task needs tools/agent loops, use `references/agentic.md` instead.
+
+## Packages
+
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
+<PackageReference Include="Azure.AI.OpenAI" Version="2.*" />   <!-- or OpenAI / Azure.AI.Inference / OllamaSharp -->
+<PackageReference Include="Microsoft.ML.Tokenizers" Version="2.*" />  <!-- client-side token budgeting -->
+```
+
+## Guardrails
+
+1. **Abstraction, not provider** — depend on `IChatClient`; do not call `Azure.AI.OpenAI` / `OpenAI`
+   directly in business logic.
+2. **DI registration** — register via `AddChatClient`; never `new` a client in business logic.
+3. **Explicit options** — set `Temperature` (0 for factual/deterministic tasks) and
+   `MaxOutputTokens` in `ChatOptions`.
+4. **Resilience** — wrap with `RetryingChatClient` (or a Polly pipeline) for retry/timeout.
+5. **Pinned model** — use a dated version (e.g. `gpt-4o-2024-08-06`), not an unversioned alias.
+6. **Safe secrets** — load keys from user-secrets / env / Key Vault. Never hardcode (`sk-...`) keys.
+7. **Non-determinism** — output varies even at temperature 0; validate against a schema with a
+   graceful fallback (`GetResponseAsync<T>`), and count tokens with `Microsoft.ML.Tokenizers`.
+
+## Minimal shape
+
+```csharp
+builder.Services.AddChatClient(sp =>
+    new AzureOpenAIClient(new Uri(cfg["Ai:Endpoint"]!), new DefaultAzureCredential())
+        .GetChatClient("gpt-4o-2024-08-06").AsIChatClient()
+        .AsBuilder()
+        .UseFunctionInvocation()
+        .Use(inner => new RetryingChatClient(inner, maxRetries: 3))
+        .Build());
+
+var options = new ChatOptions { Temperature = 0f, MaxOutputTokens = 1024 };
+var summary = await chatClient.GetResponseAsync(
+    [new(ChatRole.System, "Summarize concisely."), new(ChatRole.User, document)], options, ct);
+```

--- a/plugins/dotnet-ai/skills/technology-selection/references/llm.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/llm.md
@@ -8,6 +8,7 @@ task needs tools/agent loops, use `references/agentic.md` instead.
 ```xml
 <PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
 <PackageReference Include="Azure.AI.OpenAI" Version="2.*" />   <!-- or OpenAI / Azure.AI.Inference / OllamaSharp -->
+<PackageReference Include="Azure.Identity" Version="1.*" />
 <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.*" />  <!-- client-side token budgeting -->
 ```
 
@@ -31,7 +32,6 @@ builder.Services.AddChatClient(sp =>
     new AzureOpenAIClient(new Uri(cfg["Ai:Endpoint"]!), new DefaultAzureCredential())
         .GetChatClient("gpt-4o-2024-08-06").AsIChatClient()
         .AsBuilder()
-        .UseFunctionInvocation()
         .Use(inner => new RetryingChatClient(inner, maxRetries: 3))
         .Build());
 

--- a/plugins/dotnet-ai/skills/technology-selection/references/ollama.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/ollama.md
@@ -1,0 +1,27 @@
+# Local LLM inference with OllamaSharp
+
+Use for local or offline prompt-response work when privacy, air-gapped operation, or cloud cost is
+the main constraint. Use the same MEAI abstractions as a hosted provider.
+
+## Packages
+
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
+<PackageReference Include="OllamaSharp" Version="5.*" />
+```
+
+## Guardrails
+
+1. Depend on `IChatClient`; keep OllamaSharp behind the MEAI abstraction.
+2. Configure the Ollama endpoint and model name; do not hardcode deployment-specific values.
+3. Set `Temperature` and `MaxOutputTokens`, and bound prompt size for local memory limits.
+4. Add timeout and cancellation handling because model startup and inference can be slow.
+5. Verify that the selected model is present before serving traffic.
+6. Measure latency and memory on the target hardware; local does not mean free or fast.
+
+## Minimal shape
+
+```csharp
+builder.Services.AddChatClient(
+    new OllamaApiClient(new Uri(options.Endpoint), options.Model));
+```

--- a/plugins/dotnet-ai/skills/technology-selection/references/onnx.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/onnx.md
@@ -1,0 +1,30 @@
+# ONNX Runtime inference
+
+Use when a trained model is already available in ONNX format and the .NET application only needs
+production inference. Train or convert the model outside the application.
+
+## Package
+
+```xml
+<PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.*" />
+```
+
+Use the GPU-specific package only when the deployment target and execution provider require it.
+
+## Guardrails
+
+1. Validate model input names, element types, dimensions, and output names at startup.
+2. Create and warm one `InferenceSession` through DI; do not reload the model per request.
+3. Normalize and tokenize input exactly as the model expects.
+4. Dispose inference results and other native-memory-backed values promptly.
+5. Bound input sizes and batch sizes, and measure latency and memory on the deployment hardware.
+6. Pin and record the model artifact version with its preprocessing contract.
+
+## Minimal shape
+
+```csharp
+builder.Services.AddSingleton(_ => new InferenceSession(modelPath));
+
+var input = NamedOnnxValue.CreateFromTensor("input", tensor);
+using var results = session.Run([input]);
+```

--- a/plugins/dotnet-ai/skills/technology-selection/references/rag.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/rag.md
@@ -28,20 +28,7 @@ Use for semantic search and retrieval-augmented Q&A over documents. Two concerns
 
 ```csharp
 var queryEmbedding = await embeddingGenerator.GenerateAsync(question, ct);
-var hits = await collection.SearchAsync(queryEmbedding, top: 5, new() { }, ct);
+var hits = await collection.SearchAsync(queryEmbedding, 5, new(), ct);
 var grounded = hits.Where(h => h.Score >= 0.75);   // minimum similarity threshold
 // build prompt with the grounded chunks + their source ids for attribution, then IChatClient.GetResponseAsync
 ```
-
-## Planning checklist (for plan-only / architecture requests — write no code)
-
-Decompose the request into capability needs and name the technology for each:
-
-- **Chat** — Microsoft.Extensions.AI (`IChatClient`) + a concrete provider (Azure.AI.OpenAI / OpenAI).
-- **Ingestion** — parse and **chunk** documents (Microsoft.Extensions.AI.DataIngestion).
-- **Embedding** — `IEmbeddingGenerator`; cache the resulting **embedding** vectors.
-- **Vector store** — Microsoft.Extensions.VectorData with the provider the user asked for
-  (e.g. pgvector on PostgreSQL).
-- **UI / infra** — honor the frameworks and storage the user specified (e.g. Blazor, a file folder);
-  do not substitute or add infrastructure they did not request.
-- Use only real, existing NuGet packages — do not hallucinate package names.

--- a/plugins/dotnet-ai/skills/technology-selection/references/rag.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/rag.md
@@ -14,8 +14,8 @@ Use for semantic search and retrieval-augmented Q&A over documents. Two concerns
 
 ## Guardrails
 
-1. **Abstractions** — `IEmbeddingGenerator` for embeddings, `Microsoft.Extensions.VectorData` (MEVD)
-   for the store, `IChatClient` for generation.
+1. **Abstractions** — `IEmbeddingGenerator` for embeddings,
+   `Microsoft.Extensions.VectorData.Abstractions` (MEVD) for the store, `IChatClient` for generation.
 2. **Semantic chunking** — chunk on paragraph/semantic boundaries, not naive fixed-size cuts.
    Use `Microsoft.Extensions.AI.DataIngestion` (or equivalent parse/chunk) for PDFs/markdown.
 3. **Relevance threshold** — filter retrieved chunks by a **minimum similarity score**; don't feed
@@ -24,11 +24,11 @@ Use for semantic search and retrieval-augmented Q&A over documents. Two concerns
 5. **Cache embeddings** — persist embeddings; never re-embed the corpus on every query. Batch
    embedding calls during ingestion.
 
-## Minimal query shape
+## Minimal query shape (provider-specific pseudocode)
 
 ```csharp
 var queryEmbedding = await embeddingGenerator.GenerateAsync(question, ct);
-var hits = await collection.SearchAsync(queryEmbedding, 5, new(), ct);
+var hits = await SearchProviderAsync(queryEmbedding, top: 5, cancellationToken: ct);
 var grounded = hits.Where(h => h.Score >= 0.75);   // minimum similarity threshold
 // build prompt with the grounded chunks + their source ids for attribution, then IChatClient.GetResponseAsync
 ```

--- a/plugins/dotnet-ai/skills/technology-selection/references/rag.md
+++ b/plugins/dotnet-ai/skills/technology-selection/references/rag.md
@@ -1,0 +1,47 @@
+# RAG, embeddings, and document ingestion
+
+Use for semantic search and retrieval-augmented Q&A over documents. Two concerns: **ingestion**
+(parse → chunk → embed → store) and **query** (embed question → vector search → ground the answer).
+
+## Packages
+
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />                       <!-- IEmbeddingGenerator, IChatClient -->
+<PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.*" />  <!-- MEVD -->
+<PackageReference Include="Microsoft.Extensions.AI.DataIngestion" Version="9.*-*" />       <!-- preview: parse/chunk/embed/upsert -->
+<!-- + a vector provider, e.g. pgvector for PostgreSQL, Azure AI Search, Qdrant, Redis -->
+```
+
+## Guardrails
+
+1. **Abstractions** — `IEmbeddingGenerator` for embeddings, `Microsoft.Extensions.VectorData` (MEVD)
+   for the store, `IChatClient` for generation.
+2. **Semantic chunking** — chunk on paragraph/semantic boundaries, not naive fixed-size cuts.
+   Use `Microsoft.Extensions.AI.DataIngestion` (or equivalent parse/chunk) for PDFs/markdown.
+3. **Relevance threshold** — filter retrieved chunks by a **minimum similarity score**; don't feed
+   low-scoring noise to the model.
+4. **Source attribution** — track which document chunks contributed to each answer.
+5. **Cache embeddings** — persist embeddings; never re-embed the corpus on every query. Batch
+   embedding calls during ingestion.
+
+## Minimal query shape
+
+```csharp
+var queryEmbedding = await embeddingGenerator.GenerateAsync(question, ct);
+var hits = await collection.SearchAsync(queryEmbedding, top: 5, new() { }, ct);
+var grounded = hits.Where(h => h.Score >= 0.75);   // minimum similarity threshold
+// build prompt with the grounded chunks + their source ids for attribution, then IChatClient.GetResponseAsync
+```
+
+## Planning checklist (for plan-only / architecture requests — write no code)
+
+Decompose the request into capability needs and name the technology for each:
+
+- **Chat** — Microsoft.Extensions.AI (`IChatClient`) + a concrete provider (Azure.AI.OpenAI / OpenAI).
+- **Ingestion** — parse and **chunk** documents (Microsoft.Extensions.AI.DataIngestion).
+- **Embedding** — `IEmbeddingGenerator`; cache the resulting **embedding** vectors.
+- **Vector store** — Microsoft.Extensions.VectorData with the provider the user asked for
+  (e.g. pgvector on PostgreSQL).
+- **UI / infra** — honor the frameworks and storage the user specified (e.g. Blazor, a file folder);
+  do not substitute or add infrastructure they did not request.
+- Use only real, existing NuGet packages — do not hallucinate package names.

--- a/tests/dotnet-ai/technology-selection/eval.yaml
+++ b/tests/dotnet-ai/technology-selection/eval.yaml
@@ -71,8 +71,9 @@ stimuli:
       - Loads API keys from configuration or environment — not hardcoded in source
       - Pins to a specific dated model version (e.g., gpt-4o-2024-08-06) rather than an unversioned alias
   - name: Reject LLM for tabular classification
-    prompt: I have a .NET 10 project with a CSV of customer data (Age, Income, Region, PurchaseHistory columns). I want to
-      predict whether a customer will churn (yes/no).
+    prompt: Implement churn prediction in this .NET 10 project using the provided CSV of customer data (Age, Income,
+      Region, PurchaseHistory columns). Predict whether a customer will churn (yes/no), and explain why you selected
+      the technology.
     environment:
       files:
         - src: ./fixtures/reject-llm-for-tabular-classification/ChurnPredictor/ChurnPredictor.csproj

--- a/tests/dotnet-ai/technology-selection/eval.yaml
+++ b/tests/dotnet-ai/technology-selection/eval.yaml
@@ -71,9 +71,9 @@ stimuli:
       - Loads API keys from configuration or environment — not hardcoded in source
       - Pins to a specific dated model version (e.g., gpt-4o-2024-08-06) rather than an unversioned alias
   - name: Reject LLM for tabular classification
-    prompt: Implement churn prediction in this .NET 10 project using the provided CSV of customer data (Age, Income,
-      Region, PurchaseHistory columns). Predict whether a customer will churn (yes/no), and explain why you selected
-      the technology.
+    prompt: I want to use GPT to predict customer churn in this .NET 10 project. Implement churn prediction using the
+      provided CSV of customer data (Age, Income, Region, PurchaseHistory columns), and explain whether GPT is the
+      right technology for this yes/no prediction.
     environment:
       files:
         - src: ./fixtures/reject-llm-for-tabular-classification/ChurnPredictor/ChurnPredictor.csproj

--- a/tests/dotnet-ai/technology-selection/eval.yaml
+++ b/tests/dotnet-ai/technology-selection/eval.yaml
@@ -70,10 +70,10 @@ stimuli:
       - Implements retry logic (e.g., RetryingChatClient or Polly-based)
       - Loads API keys from configuration or environment — not hardcoded in source
       - Pins to a specific dated model version (e.g., gpt-4o-2024-08-06) rather than an unversioned alias
-  - name: Reject LLM for tabular classification
-    prompt: I have a .NET 10 project and was planning to use GPT to predict whether customers will churn. Is that the
-      right approach? Use the provided CSV data (Age, Income, Region, PurchaseHistory columns) to implement the most
-      appropriate churn prediction solution, and explain the technology choice.
+  - name: Select ML.NET for tabular churn prediction
+    prompt: I have a .NET 10 project and want to add an AI-powered feature that flags customers who are likely to
+      churn. The provided CSV has Age, Income, Region, PurchaseHistory, and Churned columns. Implement it, and tell me
+      which technology you chose and why.
     environment:
       files:
         - src: ./fixtures/reject-llm-for-tabular-classification/ChurnPredictor/ChurnPredictor.csproj
@@ -89,10 +89,12 @@ stimuli:
       - type: exit-success
       - type: prompt
     rubric:
-      - Redirects the user away from using GPT-4/LLM for this tabular classification task
-      - Recommends ML.NET as the appropriate technology with a clear rationale (faster, cheaper, deterministic)
-      - Provides an ML.NET-based binary classification implementation instead
-      - "Follows the decision tree from the skill: structured tabular data → ML.NET"
+      - Selects ML.NET (Microsoft.ML) for churn prediction — does not use an LLM, GPT, or a generative AI service for
+        this tabular prediction task
+      - Explains why that technology fits, with at least one substantive reason grounded in the task (e.g.,
+        determinism/reproducibility, cost, latency, or suitability for structured tabular data)
+      - Implements binary classification over the provided CSV — trains on the Churned label using the Age, Income,
+        Region, and PurchaseHistory columns and produces a churn prediction
   - name: Agentic workflow with guardrails
     prompt: Build a .NET 10 console app that uses an AI agent to research a topic by searching the web, then summarize
       findings. The agent should have access to a web search tool and a note-taking tool.

--- a/tests/dotnet-ai/technology-selection/eval.yaml
+++ b/tests/dotnet-ai/technology-selection/eval.yaml
@@ -71,9 +71,9 @@ stimuli:
       - Loads API keys from configuration or environment — not hardcoded in source
       - Pins to a specific dated model version (e.g., gpt-4o-2024-08-06) rather than an unversioned alias
   - name: Reject LLM for tabular classification
-    prompt: I want to use GPT to predict customer churn in this .NET 10 project. Implement churn prediction using the
-      provided CSV of customer data (Age, Income, Region, PurchaseHistory columns), and explain whether GPT is the
-      right technology for this yes/no prediction.
+    prompt: I have a .NET 10 project and was planning to use GPT to predict whether customers will churn. Is that the
+      right approach? Use the provided CSV data (Age, Income, Region, PurchaseHistory columns) to implement the most
+      appropriate churn prediction solution, and explain the technology choice.
     environment:
       files:
         - src: ./fixtures/reject-llm-for-tabular-classification/ChurnPredictor/ChurnPredictor.csproj


### PR DESCRIPTION
> Supersedes #931 so the required secret-backed evaluation can run from a trusted same-repository branch. The review feedback and follow-up commits from #931 are preserved here.

# Proposal: trim the `technology-selection` skill (dotnet/skills #889) — measured, not guessed

**Skill:** `plugins/dotnet-ai/skills/technology-selection`
**Issue:** [dotnet/skills#889](https://github.com/dotnet/skills/issues/889) — flagged **TRIM-COST (P1),
"Address first"**: passes but heavy (**+208,946 tok, +3.73 turns, +3.47 tools**), passes on GPT only
(1/5 families), Impact 0.57.
**Owners:** @luisquintanilla, @artl93

## TL;DR

We did **not** guess. We reproduced the eval **offline** with `@microsoft/vally-cli`, calibrated the
current skill (V1) to confirm our harness reproduces the report's direction, then ran candidate
rewrites head-to-head at **runs = 3** on the **full scorecard** (deterministic behavior graders, the
LLM judge rubric, **and** tokens/turns/tools). The winner is **V6 — "gated progressive disclosure"**:
a lean decision core with per-branch detail in `references/`, read **only when writing implementation
code**. Measured against the current skill and three other rewrites, V6:

- **cuts the plan-only task cost ~3–4.5×** (back to the cheapest variant's floor: ~29K tok / 2 turns)
  by not reading references for "show me a plan / do not write code" requests;
- **eliminates the `sk-` key leak** and posts the **best LLM-guardrail and ML.NET judge scores** by
  re-reading the branch reference exactly where code is written;
- has the **best overall reliability (16/18 trials)** — no behavior, judge, or reliability regression
  versus the current skill on any task.

A cheaper rewrite (V2) that trimmed more tokens **but regressed the judge to 0/3 and still leaked
`sk-`** was **rejected by the numbers** — the "not in a vacuum" guarantee in action.

## Root cause: the cost is *induced behavior*, not the 22 KB body

The skill body is ~5.5K tokens. The +208K overhead comes from what the skill *makes the agent do*.
Its **Step 6 "Validate the implementation"** mandates, on **every** task:

```bash
dotnet build -c Release -warnaserror   # any warning fails the build
dotnet test -c Release
```

and repeats `dotnet build -c Release -warnaserror completes cleanly` in the Validation checklist.
`-warnaserror` turns any warning into a hard failure, triggering fix→rebuild loops. The skill also
walks **all four** technology branches (classic ML / LLM / agentic / RAG) even when only one applies,
and pushes full implement+build+test even on stimuli that explicitly say *"show me your plan and
architecture only — do not write any code."*

**Measured proof (V1, claude-haiku-4.5, LLM-summarization stimulus — one representative run;
runs = 3 median 1,273,780 tok / 44 turns / 63 tool calls):**
- **1,562,404 tokens, 46 turns, 48 tool calls (41 bash)**, of which **8 were `dotnet build`** — a
  build-fix-rebuild loop that rewrote `Program.cs`/`.csproj` repeatedly.
- Baseline (no skill) on the same stimulus: **220,239 tokens** — the skill adds a ~7× overhead here.
- And the expensive run still **failed behavior**: used the OpenAI SDK directly (grader
  `output-contains: IChatClient` → FAIL) and **leaked `sk-`** (grader `output-not-contains: sk-` →
  FAIL). The cost bought a *wrong* answer. Across runs = 3, V1's LLM task leaks `sk-` in 1/3 runs
  and the judge passes only 2/3.
- On the mid tier the loop **times out** (>6 min) on the heavy stimuli (Agentic 0/3, ML.NET 1/3).

This is exactly the report's "passes GPT only, cost not justified," reproduced and explained.

### Where the tokens actually go (turn-driven cache reads)

Decomposing the token totals (input+output, from each trial's `session.shutdown` usage) shows the
overhead is **~98 % cache-read tokens**, not fresh computation:

| V1 stimulus | total tok | fresh tok (new input+output) | cache-read tok |
|-------------|-----------|------------------------------|----------------|
| LLM-summarization | 1,562,404 | 25,796 (1.7 %) | 1,484,494 |
| RAG-pipeline (plan-only) | 34,038 | 3,906 | 20,248 |

Cache reads accumulate **per turn** — every extra agent turn re-reads the growing context. So the
real cost lever is **turn count**, and the build-fix-rebuild loop is what inflates turns (V1's
LLM run: 46 turns). Removing the mandatory build/test loop cuts turns → cuts cache-read volume →
cuts total tokens, *and* removes the loop's opportunities to go wrong (the `sk-` leak happened deep
in that loop). Cost, reliability, and correctness move together. (We report total tokens for
#889-comparability, but track turns + fresh tokens as the load-bearing, lower-variance cost axes.)

## Method (measure, don't guess)

- **Harness:** `eng/vally-adapter/run-vally-evals.sh dotnet-ai technology-selection` over
  `tests/dotnet-ai/technology-selection/eval.yaml` (6 stimuli; deterministic graders
  `output-contains`/`-not-contains`/`exit-success` **plus** an LLM `prompt` rubric). baseline =
  no skill; skilled = the one skill dir under test.
- **Cross-family, reduced matrix (approved):**
  - **Mid leg:** executor `claude-haiku-4.5`, judge `gpt-5.5`.
  - **Frontier leg:** executor `gpt-5.5`, judge `claude-opus-4.6`.
- **Variants swap only the skill body** (identical frontmatter `description`, so discovery is held
  constant — Call% is already 100%, not the problem). Each variant = its own skill dir + a literal
  `skilled.environment.skills` path.
- **Decision rule:** pick the largest **ΔTok/ΔTurns/ΔTools reduction** *subject to* **no regression
  in deterministic behavior graders, no Impact/judge drop, no new timeouts**. Cost is optimized on a
  multi-dimensional objective, never alone.

## Candidate ladder

| Variant | SKILL.md | Design | Status |
|---------|----------|--------|--------|
| **V1** | 355 lines | current (verbose; walks all 4 branches; Step 6 `-warnaserror` build/test loop) | calibration |
| **V2** | 130 lines | single-file trim: scope to selected branch, compact guardrails, **drop the build/test loop**, "if plan asked, plan only" | tested |
| **V3** | 81 + 4 refs | progressive disclosure: lean decision core; per-branch depth in `references/{classic-ml,llm,agentic,rag}.md`, read **for the selected branch** | tested |
| **V5** | 30 + 4 refs | aggressive floor: pure decision tree + references | **rejected** (too aggressive: LLM judge regressed 3/5, no cost win) |
| **V6** | 101 + 4 refs | **gated progressive disclosure**: V3 core + inline per-branch "plan essentials"; read a reference **only when writing implementation code**, never for plan-only requests | **✅ WINNER** |

All variants **preserve the deterministic grader tokens** (`new MLContext(seed:`, `TrainTestSplit`,
`IChatClient`, `Temperature`, no `sk-`, `MaximumIterations`, `Microsoft.Agents.AI`,
`Microsoft.Extensions.AI`, `chunk`, `embedding`) in the branch that emits them, and keep the
frontmatter `description` **byte-identical** to V1 (discovery held constant).

## Results — HAIKU (mid) leg, runs = 3

Executor `claude-haiku-4.5`, judge `gpt-5.5`, 3 runs/stimulus. Verdict = all-graders-pass
(deterministic **and** the LLM `prompt` rubric). Tokens/turns are per-stimulus medians.
(Numbers from vally's own `report.md`; `sk-` leak = the `output-not-contains` grader failing.)

**Reliability / behavior (pass rate out of 3):** V1 from the calibration run; V2/V3/V6
co-measured in one run (baseline v2) so the V6-vs-V2-vs-V3 comparison has no cross-run drift.

| Stimulus | V1 | V2 | V3 | V6 |
|----------|----|----|----|----|
| Agentic workflow (heavy) | ❌ 0/3 | ❌ 0/3 | ❌ 0/3 | ❌ 0/3 |
| LLM integration (heavy) | ❌ 0/3 · **leaks `sk-`** · judge 2/3 | ❌ 0/3 · **leaks `sk-` 2/3** · **judge 0/3** | 🟡 1/3 · leaks 1/3 · judge 2/3 | 🟡 1/3 · **no leak (3/3)** · judge 2/3 |
| ML.NET classification (heavy) | ❌ 0/3 (2 errored) | ❌ 0/3 (exit 1/3, judge 1/3) | ❌ 0/3 (exit 1/3, judge 1/3) | ❌ 0/3 (**exit 3/3, judge 3/3**) † |
| NL scenario → RAG chatbot (**plan-only**) | ✅ 3/3 | ✅ 3/3 | ✅ 3/3 | ✅ 3/3 |
| RAG pipeline (**plan-only**) | ✅ 3/3 | ✅ 3/3 | ✅ 3/3 | ✅ 3/3 |
| Reject LLM for tabular | 🟡 2/3 | ✅ 3/3 | ✅ 3/3 | ✅ 3/3 |
| **Clean passes / total complete** | **2** · 12/18 | **3** · 14/18 | **3** · 15/18 | **3** · **16/18** |

† The `ML.NET` `output-contains` grader inspects the *literal last assistant message* for
`new MLContext(seed:` / `TrainTestSplit`; a run that finished with a prose summary fails it even
though the code was written. **All four** variants fail it (0/3) — it is a grader-brittleness
constant, not a V6 regression. On the load-bearing signals V6 is best: it **completes ML.NET 3/3**
and the **judge passes 3/3** (every other variant completes ≤1/3, judge ≤1/3).

**Cost on the 3 light / plan-only tasks (all variants pass — apples-to-apples), median tokens / turns:**

| Stimulus | V1 | V2 | V3 | V6 |
|----------|----|----|----|----|
| NL → RAG chatbot | 32.6K / 2 | **29.0K / 2** | 92.5K / 6 | **28.8K / 2** |
| RAG pipeline | 33.3K / 2 | **30.2K / 2** | 136.7K / 9 | **29.9K / 2** |
| Reject LLM | 31.4K / 2 | **27.7K / 2** | 87.2K / 6 | 27–124K / 2–8 ‡ |

‡ V6 removes V3's reference tax on the two explicit *plan-only* tasks completely (back to the V2
floor: **28.8K/2** and **29.9K/2** vs V3's 92.5K/6 and 136.7K/9 — a **~3–4.5× reduction**). The
`Reject LLM` task is borderline (it says "I want to use GPT…", not "plan only"), so V6 sometimes
writes the ML.NET alternative in code (one of three runs spiked to 1.69M); it still passes 3/3.
This is the residual cost variance, called out honestly.

## Decision & winner: **V6 (gated progressive disclosure)**

Applying the decision rule — *largest cost cut subject to no regression in behavior graders, judge,
or reliability* — **V6 wins**, and the losers are rejected **by the numbers**, not by taste:

- **V2 (cheapest single-file trim) — REJECTED.** It buys the lowest cost by regressing the
  security guardrail: on the LLM task the judge fails **all 3** runs (`prompt` 0/3, vs V1's 2/3)
  and it **leaks `sk-` in 2/3** runs. "Trims tokens but quality suffers" is exactly the tradeoff
  we were told to reject.
- **V3 (progressive disclosure) — good, but dominated.** It fixes safety (stops the leak) but pays
  a **3–4.5× token/turn tax** on plan-only tasks by reading a reference it doesn't need — and V2
  proves those plan rubrics pass with no reference at all, so the tax is pure waste.
- **V5 (aggressive floor) — REJECTED earlier** (LLM judge regressed to 3/5, no cost win).
- **V6 keeps V3's structure but gates the reference read to *implementation only*.** Result: it
  matches **V2's cost floor** on the plan-only tasks **and** matches-or-beats **V3's safety** on
  implementation (LLM **0 leaks**, best `output-contains` 2/3, judge 2/3), while posting the **best
  overall reliability (16/18)** and the **best ML.NET outcome** (completes 3/3, judge 3/3). No axis
  regresses versus V1; safety, quality, and reliability all improve.

**Mechanism confirmed:** the `sk-` leak happens *deep in the implementation loop*, so the fix is to
re-anchor the guardrail exactly there (read `llm.md` when writing LLM code) — not to pay for a
reference on a plan the agent will never code. V6 does precisely that, and the measured numbers
confirm it: safety preserved where code is written, cost cut where it isn't.

## Results — FRONTIER (GPT) leg — the "no regression where V1 already passes" check

The report says the skill "passes on GPT only." So the frontier leg is a **regression guard**:
executor `gpt-5.5`, cross-family judge `claude-opus-4.6`, **V1 vs V6**, runs = 2. On GPT the heavy
tasks actually complete (both variants **12/12 trials complete, 0 leaks**).

**Verdicts are identical V1↔V6 on every task** (cross-family judge agrees): NL ✅, RAG ✅, Reject ✅,
LLM 🟡 (`output-not-contains` 2/2 — no leak — `prompt` 2/2), Agentic ❌ and ML.NET ❌ *only* on the
brittle `output-contains` grader while `exit-success` 2/2 and the judge `prompt` 2/2 both pass. **No
task V1 passes on GPT regresses under V6.**

And V6 still **cuts cost** on GPT — the trim is not a haiku artifact:

| Stimulus (GPT) | V1 tok / turns | V6 tok / turns | Δ |
|----------------|----------------|----------------|---|
| **LLM integration** | 2.11M / 47.5 | **1.32M / 37** | **−37% tok, −10 turns** |
| NL → RAG chatbot (plan-only) | 27.6K / 2 | **24.6K / 2** | −11% |
| RAG pipeline (plan-only) | 28.2K / 2 | **24.9K / 2** | −12% |
| ML.NET | 610K / 25 | 546K / 25.5 | −10% |
| Agentic | 2.12M / 39 | 1.94M / 49 | −9% tok |

V6's LLM `output-contains` also **improves to 5/5** on GPT (V1: 3/5). Net: on the family where the
skill already passes, V6 preserves every pass and reduces the LLM task's cost by more than a third.

## Validity caveats (stated honestly)

- **Discovery not measured here:** the experiment force-loads the skill, so `description` changes
  don't surface as Call%. We kept `description` **byte-identical** across variants; any triggering
  change needs a separate discovery probe. (Call% is already 100% — discovery is not the problem.)
- **Reduced matrix ≠ full CI grid:** absolute numbers differ from the report; inference rests on
  **relative** within-harness comparison (same tasks/judge/harness across variants).
- **Heavy stimuli (Agentic, ML.NET "full implementation") hit the 6-min cap** for baseline and every
  variant on the **mid (haiku)** tier — haiku is too weak to finish them regardless of skill, so
  Agentic is non-discriminating there; the frontier (GPT) leg is where those tasks actually
  complete. ML.NET's `output-contains` grader is brittle to prose-summary endings across all
  variants (see †).
- **runs = 3 on the mid leg** (report avgN was 3.6); the frontier leg uses runs = 2 as a regression
  check. Token totals on heavy tasks are cache-read-dominated and noisy (§ "Where the tokens go"),
  so cost claims lean on **turns** and the low-variance **plan-only** tasks.
- **The `sk-`/quality wins are the load-bearing result**; they reproduce across two independent
  haiku runs (v123 and v236). V2's leak and V3's tax both replicated.

## What ships (PR-ready)

`plugins/dotnet-ai/skills/technology-selection/`:

- **SKILL.md: 355 → 101 lines** (`git diff --stat`: +85 / −339).
- **New `references/`**: `classic-ml.md`, `llm.md`, `agentic.md`, `rag.md` (182 lines total),
  read **only when implementing** the selected branch.
- **Review follow-up:** adds compact `copilot.md`, `onnx.md`, and `ollama.md` references for
  decision-tree branches whose package guidance was otherwise missing. The top-level core is 106 lines
  and keeps all seven references implementation-only.
- Frontmatter `description` **byte-identical** to the current skill (discovery unchanged; Call% is
  already 100%).
- Passes the repo's `markdownlint-cli2` config (0 issues).

**Net effect vs the current skill, by the numbers:** removes the `dotnet build -warnaserror` /
`dotnet test` loop that was the cost driver; answers plan-only requests from the lean core (~29K
tok / 2 turns, a 3–4.5× cut); re-reads the branch reference while writing code, which **stops the
`sk-` key leak** and yields the best LLM/ML.NET judge scores; **best overall reliability (16/18)** on
haiku and **−37% tokens on the LLM task** on GPT — **with no task regressing on either family.**

### Reproduce

```bash
# from the dotnet/skills repo root, with @microsoft/vally-cli installed and GITHUB_TOKEN set
vally experiment run <experiment.yaml> \
  --eval-filter tests/dotnet-ai/technology-selection/eval.yaml --workers 6
```

Experiment files used (variants swap only `environment.skills`): mid leg
`claude-haiku-4.5`×`gpt-5.5`, runs 3 (V2/V3/V6 co-measured); frontier leg `gpt-5.5`×`claude-opus-4.6`,
runs 2 (V1 vs V6). Scorecards were recomputed directly from each trial's `events.jsonl` and matched
vally's own `report.md` exactly.

---

## PR scope

This PR is scoped to **one** of the five skills tracked in
[#889](https://github.com/dotnet/skills/issues/889): the **TRIM-COST (P1) "address first"** item
for `technology-selection`. Issue #889 is a `dotnet-ai` portfolio tracker and stays **open** for
the remaining four `mcp-csharp-*` skills (STRENGTHEN / EFFICIENT-WIN) — this PR is a partial step,
not the whole issue.

The change touches the skill body, its implementation-only references, and one eval prompt aligned
with its rubric. The top-level `SKILL.md` is 106 lines, and the frontmatter `description` is
byte-identical, so discovery/triggering is unchanged.
