### PR TITLE
Fix eval PAT probe wrongly rejecting claude-haiku-4.5 legs

### DIFF
--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -521,6 +521,14 @@ jobs:
             rm -rf "$PROBE_HOME"
             PROBE_HOME=$(mktemp -d)
             for probe_model in "${PROBE_MODELS[@]}"; do
+              # Some models (e.g. claude-haiku-4.5) do not support reasoning-effort
+              # configuration and exit non-zero when given --effort, which would
+              # wrongly reject an otherwise-healthy PAT. Only pass --effort to
+              # models that accept it.
+              probe_effort_args=(--effort=low)
+              case "$probe_model" in
+                claude-haiku-4.5) probe_effort_args=() ;;
+              esac
               set +e
               (
                 cd "$RUNNER_TEMP"
@@ -533,7 +541,7 @@ jobs:
                   --model "$probe_model" \
                   --output-format=json \
                   --silent \
-                  --effort=low >"$PROBE_LOG" 2>&1
+                  "${probe_effort_args[@]}" >"$PROBE_LOG" 2>&1
               )
               probe_status=$?
               set -e


### PR DESCRIPTION
## Problem

Scheduled cross-family eval runs on the `mid` and `full` profiles fail on every `claude-haiku-4.5` executor leg. The PAT-pool availability probe in `evaluation-run.yml` runs each probe model with `--effort=low`:

```
Error: Model "claude-haiku-4.5" does not support reasoning effort configuration (requested: "low")
```

The probe exits non-zero, so the leg is rejected as a *non-rate-limit error* and fails wholesale ? even though the real eval never passes an effort flag.

## Blast radius (verified)

`--effort` is passed in **exactly one place** ? the probe. The actual eval path (`vally experiment run` + `gen-experiment.mjs --model` + `adapt.mjs --model/--judge-model`) passes the model but no reasoning effort. So the failure is purely at the pre-flight probe, and fixing the probe fully unblocks haiku legs.

Only `claude-haiku-4.5` is a no-effort model in any profile/judge route; all others support reasoning effort.

## Fix

Guard the probe so `--effort=low` is only passed to models that accept it. One-line behavior change, isolated to the probe loop.

## Notes

- This bug **predates** the cross-family cadence work; it surfaced now because scheduled `mid`-profile runs exercise the haiku executor leg.
- Empty-array expansion (`"${probe_effort_args[@]}"`) is safe under the step's `set -euo pipefail` on the runner's bash 5.x.
- `actionlint` clean.
