### PR TITLE
Harden eval verdict correctness and failure accounting

### DIFF
--- a/.agents/skills/create-skill-test/SKILL.md
+++ b/.agents/skills/create-skill-test/SKILL.md
@@ -46,9 +46,9 @@ Verify the target exists at `plugins/<plugin>/skills/<skill-name>/SKILL.md` or
 
 **Agent evals sit outside the verdict flow.** The canonical experiment declares
 `evals: tests/*/!(agent.*)/eval.yaml`, so `agent.*` specs are excluded: no verdict is ever computed
-for them, the trial floor does not apply, and `./eng/run-skill-evals.sh` drops them even when you
-name one explicitly (its `--eval-filter` is intersected with that glob). Everything below about
-sizing for statistical power therefore applies to **skill** evals. Author agent evals for the
+for them, the stimulus floor does not apply, and `./eng/run-skill-evals.sh` drops them even when you
+name one explicitly (its `--eval-filter` is intersected with that glob). The distinct-stimulus
+floor therefore applies to **skill** evals only. Author agent evals for the
 scenario coverage and the deterministic graders, and run them as described in Step 10.
 
 **Be careful with a skill that sets `disable-model-invocation: true`.** The model cannot invoke it,
@@ -89,34 +89,33 @@ stimuli:
 ```
 
 > **`defaults:` replaces `config:` — it does not join it.** `config` is a deprecated alias for the
-> same block and vally **throws** on a spec declaring both. Most existing evals here still open with
-> `config:`; when you add `runs`, merge the two into one `defaults:` block carrying `timeout` and
-> `runs`. The failure is invisible otherwise: the job exits 0 with no verdicts and the PR comment
+> same block and vally **throws** on a spec declaring both. Some existing evals still open with
+> `config:`; when you change settings, replace it with one `defaults:` block. The failure is
+> invisible otherwise: the job exits 0 with no verdicts and the PR comment
 > blames "transient infrastructure".
 
 ### Step 3: Size the eval for power before writing content
 
-`trials = stimuli × runs`, and the gate has two independent bars:
+The gate gives each distinct stimulus one vote. Repeated runs for one stimulus collapse to one
+majority-direction vote and remain available as reliability evidence.
 
-1. **Counted trials ≥ 5**, else the verdict is `underpowered` — never a pass, never a regression.
-2. **p ≤ 0.05 on an exact one-sided sign test over the *discordant* (non-tie) trials.** Ties are not
+1. **Distinct stimuli ≥ 5**, else the verdict is `underpowered` — never a pass, never a regression.
+2. **p ≤ 0.05 on an exact one-sided sign test over *discordant* (non-tie) stimulus votes.** Ties are not
    discarded; they hold the discordant count down.
 
-| discordant trials | records that pass | p |
+| discordant stimulus votes | records that pass | p |
 |---:|---|---:|
 | ≤ 4 | none | ≥ 0.0625 |
 | 5–7 | zero losses only (5W/0L) | 0.031 |
 | 8 | one loss survivable (7W/1L) | 0.035 |
 
-At exactly 5 counted trials a single tie is fatal — it leaves 4 discordant. At 6 counted trials one
-tie is survivable (5W/1T/0L); at 7, up to two are (5W/2T/0L). A loss is not. Five is an
-**eligibility floor**, not adequate power — one tie at five trials makes a pass
-arithmetically unreachable. A run measuring a 32% tie rate certified a genuinely-helping five-trial
-eval roughly one time in ten; at fifteen trials, nine times in ten.
+At exactly 5 stimuli, one tie is fatal because it leaves 4 discordant votes. At 6 stimuli one tie
+is survivable; at 7, up to two are. A loss is not. Five is an **eligibility floor**, not adequate
+power. For example, 80% power needs 8 discordant votes only for a true 90% conditional win rate;
+it needs 18 at 80%, 37 at 70%, and 158 at 60%. Size for the effect and tie rate you need to detect.
 
-Prefer **more stimuli** over more `runs`: repeats measure the same task. Raise `runs` only when a
-stimulus is genuinely expensive to add (full build/test pipelines), and write the reasoning in a
-comment above `defaults:`.
+Use `runs` for reliability, not task breadth. Vally recommends 3 runs in CI and 5–10 nightly for
+pass rate, pass@k, pass^k, and flakiness. Extra runs never clear the five-stimulus floor.
 
 Do not set `runs` in `dotnet-skills.experiment.yaml`; experiment overrides overwrite every eval's
 own value rather than defaulting it.
@@ -302,7 +301,7 @@ Read the trajectories rather than the verdict — there is no sign-test result f
 
 `check_eval_quality.py` blocks ten structural defect classes that each already cost a real result:
 missing or untracked fixtures, self-contradicting coverage fixtures, empty grader configs, dormancy
-guards with `reject_skills`, sub-floor trial counts, duplicate YAML keys, and `config:`/`defaults:`
+guards with `reject_skills`, sub-floor stimulus counts, duplicate YAML keys, and `config:`/`defaults:`
 collisions. Do not add a new eval to `eng/eval-quality/underpowered-allowlist.txt` — the gate rejects
 allowlist entries that are new relative to the base branch.
 
@@ -312,7 +311,7 @@ For the official run, submit a PR review containing `/evaluate` so it binds to t
 
 - [ ] Directory is `tests/<plugin>/<skill-name>/` or `tests/<plugin>/agent.<agent-name>/`
 - [ ] Spec uses `stimuli:` / `graders:`, and exactly one of `defaults:` or `config:`
-- [ ] For a skill eval, `stimuli × runs` clears 5 with room for the expected tie rate (agent evals are exempt — they get no verdict)
+- [ ] For a skill eval, at least 5 distinct stimuli exist, with more for the effect and tie rate that must be detected (agent evals are exempt)
 - [ ] Each stimulus discriminates a different property
 - [ ] Prompts never name the skill, the agent, or its vocabulary
 - [ ] Every referenced fixture exists and is tracked by `git ls-files`
@@ -329,8 +328,8 @@ For the official run, submit a PR review containing `/evaluate` so it binds to t
 |---------|----------|
 | Writing `scenarios:` / `assertions:` | That format no longer loads; use `stimuli:` / `graders:` |
 | Adding `defaults: runs:` beside an existing `config:` | Merge into one `defaults:` block |
-| Landing an eval at exactly 5 trials | A single tie makes a pass unreachable; size for the tie rate |
-| Raising `runs` instead of adding stimuli | Repeats measure one task and add no cross-task evidence |
+| Landing an eval at exactly 5 stimuli | A single tie makes a pass unreachable; size for the effect and tie rate |
+| Raising `runs` to clear the floor | Repeats measure reliability for one task; add stimuli |
 | Prompt mentions the skill or agent by name | Rewrite as a natural developer request |
 | Rubric rewards using the skill | Drop the item — the harness reports activation separately; rubrics measure outcomes |
 | Fixture present but ignored by git | Verify with `git ls-files`; CI setup will fail otherwise |
@@ -340,7 +339,7 @@ For the official run, submit a PR review containing `/evaluate` so it binds to t
 | Timeout too short for code generation | Use ~360s; empty output fails every grader |
 | Duplicate YAML key left behind by an edit | It overwrites the next stimulus field by field — delete the stray block |
 | Direct activation-graded eval for a `disable-model-invocation: true` skill | Cover it through a consumer skill, or grade the answer content as `filter-syntax` does |
-| Agent eval sized for the trial floor | `agent.*` evals get no verdict; size them for scenario coverage instead |
+| Agent eval sized for the stimulus floor | `agent.*` evals get no verdict; size them for scenario coverage instead |
 | Agent eval "run" with `./eng/run-skill-evals.sh` | The glob drops it — use a widened `EXPERIMENT_FILE` |
 | Agent eval missing `environment.skills` | Declare the skills the agent routes to, or it cannot invoke them |
 | `environment.skills` set in a **skill** eval | The experiment varies that key and replaces it in every arm; the declaration does nothing |

--- a/.agents/skills/create-skill-test/SKILL.md
+++ b/.agents/skills/create-skill-test/SKILL.md
@@ -127,6 +127,8 @@ own value rather than defaulting it.
   cued prompts inflate the overfit score and bias the baseline.
 - Each stimulus should discriminate a **different** property of the skill. Five stimuli covering one
   property give arithmetic, not evidence.
+- Give every stimulus a stable, unique `name`. Vally pairs comparison trajectories by
+  `(stimulus name, trial index)`; duplicate names make slot identity ambiguous.
 - Include a boundary / no-op stimulus for any skill that migrates or rewrites code, proving it
   leaves already-correct input alone.
 
@@ -299,10 +301,11 @@ EXPERIMENT_FILE=my-agent.experiment.yaml ./eng/run-skill-evals.sh <plugin>
 
 Read the trajectories rather than the verdict — there is no sign-test result for an agent eval.
 
-`check_eval_quality.py` blocks ten structural defect classes that each already cost a real result:
+`check_eval_quality.py` blocks eleven structural defect classes that can corrupt a result:
 missing or untracked fixtures, self-contradicting coverage fixtures, empty grader configs, dormancy
-guards with `reject_skills`, sub-floor stimulus counts, duplicate YAML keys, and `config:`/`defaults:`
-collisions. Do not add a new eval to `eng/eval-quality/underpowered-allowlist.txt` — the gate rejects
+guards with `reject_skills`, sub-floor stimulus counts, duplicate YAML keys or stimulus names, and
+`config:`/`defaults:` collisions. Do not add a new eval to
+`eng/eval-quality/underpowered-allowlist.txt` — the gate rejects
 allowlist entries that are new relative to the base branch.
 
 For the official run, submit a PR review containing `/evaluate` so it binds to the reviewed commit.
@@ -312,7 +315,7 @@ For the official run, submit a PR review containing `/evaluate` so it binds to t
 - [ ] Directory is `tests/<plugin>/<skill-name>/` or `tests/<plugin>/agent.<agent-name>/`
 - [ ] Spec uses `stimuli:` / `graders:`, and exactly one of `defaults:` or `config:`
 - [ ] For a skill eval, at least 5 distinct stimuli exist, with more for the effect and tie rate that must be detected (agent evals are exempt)
-- [ ] Each stimulus discriminates a different property
+- [ ] Each stimulus discriminates a different property and has a stable, unique name
 - [ ] Prompts never name the skill, the agent, or its vocabulary
 - [ ] Every referenced fixture exists and is tracked by `git ls-files`
 - [ ] Every fixture behaves as its stimulus assumes — healthy ones build, deliberately broken ones fail only for the stated reason
@@ -338,6 +341,7 @@ For the official run, submit a PR review containing `/evaluate` so it binds to t
 | `expect_tools: [bash]` on an advisory question | Drop it; it causes timeouts, not quality |
 | Timeout too short for code generation | Use ~360s; empty output fails every grader |
 | Duplicate YAML key left behind by an edit | It overwrites the next stimulus field by field — delete the stray block |
+| Duplicate stimulus names | Vally uses names as comparison identity — give every stimulus a stable, unique name |
 | Direct activation-graded eval for a `disable-model-invocation: true` skill | Cover it through a consumer skill, or grade the answer content as `filter-syntax` does |
 | Agent eval sized for the stimulus floor | `agent.*` evals get no verdict; size them for scenario coverage instead |
 | Agent eval "run" with `./eng/run-skill-evals.sh` | The glob drops it — use a widened `EXPERIMENT_FILE` |

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -144,7 +144,7 @@ Match the owner pattern used by sibling skills in the same plugin.
 
 A skill without an `eval.yaml` has no evidence that it improves on the baseline. Use
 `create-skill-test` to add one in the same pull request, and size it for statistical power — an eval
-below five counted trials can never return a passing verdict.
+below five distinct stimuli can never return a passing verdict.
 
 The exception is a helper skill with `disable-model-invocation: true`: the model cannot
 self-activate it, so an activation-graded eval compares two identical arms. Cover it through the
@@ -218,7 +218,7 @@ After creating a skill, verify:
 - [ ] The description names concrete triggers and excludes the nearest sibling skills
 - [ ] Every section changes a decision the unskilled model would otherwise get wrong
 - [ ] The skill states when **not** to act, and what a truthful failure report looks like
-- [ ] An `eval.yaml` exists and clears the trial floor (or the skill is `disable-model-invocation: true` and covered through its consumers)
+- [ ] An `eval.yaml` exists and clears the distinct-stimulus floor (or the skill is `disable-model-invocation: true` and covered through its consumers)
 
 ## Common Pitfalls
 

--- a/.agents/skills/improve-skill-quality/SKILL.md
+++ b/.agents/skills/improve-skill-quality/SKILL.md
@@ -90,7 +90,7 @@ See [references/eval-triage.md](references/eval-triage.md) for the full catalogu
 
 ### Step 4: Verify the fixtures before touching the skill
 
-Run `python eng/eval-quality/check_eval_quality.py` — it blocks ten defect classes that each already
+Run `python eng/eval-quality/check_eval_quality.py` — it blocks eleven defect classes that can
 cost a real result here. Then confirm by hand:
 
 - every fixture behaves as its stimulus assumes — a fixture meant to be healthy builds, and one
@@ -204,5 +204,5 @@ result, confirm the skill payload actually changed — reruns on byte-identical 
 
 - [references/writing-for-baseline-delta.md](references/writing-for-baseline-delta.md) — content patterns that beat the unskilled model
 - [references/eval-triage.md](references/eval-triage.md) — symptom, cause and fix catalogue with PR citations
-- [eng/eval-quality/README.md](../../../eng/eval-quality/README.md) — the ten structural gate checks and why each exists
+- [eng/eval-quality/README.md](../../../eng/eval-quality/README.md) — the eleven structural gate checks and why each exists
 - [eng/vally-adapter/InvestigatingResults.md](../../../eng/vally-adapter/InvestigatingResults.md) — downloading artifacts and reading `results.json`. This is the current guide; the similarly-named `eng/skill-validator/src/docs/InvestigatingResults.md` documents the retired `skill-validator evaluate` schema and does not describe today's results.

--- a/.agents/skills/improve-skill-quality/SKILL.md
+++ b/.agents/skills/improve-skill-quality/SKILL.md
@@ -29,7 +29,7 @@ the fixtures, or the harness. Classify first, then fix.
 |-------|----------|-------------|
 | Verdict evidence | Yes | The `/evaluate` PR comment, or `results.json` from the run artifacts |
 | Losing trial transcripts | Yes for content fixes | Baseline vs. skilled output plus the judge's stated reason |
-| W/T/L record and trial count | Yes | Distinguishes a real regression from an underpowered eval |
+| Stimulus-vote W/T/L and repeated-run W/T/L | Yes | Separates cross-task evidence from reliability |
 | Activation status per arm | Yes | Isolated and plugin activation are different failures |
 
 ## Workflow
@@ -39,7 +39,7 @@ the fixtures, or the harness. Classify first, then fix.
 Read [InvestigatingResults.md](../../../eng/vally-adapter/InvestigatingResults.md) for how to
 download artifacts and read `results.json`. Extract, per failing stimulus:
 
-- win / tie / loss record and total trials (`trials = stimuli × runs`)
+- authoritative stimulus-vote W/T/L and separate repeated-run W/T/L
 - activation status in the **isolated** and **plugin** arms, separately
 - the judge's verbatim reason on each losing trial
 - whether any trial errored, timed out, or produced empty output
@@ -105,24 +105,23 @@ cost a real result here. Then confirm by hand:
 
 The gate has two independent bars, and confusing them is the usual misdiagnosis:
 
-1. **Counted trials ≥ 5** (`trials = stimuli × runs`). Below that the verdict is reported
+1. **Distinct stimuli ≥ 5.** Below that the verdict is reported
    `underpowered` — never a pass, never a regression.
-2. **The sign test must reach p ≤ 0.05 over the *discordant* (non-tie) trials.** Ties are not
+2. **The sign test must reach p ≤ 0.05 over the *discordant* (non-tie) stimulus votes.** Ties are not
    discarded silently; they hold the discordant count down.
 
-| discordant trials | records that pass | p |
+| discordant stimulus votes | records that pass | p |
 |---:|---|---:|
 | ≤ 4 | none, however good the skill | ≥ 0.0625 |
 | 5–7 | zero losses only (5W/0L) | 0.031 |
 | 8 | one loss survivable (7W/1L) | 0.035 |
 
-So at exactly 5 counted trials a single tie is fatal — it leaves 4 discordant. At 6 counted trials
+So at exactly 5 stimuli a single tie is fatal — it leaves 4 discordant. At 6 stimuli
 one tie is survivable (5W/1T/0L); at 7, up to two are (5W/2T/0L). A loss is not.
 
 So a positive record with a failing verdict is a power problem, not a content problem. Fix it by
-adding **discriminating stimuli** (cross-task evidence) rather than raising `runs` (repetition
-only) — except where each stimulus drives an expensive pipeline. Record the reasoning in a comment
-above `defaults:`, as `tests/dotnet-test/grade-tests/eval.yaml` does.
+adding **discriminating stimuli**. Raising `runs` measures reliability for the same task and cannot
+clear the floor.
 
 ### Step 6: Check whether the two arms differ at all
 
@@ -185,7 +184,7 @@ result, confirm the skill payload actually changed — reruns on byte-identical 
 - [ ] For a content fix, a losing trial and the judge's stated reason are quoted in the PR description.
 - [ ] The failure was classified before any content was edited.
 - [ ] `check_eval_quality.py` and `skill-validator check` both pass.
-- [ ] Trial count clears the power bar for the observed tie rate, not just the floor of 5.
+- [ ] Distinct-stimulus count clears the power bar for the target effect and observed tie rate.
 - [ ] Isolated **and** plugin activation are both reported.
 - [ ] The PR body records root cause, fix, and validation so the lesson is reusable.
 
@@ -193,9 +192,9 @@ result, confirm the skill payload actually changed — reruns on byte-identical 
 
 | Pitfall | Solution |
 |---------|----------|
-| Rewriting skill prose in response to an underpowered verdict | Underpowered means too few discordant trials; add discriminating stimuli instead |
+| Rewriting skill prose in response to an underpowered verdict | Underpowered means too few distinct stimuli; add discriminating stimuli instead |
 | Adding `defaults: runs:` to a spec that already has `config:` | Merge into a single `defaults:` block; vally rejects specs with both |
-| Padding `runs` to clear the trial floor | Five repeats of one stimulus measure one task; add stimuli |
+| Padding `runs` to clear the stimulus floor | Repeats measure reliability for one task; add stimuli |
 | Treating an errored trial as fixture nondeterminism | Read the stderr first; judge-side auth failures need harness fixes |
 | Fixing a "wrong" answer that the fixture actually made wrong | Check fixture self-consistency before blaming the response |
 | Strengthening a skill nobody uses and nothing passes | Weak eval signal plus thin telemetry is a valid retirement case |

--- a/.agents/skills/improve-skill-quality/references/eval-triage.md
+++ b/.agents/skills/improve-skill-quality/references/eval-triage.md
@@ -29,30 +29,29 @@ Symptom → cause → fix, with the PR where each was diagnosed. Use with
 
 ## Statistical power
 
-The gate has two independent bars: **counted trials ≥ 5** (else `underpowered`), and **p ≤ 0.05 on
-an exact one-sided sign test over the discordant (non-tie) trials**. `trials = stimuli × runs`.
+The gate has two independent bars: **distinct stimuli ≥ 5** (else `underpowered`), and **p ≤ 0.05
+on an exact one-sided sign test over discordant (non-tie) stimulus votes**. Repeated runs collapse
+to one vote per stimulus and remain reliability evidence.
 
-| discordant trials | records that pass | p |
+| discordant stimulus votes | records that pass | p |
 |---:|---|---:|
 | ≤ 4 | none | ≥ 0.0625 |
 | 5–7 | zero losses only (5W/0L) | 0.031 |
 | 8 | one loss survivable (7W/1L) | 0.035 |
 
-At exactly 5 counted trials one tie is fatal — it leaves 4 discordant. At 6 counted trials one tie is
-survivable (5W/1T/0L); at 7, up to two are (5W/2T/0L). A loss is not: 4W/3T/1L over eight trials is
-five discordant and fails.
+At exactly 5 stimuli one tie is fatal — it leaves 4 discordant votes. At 6 stimuli one tie is
+survivable; at 7, up to two are. A loss is not: 4W/3T/1L over eight stimulus votes fails.
 
 Consequences seen in real runs:
 
-- Five `dotnet-test` evals raised to exactly 5 trials returned 16W/8T/1L overall — every skill
+- Five `dotnet-test` evals raised to exactly 5 distinct stimuli returned 16W/8T/1L overall — every skill
   winning, none regressing — and **all five failed**, four because ties made a pass unreachable
   before the run started. (PR #971, `eng/eval-quality/README.md`)
-- At the 32% tie rate measured there, a genuinely-helping skill parked at 5 trials is certified
-  about one run in ten; at 15 trials, about nine in ten.
-- Adding stimuli is strictly better than raising `runs`: repeats measure one task. Use `runs` only
-  where a stimulus is genuinely expensive — `code-testing-agent` uses `defaults.runs: 2` because
-  each stimulus drives a full npm/pytest/dotnet pipeline inside a 60-minute budget. (PR #974)
-- The verdict reads each trial's **winner**, never its magnitude: weighting a confidence interval by
+- At the 32% tie rate measured there, a genuinely-helping skill parked at 5 stimulus votes is
+  certified about one run in ten; at 15 stimulus votes, about nine in ten.
+- Adding stimuli increases task breadth. Raising `runs` measures reliability for the same tasks and
+  cannot clear the stimulus floor.
+- The verdict reads each repeated run's **winner**, never its magnitude: weighting a confidence interval by
   "slightly better" vs "much better" made a stronger win look like variance and reversed verdicts on
   identical records. (PR #965, PR #952)
 

--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -15,7 +15,7 @@ on:
       - "tests/**"
       - "plugins/**"
       - "eng/eval-quality/**"
-      # check_floor_agreement() reads MIN_CREDIBLE_TRIALS out of the adapter, so
+      # check_floor_agreement() reads MIN_CREDIBLE_STIMULI out of the adapter, so
       # the one diff that can break the floor's two-language agreement is a diff
       # to the adapter. Without this the guard would never run on it.
       - "eng/vally-adapter/**"
@@ -25,7 +25,7 @@ on:
     branches: [main]
     # Kept in sync with the pull_request paths above. The gate reads plugins/*
     # (skills with no eval), .gitignore (fixtures excluded from the index), and
-    # eng/vally-adapter (the trial floor it must agree with), so omitting any of
+    # eng/vally-adapter (the stimulus floor it must agree with), so omitting any of
     # them here would let a direct push or a squash-merge that touches only
     # those land on main without the gate ever running.
     paths:

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -880,6 +880,7 @@ jobs:
           name: vally-results-${{ matrix.entry.name }}
           path: artifacts/TestResults/vally/${{ matrix.entry.name }}/
           include-hidden-files: true
+          if-no-files-found: error
           retention-days: 14
 
       - name: Upload cross-family second-judge results

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -529,22 +529,34 @@ jobs:
             rm -rf "$PROBE_HOME"
             PROBE_HOME=$(mktemp -d)
             for probe_model in "${PROBE_MODELS[@]}"; do
-              set +e
-              (
-                cd "$RUNNER_TEMP"
-                COPILOT_HOME="$PROBE_HOME" COPILOT_GITHUB_TOKEN="$candidate_token" timeout 60s copilot \
-                  --prompt "Reply with exactly OK." \
-                  --available-tools="" \
-                  --no-bash-env \
-                  --no-custom-instructions \
-                  --no-experimental \
-                  --model "$probe_model" \
-                  --output-format=json \
-                  --silent \
-                  --effort=low >"$PROBE_LOG" 2>&1
-              )
-              probe_status=$?
-              set -e
+              effort_args=(--effort=low)
+              while true; do
+                set +e
+                (
+                  cd "$RUNNER_TEMP"
+                  COPILOT_HOME="$PROBE_HOME" COPILOT_GITHUB_TOKEN="$candidate_token" timeout 60s copilot \
+                    --prompt "Reply with exactly OK." \
+                    --available-tools="" \
+                    --no-bash-env \
+                    --no-custom-instructions \
+                    --no-experimental \
+                    --model "$probe_model" \
+                    --output-format=json \
+                    --silent \
+                    "${effort_args[@]}" >"$PROBE_LOG" 2>&1
+                )
+                probe_status=$?
+                set -e
+
+                if [ "$probe_status" -ne 0 ] \
+                  && [ ${#effort_args[@]} -gt 0 ] \
+                  && grep -Fq "does not support reasoning effort configuration" "$PROBE_LOG"; then
+                  echo "::notice::$probe_model does not support reasoning effort; retrying its availability probe without --effort"
+                  effort_args=()
+                  continue
+                fi
+                break
+              done
 
               if [ "$probe_status" -eq 0 ]; then
                 continue

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -165,7 +165,7 @@ jobs:
           key: ${{ steps.cache-key.outputs.key }}
 
       - name: Upload trusted skill-validator archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trusted-skill-validator-${{ github.run_id }}
           path: skill-validator-dist.tar.gz
@@ -432,7 +432,7 @@ jobs:
       # run; matrix jobs never build it from the evaluated checkout.
       - name: Download trusted skill-validator archive
         if: steps.find-evals.outputs.has_evals == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: trusted-skill-validator-${{ github.run_id }}
           path: ${{ runner.temp }}/trusted-validator-archive

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -184,6 +184,8 @@ jobs:
     env:
       COPILOT_RATE_LIMIT_PATTERN: >-
         "errorType"[[:space:]]*:[[:space:]]*"rate_limit"|API rate limit exceeded|rate[ -]?limit exceeded|too many requests|user_weekly_rate_limited|weekly[ _-]?rate[ _-]?limit|HTTP([[:space:]]+status)?[[:space:]]+429|status([[:space:]]*code)?[[:space:]=:]+429
+      COPILOT_TOKEN_UNAVAILABLE_PATTERN: >-
+        HTTP([[:space:]]+status)?[[:space:]:=]+401|status([[:space:]]*code)?[[:space:]=:]+401|unauthori[sz]ed|bad credentials|authentication token[[:space:]]+(found[[:space:]]+but[[:space:]]+)?could not be validated|(invalid|expired|revoked)[[:space:]]+(authentication[[:space:]]+|access[[:space:]]+)?(credential(s)?|token)|(authentication|access|github|copilot)[[:space:]]+(credential(s)?|token)[[:space:]]+(is[[:space:]]+|was[[:space:]]+|has([[:space:]]+been)?[[:space:]]+)?(invalid|expired|revoked)|organi[sz]ation[[:space:]]+(has[[:space:]]+been|is|was)[[:space:]]+(disabled|suspended)|(disabled|suspended)[[:space:]]+by[[:space:]]+(your|the|this|an?)[[:space:]]+organi[sz]ation
     name: vally (${{ matrix.entry.name }})
     strategy:
       fail-fast: false
@@ -508,6 +510,7 @@ jobs:
           PROBE_HOME=$(mktemp -d)
           trap 'rm -f "$PROBE_LOG"; rm -rf "$PROBE_HOME"' EXIT
           saw_timed_out=false
+          saw_unavailable=false
 
           for ((candidate_index = 0; candidate_index < ${#PAT_NUMBERS[@]}; candidate_index++)); do
             candidate_number="${PAT_NUMBERS[$candidate_index]}"
@@ -563,7 +566,15 @@ jobs:
                 break
               fi
 
-              echo "::error::Copilot PAT pool entry $candidate_number failed its $probe_model availability probe with a non-rate-limit error (exit $probe_status); refusing to hide a token or service configuration failure"
+              if grep -Eiq "$COPILOT_TOKEN_UNAVAILABLE_PATTERN" "$PROBE_LOG"; then
+                echo "::warning::Copilot PAT pool entry $candidate_number has unusable credentials or belongs to a disabled organization; quarantining it and trying another entry"
+                cat "$PROBE_LOG"
+                candidate_rejected=true
+                saw_unavailable=true
+                break
+              fi
+
+              echo "::error::Copilot PAT pool entry $candidate_number failed its $probe_model availability probe with an unexpected non-rate-limit error (exit $probe_status); refusing to hide a service or configuration failure"
               cat "$PROBE_LOG"
               exit "$probe_status"
             done
@@ -579,7 +590,9 @@ jobs:
             exit 0
           done
 
-          if [ "$saw_timed_out" = true ]; then
+          if [ "$saw_unavailable" = true ]; then
+            echo "::error::No healthy Copilot PAT pool entry was found; at least one configured entry was unavailable and the remaining entries were unavailable, rate-limited, or timed out"
+          elif [ "$saw_timed_out" = true ]; then
             echo "::error::No healthy Copilot PAT pool entry was found; configured entries were rate-limited or timed out"
           else
             echo "::error::Every configured Copilot PAT pool entry is rate-limited"

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -307,9 +307,14 @@ jobs:
           if [ -z "$EVALS" ]; then
             echo "No eval.yaml files found for ${PLUGIN}"
             echo "has_evals=false" >> "$GITHUB_OUTPUT"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            : > "$RUNNER_TEMP/evaluation-expected-evals.txt"
           else
+            EVAL_COUNT=$(printf '%s\n' "$EVALS" | wc -l | tr -d ' ')
             echo "has_evals=true" >> "$GITHUB_OUTPUT"
-            echo "Found $(printf '%s\n' "$EVALS" | wc -l | tr -d ' ') eval specs"
+            echo "count=$EVAL_COUNT" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "$EVALS" > "$RUNNER_TEMP/evaluation-expected-evals.txt"
+            echo "Found $EVAL_COUNT eval specs"
           fi
 
       - name: Resolve evaluation models
@@ -592,6 +597,7 @@ jobs:
           MODEL: ${{ steps.eval-models.outputs.model }}
           JUDGE_MODEL: ${{ steps.eval-models.outputs.judge-model }}
           JUDGE2_MODEL: ${{ steps.eval-models.outputs.judge2 }}
+          EXPECTED_EVAL_COUNT: ${{ steps.find-evals.outputs.count }}
           # ENTRY_MODEL is kept only to gate the static-experiment sed fallback
           # below (cross-family leg that failed plugin-variant generation).
           ENTRY_MODEL: ${{ matrix.entry.model }}
@@ -778,13 +784,15 @@ jobs:
               --output-root "$RESULTS_DIR" \
               --vally "vally" \
               --repo-root "$GITHUB_WORKSPACE" \
+              --expected-evals "$RUNNER_TEMP/evaluation-expected-evals.txt" \
               --model "$MODEL" \
               --judge-model "$JUDGE_MODEL" \
               "${OVERFIT_ARGS[@]}"
           ADAPT_STATUS=$?
           set -e
           if [ "$ADAPT_STATUS" -eq 124 ]; then
-            echo "::warning::Vally comparison watchdog expired after 45 minutes; uploading partial results"
+            echo "::error::Vally comparison watchdog expired after 45 minutes. Partial results will be uploaded, but the eval result set is invalid."
+            exit 124
           elif [ "$ADAPT_STATUS" -ne 0 ]; then
             echo "::error::Vally adapter exited unexpectedly with status $ADAPT_STATUS"
             exit "$ADAPT_STATUS"
@@ -807,6 +815,7 @@ jobs:
               --output-root "$RESULTS_DIR2" \
               --vally "vally" \
               --repo-root "$GITHUB_WORKSPACE" \
+              --expected-evals "$RUNNER_TEMP/evaluation-expected-evals.txt" \
               --model "$MODEL" \
               --judge-model "$JUDGE2_MODEL" \
               "${OVERFIT_ARGS[@]}" || echo "::warning::secondary judge ($JUDGE2_MODEL) re-score failed for $PLUGIN"
@@ -814,11 +823,35 @@ jobs:
 
           # Surface how many verdicts were produced.
           PRODUCED=$(find "$RESULTS_DIR" -name results.json -not -path "$EXPERIMENT_OUT/*" | wc -l | tr -d ' ')
-          echo "Produced $PRODUCED skill verdict(s) for $PLUGIN"
-          if [ "$PRODUCED" -eq 0 ]; then
-            echo "::error::vally produced no skill verdicts for $PLUGIN; evals failed to run or validate (see logs above)"
+          echo "Produced $PRODUCED of $EXPECTED_EVAL_COUNT expected skill verdict(s) for $PLUGIN"
+          if [ "$PRODUCED" -ne "$EXPECTED_EVAL_COUNT" ]; then
+            echo "::error::vally produced $PRODUCED result file(s), but the pre-run manifest required $EXPECTED_EVAL_COUNT. The result set is incomplete or contains an unexpected eval."
             exit 1
           fi
+          ADAPTER_SUMMARY="$RESULTS_DIR/adapter-summary.json"
+          if [ ! -f "$ADAPTER_SUMMARY" ] || ! node -e "
+            const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            const expected = Number(process.argv[2]);
+            const ok = s.expectedManifestProvided === true
+              && s.expectedEvalCount === expected
+              && s.writtenResultCount === expected
+              && s.unexpectedEvalCount === 0;
+            if (!ok) {
+              console.error(JSON.stringify(s));
+              process.exit(1);
+            }
+          " "$ADAPTER_SUMMARY" "$EXPECTED_EVAL_COUNT"; then
+            echo "::error::Adapter result accounting did not reconcile exactly with the pre-run eval manifest."
+            exit 1
+          fi
+          node -e "
+            const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            console.log('Result accounting: expected=' + s.expectedEvalCount
+              + ', written=' + s.writtenResultCount
+              + ', invalid=' + s.invalidEvalCount
+              + ', manifest-missing=' + s.missingEvalCount
+              + ', unexpected=' + s.unexpectedEvalCount);
+          " "$ADAPTER_SUMMARY"
 
       - name: Remove selected Copilot token
         if: always()
@@ -854,7 +887,7 @@ jobs:
         run: |
           echo "## 🔬 Vally Evaluation Results: $ENTRY_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible net win — more wins than losses, by an exact one-sided sign test at p ≤ 0.05 — over enough trials for any record to reach that bar. ⚠️ marks a verdict that can't be reached: an underpowered eval, or a comparison that didn't complete." >> $GITHUB_STEP_SUMMARY
+          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible net win — more wins than losses, by an exact one-sided sign test at p ≤ 0.05 — over enough trials for any record to reach that bar. ⚠️ marks an invalid or inconclusive result. 📉 marks a report-only LLM preference loss, not an objective completion regression." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           RESULTS_DIR="artifacts/TestResults/vally/$ENTRY_NAME"
@@ -862,19 +895,23 @@ jobs:
             if [ ! -f "$RESULTS_JSON" ]; then continue; fi
             EVAL_NAME=$(basename "$(dirname "$RESULTS_JSON")")
 
-            CONCLUSIVE=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].conclusive)" "$RESULTS_JSON")
-            UNDERPOWERED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].underpowered === true)" "$RESULTS_JSON")
-            PASSED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].passed)" "$RESULTS_JSON")
+            STATE=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); const v=r.verdicts[0]; console.log(v.state ?? (v.conclusive === false || v.underpowered ? 'INVALID_INCONCLUSIVE' : v.passed ? 'VALID_PASS' : 'VALID_NO_CHANGE'))" "$RESULTS_JSON")
+            PREFERENCE_REGRESSED=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); const v=r.verdicts[0]; console.log(v.preferenceRegressed === true || (v.regressed === true && (v.state == null || v.state === 'VALID_NO_CHANGE')))" "$RESULTS_JSON")
             REASON=$(node -e "const r=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); console.log(r.verdicts[0].reason)" "$RESULTS_JSON")
-            if [ "$CONCLUSIVE" != "true" ] || [ "$UNDERPOWERED" = "true" ]; then
+            if [ "$STATE" = "INVALID_INCONCLUSIVE" ]; then
               ICON="⚠️"
-            elif [ "$PASSED" = "true" ]; then
+            elif [ "$STATE" = "VALID_PASS" ]; then
               ICON="✅"
+            elif [ "$STATE" = "VALID_REGRESSION" ]; then
+              ICON="🔻"
+            elif [ "$PREFERENCE_REGRESSED" = "true" ]; then
+              ICON="📉"
             else
               ICON="❌"
             fi
 
             echo "### $ICON $EVAL_NAME" >> $GITHUB_STEP_SUMMARY
+            echo "State: \`$STATE\`" >> $GITHUB_STEP_SUMMARY
             echo "$REASON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -902,7 +902,7 @@ jobs:
         run: |
           echo "## 🔬 Vally Evaluation Results: $ENTRY_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. A skill passes only on a complete comparison with a credible net win — more wins than losses, by an exact one-sided sign test at p ≤ 0.05 — over enough trials for any record to reach that bar. ⚠️ marks an invalid or inconclusive result. 📉 marks a report-only LLM preference loss, not an objective completion regression." >> $GITHUB_STEP_SUMMARY
+          echo "Skilled vs baseline, judged head-to-head by \`vally compare\`. Each distinct stimulus gives one gate vote; repeated runs report reliability only. A pass needs a complete comparison, an exact one-sided sign test at p ≤ 0.05, and at least a 20% net win. ⚠️ marks an invalid or inconclusive result. 📉 marks a report-only LLM preference loss, not an objective completion regression." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           RESULTS_DIR="artifacts/TestResults/vally/$ENTRY_NAME"
@@ -930,12 +930,10 @@ jobs:
             echo "$REASON" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            # Per-scenario table: net win (the basis the gate reads), the
-            # magnitude-weighted preference for triage, and win/tie/loss. The
-            # arrow follows the net win so a row can never point the opposite
-            # way to the verdict it feeds. adapt.mjs computes these per
-            # scenario; the fallback covers results.json written before it did.
-            echo "| Scenario | Net win | Δ Pref | Trials (W/T/L) |" >> $GITHUB_STEP_SUMMARY
+            # Per-scenario table: repeated-run direction, magnitude-weighted
+            # preference, and win/tie/loss. The adapter collapses each row to one
+            # majority-direction stimulus vote for the authoritative gate.
+            echo "| Scenario | Net win | Δ Pref | Runs (W/T/L) |" >> $GITHUB_STEP_SUMMARY
             echo "|----------|---------|--------|----------------|" >> $GITHUB_STEP_SUMMARY
             node -e "
               const r = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8'));

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -111,12 +111,11 @@ jobs:
           }
           "entries=$json" >> $env:GITHUB_OUTPUT
 
-  # Build and save the executable validator cache before any PR content is
-  # checked out. The evaluation matrix restores this cache but never saves it.
+  # Build or restore the executable validator before any PR content is checked
+  # out, then publish it as a same-run artifact for every matrix job. The cache
+  # is only an optimization; artifact handoff is the correctness boundary.
   prepare-validator:
     runs-on: ubuntu-latest
-    outputs:
-      cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Checkout trusted validator source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -157,11 +156,21 @@ jobs:
         run: tar -czf skill-validator-dist.tar.gz -C artifacts/publish/SkillValidator/release .
 
       - name: Save skill-validator archive
-        if: steps.cache-validator.outputs.cache-hit != 'true'
+        # issue_comment tokens cannot save caches. The same-run artifact below
+        # carries the archive regardless of whether this optimization succeeds.
+        if: steps.cache-validator.outputs.cache-hit != 'true' && github.event_name != 'issue_comment'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: skill-validator-dist.tar.gz
           key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Upload trusted skill-validator archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: trusted-skill-validator-${{ github.run_id }}
+          path: skill-validator-dist.tar.gz
+          if-no-files-found: error
+          retention-days: 1
 
   # --------------------------------------------------------------------------
   # Run vally evaluation
@@ -416,44 +425,23 @@ jobs:
           )
           echo "$RUNNER_TEMP/evaluation-tools/node_modules/.bin" >> "$GITHUB_PATH"
 
-      # Build (or restore from cache) the skill-validator binary. Vally has no
-      # overfitting judge, so we retain skill-validator's standalone
-      # `overfitting` command (same rationale as retaining its `check` linter)
-      # and run it alongside the Vally comparison. The trusted-only cache is
-      # populated by prepare-validator before this job checks out PR content.
-      - name: Remove untrusted validator archive
+      # Vally has no overfitting judge, so retain skill-validator's standalone
+      # `overfitting` command. Its archive comes from prepare-validator in this
+      # run; matrix jobs never build it from the evaluated checkout.
+      - name: Download trusted skill-validator archive
         if: steps.find-evals.outputs.has_evals == 'true'
-        run: rm -f skill-validator-dist.tar.gz
-
-      - name: Restore skill-validator archive
-        id: cache-validator
-        if: steps.find-evals.outputs.has_evals == 'true'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4.3.0
         with:
-          # Keep this path and key identical to the trusted producer above.
-          path: skill-validator-dist.tar.gz
-          key: ${{ needs.prepare-validator.outputs.cache-key }}
-
-      - name: Setup .NET SDK
-        if: steps.find-evals.outputs.has_evals == 'true' && steps.cache-validator.outputs.cache-hit != 'true'
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v5
-        with:
-          global-json-file: _trusted-validator-src/global.json
-
-      - name: Build trusted skill-validator
-        if: steps.find-evals.outputs.has_evals == 'true' && steps.cache-validator.outputs.cache-hit != 'true'
-        run: |
-          rm -rf "$RUNNER_TEMP/trusted-validator"
-          cd "$RUNNER_TEMP/trusted-validator-src"
-          dotnet publish \
-            "eng/skill-validator/src/SkillValidator.csproj" \
-            --output "$RUNNER_TEMP/trusted-validator"
+          name: trusted-skill-validator-${{ github.run_id }}
+          path: ${{ runner.temp }}/trusted-validator-archive
 
       - name: Extract skill-validator
-        if: steps.find-evals.outputs.has_evals == 'true' && steps.cache-validator.outputs.cache-hit == 'true'
+        if: steps.find-evals.outputs.has_evals == 'true'
         run: |
+          rm -rf "$RUNNER_TEMP/trusted-validator"
           mkdir -p "$RUNNER_TEMP/trusted-validator"
-          tar -xzf skill-validator-dist.tar.gz -C "$RUNNER_TEMP/trusted-validator"
+          tar -xzf "$RUNNER_TEMP/trusted-validator-archive/skill-validator-dist.tar.gz" \
+            -C "$RUNNER_TEMP/trusted-validator"
 
       - name: Select available Copilot token from pool
         id: select-token
@@ -922,7 +910,7 @@ jobs:
             elif [ "$PREFERENCE_REGRESSED" = "true" ]; then
               ICON="📉"
             else
-              ICON="❌"
+              ICON="➖"
             fi
 
             echo "### $ICON $EVAL_NAME" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -855,7 +855,8 @@ jobs:
             const ok = s.expectedManifestProvided === true
               && s.expectedEvalCount === expected
               && s.writtenResultCount === expected
-              && s.unexpectedEvalCount === 0;
+              && s.unexpectedEvalCount === 0
+              && s.measurementInvalidEvalCount === 0;
             if (!ok) {
               console.error(JSON.stringify(s));
               process.exit(1);
@@ -869,6 +870,7 @@ jobs:
             console.log('Result accounting: expected=' + s.expectedEvalCount
               + ', written=' + s.writtenResultCount
               + ', invalid=' + s.invalidEvalCount
+              + ', measurement-invalid=' + s.measurementInvalidEvalCount
               + ', manifest-missing=' + s.missingEvalCount
               + ', unexpected=' + s.unexpectedEvalCount);
           " "$ADAPTER_SUMMARY"

--- a/.github/workflows/evaluation-workflow-tests.yml
+++ b/.github/workflows/evaluation-workflow-tests.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/evaluation-workflow-tests.yml"
       - "eng/evaluation-tools/**"
       - "eng/evaluation/test_token_failover.py"
+      - "eng/vally-adapter/**"
   push:
     branches: [main]
     paths:
@@ -16,12 +17,30 @@ on:
       - ".github/workflows/evaluation-workflow-tests.yml"
       - "eng/evaluation-tools/**"
       - "eng/evaluation/test_token_failover.py"
+      - "eng/vally-adapter/**"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  vally-adapter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Run adapter fault-injection and report tests
+        run: node --test eng/vally-adapter/*.test.mjs
+
   evaluation-tools:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1873,7 +1873,8 @@ jobs:
         # verdict (claude-opus-4.8 judge) with its SECOND-judge verdict (claude-haiku-4.5) by
         # (executor model, skill) and record the SAME stat set for both judges
         # (state, preferenceRegressed, passed, conclusive, underpowered,
-        # meanScore, winRate, trialCount) plus an agreement flag, appending to an isolated
+        # meanScore, winRate, stimulus-vote count in legacy field `trialCount`) plus an
+        # agreement flag, appending to an isolated
         # judge-comparison.json. This is experiment-only data: it runs ONLY on the
         # scheduled dual-judge cadence (no crossjudge artifacts exist on PR runs, so
         # this step no-ops there), it is deliberately NOT listed in components.json

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1290,22 +1290,18 @@ jobs:
           # If results exist, consolidate them into a summary comment
           JSON_FILES=$(find all-results/ -name results.json 2>/dev/null || true)
           if [ -n "$JSON_FILES" ]; then
-            # Full table (all columns incl. Quality (Plugin)) for the step summary,
-            # simplified table (Quality (Plugin) dropped) for the PR comment.
-            node eng/vally-adapter/consolidate.mjs --format full --root all-results/ --output summary-body.md
-            node eng/vally-adapter/consolidate.mjs --format simple --root all-results/ --output simplified-body.md
+            # Full metrics for the step summary and a decision-first repair view
+            # for the PR comment. Both bind the report to the evaluated commit.
+            node eng/vally-adapter/consolidate.mjs --format full --root all-results/ --output summary-body.md --commit "${{ needs.gate.outputs.head_sha }}"
+            node eng/vally-adapter/consolidate.mjs --format simple --root all-results/ --output simplified-body.md --commit "${{ needs.gate.outputs.head_sha }}"
 
             INVESTIGATE_PROMPT=""
-            # If any skill genuinely lost to its baseline, build a copy-paste
-            # prompt for AI-assisted investigation. Underpowered and inconclusive
-            # verdicts also carry `passed: false`, but neither is evidence that
-            # the skill regressed — attaching the prompt to those would fire on
-            # nearly every run and contradict the ⚠️ semantics of the comment
-            # body. The `!= false` / `!= true` form keeps results.json files that
-            # predate those fields classifying exactly as they did before.
-            if jq -se '[.[].verdicts[] | select(.passed == false and .conclusive != false and .underpowered != true)] | length > 0' $JSON_FILES > /dev/null 2>&1; then
+            # Any non-pass or comparison warning needs repair guidance, but the
+            # prompt must preserve the distinction between invalid evidence,
+            # unproven improvement, and report-only preference loss.
+            if jq -se '[.[].verdicts[] | select(.state != "VALID_PASS" or ((.errors // []) | length > 0) or ((.recoveredErrors // []) | length > 0))] | length > 0' $JSON_FILES > /dev/null 2>&1; then
               RUN_ID="${{ github.run_id }}"
-              INVESTIGATE_PROMPT=$(printf '\n> **To investigate failures**, paste this to your AI coding agent:\n>\n> _For PR %s in %s, download eval artifacts with `gh run download %s --repo %s --pattern "vally-results-*" --dir ./eval-results`, then fetch https://raw.githubusercontent.com/%s/%s/eng/vally-adapter/InvestigatingResults.md and follow it to analyze the results.json files. Diagnose each failure, suggest fixes to the eval.yaml and skill content, and tell me what to fix first._' \
+              INVESTIGATE_PROMPT=$(printf '\n> **To investigate non-passing or warning results**, paste this to your AI coding agent:\n>\n> _For PR %s in %s, download eval artifacts with `gh run download %s --repo %s --pattern "vally-results-*" --dir ./eval-results`, then fetch https://raw.githubusercontent.com/%s/%s/eng/vally-adapter/InvestigatingResults.md and follow it. Classify each result as measurement-invalid, underpowered, not-proven, preference-loss, or passing-with-warning. Use stateReason, result accounting, weak scenarios, and judge evidence to give the cause and exact next fix._' \
                 "${PR_NUMBER}" "${{ github.repository }}" "${RUN_ID}" "${{ github.repository }}" "${{ github.repository }}" "${{ needs.gate.outputs.head_sha }}")
             fi
 
@@ -1313,7 +1309,7 @@ jobs:
             {
               cat simplified-body.md
               echo ""
-              echo "[🔍 Full Results - additional metrics and failure investigation steps]($RUN_URL)"
+              echo "[🔍 Full Results - all metrics and investigation details]($RUN_URL)"
               if [ -n "$INVESTIGATE_PROMPT" ]; then
                 echo "$INVESTIGATE_PROMPT"
               fi
@@ -1354,12 +1350,12 @@ jobs:
               BODY="❌ Evaluation did not complete (an upstream job failed or was skipped, so evaluation never ran). [View workflow run](${RUN_URL})"
             elif [[ "${{ needs.evaluate.result }}" != "success" ]]; then
               # The evaluate job failed or was cancelled — it did not complete successfully.
-              BODY=$(printf '❌ Evaluation did not complete successfully (the evaluate job reported `%s`). Check the [workflow run](%s) logs, then re-post `/evaluate` to try again.' "${{ needs.evaluate.result }}" "${RUN_URL}")
+              BODY=$(printf '❌ Evaluation did not complete successfully (the evaluate job reported `%s`). Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "${{ needs.evaluate.result }}" "${RUN_URL}" "${{ needs.gate.outputs.head_sha }}")
             else
               # The evaluate job completed but produced zero verdicts — most often a
               # transient LLM-session auth failure ("Session was not created with
               # authentication info or custom provider") rather than a skill regression.
-              BODY=$(printf '❌ Evaluation ran but produced no results.\n\nThe evaluate job completed but no `results.json` verdicts were generated. This is usually a **transient infrastructure failure** — commonly an LLM-session auth error (`Session was not created with authentication info or custom provider`) — not a problem with your skill. Check the [workflow run](%s) logs, then re-post `/evaluate` to try again.' "${RUN_URL}")
+              BODY=$(printf '❌ Evaluation ran but produced no results.\n\nThe evaluate job completed but no `results.json` verdicts were generated. This is usually a **transient infrastructure failure** — commonly an LLM-session auth error (`Session was not created with authentication info or custom provider`) — not a problem with your skill. Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "${RUN_URL}" "${{ needs.gate.outputs.head_sha }}")
             fi
 
             gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -821,9 +821,9 @@ jobs:
           $entries = @()
           $plugins = @()
 
-          # Build matrix entries for a full-plugin evaluation, sharding the
-          # plugin's skills by the optional `executionShard:` top-level tag
-          # in tests/<plugin>/<skill>/eval.yaml. Untagged skills fall into a
+          # Build matrix entries for a full-plugin evaluation, sharding skills
+          # that have eval specs by the optional `executionShard:` top-level tag
+          # in tests/<plugin>/<skill>/eval.yaml. Untagged evals fall into a
           # synthetic "default" bucket. Plugins with all skills in one bucket
           # produce a single entry (unchanged behavior); plugins with multiple
           # buckets fan out into one matrix entry per shard so each shard
@@ -841,8 +841,7 @@ jobs:
             $skillsRoot = Join-Path $contentRoot $skillsDir
             $singleEntry = @{ name = $plugin; plugin = $plugin; skills_path = $skillsDir }
             if (-not (Test-Path $skillsRoot)) {
-              if ($selectedSkills.Count -gt 0) { return @() }
-              return @($singleEntry)
+              return @()
             }
             $skillDirs = @(Get-ChildItem -Path $skillsRoot -Directory -ErrorAction SilentlyContinue |
               Sort-Object Name | Select-Object -ExpandProperty Name)
@@ -852,27 +851,28 @@ jobs:
               $skillDirs = @($skillDirs | Where-Object { $selected.ContainsKey($_) })
             }
             if ($skillDirs.Count -eq 0) {
-              if ($selectedSkills.Count -gt 0) { return @() }
-              return @($singleEntry)
+              return @()
             }
             $shardGroups = @{}
+            $evalSkills = @()
             foreach ($skill in $skillDirs) {
               $evalPath = Join-Path $contentRoot "tests" $plugin $skill "eval.yaml"
+              if (-not (Test-Path $evalPath)) { continue }
+              $evalSkills += $skill
               $shard = "default"
-              if (Test-Path $evalPath) {
-                # Allow optional leading whitespace so an accidentally indented
-                # executionShard: key still groups correctly (rather than silently
-                # collapsing back to the default bucket).
-                $m = Select-String -Path $evalPath -Pattern '^\s*executionShard:\s*[\x27"]?([\w.\-]+)' -List
-                if ($m) { $shard = $m.Matches[0].Groups[1].Value }
-              }
+              # Allow optional leading whitespace so an accidentally indented
+              # executionShard: key still groups correctly (rather than silently
+              # collapsing back to the default bucket).
+              $m = Select-String -Path $evalPath -Pattern '^\s*executionShard:\s*[\x27"]?([\w.\-]+)' -List
+              if ($m) { $shard = $m.Matches[0].Groups[1].Value }
               if (-not $shardGroups.ContainsKey($shard)) { $shardGroups[$shard] = @() }
               $shardGroups[$shard] += $skill
             }
+            if ($shardGroups.Count -eq 0) { return @() }
             if ($shardGroups.Count -le 1) {
               if ($selectedSkills.Count -gt 0) {
-                $paths = ($skillDirs | ForEach-Object { "$skillsDir/$_" }) -join ' '
-                $name = if ($skillDirs.Count -eq 1) { "$plugin--$($skillDirs[0])" } else { $plugin }
+                $paths = ($evalSkills | ForEach-Object { "$skillsDir/$_" }) -join ' '
+                $name = if ($evalSkills.Count -eq 1) { "$plugin--$($evalSkills[0])" } else { $plugin }
                 return @(@{ name = $name; plugin = $plugin; skills_path = $paths })
               }
               return @($singleEntry)
@@ -964,8 +964,6 @@ jobs:
                 $plugin = $_
                 Get-PluginShardEntries -plugin $plugin -contentRoot $contentRoot -selectedSkills ($changedSkillsByPlugin[$plugin] | Sort-Object -Unique)
               })
-
-              $plugins = @($entries | ForEach-Object { $_.plugin } | Sort-Object -Unique)
             }
 
             git worktree remove /tmp/pr-content --force 2>$null
@@ -998,6 +996,9 @@ jobs:
             }
             $entries = @($plugins | ForEach-Object { Get-PluginShardEntries -plugin $_ })
           }
+          # Only plugins represented by a non-empty eval entry are downstream
+          # publication targets.
+          $plugins = @($entries | ForEach-Object { $_.plugin } | Sort-Object -Unique)
 
           # ---- Cross-family model dimension (IMPACT-ANALYSIS.md §10) ----------
           # Resolve a matrix profile, then expand each plugin/shard entry across
@@ -1254,7 +1255,6 @@ jobs:
     needs: [gate, discover, evaluate, publish-session-data]
     if: >-
       always() &&
-      needs.evaluate.result != 'cancelled' &&
       needs.gate.outputs.is_fork != 'true' &&
       needs.gate.outputs.pr_number != '' &&
       needs.discover.outputs.has_entries == 'true'
@@ -1280,15 +1280,46 @@ jobs:
         continue-on-error: ${{ needs.evaluate.result != 'success' }}
 
       - name: Consolidate and post results
+        if: always()
         continue-on-error: true
         env:
+          EVALUATE_RESULT: ${{ needs.evaluate.result }}
+          EXPECTED_ENTRIES: ${{ needs.discover.outputs.entries }}
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ needs.gate.outputs.pr_number }}
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # If results exist, consolidate them into a summary comment
+          mkdir -p all-results
           JSON_FILES=$(find all-results/ -name results.json 2>/dev/null || true)
+          EXPECTED_LEG_COUNT=$(printf '%s' "$EXPECTED_ENTRIES" | jq -e 'if type == "array" then length else error("expected matrix entries must be an array") end')
+          OBSERVED_LEG_COUNT=$(find all-results/ -name adapter-summary.json -type f 2>/dev/null | wc -l | tr -d ' ')
+          # Per-leg adapter summaries prove completeness only inside artifacts
+          # that exist. Never turn a surviving subset into a matrix-wide verdict.
+          if [[ "$EVALUATE_RESULT" != "success" || "$OBSERVED_LEG_COUNT" -ne "$EXPECTED_LEG_COUNT" ]]; then
+            if [[ "$EVALUATE_RESULT" == "skipped" ]]; then
+              BODY="❌ Evaluation did not complete (an upstream job failed or was skipped, so evaluation never ran). [View workflow run](${RUN_URL})"
+            elif [[ "$EVALUATE_RESULT" == "success" ]]; then
+              BODY=$(printf '❌ Evaluation result artifacts are incomplete: expected %s matrix leg artifact(s), but found %s. Check the [workflow run](%s) artifact upload and download logs, then comment `/evaluate %s` to retry this exact commit.' "$EXPECTED_LEG_COUNT" "$OBSERVED_LEG_COUNT" "$RUN_URL" "${{ needs.gate.outputs.head_sha }}")
+            else
+              BODY=$(printf '❌ Evaluation did not complete successfully (the evaluate job reported `%s`). Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "$EVALUATE_RESULT" "$RUN_URL" "${{ needs.gate.outputs.head_sha }}")
+            fi
+
+            if [ -n "$JSON_FILES" ]; then
+              PARTIAL_COUNT=$(printf '%s\n' "$JSON_FILES" | sed '/^$/d' | wc -l | tr -d ' ')
+              BODY=$(printf '%s\n\n%s partial result file(s) were preserved for diagnosis but were not consolidated because the full matrix did not complete.' "$BODY" "$PARTIAL_COUNT")
+            fi
+
+            {
+              echo "## ❌ Evaluation incomplete"
+              echo ""
+              printf '%s\n' "$BODY"
+            } >> "$GITHUB_STEP_SUMMARY"
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
+            exit 0
+          fi
+
+          # Only a successful full matrix may be consolidated into verdicts.
           if [ -n "$JSON_FILES" ]; then
             # Full metrics for the step summary and a decision-first repair view
             # for the PR comment. Both bind the report to the evaluated commit.
@@ -1344,20 +1375,9 @@ jobs:
             gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
               -X POST -F "body=@consolidated-comment.md"
           else
-            # No results.json anywhere. Three distinct causes:
-            if [[ "${{ needs.evaluate.result }}" == "skipped" ]]; then
-              # The evaluate job never ran (an upstream job failed or was skipped).
-              BODY="❌ Evaluation did not complete (an upstream job failed or was skipped, so evaluation never ran). [View workflow run](${RUN_URL})"
-            elif [[ "${{ needs.evaluate.result }}" != "success" ]]; then
-              # The evaluate job failed or was cancelled — it did not complete successfully.
-              BODY=$(printf '❌ Evaluation did not complete successfully (the evaluate job reported `%s`). Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "${{ needs.evaluate.result }}" "${RUN_URL}" "${{ needs.gate.outputs.head_sha }}")
-            else
-              # The evaluate job completed but produced zero verdicts — most often a
-              # transient LLM-session auth failure ("Session was not created with
-              # authentication info or custom provider") rather than a skill regression.
-              BODY=$(printf '❌ Evaluation ran but produced no results.\n\nThe evaluate job completed but no `results.json` verdicts were generated. This is usually a **transient infrastructure failure** — commonly an LLM-session auth error (`Session was not created with authentication info or custom provider`) — not a problem with your skill. Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "${RUN_URL}" "${{ needs.gate.outputs.head_sha }}")
-            fi
-
+            # A successful matrix with zero verdicts is an infrastructure fault,
+            # not evidence about skill quality.
+            BODY=$(printf '❌ Evaluation ran but produced no results.\n\nThe evaluate job completed but no `results.json` verdicts were generated. This is usually a **transient infrastructure failure** — commonly an LLM-session auth error (`Session was not created with authentication info or custom provider`) — not a problem with your skill. Check the [workflow run](%s) logs, then comment `/evaluate %s` to retry this exact commit.' "${RUN_URL}" "${{ needs.gate.outputs.head_sha }}")
             gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -X POST -f body="$BODY"
           fi
 

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1872,8 +1872,8 @@ jobs:
         # GPT-executor dual-judge comparison (§10.6). Pair each skill's PRIMARY
         # verdict (claude-opus-4.8 judge) with its SECOND-judge verdict (claude-haiku-4.5) by
         # (executor model, skill) and record the SAME stat set for both judges
-        # (passed, regressed, conclusive, underpowered, meanScore, winRate,
-        # trialCount) plus an agreement flag, appending to an isolated
+        # (state, preferenceRegressed, passed, conclusive, underpowered,
+        # meanScore, winRate, trialCount) plus an agreement flag, appending to an isolated
         # judge-comparison.json. This is experiment-only data: it runs ONLY on the
         # scheduled dual-judge cadence (no crossjudge artifacts exist on PR runs, so
         # this step no-ops there), it is deliberately NOT listed in components.json
@@ -1901,12 +1901,24 @@ jobs:
               $j = Get-Content $_.FullName -Raw | ConvertFrom-Json
               foreach ($v in @($j.verdicts)) {
                 if (-not $v.skillName) { continue }
+                $state = if ($v.state) {
+                  [string]$v.state
+                } elseif (-not [bool]$v.conclusive -or [bool]$v.underpowered) {
+                  "INVALID_INCONCLUSIVE"
+                } elseif ([bool]$v.passed) {
+                  "VALID_PASS"
+                } else {
+                  "VALID_NO_CHANGE"
+                }
+                $preferenceRegressed = [bool]$v.preferenceRegressed -or
+                  ($state -eq "VALID_NO_CHANGE" -and [bool]$v.regressed)
                 # Capture the SAME stat set for whichever judge produced this file,
                 # so the primary and second judge are compared apples-to-apples
                 # (not just on the pass/fail decision but on the underlying score,
                 # win rate, and power flags too).
                 $map["$plugin|$($j.model)|$($v.skillName)"] = [pscustomobject]@{
                   plugin = "$plugin"; model = "$($j.model)"; judge = "$($j.judgeModel)"; skill = "$($v.skillName)"
+                  state = $state; preferenceRegressed = $preferenceRegressed
                   passed = [bool]$v.passed; regressed = [bool]$v.regressed
                   conclusive = [bool]$v.conclusive; underpowered = [bool]$v.underpowered
                   meanScore = $v.meanScore; winRate = $v.winRate; trialCount = $v.trialCount
@@ -1932,13 +1944,15 @@ jobs:
             $p = $primary[$key]; $s = $second[$key]
             $new += [pscustomobject]@{
               date = $date; commit = $sha; plugin = $p.plugin; model = $p.model; skill = $p.skill
+              primaryState = $p.state; primaryPreferenceRegressed = $p.preferenceRegressed
               primaryJudge = $p.judge; primaryPassed = $p.passed; primaryRegressed = $p.regressed
               primaryConclusive = $p.conclusive; primaryUnderpowered = $p.underpowered
               primaryMeanScore = $p.meanScore; primaryWinRate = $p.winRate; primaryTrialCount = $p.trialCount
+              secondState = $s.state; secondPreferenceRegressed = $s.preferenceRegressed
               secondJudge  = $s.judge; secondPassed  = $s.passed; secondRegressed  = $s.regressed
               secondConclusive = $s.conclusive; secondUnderpowered = $s.underpowered
               secondMeanScore = $s.meanScore; secondWinRate = $s.winRate; secondTrialCount = $s.trialCount
-              agree = (($p.passed -eq $s.passed) -and ($p.regressed -eq $s.regressed))
+              agree = (($p.state -eq $s.state) -and ($p.preferenceRegressed -eq $s.preferenceRegressed))
             }
           }
           Write-Host "Paired $($new.Count) skill verdict(s) across both judges this run."

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1292,12 +1292,18 @@ jobs:
 
           mkdir -p all-results
           JSON_FILES=$(find all-results/ -name results.json 2>/dev/null || true)
-          EXPECTED_LEG_COUNT=$(printf '%s' "$EXPECTED_ENTRIES" | jq -e 'if type == "array" then length else error("expected matrix entries must be an array") end')
+          MATRIX_MANIFEST_VALID=true
+          if ! EXPECTED_LEG_COUNT=$(printf '%s' "$EXPECTED_ENTRIES" | jq -e 'if type == "array" then length else error("expected matrix entries must be an array") end'); then
+            MATRIX_MANIFEST_VALID=false
+            EXPECTED_LEG_COUNT=0
+          fi
           OBSERVED_LEG_COUNT=$(find all-results/ -name adapter-summary.json -type f 2>/dev/null | wc -l | tr -d ' ')
           # Per-leg adapter summaries prove completeness only inside artifacts
           # that exist. Never turn a surviving subset into a matrix-wide verdict.
-          if [[ "$EVALUATE_RESULT" != "success" || "$OBSERVED_LEG_COUNT" -ne "$EXPECTED_LEG_COUNT" ]]; then
-            if [[ "$EVALUATE_RESULT" == "skipped" ]]; then
+          if [[ "$MATRIX_MANIFEST_VALID" != "true" || "$EVALUATE_RESULT" != "success" || "$OBSERVED_LEG_COUNT" -ne "$EXPECTED_LEG_COUNT" ]]; then
+            if [[ "$MATRIX_MANIFEST_VALID" != "true" ]]; then
+              BODY=$(printf '❌ Evaluation matrix metadata is invalid: the discovered entry list was missing, malformed, or not a JSON array. Check the discover job output in the [workflow run](%s); no quality verdict was published.' "$RUN_URL")
+            elif [[ "$EVALUATE_RESULT" == "skipped" ]]; then
               BODY="❌ Evaluation did not complete (an upstream job failed or was skipped, so evaluation never ran). [View workflow run](${RUN_URL})"
             elif [[ "$EVALUATE_RESULT" == "success" ]]; then
               BODY=$(printf '❌ Evaluation result artifacts are incomplete: expected %s matrix leg artifact(s), but found %s. Check the [workflow run](%s) artifact upload and download logs, then comment `/evaluate %s` to retry this exact commit.' "$EXPECTED_LEG_COUNT" "$OBSERVED_LEG_COUNT" "$RUN_URL" "${{ needs.gate.outputs.head_sha }}")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@ Use the repository's own authoring skills under `.agents/skills/` instead of imp
   Classify the failure before editing skill content; broken fixtures, underpowered trial counts and
   harness errors routinely masquerade as skill regressions.
 
-Before pushing eval changes, run `python eng/eval-quality/check_eval_quality.py`. It blocks ten
-structural defect classes documented in `eng/eval-quality/README.md`, each of which has already cost
-a real evaluation result here.
+Before pushing eval changes, run `python eng/eval-quality/check_eval_quality.py`. It blocks eleven
+structural defect classes documented in `eng/eval-quality/README.md` that can corrupt a real
+evaluation result.
 
 The distilled quality rules — what makes a skill beat its own baseline — live in the "Quality bar"
 section of `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,12 @@ Per-skill verdicts are written to `./eval-results/<plugin>/<skill>/results.json`
 
 Tests do **not** run automatically on pull requests. When a PR changes skills, the `pr-status` job posts a pending commit status and a maintainer must trigger the evaluation, binding it to a specific reviewed commit — either by submitting a PR review ("Files changed" → "Review changes") whose body contains `/evaluate` (recommended, no SHA to copy), or by commenting `/evaluate <sha>`. A bare `/evaluate` comment only posts guidance. Results are posted as a PR comment and uploaded as build artifacts.
 
-If a scenario fails or regresses, see [Investigating Results](eng/vally-adapter/InvestigatingResults.md) for how to download artifacts, interpret `results.json`, and diagnose common failure patterns.
+For the architecture, metrics, verdict policy, and real repair examples, see the
+[Skill evaluation infrastructure overview](eng/vally-adapter/README.md). If a
+scenario fails or regresses, see
+[Investigating Results](eng/vally-adapter/InvestigatingResults.md) for how to
+download artifacts, interpret `results.json`, and diagnose common failure
+patterns.
 
 ## Writing style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,33 +277,33 @@ stimuli:
 
 > [!IMPORTANT]
 > `defaults:` and `config:` are the same block — `config` is a deprecated alias — and vally
-> **rejects** a spec declaring both. Many existing evals still open with `config:`; when you add
-> `runs`, merge the two into a single `defaults:` block. The failure is silent: the job exits 0 with
+> **rejects** a spec declaring both. Some existing evals still open with `config:`; replace it with
+> one `defaults:` block when settings change. The failure is silent: the job exits 0 with
 > no verdicts and the PR comment blames "transient infrastructure".
 
 Each skill is evaluated in up to three variants — **baseline** (no skills), **skilled** (only the skill under test), and **plugin** (the whole plugin loaded) — and a skill "passes" only when the skilled run is a *credible* improvement over baseline. To assert that a skill should stay dormant for an out-of-scope task, add `expect_activation: false` to that stimulus. See any existing `tests/*/*/eval.yaml` for a fuller example of the grader and stimulus format.
 
 #### Size the eval so it can return a verdict
 
-The pass gate has two independent bars. `trials = stimuli × runs`.
+The pass gate gives each distinct stimulus one vote. Repeated runs collapse to one
+majority-direction vote and remain available as reliability evidence.
 
-1. **Counted trials ≥ 5**, else the verdict is reported `underpowered` — never a pass, never a
+1. **Distinct stimuli ≥ 5**, else the verdict is reported `underpowered` — never a pass, never a
    regression.
-2. **p ≤ 0.05 on an exact one-sided sign test over the *discordant* (non-tie) trials.** Ties are not
+2. **p ≤ 0.05 on an exact one-sided sign test over *discordant* (non-tie) stimulus votes.** Ties are not
    discarded; they hold the discordant count down.
 
-| discordant trials | records that pass | p |
+| discordant stimulus votes | records that pass | p |
 | ---: | --- | ---: |
 | ≤ 4 | none, however good the skill | ≥ 0.0625 |
 | 5–7 | zero losses only (5W/0L) | 0.031 |
 | 8 | one loss survivable (7W/1L) | 0.035 |
 
-At exactly 5 counted trials a single tie is fatal — it leaves 4 discordant. At 6 counted trials one
+At exactly 5 stimuli a single tie is fatal — it leaves 4 discordant votes. At 6 stimuli one
 tie is survivable (5W/1T/0L); at 7, up to two are (5W/2T/0L). A loss is not. Five is an *eligibility
 floor*, not adequate
-power. A run that measured a 32% tie rate certified a
-genuinely-helping five-trial eval about one time in ten; at fifteen trials, about nine times in ten.
-Prefer adding **discriminating stimuli** over raising `runs` — repeats measure the same task. See
+power. Add **discriminating stimuli** for task breadth. Use `runs` only to measure pass rate,
+pass@k, pass^k, and flakiness for the same tasks. See
 [`eng/eval-quality/README.md`](eng/eval-quality/README.md) for the full derivation and for the ten
 structural defects the CI quality gate blocks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,7 @@ tie is survivable (5W/1T/0L); at 7, up to two are (5W/2T/0L). A loss is not. Fiv
 floor*, not adequate
 power. Add **discriminating stimuli** for task breadth. Use `runs` only to measure pass rate,
 pass@k, pass^k, and flakiness for the same tasks. See
-[`eng/eval-quality/README.md`](eng/eval-quality/README.md) for the full derivation and for the ten
+[`eng/eval-quality/README.md`](eng/eval-quality/README.md) for the full derivation and for the eleven
 structural defects the CI quality gate blocks.
 
 Run the gate locally before pushing:

--- a/dotnet-skills.experiment.yaml
+++ b/dotnet-skills.experiment.yaml
@@ -15,15 +15,15 @@
 # "CLI flags > experiment overrides > eval defaults", and the merge is a plain
 # spread (`{ ...eval.defaults, ...experiment.overrides }`), so an `overrides:
 # runs:` here does not set a *default* — it overwrites every eval's own
-# `defaults.runs` and makes per-eval trial counts impossible to express. An eval
-# that needs more trials than it has scenarios raises its own count:
+# `defaults.runs` and makes per-eval reliability budgets impossible to express.
+# An eval that needs more repeated samples sets its own count:
 #
 #   defaults:
 #     runs: 3
 #
-# Trials per eval = scenarios x runs, and that product is what the pass gate's
-# confidence interval is computed over. See eng/eval-quality/README.md for the
-# floor and why it sits where it does.
+# Paired runs per eval = stimuli x runs. The gate does not treat those repeats as
+# independent: it collapses each stimulus to one vote. See
+# eng/eval-quality/README.md for the distinct-stimulus floor.
 name: dotnet-skills
 evals:
   - tests/*/!(agent.*)/eval.yaml

--- a/eng/eval-quality/README.md
+++ b/eng/eval-quality/README.md
@@ -162,9 +162,9 @@ five distinct stimuli no possible record passes**, however good the skill is.
 Five is derived from this repository's predeclared `alpha=0.05`; it is not a
 Vally recommendation.
 
-| Stimulus votes | Best possible record | Exact `p` |
+| Stimulus votes | Minimum passing record | Exact `p` |
 | ---: | --- | ---: |
-| 1–4 | a clean sweep | ≥ 0.0625 — cannot pass |
+| 1–4 | none; even a clean sweep cannot pass | ≥ 0.0625 |
 | 5 | 5W/0T/0L | 0.03125 |
 | 8 | 5W/3T/0L | 0.03125 |
 

--- a/eng/eval-quality/README.md
+++ b/eng/eval-quality/README.md
@@ -145,89 +145,65 @@ The repo convention is `expect_activation: false` **alone** (see
 `system-text-json-net11`), so the skill is actually loaded and the guard
 measures the real property.
 
-### 8. Fewer than 5 trials behind a verdict
+### 8. Fewer than 5 distinct stimuli behind a verdict
 
-Trials, not stimuli, are what the pass gate is computed over. `vally compare`
-produces one head-to-head trial per stimulus per run, so
+Vally defines a [stimulus as a test case](https://microsoft.github.io/vally/concepts/how-it-works/).
+It defines repeated runs as inputs to pass rate, pass@k, pass^k, and flakiness.
+Its [scoring guidance](https://microsoft.github.io/vally/concepts/scoring/)
+recommends 3 runs for CI and 5–10 for nightly evaluation. Those runs measure how
+reliably the agent handles the same task. They are not independent task samples.
 
-```
-trials = stimuli × defaults.runs
-```
+The repository gate therefore collapses repeated runs to one majority-direction
+vote per stimulus, then applies an exact one-sided **sign test**: more stimulus
+wins than losses at `p ≤ 0.05`. Five stimuli run three times produce 15 paired
+runs for reliability analysis, but only five gate votes.
 
-and the gate is an exact one-sided **sign test**: more wins than losses, at
-`p ≤ 0.05`.
+The sign test cannot reach 5% on fewer than five discordant (non-tie) votes:
+`0.5⁴ = 0.0625` is above alpha, while `0.5⁵ = 0.03125` is below it. So **below
+five distinct stimuli no possible record passes**, however good the skill is.
+Five is derived from this repository's predeclared `alpha=0.05`; it is not a
+Vally recommendation.
 
-That test cannot reach 5% on fewer than five discordant (non-tie) trials —
-`0.5⁴ = 0.0625` is already above alpha, `0.5⁵ = 0.031` is not — and discordant
-trials can never exceed counted trials. So **below five trials no possible
-record passes**, however good the skill is: the eval cannot answer the question
-it exists to answer. Five is not a chosen constant; it is where the test becomes
-attainable.
-
-| trials | best possible record | its `p` |
+| Stimulus votes | Best possible record | Exact `p` |
 | ---: | --- | ---: |
 | 1–4 | a clean sweep | ≥ 0.0625 — cannot pass |
-| 5 | 5W/0T/0L | 0.031 |
-| 8 | 5W/3T/0L | 0.031 |
+| 5 | 5W/0T/0L | 0.03125 |
+| 8 | 5W/3T/0L | 0.03125 |
 
-This is an *eligibility* floor — the minimum evidence a verdict may rest on —
-not a guarantee of adequate power for a realistic effect, which needs
-considerably more. Below it, `eng/vally-adapter/adapt.mjs` marks the verdict
-`underpowered` and the PR comment shows ⚠️: never a pass, never a regression.
-This check makes that state un-shippable for *new* evals.
+This is an *eligibility* floor, not adequate power for a realistic effect. Below
+it, `eng/vally-adapter/adapt.mjs` reports `underpowered` and the PR comment shows
+⚠️: never a pass, never a regression. This check makes that state unshippable
+for new evals.
 
-> **Landing on 5 exactly is a trap, and the gate now warns about it.** The table
-> above is the *best possible* record. A pass needs **five discordant (non-tie)
-> trials with no losses**, so at exactly 5 trials a single tie is fatal — it
-> leaves 4 discordant, back below the floor. At 6 trials one tie is survivable
-> (5W/1T/0L is 5 discordant and passes at p = 0.031) and at 7 trials up to two
-> are, but a loss still is not: tolerating one needs 8 discordant trials.
->
-> Run `30611635547` is the worked example. Five `dotnet-test` evals had just been
-> raised to exactly 5 trials. They returned **16W / 8T / 1L** overall — every
-> skill winning, not one regressing — and **all five failed**, four of them
-> because ties had made a pass arithmetically unreachable before the run started.
-> At the 32% tie rate measured there, a genuinely-helping skill parked at 5
-> trials is certified about **one run in ten**; at 15 trials it is about nine in
-> ten. Size an eval for the tie rate you expect, not for the floor.
+> **Five is fragile.** A pass at exactly five stimuli needs 5W/0T/0L. One tie
+> leaves four discordant votes and makes a pass impossible. At six stimuli one
+> tie is survivable; at seven, two ties are survivable. Tolerating one loss needs
+> eight discordant votes (`7W/1L`, `p=0.03515625`).
 
-Raising an eval over the floor by adding scenarios is strictly better than
-raising `runs`: five repeats of one scenario satisfy the arithmetic but provide
-no cross-scenario evidence, so the skill is still only measured on one task.
-Use `runs` where a scenario is genuinely expensive to add:
+Power depends on the effect that the eval must detect. Under an idealized no-tie
+model, the exact discordant-vote counts for at least 80% power at one-sided
+`alpha=0.05` are:
 
-```yaml
-defaults:
-  runs: 3
-```
+| True conditional win probability | Discordant votes needed |
+|---:|---:|
+| 0.60 | 158 |
+| 0.65 | 69 |
+| 0.70 | 37 |
+| 0.75 | 23 |
+| 0.80 | 18 |
+| 0.90 | 8 |
 
-> **`defaults:` replaces `config:`, it does not join it.** `config` is a
-> deprecated alias for the same block, and vally's loader **throws** on a spec
-> declaring both — so pasting the snippet above into one of the many evals that
-> still open with
->
-> ```yaml
-> config:
->   timeout: 5m
-> ```
->
-> breaks it. Merge instead: `defaults:` with `timeout` and `runs` together.
->
-> This is worth spelling out because the failure is invisible. `vally` rejects
-> the spec, the evaluate job still exits 0 having produced no verdicts, and the
-> PR comment reads *"Evaluation ran but produced no results … usually a transient
-> infrastructure failure … re-post `/evaluate` to try again"* — advice that
-> re-runs a spec which can never load. Failing check 10 exists so the gate says
-> so instead.
+These are planning values, not universal minimums. Ties require more total
+stimuli because they do not enter the test. Eight stimuli are enough for 80%
+power only for a near-deterministic 90% conditional win rate. A non-pass is not
+proof of no effect.
 
-`dotnet-skills.experiment.yaml` deliberately does not set `runs` in its
-`overrides:` block. Precedence there is *CLI flags > experiment overrides > eval
-defaults* and the merge is a plain spread, so an experiment-level `runs` does
-not *default* anything — it overwrites every eval's own value and makes
-per-eval trial counts impossible to express.
+Repeated runs still matter. Keep Vally's recommended run counts where the cost
+allows, and read `comparisonTrialEvidence` plus per-stimulus run W/T/L for
+reliability. Do not use those runs to clear the distinct-stimulus floor.
 
-**Grandfathering.** `underpowered-allowlist.txt` carries the evals that predate
-the floor. It is a debt ledger and it is shrink-only in the mechanical sense:
+**Grandfathering.** `underpowered-allowlist.txt` carries the evals that predate the floor. It is a
+debt ledger and it is shrink-only in the mechanical sense:
 the gate errors on an entry that is stale, duplicated, or no longer needed, and
 `--base-ref` (which CI passes on every pull request) rejects entries that are
 *new* relative to the base branch. Without that second half, a PR could add a
@@ -250,7 +226,7 @@ byte-identical rerun of another. It runs the wrong prompt against the wrong
 fixture, and the discriminator it was added for does not exist.
 
 Observed live in #971. `grade-tests` was raised from 4 to 5 scenarios to clear
-the trial floor, and the new "production code available" scenario shipped as a
+the stimulus floor, and the new "production code available" scenario shipped as a
 silent clone of the "production code unavailable" one:
 
 ```yaml
@@ -282,11 +258,8 @@ into the other and throws when a spec carries both:
 eval spec: cannot specify both 'config' and 'defaults'
 ```
 
-Seventeen evals here still open with a `config:` block, and every instruction
-for raising an eval's trial count — this file, `adapt.mjs`, `consolidate.mjs`,
-`InvestigatingResults.md`, the allowlist header — says to add `defaults: runs: N`
-without mentioning the collision. Following the documented remedy is enough to
-break the spec.
+Some evals still open with a `config:` block. Adding a separate `defaults:`
+block for any modern setting, including `runs`, breaks those specs.
 
 What makes it worth a gate is how it fails. `vally` rejects the spec, but the
 evaluate job still exits 0 with no verdicts, and the PR comment reports:
@@ -296,8 +269,8 @@ evaluate job still exits 0 with no verdicts, and the PR comment reports:
 > `/evaluate` to try again.
 
 So the one actionable signal points away from the cause, and the suggested fix
-re-runs a spec that can never load. Merge the two blocks into one `defaults:`
-carrying both `timeout` and `runs`.
+re-runs a spec that can never load. Replace `config:` with one `defaults:` block
+that carries all settings.
 
 ## Why the gate scores direction, not magnitude
 
@@ -344,27 +317,25 @@ CI runs the gate without `--strict`, so these are informational there. Passing
 
 ### Statistical power
 
-The evals that are still below the five-trial floor of failing check 8, listed
-from `underpowered-allowlist.txt` with their current
-`scenarios × runs`. Their verdicts are reported as ⚠️ underpowered rather than
-as a pass or a failure, so raising them is the highest-value eval work
-available. See check 8 for how, and for why the floor sits at five.
+The evals that are still below the five-distinct-stimulus floor of failing
+check 8. The warning lists distinct stimuli, runs per stimulus, and total paired
+runs separately. Their verdicts are ⚠️ underpowered rather than a pass or a
+failure, so adding independent stimuli is the highest-value eval work available.
+See check 8 for why the floor sits at five.
 
 ### Evals parked at the floor
 
-Evals at 5–7 trials, where a pass still requires a loss-free record and enough
-non-tie trials to clear the floor. These *are* eligible for a verdict, so they
-are not underpowered — but at 5 trials a single tie removes the possibility of
-one, and at 6–7 it takes only one or two more. See the callout under check 8 for
-the run that made this concrete. Raise them unless their scenarios are
-near-certain discriminators.
+Evals at 5–7 distinct stimuli, where a pass still requires a loss-free record
+and enough non-tie votes to clear the floor. These are eligible for a verdict,
+so they are not underpowered. At five stimuli, one tie removes the possibility
+of a pass. Add stimuli unless the current cases are near-certain discriminators.
 
 ### Orphaned fixtures
 
 A fixture directory that is committed but that no stimulus references. Usually
 means a scenario was planned and dropped, so the coverage it was built for is
 being paid for in repo size but never exercised. Wiring these up is the cheapest
-way to raise an eval's trial count, because the fixture already exists —
+way to raise an eval's independent task count, because the fixture already exists —
 `migrate-nullable-references` sits at 3 scenarios with three unreferenced
 fixtures beside it.
 

--- a/eng/eval-quality/README.md
+++ b/eng/eval-quality/README.md
@@ -1,10 +1,8 @@
 # Eval quality gate
 
-`check_eval_quality.py` blocks defect classes that have each already cost a real
-evaluation result on this repo. Every one of them was invisible to the existing
-checks: the eval specs parsed, `skill-validator` passed, and the damage only
-showed up as a skill mysteriously losing to its own baseline — or as a skill
-winning every trial and failing anyway.
+`check_eval_quality.py` blocks structural defects that can corrupt an eval
+result. Most were first found only after an eval mysteriously lost to its own
+baseline or won every trial and still failed.
 
 Run it from the repository root:
 
@@ -16,7 +14,7 @@ python eng/eval-quality/selftest_eval_quality.py       # prove the gate still fi
 
 ## Failing checks
 
-All ten are **structural** — they inspect file existence, git state, declared
+All eleven are **structural** — they inspect file existence, git state, declared
 numbers, or YAML shape/keys. None of them interprets prose, so they cannot fire
 spuriously on a well-written eval.
 
@@ -198,6 +196,12 @@ stimuli because they do not enter the test. Eight stimuli are enough for 80%
 power only for a near-deterministic 90% conditional win rate. A non-pass is not
 proof of no effect.
 
+The table gives **sign-test power**, before the 20% practical floor is applied.
+At a true 60% conditional win rate, the floor is exactly at the expected effect:
+with 158 votes the sign test has 80.6% power, but the combined gate passes about
+52.2% of records and approaches 50% as the sample grows. The gate is designed to
+certify effects above its practical threshold, not effects that only equal it.
+
 Repeated runs still matter. Keep Vally's recommended run counts where the cost
 allows, and read `comparisonTrialEvidence` plus per-stimulus run W/T/L for
 reliability. Do not use those runs to clear the distinct-stimulus floor.
@@ -271,6 +275,14 @@ evaluate job still exits 0 with no verdicts, and the PR comment reports:
 So the one actionable signal points away from the cause, and the suggested fix
 re-runs a spec that can never load. Replace `config:` with one `defaults:` block
 that carries all settings.
+
+### 11. Duplicate stimulus names
+
+Vally pairs baseline and treatment trajectories by `(stimulus name, trial
+index)`. Two stimuli with the same name therefore create ambiguous comparison
+slots even when their prompts differ. The authoring gate requires every
+stimulus name in one eval to be unique; the runtime adapter also rejects missing
+or duplicate comparison slot identities.
 
 ## Why the gate scores direction, not magnitude
 

--- a/eng/eval-quality/check_eval_quality.py
+++ b/eng/eval-quality/check_eval_quality.py
@@ -364,12 +364,13 @@ def check_cobertura() -> None:
 def eval_evidence_counts(doc: dict) -> tuple[int, int, int]:
     """(distinct stimuli, runs per stimulus, paired runs) for one eval spec.
 
-    The pass gate gives each distinct stimulus one vote. `defaults.runs`
-    measures reliability within that stimulus and does not increase the
-    cross-task sample size.
+    The pass gate gives each distinct stimulus one vote. `defaults.runs` (or
+    its deprecated `config.runs` alias) measures reliability within that
+    stimulus and does not increase the cross-task sample size.
     """
     scenarios = len(doc.get("stimuli") or [])
-    runs = (doc.get("defaults") or {}).get("runs", 1)
+    settings = doc.get("defaults") or doc.get("config") or {}
+    runs = settings.get("runs", 1)
     if not isinstance(runs, int) or isinstance(runs, bool) or runs < 1:
         runs = 1
     return scenarios, runs, scenarios * runs

--- a/eng/eval-quality/check_eval_quality.py
+++ b/eng/eval-quality/check_eval_quality.py
@@ -27,13 +27,12 @@ FAILS on unambiguous bugs:
   7. Dormancy guard that also sets `reject_skills`. That forces the skilled arm
      skill-free, making it identical to the baseline arm, so the score is judge
      noise.
-  8. Fewer than MIN_TRIALS trials (scenarios x `defaults.runs`). The pass gate
-     is an exact one-sided sign test over the head-to-head trials, which cannot
-     reach 5% on fewer than five discordant trials
-     (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5). Discordant trials can never
-     exceed counted trials, so below five no possible record produces a pass —
-     the eval cannot answer the question it exists to answer. Existing evals are
-     grandfathered through a shrink-only allowlist.
+  8. Fewer than MIN_STIMULI distinct stimuli. The pass gate gives each
+     stimulus one vote and applies an exact one-sided sign test. It cannot reach
+     5% on fewer than five discordant votes
+     (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5). Repeated runs measure the
+     reliability of one task; they do not create independent task samples.
+     Existing evals are grandfathered through a shrink-only allowlist.
   9. Duplicate key in a mapping. YAML keeps the last one, so a stray second
      `prompt:`/`environment:`/`graders:` block silently overwrites the scenario
      it lands in, turning it into a clone of another. Scenario counts still look
@@ -73,14 +72,14 @@ except ImportError:  # pragma: no cover
     print("PyYAML is required: pip install pyyaml", file=sys.stderr)
     raise SystemExit(2)
 
-# Minimum trials (scenarios x runs) behind a verdict. Below this the pass gate
-# stops measuring the skill — see check_power() and eng/eval-quality/README.md.
-# Must equal MIN_CREDIBLE_TRIALS in the adapter, which is what actually enforces
+# Minimum distinct stimuli behind a verdict. Below this the pass gate cannot
+# reach alpha — see check_power() and eng/eval-quality/README.md. Must equal
+# MIN_CREDIBLE_STIMULI in the adapter, which is what actually enforces
 # it at scoring time; check_floor_agreement() fails the build if they drift.
 #
 # (The t critical values this file used to carry went with report_power: the
 # gate is an exact sign test now, so no interval is computed on this side.)
-MIN_TRIALS = 5
+MIN_STIMULI = 5
 ADAPTER = "eng/vally-adapter/adapt.mjs"
 
 # Debt ledger for evals that predate the floor. Shrink-only: check_power()
@@ -225,16 +224,14 @@ def check_spec_shape(spec: str, doc: dict, raw: str) -> None:
     """Reject a spec vally's loader will refuse, since CI misreports that.
 
     `config:` is a deprecated alias for `defaults:` in vally 0.9 — the loader
-    folds one into the other and **throws** when a spec carries both. Seventeen
-    evals here still use `config:`, and every doc that tells a contributor how to
-    raise an eval's trial count says to add
+    folds one into the other and **throws** when a spec carries both. Some evals
+    here still use `config:`, so adding a modern defaults block such as
 
         defaults:
           runs: N
 
-    without mentioning that the `config:` block already sitting in the file makes
-    that combination illegal. Following the documented remedy is therefore enough
-    to break the spec, which is exactly what happened on run 30618878715.
+    without replacing the existing `config:` block breaks the spec. That happened
+    on run 30618878715.
 
     The failure is silent in the worst way: `vally` rejects the spec, the
     evaluate job still exits 0 with no verdicts, and the PR comment reports
@@ -345,14 +342,12 @@ def check_cobertura() -> None:
                     f"or rubric quotes the old figure, update it too")
 
 
-def eval_trial_count(doc: dict) -> tuple[int, int, int]:
-    """(scenarios, runs, trials) for one eval spec.
+def eval_evidence_counts(doc: dict) -> tuple[int, int, int]:
+    """(distinct stimuli, runs per stimulus, paired runs) for one eval spec.
 
-    Trials, not scenarios, is what the pass gate is computed over: `vally
-    compare` produces one head-to-head trial per stimulus per run, and the
-    adapter's sign test is over all of them together. `defaults.runs` is
-    honoured because dotnet-skills.experiment.yaml no longer overrides it
-    globally.
+    The pass gate gives each distinct stimulus one vote. `defaults.runs`
+    measures reliability within that stimulus and does not increase the
+    cross-task sample size.
     """
     scenarios = len(doc.get("stimuli") or [])
     runs = (doc.get("defaults") or {}).get("runs", 1)
@@ -372,20 +367,19 @@ def load_allowlist() -> list[str]:
 def report_knife_edge(specs: list[str]) -> None:
     """Flag evals whose passing records cannot tolerate a loss.
 
-    MIN_TRIALS is where a verdict becomes *possible*, not where it becomes
-    *likely*. The sign test conditions on the discordant (non-tie) trials, so at
-    5, 6 or 7 counted trials a passing record needs at least five wins and no
-    losses. At 5 counted trials one tie is fatal; at 6 one tie is survivable, and
-    at 7 two ties are survivable. Tolerating even one loss needs 8 discordant
-    trials.
+    MIN_STIMULI is where a verdict becomes *possible*, not where it becomes
+    *likely*. The sign test conditions on discordant (non-tie) stimulus votes, so at
+    5, 6 or 7 stimulus votes a passing record needs at least five wins and no
+    losses. At 5 votes one tie is fatal; at 6 one tie is survivable, and at 7 two
+    ties are survivable. Tolerating even one loss needs 8 discordant votes.
 
     This is not hypothetical. Run 30611635547 put five dotnet-test evals at
-    exactly 5 trials; they returned 16W/8T/1L overall — every skill winning, none
+    exactly 5 distinct stimuli; they returned 16W/8T/1L overall — every skill winning, none
     regressing — and all five failed, four of them because ties had made any pass
     arithmetically unreachable. At the 32% tie rate measured there, a
-    genuinely-helping skill parked at 5 trials is certified about one run in ten.
+    genuinely-helping skill parked at 5 stimulus votes is certified about one run in ten.
 
-    A warning rather than an error: the right trial count depends on how sharply
+    A warning rather than an error: the right stimulus count depends on how sharply
     an eval's scenarios discriminate, which this gate cannot know, and blocking
     on a judgement call is how gates get switched off.
     """
@@ -398,28 +392,28 @@ def report_knife_edge(specs: list[str]) -> None:
                 doc = yaml.load(fh, NoDuplicateKeys) or {}
         except yaml.YAMLError:
             continue  # already reported by main()
-        scenarios, runs, trials = eval_trial_count(doc)
-        if MIN_TRIALS <= trials <= 7:
-            band.append((trials, scenarios, runs, spec))
+        scenarios, runs, paired_runs = eval_evidence_counts(doc)
+        if MIN_STIMULI <= scenarios <= 7:
+            band.append((scenarios, runs, paired_runs, spec))
     if not band:
         return
     warnings.append(
-        f"{len(band)} eval(s) sit at {MIN_TRIALS}-7 trials, where any loss is fatal and ties "
-        f"can leave fewer than {MIN_TRIALS} discordant trials. At exactly {MIN_TRIALS} counted "
-        f"trials, one tie makes a pass impossible. Raise them if their scenarios are not "
+        f"{len(band)} eval(s) sit at {MIN_STIMULI}-7 distinct stimuli, where any loss is fatal and ties "
+        f"can leave fewer than {MIN_STIMULI} discordant votes. At exactly {MIN_STIMULI} counted "
+        f"stimulus votes, one tie makes a pass impossible. Raise them if their scenarios are not "
         f"near-certain discriminators:")
     warnings.extend(
-        f"    {t} trial(s) = {sc} scenario(s) x runs={r}  {spec}"
-        for t, sc, r, spec in sorted(band))
+        f"    {sc} distinct stimulus/stimuli x runs={r} ({paired} paired run(s))  {spec}"
+        for sc, r, paired, spec in sorted(band))
 
 
 def check_power(specs: list[str]) -> None:
     """Fail an eval that cannot produce a credible verdict at any effect size.
 
-    The gate is an exact one-sided sign test over the head-to-head trials. It
-    cannot reach 5% on fewer than five discordant trials (0.5^4 = 0.0625 is
-    already above alpha), and discordant trials can never exceed counted
-    trials — so below MIN_TRIALS no possible record passes, however good the
+    The gate is an exact one-sided sign test over one vote per stimulus. It
+    cannot reach 5% on fewer than five discordant stimulus votes (0.5^4 = 0.0625 is
+    already above alpha), and discordant votes can never exceed counted stimulus
+    votes — so below MIN_STIMULI no possible record passes, however good the
     skill is. See eng/eval-quality/README.md.
 
     Existing debt is grandfathered through an allowlist that may only shrink: an
@@ -441,30 +435,31 @@ def check_power(specs: list[str]) -> None:
             continue
         with open(spec, encoding="utf-8") as fh:
             doc = yaml.safe_load(fh) or {}
-        scenarios, runs, trials = eval_trial_count(doc)
-        if trials >= MIN_TRIALS:
+        scenarios, runs, paired_runs = eval_evidence_counts(doc)
+        if scenarios >= MIN_STIMULI:
             continue
-        (listed_thin if spec in allowed_set else thin).append((trials, scenarios, runs, spec))
+        (listed_thin if spec in allowed_set else thin).append((scenarios, runs, paired_runs, spec))
 
     if thin:
         errors.append(
-            f"{len(thin)} eval(s) have fewer than {MIN_TRIALS} trials, so no effect size can "
-            f"produce a credible verdict. Add scenarios (preferred — scenarios also widen what "
-            f"the skill is measured on, where extra runs only re-measure the same one), or set "
-            f"`defaults: {{ runs: N }}` so scenarios x runs >= {MIN_TRIALS}:")
-        for trials, scenarios, runs, spec in sorted(thin):
-            need = "N/A" if scenarios == 0 else -(-MIN_TRIALS // scenarios)
+            f"{len(thin)} eval(s) have fewer than {MIN_STIMULI} distinct stimuli, so no effect size can "
+            f"produce a credible verdict. Add independent, discriminating stimuli; extra runs only "
+            f"re-measure the same task:")
+        for scenarios, runs, paired_runs, spec in sorted(thin):
             errors.append(
-                f"    {trials} trial(s) = {scenarios} scenario(s) x runs={runs}  {spec}  "
-                f"(needs runs>={need})")
+                f"    {scenarios} distinct stimulus/stimuli x runs={runs} "
+                f"({paired_runs} paired run(s))  {spec}  "
+                f"(needs {MIN_STIMULI - scenarios} more distinct stimulus/stimuli)")
 
     if listed_thin:
         warnings.append(
-            f"{len(listed_thin)} eval(s) are below the {MIN_TRIALS}-trial floor and grandfathered "
+            f"{len(listed_thin)} eval(s) are below the {MIN_STIMULI}-stimulus floor and grandfathered "
             f"in {ALLOWLIST}. Their verdicts are reported as underpowered, never as a pass or a "
             f"failure. Raising them is the highest-value eval work available:")
-        for trials, scenarios, runs, spec in sorted(listed_thin):
-            warnings.append(f"    {trials} trial(s) = {scenarios} scenario(s) x runs={runs}  {spec}")
+        for scenarios, runs, paired_runs, spec in sorted(listed_thin):
+            warnings.append(
+                f"    {scenarios} distinct stimulus/stimuli x runs={runs} "
+                f"({paired_runs} paired run(s))  {spec}")
 
     # Ratchet: the allowlist is a debt ledger, so it must only ever shrink.
     for spec in sorted(allowed_set - {s for _, _, _, s in listed_thin}):
@@ -478,7 +473,7 @@ def check_power(specs: list[str]) -> None:
                 f"Remove the stale line.")
         else:
             errors.append(
-                f"{ALLOWLIST} lists '{spec}', but it now meets the {MIN_TRIALS}-trial floor. "
+                f"{ALLOWLIST} lists '{spec}', but it now meets the {MIN_STIMULI}-stimulus floor. "
                 f"Remove the line so the exemption can't be silently reused.")
     for spec in sorted({s for s in allowed if allowed.count(s) > 1}):
         errors.append(f"{ALLOWLIST} lists '{spec}' more than once.")
@@ -546,7 +541,7 @@ def check_allowlist_growth(base_ref: str) -> None:
     if added:
         errors.append(
             f"{len(added)} new exemption(s) added to {ALLOWLIST}. The ledger is shrink-only: an "
-            f"eval below the {MIN_TRIALS}-trial floor must be given enough trials, not exempted.")
+            f"eval below the {MIN_STIMULI}-stimulus floor must be given enough distinct stimuli, not exempted.")
         errors.extend(f"    {spec}" for spec in added)
 
 
@@ -636,7 +631,7 @@ def report_uncovered() -> None:
 def check_floor_agreement() -> None:
     """The floor lives in two languages; make them unable to drift apart.
 
-    This gate refuses a spec below MIN_TRIALS, but the adapter is what actually
+    This gate refuses a spec below MIN_STIMULI, but the adapter is what actually
     withholds a verdict at scoring time. If the two constants disagree, the
     repo either blocks evals that would have been scored, or accepts evals that
     can never produce a verdict — both silent. Nothing else ties them together,
@@ -649,17 +644,17 @@ def check_floor_agreement() -> None:
         with open(ADAPTER, encoding="utf-8") as fh:
             source = fh.read()
     except OSError as exc:
-        errors.append(f"could not read {ADAPTER} to verify the trial floor: {exc}")
+        errors.append(f"could not read {ADAPTER} to verify the stimulus floor: {exc}")
         return
-    match = re.search(r"^const MIN_CREDIBLE_TRIALS = (\d+);", source, re.M)
+    match = re.search(r"^const MIN_CREDIBLE_STIMULI = (\d+);", source, re.M)
     if match is None:
         errors.append(
-            f"could not find `const MIN_CREDIBLE_TRIALS = <n>;` in {ADAPTER}, so this gate's "
-            f"floor of {MIN_TRIALS} is unverified. Update the pattern in check_floor_agreement() "
+            f"could not find `const MIN_CREDIBLE_STIMULI = <n>;` in {ADAPTER}, so this gate's "
+            f"floor of {MIN_STIMULI} is unverified. Update the pattern in check_floor_agreement() "
             f"if the declaration moved.")
-    elif int(match.group(1)) != MIN_TRIALS:
+    elif int(match.group(1)) != MIN_STIMULI:
         errors.append(
-            f"trial floor mismatch: this gate uses {MIN_TRIALS} but {ADAPTER} enforces "
+            f"stimulus floor mismatch: this gate uses {MIN_STIMULI} but {ADAPTER} enforces "
             f"{match.group(1)}. They must agree, or evals are blocked that would be scored "
             f"(or accepted that can never produce a verdict).")
 

--- a/eng/eval-quality/check_eval_quality.py
+++ b/eng/eval-quality/check_eval_quality.py
@@ -370,14 +370,14 @@ def load_allowlist() -> list[str]:
 
 
 def report_knife_edge(specs: list[str]) -> None:
-    """Flag evals whose only passing record is a flawless sweep.
+    """Flag evals whose passing records cannot tolerate a loss.
 
     MIN_TRIALS is where a verdict becomes *possible*, not where it becomes
     *likely*. The sign test conditions on the discordant (non-tie) trials, so at
-    5, 6 or 7 counted trials the only record reaching alpha is every trial a win
-    with no ties and no losses. One tie is enough to make the eval unwinnable —
-    at 5 counted trials a single tie leaves 4 discordant, which is back below the
-    floor. Tolerating even one loss needs 8 discordant trials.
+    5, 6 or 7 counted trials a passing record needs at least five wins and no
+    losses. At 5 counted trials one tie is fatal; at 6 one tie is survivable, and
+    at 7 two ties are survivable. Tolerating even one loss needs 8 discordant
+    trials.
 
     This is not hypothetical. Run 30611635547 put five dotnet-test evals at
     exactly 5 trials; they returned 16W/8T/1L overall — every skill winning, none
@@ -404,9 +404,10 @@ def report_knife_edge(specs: list[str]) -> None:
     if not band:
         return
     warnings.append(
-        f"{len(band)} eval(s) sit at {MIN_TRIALS}-7 trials, where the only passing record is "
-        f"every trial a win with no ties and no losses. One tie makes them unwinnable. Raise "
-        f"them if their scenarios are not near-certain discriminators:")
+        f"{len(band)} eval(s) sit at {MIN_TRIALS}-7 trials, where any loss is fatal and ties "
+        f"can leave fewer than {MIN_TRIALS} discordant trials. At exactly {MIN_TRIALS} counted "
+        f"trials, one tie makes a pass impossible. Raise them if their scenarios are not "
+        f"near-certain discriminators:")
     warnings.extend(
         f"    {t} trial(s) = {sc} scenario(s) x runs={r}  {spec}"
         for t, sc, r, spec in sorted(band))

--- a/eng/eval-quality/check_eval_quality.py
+++ b/eng/eval-quality/check_eval_quality.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Eval quality gate.
 
-Codifies defect classes that have each cost a real evaluation result, so they
-cannot silently recur in any plugin.
+Codifies structural defect classes that can corrupt an evaluation result, so
+they cannot silently recur in any plugin.
 
 FAILS on unambiguous bugs:
   1. Referenced fixture missing on disk. The scenario fails at setup, which
@@ -41,6 +41,8 @@ FAILS on unambiguous bugs:
      alias for `defaults`; vally's loader throws on a spec carrying both, the
      evaluate job then produces no verdicts, and CI misreports that as a
      transient infrastructure failure.
+ 11. Duplicate stimulus names. Vally pairs comparison trajectories by stimulus
+     name and trial index, so names are slot identity, not display text.
 
 Every failing check above is structural — it inspects file existence, git
 state, declared numbers, or YAML shape/keys — so it cannot fire spuriously on
@@ -247,6 +249,23 @@ def check_spec_shape(spec: str, doc: dict, raw: str) -> None:
             f"for 'defaults' and vally's loader throws on a spec carrying both, so the evaluate "
             f"job produces no verdicts and CI misreports it as a transient infrastructure "
             f"failure. Merge them into one 'defaults:' block")
+
+
+def check_stimulus_names(spec: str, doc: dict) -> None:
+    """Require unique names because Vally uses them as comparison slot identity."""
+    seen: set[str] = set()
+    for index, stimulus in enumerate(doc.get("stimuli") or []):
+        if not isinstance(stimulus, dict):
+            continue
+        name = stimulus.get("name")
+        if not isinstance(name, str) or not name:
+            continue  # Vally schema validation owns missing or malformed names.
+        if name in seen:
+            errors.append(
+                f"{spec}: duplicate stimulus name {name!r} at stimuli[{index}]. "
+                f"Vally pairs trajectories by (stimulus name, trial index), so every "
+                f"stimulus name must be unique.")
+        seen.add(name)
 
 
 def check_dormancy_guards(spec: str, doc: dict) -> None:
@@ -687,6 +706,7 @@ def main() -> int:
         check_fixtures(spec, doc, tracked)
         check_graders(spec, doc)
         check_spec_shape(spec, doc, raw)
+        check_stimulus_names(spec, doc)
         check_dormancy_guards(spec, doc)
 
     check_cobertura()

--- a/eng/eval-quality/selftest_eval_quality.py
+++ b/eng/eval-quality/selftest_eval_quality.py
@@ -248,6 +248,14 @@ def config_and_defaults_together(d):
         f.write("config:\n  timeout: 5m\n")
 
 
+def duplicate_stimulus_names(d):
+    path = EV(d)
+    with open(path) as f:
+        raw = f.read()
+    with open(path, "w") as f:
+        f.write(raw.replace("name: Does the edge thing", "name: Does the thing", 1))
+
+
 def grandfathered_reports_its_arithmetic(d):
     # The gate's job for a grandfathered eval is to tell the contributor what to
     # change, so the report must separate distinct stimuli from repeated runs.
@@ -427,6 +435,8 @@ results = [
     case("grader with an empty config enforces nothing", empty_grader_config, expect_fail=True),
     case("duplicate key silently overwrites a scenario", duplicate_stimulus_keys, expect_fail=True),
     case("spec declares both config: and defaults:", config_and_defaults_together, expect_fail=True),
+    case("duplicate stimulus names make slot identity ambiguous",
+         duplicate_stimulus_names, expect_fail=True),
     case("dormancy guard also sets reject_skills", guard_with_reject_skills, expect_fail=True),
     case("well-formed dormancy guard", guard_ok, expect_fail=False),
     output_case("reference skill carrying a direct-activation eval",

--- a/eng/eval-quality/selftest_eval_quality.py
+++ b/eng/eval-quality/selftest_eval_quality.py
@@ -30,10 +30,8 @@ def scratch():
     with open(os.path.join(ev, "eval.yaml"), "w") as f:
         f.write(
             "name: widget\n"
-            # Meets the MIN_TRIALS floor with a single scenario, which keeps the
-            # rest of the cases small. Trials = scenarios x runs.
             "defaults:\n"
-            "  runs: 5\n"
+            "  runs: 1\n"
             "stimuli:\n"
             "  - name: Does the thing\n"
             "    prompt: do it\n"
@@ -43,6 +41,22 @@ def scratch():
             "          dest: sample\n"
             "    rubric:\n"
             "      - Did the thing\n"
+            "  - name: Does the edge thing\n"
+            "    prompt: do the edge thing\n"
+            "    rubric:\n"
+            "      - Did the edge thing\n"
+            "  - name: Does the other thing\n"
+            "    prompt: do the other thing\n"
+            "    rubric:\n"
+            "      - Did the other thing\n"
+            "  - name: Does the hard thing\n"
+            "    prompt: do the hard thing\n"
+            "    rubric:\n"
+            "      - Did the hard thing\n"
+            "  - name: Does the last thing\n"
+            "    prompt: do the last thing\n"
+            "    rubric:\n"
+            "      - Did the last thing\n"
         )
     # Make everything git-tracked so the tracked-files check is satisfied.
     # The commit matters: without a HEAD, `git diff --cached` fails, which used
@@ -236,10 +250,8 @@ def config_and_defaults_together(d):
 
 def grandfathered_reports_its_arithmetic(d):
     # The gate's job for a grandfathered eval is to tell the contributor what to
-    # change, so the reported figure must be the trial arithmetic and not just
-    # the scenario count. (This replaces #964's t(n-1) case: the gate is an
-    # exact sign test now, so there is no critical value left to misquote.)
-    drop_runs(d)
+    # change, so the report must separate distinct stimuli from repeated runs.
+    write_single_stimulus(d)
     write_allowlist(d, SPEC)
 
 
@@ -292,8 +304,8 @@ def invocable_skill_with_a_direct_eval(d):
 
 
 # --- statistical power ------------------------------------------------------
-# Trials = scenarios x runs. Below the floor the pass gate cannot reach a
-# credible verdict at any effect size, so a new eval must not land there.
+# The gate gives each distinct stimulus one vote. Below the floor it cannot
+# reach a credible verdict at any effect size, so a new eval must not land there.
 
 SPEC = "tests/demo/widget/eval.yaml"
 
@@ -307,20 +319,30 @@ def write_allowlist(d, *entries):
             f.write(entry + "\n")
 
 
-def drop_runs(d):
-    """1 scenario x runs=1 = 1 trial: vally reports no interval at all there."""
-    with open(EV(d)) as f:
-        text = f.read()
+def write_single_stimulus(d, runs=1):
     with open(EV(d), "w") as f:
-        f.write(text.replace("defaults:\n  runs: 5\n", ""))
+        f.write(
+            "name: widget\n"
+            "defaults:\n"
+            f"  runs: {runs}\n"
+            "stimuli:\n"
+            "  - name: Does the thing\n"
+            "    prompt: do it\n"
+            "    environment:\n"
+            "      files:\n"
+            "        - src: fixtures/sample\n"
+            "          dest: sample\n"
+            "    rubric:\n"
+            "      - Did the thing\n"
+        )
 
 
 def underpowered(d):
-    drop_runs(d)
+    write_single_stimulus(d)
 
 
 def underpowered_but_allowlisted(d):
-    drop_runs(d)
+    write_single_stimulus(d)
     write_allowlist(d, SPEC)
 
 
@@ -334,10 +356,8 @@ def allowlist_entry_for_a_spec_that_does_not_exist(d):
     write_allowlist(d, "tests/demo/deleted/eval.yaml")
 
 
-def runs_lifts_a_single_scenario_over_the_floor(d):
-    # Already the scratch tree's shape; asserted explicitly so a regression in
-    # the scenarios-x-runs arithmetic can't hide behind the other cases.
-    pass
+def runs_do_not_lift_a_single_scenario_over_the_floor(d):
+    write_single_stimulus(d, runs=5)
 
 
 def agent_eval_exempted(d):
@@ -357,7 +377,7 @@ def commit(d, message):
 
 def _seed_allowlist_on_a_base_commit(d):
     """Commit a below-floor eval + its exemption, so HEAD~1 is a real base ref."""
-    drop_runs(d)
+    write_single_stimulus(d)
     write_allowlist(d, SPEC)
     commit(d, "grandfather the existing eval")
 
@@ -415,14 +435,16 @@ results = [
     silent_case("model-invocable skill with a direct eval",
                 invocable_skill_with_a_direct_eval,
                 "carry a direct-activation eval"),
-    case("eval below the trial floor", underpowered, expect_fail=True),
+    case("eval below the stimulus floor", underpowered, expect_fail=True),
     case("below the floor but grandfathered", underpowered_but_allowlisted, expect_fail=False),
-    output_case("grandfathered warning reports scenarios x runs",
-                grandfathered_reports_its_arithmetic, "1 trial(s) = 1 scenario(s) x runs=1"),
+    output_case("grandfathered warning separates stimuli and runs",
+                grandfathered_reports_its_arithmetic,
+                "1 distinct stimulus/stimuli x runs=1 (1 paired run(s))"),
     case("stale exemption for an eval that now qualifies", allowlisted_eval_that_now_meets_the_floor, expect_fail=True),
     case("exemption for a spec that no longer exists", allowlist_entry_for_a_spec_that_does_not_exist, expect_fail=True),
     case("exemption for an agent.* eval that never needs one", agent_eval_exempted, expect_fail=True),
-    case("runs lifts one scenario over the floor", runs_lifts_a_single_scenario_over_the_floor, expect_fail=False),
+    case("runs cannot lift one scenario over the floor",
+         runs_do_not_lift_a_single_scenario_over_the_floor, expect_fail=True),
     case("ledger unchanged since its base", allowlist_unchanged_since_base,
          expect_fail=False, gate_args=("--base-ref", "HEAD")),
     case("new exemption added since the base ref", new_exemption_added_since_base,

--- a/eng/eval-quality/selftest_eval_quality.py
+++ b/eng/eval-quality/selftest_eval_quality.py
@@ -263,6 +263,13 @@ def grandfathered_reports_its_arithmetic(d):
     write_allowlist(d, SPEC)
 
 
+def grandfathered_config_alias_reports_its_runs(d):
+    # Existing specs can still use Vally's deprecated `config:` alias. The
+    # quality report must not silently reset their reliability count to one.
+    write_single_stimulus(d, runs=4, settings_key="config")
+    write_allowlist(d, SPEC)
+
+
 def guard_with_reject_skills(d):
     with open(EV(d), "a") as f:
         f.write(
@@ -327,11 +334,11 @@ def write_allowlist(d, *entries):
             f.write(entry + "\n")
 
 
-def write_single_stimulus(d, runs=1):
+def write_single_stimulus(d, runs=1, settings_key="defaults"):
     with open(EV(d), "w") as f:
         f.write(
             "name: widget\n"
-            "defaults:\n"
+            f"{settings_key}:\n"
             f"  runs: {runs}\n"
             "stimuli:\n"
             "  - name: Does the thing\n"
@@ -450,6 +457,9 @@ results = [
     output_case("grandfathered warning separates stimuli and runs",
                 grandfathered_reports_its_arithmetic,
                 "1 distinct stimulus/stimuli x runs=1 (1 paired run(s))"),
+    output_case("deprecated config.runs remains visible",
+                grandfathered_config_alias_reports_its_runs,
+                "1 distinct stimulus/stimuli x runs=4 (4 paired run(s))"),
     case("stale exemption for an eval that now qualifies", allowlisted_eval_that_now_meets_the_floor, expect_fail=True),
     case("exemption for a spec that no longer exists", allowlist_entry_for_a_spec_that_does_not_exist, expect_fail=True),
     case("exemption for an agent.* eval that never needs one", agent_eval_exempted, expect_fail=True),

--- a/eng/eval-quality/underpowered-allowlist.txt
+++ b/eng/eval-quality/underpowered-allowlist.txt
@@ -1,9 +1,10 @@
-# Evals below the 5-trial floor enforced by eng/eval-quality/check_eval_quality.py.
+# Evals below the 5-distinct-stimulus floor enforced by check_eval_quality.py.
 #
-# Trials = scenarios x `defaults.runs`. Below 5 trials the pass gate cannot
-# reach a credible verdict at any effect size, so eng/vally-adapter/adapt.mjs
-# reports these as underpowered — never as a pass, never as a regression.
-# eng/eval-quality/README.md explains why the floor sits at 5.
+# Each distinct stimulus gives one gate vote. Repeated runs measure reliability
+# for that stimulus and do not increase the independent task sample. Below 5
+# stimuli the sign test cannot reach p <= 0.05 at any effect size, so the adapter
+# reports these as underpowered — never as a pass or a regression. The README
+# explains why the floor sits at 5.
 #
 # This file is a debt ledger and it is SHRINK-ONLY, mechanically:
 #   - the gate errors on any entry that is stale, duplicated, or no longer
@@ -16,20 +17,11 @@
 # checks the merge with the base branch, so an entry left behind for a deleted
 # eval fails the gate even though it passes on the retiring branch alone.
 #
-# To remove a line, either give the eval more scenarios (strongly preferred:
-# five repeats of one scenario satisfy the arithmetic but still measure the
-# skill on a single task) or add
-#
-#   defaults:
-#     runs: N
-#
-# to its eval.yaml so that scenarios x runs >= 5. If the spec still opens with
-# the deprecated `config:` block, merge the two — vally's loader throws on a spec
-# declaring both, and the evaluate job then reports "no results" rather than a
-# spec error.
+# To remove a line, give the eval at least five independent, discriminating
+# stimuli. Raising `defaults.runs` cannot clear this floor.
 #
 # Clearing the floor is necessary, not sufficient: the sign test conditions on
-# the discordant (non-tie) trials, so an eval at exactly 5 only passes on a
+# discordant (non-tie) stimulus votes, so an eval at exactly 5 only passes on a
 # flawless sweep. See the callout under check 8 in eng/eval-quality/README.md.
 
 tests/dotnet-advanced/csharp-scripts/eval.yaml

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -43,6 +43,13 @@ def rate_limit_pattern() -> str:
     return workflow["jobs"]["vally-evaluate"]["env"]["COPILOT_RATE_LIMIT_PATTERN"]
 
 
+def token_unavailable_pattern() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["vally-evaluate"]["env"][
+        "COPILOT_TOKEN_UNAVAILABLE_PATTERN"
+    ]
+
+
 class TokenFailoverTests(unittest.TestCase):
     def run_selector(
         self,
@@ -90,6 +97,9 @@ case "$COPILOT_GITHUB_TOKEN" in
   timed-out) exit 124 ;;
   unauthorized) echo "401 Unauthorized" >&2; exit 7 ;;
   unauthorized-after-effort) echo "401 Unauthorized after effort retry" >&2; exit 7 ;;
+  disabled) echo "This organization has been disabled" >&2; exit 8 ;;
+  service-error) echo "Unexpected internal service failure" >&2; exit 9 ;;
+  model-error) echo "Model gpt-401 not found" >&2; exit 10 ;;
   healthy) exit 0 ;;
   *) echo "unexpected test token" >&2; exit 9 ;;
 esac
@@ -114,6 +124,7 @@ esac
                     "PROBE_MODEL": model,
                     "PROBE_JUDGE_MODEL": judge_model,
                     "COPILOT_RATE_LIMIT_PATTERN": rate_limit_pattern(),
+                    "COPILOT_TOKEN_UNAVAILABLE_PATTERN": token_unavailable_pattern(),
                     "TOKEN_RANDOM_SEED": "1",
                 }
             )
@@ -210,31 +221,84 @@ esac
         self.assertEqual(result.selected_token, "healthy")
         self.assertIn("retrying its availability probe without --effort", result.stdout)
 
-    def test_model_without_effort_support_fails_closed_after_one_retry(self) -> None:
+    def test_model_without_effort_support_fails_over_after_one_retry(self) -> None:
         result = self.run_selector(
             {0: "unauthorized-after-effort", 1: "healthy"},
             model="no-effort-model",
             judge_model="judge-model",
         )
 
-        self.assertEqual(result.returncode, 7)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
             result.attempts,
-            ["unauthorized-after-effort", "unauthorized-after-effort"],
+            [
+                "unauthorized-after-effort",
+                "unauthorized-after-effort",
+                "healthy",
+                "healthy",
+                "healthy",
+            ],
         )
-        self.assertEqual(result.models, ["no-effort-model", "no-effort-model"])
-        self.assertIsNone(result.selected_token)
-        self.assertIn("non-rate-limit error", result.stdout)
+        self.assertEqual(
+            result.models,
+            [
+                "no-effort-model",
+                "no-effort-model",
+                "no-effort-model",
+                "no-effort-model",
+                "judge-model",
+            ],
+        )
+        self.assertEqual(result.selected_token, "healthy")
+        self.assertIn("has unusable credentials", result.stdout)
         self.assertIn("401 Unauthorized after effort retry", result.stdout)
 
-    def test_non_rate_limit_failure_does_not_try_another_token(self) -> None:
-        result = self.run_selector({0: "unauthorized", 1: "healthy"})
+    def test_unavailable_candidate_fails_over_to_healthy_candidate(self) -> None:
+        for unavailable_token in ("unauthorized", "disabled"):
+            with self.subTest(unavailable_token=unavailable_token):
+                result = self.run_selector(
+                    {0: unavailable_token, 1: "healthy"}
+                )
 
-        self.assertEqual(result.returncode, 7)
-        self.assertEqual(result.attempts, ["unauthorized"])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    result.attempts, [unavailable_token, "healthy"]
+                )
+                self.assertEqual(result.selected_token, "healthy")
+                self.assertIn(
+                    "quarantining it and trying another entry", result.stdout
+                )
+
+    def test_unrelated_failure_does_not_try_another_candidate(self) -> None:
+        for failing_token in ("service-error", "model-error"):
+            with self.subTest(failing_token=failing_token):
+                result = self.run_selector(
+                    {0: failing_token, 1: "healthy"}
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.attempts, [failing_token])
+                self.assertIsNone(result.selected_token)
+                self.assertIn(
+                    "unexpected non-rate-limit error", result.stdout
+                )
+                self.assertIn(
+                    "refusing to hide a service or configuration failure",
+                    result.stdout,
+                )
+
+    def test_all_unavailable_candidates_fail_clearly(self) -> None:
+        result = self.run_selector({0: "unauthorized", 1: "disabled"})
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.attempts, ["unauthorized", "disabled"])
         self.assertIsNone(result.selected_token)
-        self.assertIn("non-rate-limit error", result.stdout)
-        self.assertIn("401 Unauthorized", result.stdout)
+        self.assertIn(
+            "No healthy Copilot PAT pool entry was found", result.stdout
+        )
+        self.assertIn(
+            "at least one configured entry was unavailable", result.stdout
+        )
 
     def test_all_rate_limited_candidates_fail_clearly(self) -> None:
         result = self.run_selector({0: "rate-limited", 1: "weekly-rate-limited"})
@@ -243,6 +307,45 @@ esac
         self.assertEqual(result.attempts, ["rate-limited", "weekly-rate-limited"])
         self.assertIsNone(result.selected_token)
         self.assertIn("Every configured Copilot PAT pool entry is rate-limited", result.stdout)
+
+    def test_token_unavailable_pattern_matches_credential_failures(self) -> None:
+        pattern = token_unavailable_pattern()
+
+        for message in (
+            "Failed to fetch PAT user login (401): Bad credentials.",
+            "Authentication token found but could not be validated.",
+            "The authentication token has expired.",
+            "This organization has been disabled.",
+            "Copilot access was disabled by your organization.",
+        ):
+            with self.subTest(message=message):
+                env = os.environ.copy()
+                env.update({"PATTERN": pattern, "MESSAGE": message})
+                result = subprocess.run(
+                    [BASH, "-c", 'printf "%s\\n" "$MESSAGE" | grep -Eiq "$PATTERN"'],
+                    env=env,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, message)
+
+        for message in (
+            "Unexpected internal service failure",
+            "Internal server error: request id req-2401 failed",
+            "Upstream returned HTTP 500 after 2.401 seconds",
+            "Model gpt-401 not found",
+            "Processed 12401 tokens before crashing",
+            "Service unavailable: token bucket refill expired",
+            "Configuration error: organization policy disabled telemetry",
+        ):
+            with self.subTest(message=message):
+                env = os.environ.copy()
+                env.update({"PATTERN": pattern, "MESSAGE": message})
+                result = subprocess.run(
+                    [BASH, "-c", 'printf "%s\\n" "$MESSAGE" | grep -Eiq "$PATTERN"'],
+                    env=env,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 1, message)
 
     def test_actual_run_uses_shared_rate_limit_pattern(self) -> None:
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -468,9 +468,10 @@ esac
 
     def test_pr_report_binds_identity_and_reruns_to_exact_commit(self) -> None:
         workflow = yaml.safe_load(CALLER_WORKFLOW.read_text(encoding="utf-8"))
+        comment_job = workflow["jobs"]["comment-on-pr"]
         steps = {
             step.get("name"): step
-            for step in workflow["jobs"]["comment-on-pr"]["steps"]
+            for step in comment_job["steps"]
         }
         script = steps["Consolidate and post results"]["run"]
 
@@ -489,6 +490,74 @@ esac
             script,
         )
         self.assertNotIn("re-post `/evaluate`", script)
+
+    def test_partial_matrix_results_never_become_complete_verdicts(self) -> None:
+        caller = yaml.safe_load(CALLER_WORKFLOW.read_text(encoding="utf-8"))
+        comment_job = caller["jobs"]["comment-on-pr"]
+        self.assertNotIn(
+            "needs.evaluate.result != 'cancelled'",
+            comment_job["if"],
+        )
+
+        comment_steps = {
+            step.get("name"): step for step in comment_job["steps"]
+        }
+        consolidate_step = comment_steps["Consolidate and post results"]
+        self.assertEqual(consolidate_step["if"], "always()")
+        self.assertEqual(
+            consolidate_step["env"]["EXPECTED_ENTRIES"],
+            "${{ needs.discover.outputs.entries }}",
+        )
+        script = consolidate_step["run"]
+        incomplete_guard = (
+            'if [[ "$EVALUATE_RESULT" != "success" '
+            '|| "$OBSERVED_LEG_COUNT" -ne "$EXPECTED_LEG_COUNT" ]]'
+        )
+        guard_index = script.index(incomplete_guard)
+        consolidation_index = script.index(
+            "node eng/vally-adapter/consolidate.mjs"
+        )
+        self.assertLess(guard_index, consolidation_index)
+        self.assertIn(
+            "were preserved for diagnosis but were not consolidated",
+            script[guard_index:consolidation_index],
+        )
+        self.assertIn(
+            "exit 0",
+            script[guard_index:consolidation_index],
+        )
+        self.assertIn(
+            "find all-results/ -name adapter-summary.json",
+            script[:guard_index],
+        )
+        self.assertIn(
+            "expected %s matrix leg artifact(s), but found %s",
+            script[guard_index:consolidation_index],
+        )
+
+        discover_script = next(
+            step["run"]
+            for step in caller["jobs"]["discover"]["steps"]
+            if "function Get-PluginShardEntries" in step.get("run", "")
+        )
+        self.assertIn(
+            'if (-not (Test-Path $evalPath)) { continue }',
+            discover_script,
+        )
+        self.assertIn(
+            'if ($shardGroups.Count -eq 0) { return @() }',
+            discover_script,
+        )
+
+        runner = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        runner_steps = {
+            step.get("name"): step
+            for step in runner["jobs"]["vally-evaluate"]["steps"]
+        }
+        self.assertEqual(
+            runner_steps["Upload results"]["with"]["if-no-files-found"],
+            "error",
+        )
 
     def test_fork_checkout_is_blocked_and_adapter_code_is_trusted(self) -> None:
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -363,6 +363,30 @@ esac
             steps["Run adapter fault-injection and report tests"]["run"],
         )
 
+    def test_pr_report_binds_identity_and_reruns_to_exact_commit(self) -> None:
+        workflow = yaml.safe_load(CALLER_WORKFLOW.read_text(encoding="utf-8"))
+        steps = {
+            step.get("name"): step
+            for step in workflow["jobs"]["comment-on-pr"]["steps"]
+        }
+        script = steps["Consolidate and post results"]["run"]
+
+        self.assertEqual(
+            script.count(
+                '--commit "${{ needs.gate.outputs.head_sha }}"'
+            ),
+            2,
+        )
+        self.assertIn(
+            "To investigate non-passing or warning results",
+            script,
+        )
+        self.assertIn(
+            "comment `/evaluate %s` to retry this exact commit",
+            script,
+        )
+        self.assertNotIn("re-post `/evaluate`", script)
+
     def test_fork_checkout_is_blocked_and_adapter_code_is_trusted(self) -> None:
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         steps = workflow["jobs"]["vally-evaluate"]["steps"]
@@ -384,23 +408,55 @@ esac
             caller["jobs"]["deploy-dashboard"]["if"],
         )
 
-        restore = by_name["Restore skill-validator archive"]
-        self.assertTrue(restore["uses"].startswith("actions/cache/restore@"))
+        download = by_name["Download trusted skill-validator archive"]
+        self.assertTrue(download["uses"].startswith("actions/download-artifact@"))
         self.assertEqual(
-            restore["with"]["key"],
-            "${{ needs.prepare-validator.outputs.cache-key }}",
+            download["with"]["name"],
+            "trusted-skill-validator-${{ github.run_id }}",
+        )
+        self.assertEqual(
+            download["with"]["path"],
+            "${{ runner.temp }}/trusted-validator-archive",
         )
         self.assertFalse(
-            any(step.get("uses", "").startswith("actions/cache@") for step in steps)
+            any(
+                step.get("uses", "").startswith(
+                    ("actions/cache", "actions/setup-dotnet")
+                )
+                for step in steps
+            )
+        )
+        self.assertFalse(
+            any("dotnet publish" in step.get("run", "") for step in steps)
         )
         producer_steps = workflow["jobs"]["prepare-validator"]["steps"]
         producer_by_name = {step.get("name"): step for step in producer_steps}
         producer_restore = producer_by_name["Restore skill-validator archive"]
         producer_save = producer_by_name["Save skill-validator archive"]
+        producer_upload = producer_by_name["Upload trusted skill-validator archive"]
         self.assertTrue(producer_save["uses"].startswith("actions/cache/save@"))
+        self.assertIn(
+            "github.event_name != 'issue_comment'",
+            producer_save["if"],
+        )
         self.assertEqual(
             producer_restore["with"]["key"],
             "${{ steps.cache-key.outputs.key }}",
+        )
+        self.assertTrue(
+            producer_upload["uses"].startswith("actions/upload-artifact@")
+        )
+        self.assertEqual(
+            producer_upload["with"]["name"],
+            download["with"]["name"],
+        )
+        self.assertEqual(
+            producer_upload["with"]["path"],
+            "skill-validator-dist.tar.gz",
+        )
+        self.assertEqual(
+            producer_upload["with"]["if-no-files-found"],
+            "error",
         )
         cache_key_script = producer_by_name["Resolve trusted cache key"]["run"]
         self.assertIn(
@@ -419,11 +475,10 @@ esac
             stage_script,
         )
 
-        build_script = by_name["Build trusted skill-validator"]["run"]
-        self.assertIn('cd "$RUNNER_TEMP/trusted-validator-src"', build_script)
+        extract_script = by_name["Extract skill-validator"]["run"]
         self.assertIn(
-            '"eng/skill-validator/src/SkillValidator.csproj"',
-            build_script,
+            '"$RUNNER_TEMP/trusted-validator-archive/skill-validator-dist.tar.gz"',
+            extract_script,
         )
 
         run_script = by_name["Run vally evaluations"]["run"]
@@ -455,6 +510,9 @@ esac
             "Vally comparison watchdog expired after 45 minutes",
             run_script,
         )
+        summary_script = by_name["Write summary"]["run"]
+        self.assertIn('ICON="➖"', summary_script)
+        self.assertNotIn('ICON="❌"', summary_script)
         self.assertNotIn(
             "watchdog expired after 45 minutes; uploading partial results",
             run_script,

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -343,9 +343,35 @@ esac
             run_script,
         )
         self.assertIn(
-            'echo "::error::vally produced no skill verdicts for $PLUGIN;',
+            'The result set is incomplete or contains an unexpected eval.',
             run_script,
         )
+        self.assertEqual(
+            run_script.count(
+                '--expected-evals "$RUNNER_TEMP/evaluation-expected-evals.txt"'
+            ),
+            2,
+        )
+        self.assertIn(
+            'if [ "$PRODUCED" -ne "$EXPECTED_EVAL_COUNT" ]',
+            run_script,
+        )
+        self.assertIn("s.expectedManifestProvided === true", run_script)
+        self.assertIn("s.unexpectedEvalCount === 0", run_script)
+        self.assertIn(
+            "Vally comparison watchdog expired after 45 minutes",
+            run_script,
+        )
+        self.assertNotIn(
+            "watchdog expired after 45 minutes; uploading partial results",
+            run_script,
+        )
+        find_script = by_name["Find eval specs"]["run"]
+        self.assertIn(
+            'printf \'%s\\n\' "$EVALS" > "$RUNNER_TEMP/evaluation-expected-evals.txt"',
+            find_script,
+        )
+        self.assertIn('echo "count=$EVAL_COUNT" >> "$GITHUB_OUTPUT"', find_script)
         self.assertIn(
             'grep -Eiq "$COPILOT_RATE_LIMIT_PATTERN" "$VALLY_LOG"',
             run_script,
@@ -361,6 +387,25 @@ esac
         self.assertIn(f"node {trusted_adapter}gen-experiment.mjs", run_script)
         self.assertIn(f"node {trusted_adapter}adapt.mjs", run_script)
         self.assertNotIn("node eng/vally-adapter/", run_script)
+
+    def test_result_consumers_use_explicit_verdict_states(self) -> None:
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["vally-evaluate"]["steps"]
+        summary_script = next(
+            step["run"] for step in steps if step.get("name") == "Write summary"
+        )
+        self.assertIn("INVALID_INCONCLUSIVE", summary_script)
+        self.assertIn("VALID_REGRESSION", summary_script)
+        self.assertIn("PREFERENCE_REGRESSED", summary_script)
+        self.assertNotIn("v.regressed ? 'VALID_REGRESSION'", summary_script)
+        self.assertIn("v.state == null", summary_script)
+
+        caller_text = CALLER_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("primaryState = $p.state", caller_text)
+        self.assertIn(
+            "$p.preferenceRegressed -eq $s.preferenceRegressed",
+            caller_text,
+        )
 
 
 if __name__ == "__main__":

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -307,6 +307,21 @@ esac
             smoke_script,
         )
 
+    def test_adapter_fault_injection_runs_in_pr_ci(self) -> None:
+        workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
+        triggers = workflow.get("on", workflow.get(True))
+        adapter_path = "eng/vally-adapter/**"
+        for event in ("pull_request", "push"):
+            self.assertEqual(triggers[event]["paths"].count(adapter_path), 1)
+
+        job = workflow["jobs"]["vally-adapter"]
+        self.assertEqual(job["runs-on"], "ubuntu-latest")
+        steps = {step.get("name"): step for step in job["steps"]}
+        self.assertIn(
+            "node --test eng/vally-adapter/*.test.mjs",
+            steps["Run adapter fault-injection and report tests"]["run"],
+        )
+
     def test_fork_checkout_is_blocked_and_adapter_code_is_trusted(self) -> None:
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         steps = workflow["jobs"]["vally-evaluate"]["steps"]

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -67,13 +67,20 @@ if env | grep -Eq '^COPILOT_PAT_[0-9]='; then
   exit 11
 fi
 echo "$COPILOT_GITHUB_TOKEN" >> "$ATTEMPTS"
+model=""
+has_effort=false
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--model" ]; then
-    echo "$2" >> "$MODELS"
-    break
-  fi
-  shift
+  case "$1" in
+    --model) model="$2"; shift 2 ;;
+    --effort=*) has_effort=true; shift ;;
+    *) shift ;;
+  esac
 done
+echo "$model" >> "$MODELS"
+if [ "$model" = "no-effort-model" ] && [ "$has_effort" = true ]; then
+  echo 'Error: Model "no-effort-model" does not support reasoning effort configuration (requested: "low").' >&2
+  exit 1
+fi
 case "$COPILOT_GITHUB_TOKEN" in
   rate-limited) echo "403 API rate limit exceeded" >&2; exit 1 ;;
   weekly-rate-limited) echo '{"type":"session.error","data":{"errorType":"rate_limit","errorCode":"user_weekly_rate_limited","message":"You have reached your weekly rate limit"}}' >&2; exit 1 ;;
@@ -82,6 +89,7 @@ case "$COPILOT_GITHUB_TOKEN" in
   weekly-message) echo "You have reached your weekly rate limit" >&2; exit 1 ;;
   timed-out) exit 124 ;;
   unauthorized) echo "401 Unauthorized" >&2; exit 7 ;;
+  unauthorized-after-effort) echo "401 Unauthorized after effort retry" >&2; exit 7 ;;
   healthy) exit 0 ;;
   *) echo "unexpected test token" >&2; exit 9 ;;
 esac
@@ -185,6 +193,39 @@ esac
         self.assertEqual(result.attempts, ["healthy", "healthy"])
         self.assertEqual(result.models, ["agent-model", "judge-model"])
         self.assertEqual(result.selected_token, "healthy")
+
+    def test_model_without_effort_support_is_retried_without_effort(self) -> None:
+        result = self.run_selector(
+            {0: "healthy"},
+            model="no-effort-model",
+            judge_model="judge-model",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.attempts, ["healthy", "healthy", "healthy"])
+        self.assertEqual(
+            result.models,
+            ["no-effort-model", "no-effort-model", "judge-model"],
+        )
+        self.assertEqual(result.selected_token, "healthy")
+        self.assertIn("retrying its availability probe without --effort", result.stdout)
+
+    def test_model_without_effort_support_fails_closed_after_one_retry(self) -> None:
+        result = self.run_selector(
+            {0: "unauthorized-after-effort", 1: "healthy"},
+            model="no-effort-model",
+            judge_model="judge-model",
+        )
+
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(
+            result.attempts,
+            ["unauthorized-after-effort", "unauthorized-after-effort"],
+        )
+        self.assertEqual(result.models, ["no-effort-model", "no-effort-model"])
+        self.assertIsNone(result.selected_token)
+        self.assertIn("non-rate-limit error", result.stdout)
+        self.assertIn("401 Unauthorized after effort retry", result.stdout)
 
     def test_non_rate_limit_failure_does_not_try_another_token(self) -> None:
         result = self.run_selector({0: "unauthorized", 1: "healthy"})

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -510,7 +510,8 @@ esac
         )
         script = consolidate_step["run"]
         incomplete_guard = (
-            'if [[ "$EVALUATE_RESULT" != "success" '
+            'if [[ "$MATRIX_MANIFEST_VALID" != "true" '
+            '|| "$EVALUATE_RESULT" != "success" '
             '|| "$OBSERVED_LEG_COUNT" -ne "$EXPECTED_LEG_COUNT" ]]'
         )
         guard_index = script.index(incomplete_guard)
@@ -529,6 +530,14 @@ esac
         self.assertIn(
             "find all-results/ -name adapter-summary.json",
             script[:guard_index],
+        )
+        self.assertIn(
+            "if ! EXPECTED_LEG_COUNT=$(printf",
+            script[:guard_index],
+        )
+        self.assertIn(
+            "the discovered entry list was missing, malformed, or not a JSON array",
+            script[guard_index:consolidation_index],
         )
         self.assertIn(
             "expected %s matrix leg artifact(s), but found %s",
@@ -678,6 +687,8 @@ esac
         )
         self.assertIn("s.expectedManifestProvided === true", run_script)
         self.assertIn("s.unexpectedEvalCount === 0", run_script)
+        self.assertIn("s.measurementInvalidEvalCount === 0", run_script)
+        self.assertNotIn("s.invalidEvalCount === 0", run_script)
         self.assertIn(
             "Vally comparison watchdog expired after 45 minutes",
             run_script,

--- a/eng/skill-validator/src/README.md
+++ b/eng/skill-validator/src/README.md
@@ -466,4 +466,6 @@ Results include bootstrap confidence intervals computed across individual runs. 
 - **not significant**: the CI crosses zero — could be noise
 - **g=**: normalized gain, controlling for ceiling effects (a skill improving a strong baseline is harder than improving a weak one)
 
-The default of 5 runs provides sufficient precision for significance testing (validated by [SkillsBench](https://arxiv.org/abs/2602.12670)).
+These intervals describe the legacy run-pooled report. The repository's current
+Vally gate does not treat repeated runs as independent task samples: runs measure
+within-stimulus reliability, while distinct stimuli supply the statistical votes.

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -2,6 +2,14 @@
 
 > **⚠️ Skill evaluations now run on the Vally harness.** As of the Vally migration, the LLM eval pipeline (`evaluation.yml`) no longer uses `skill-validator evaluate`; it runs Vally via `eng/vally-adapter/` and uploads `vally-results-*` artifacts. For investigating current eval failures, use the guide at `eng/vally-adapter/InvestigatingResults.md` in the repository root instead. This document describes the legacy `skill-validator evaluate` schema and is retained for historical results and reference. (The `skill-validator check` **linter** is unaffected and still runs via `skill-check.yml`.)
 
+> **Current Vally schema:** `state` is authoritative:
+> `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or
+> `INVALID_INCONCLUSIVE`. Use `stateReason` and `errors[]` for machine-readable
+> causes. `preferenceRegressed` is report-only LLM preference evidence and is
+> not an objective completion regression. `adapter-summary.json` reconciles the
+> exact expected-eval manifest with observed and written results. These fields
+> do not exist in the legacy schema documented below.
+
 This guide is intended primarily for AI agents investigating skill evaluation failures, though humans will find it useful too. It documents the `results.json` schema, common failure patterns, and recommended fixes.
 
 ## Using this guide with an AI agent

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -7,8 +7,11 @@
 > `INVALID_INCONCLUSIVE`. Use `stateReason` and `errors[]` for machine-readable
 > causes. `preferenceRegressed` is report-only LLM preference evidence and is
 > not an objective completion regression. `adapter-summary.json` reconciles the
-> exact expected-eval manifest with observed and written results. These fields
-> do not exist in the legacy schema documented below.
+> exact expected-eval manifest with observed and written results.
+> `practicalSignificance` adds the 20% net-win floor. Objective completion is a
+> separately defined tri-state over explicitly selected deterministic graders;
+> aggregate Vally pass booleans remain report-only. These fields do not exist
+> in the legacy schema documented below.
 
 This guide is intended primarily for AI agents investigating skill evaluation failures, though humans will find it useful too. It documents the `results.json` schema, common failure patterns, and recommended fixes.
 

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -2,6 +2,10 @@
 
 This guide is for AI agents (and humans) investigating non-passing, invalid, or warning-bearing skill evaluation results produced by the **Vally** harness via `eng/vally-adapter/adapt.mjs`. It documents the `results.json` schema, how to reach the raw Vally output, common result patterns, and recommended fixes.
 
+For the end-to-end architecture, decision policy, metric definitions, and
+historical examples, start with the
+[Skill evaluation infrastructure overview](./README.md).
+
 Evaluations run through Vally (`@microsoft/vally-cli`): every skill's `tests/<plugin>/<skill>/eval.yaml` is run in up to three variants — **baseline** (no skills), **skilled** (only the skill under test), and **plugin** (the whole plugin loaded). The workflow records the exact expected-eval manifest before execution. The adapter then runs `vally compare` (a debiased, position-swapped head-to-head judgment of skilled vs baseline) and writes one `results.json` per expected skill, including an explicit invalid result when required evidence is missing.
 
 > Note: the linter (`skill-validator check`) is a **separate** workflow (`skill-check.yml`) and is unrelated to these eval results.

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -126,9 +126,14 @@ Each scenario merges the compare preference for that stimulus with the absolute 
 
 `adapter-summary.json` is the result-set accounting record. It contains
 `expectedEvalCount`, `observedEvalCount`, `writtenResultCount`, `missingEvals`,
-`unexpectedEvals`, and `invalidEvals`. The workflow also checks that the number
-of primary result files equals the exact pre-run manifest count. A missing eval
-cannot disappear while unrelated results make the job look complete.
+`unexpectedEvals`, `invalidEvals`, and `measurementInvalidEvals`.
+`measurementInvalidEvals` is the fail-closed subset: missing baseline or skilled
+records, unresolved judge or pairing failures, malformed reports, and other
+adapter failures. It excludes only the explicit `underpowered` eval-design
+state. The workflow requires this list to be empty and also checks that the
+number of primary result files equals the exact pre-run manifest count. A
+missing or invalid measurement cannot disappear while unrelated results make
+the job look complete.
 
 ## Reaching the raw Vally output
 

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -28,7 +28,7 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 |--------|---------|
 | `Skill` | Skill under test |
 | `Result` | ✅ `VALID_PASS` / 🔻 objective `VALID_REGRESSION` / ❌ `VALID_NO_CHANGE` / 📉 report-only LLM preference loss / ⚠️ `INVALID_INCONCLUSIVE` |
-| `Net win` | `(wins − losses) / trials`. **The deciding effect size** |
+| `Net win` | `(wins − losses) / trials`. Must be at least +20% for a pass |
 | `p` | One-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials |
 | `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |
 | `W/T/L` | Wins / ties / losses across trials |
@@ -60,8 +60,9 @@ A verdict carries **both** the head-to-head preference and absolute per-role dat
 | `skillName` / `skillPath` | The skill under test |
 | `state` | One of `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or `INVALID_INCONCLUSIVE` |
 | `stateReason` | Machine-readable `{ code, phase }`. Use this field for automation; do not parse `reason` |
-| `passed` | **The gate.** `true` only on a credible net win: more wins than losses at `signTest.pValue <= 0.05`, `conclusive`, and not `underpowered` |
+| `passed` | **The gate.** `true` only when `conclusive`, not `underpowered`, `signTest.pValue <= 0.05`, and `netWin >= 0.20` |
 | `netWin` | `(wins − losses) / trials` — the effect size the gate reads. Magnitude-free, so an identical W/T/L record always yields an identical verdict |
+| `practicalSignificance` | `{ netWin, minimum, passed }`. The absolute directional effect must reach 20%; this blocks sparse records such as `5W/95T/0L` |
 | `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over the discordant (non-tie) trials. **This is what decides.** Ties can't support a win, so they hold `discordant` down |
 | `regressed` / `preferenceRegressed` | Compatibility and explicit fields for a credible LLM preference loss. Under schema version 2 this maps to `VALID_NO_CHANGE`, not `VALID_REGRESSION`, because ordinal LLM preference is not objective completion evidence. Renderers apply the same report-only meaning to legacy records that have `regressed: true` but no `state` |
 | `conclusive` | `false` when the comparison didn't complete: errored trials, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
@@ -120,6 +121,11 @@ Work top-down; earlier categories often cause later ones.
 ### 1. Errored or missing trials (`state == "INVALID_INCONCLUSIVE"`)
 The agent crashed, the model was unavailable, evidence was missing, or the comparison judge failed. Check `stateReason`, `errors[]`, `adapter-summary.json`, and the variant's `results.jsonl`/session logs. These are invalid measurements, not skill regressions. If a required variant produced no records, the adapter writes an explicit invalid result with `missing_baseline_records` or `missing_skilled_records`.
 
+If Vally writes a JSON record that cannot satisfy the comparison schema, the
+adapter emits `comparison_report_invalid` for that eval and continues the batch.
+This preserves exact result accounting without treating malformed evidence as a
+quality result.
+
 For comparison-judge failures, inspect `errors[].code`. Known codes include
 `judge_session_idle_timeout`, `judge_organization_disabled`,
 `judge_rate_limited`, and `judge_service_error`. The adapter makes one targeted retry. It keeps every
@@ -140,10 +146,11 @@ Do not "fix" the skill in response to this. Fix the eval: add scenarios (strongl
 
 Clearing the floor is necessary, not sufficient. The sign test conditions on the **discordant** (non-tie) trials, so an eval at exactly 5 counted trials only passes on a flawless 5W/0T/0L sweep — one tie leaves 4 discordant and puts it back below the floor without setting `underpowered`. Check `signTest.discordant`, not `trialCount`, when a record with more wins than losses still fails.
 
-### 5. No credible net win (`passed == false` with `netWin <= 0` or `signTest.pValue > 0.05`)
+### 5. No credible or practical net win
 The judge didn't consistently prefer the skilled run over baseline.
 - **`netWin <= 0`** — at least as many losses as wins. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. If `preferenceRegressed` is `true`, the LLM judge credibly preferred baseline. This is report-only preference evidence, not an objective completion regression.
 - **`netWin > 0` but `signTest.pValue > 0.05`** — a real but inconsistent signal: the skill wins some scenarios and ties or loses others. Ties count against here, because they hold the discordant trial count down. Add more/broader scenarios so there is enough evidence, and make the skill help consistently rather than occasionally.
+- **`signTest.pValue <= 0.05` but `practicalSignificance.passed == false`** — the direction is statistically credible but too sparse to matter across counted trials. For example, `5W/95T/0L` has `p=0.03125` but only a 5% net win. Add discriminating scenarios or improve the skill; do not add repeated ties.
 - Do **not** read `meanScore` here. It is magnitude-weighted and reported for triage only; a verdict never turns on it (see `eng/eval-quality/README.md`, "Why the gate scores direction, not magnitude").
 - Inspect `scenarios[].trials[].evidence` for the judge's reasoning on losses/ties, and compare the skilled vs baseline `events.jsonl` to see what the skill changed (or failed to change).
 
@@ -152,9 +159,32 @@ The judge didn't consistently prefer the skilled run over baseline.
 `completionTransitions` counts aggregate `baselinePassed` and
 `treatmentPassed` transitions from Vally compare. It is not a hard gate:
 Vally's aggregate pass can include LLM grader output, so it is not an objective
-task-completion primitive. `VALID_REGRESSION` is reserved until Vally exposes
-objective per-grader completion evidence. Do not infer an objective regression
-from `completionTransitions.baselineOnly`.
+task-completion primitive. Do not infer an objective regression from
+`completionTransitions.baselineOnly`.
+
+The required objective primitive is tri-state per
+`(eval, stimulus, trialIndex, arm)`: `true` only when all explicitly marked,
+allowlisted deterministic completion graders pass; `false` when one explicitly
+fails and none is missing or errored; otherwise `unknown`. It must use raw
+per-grader details matched by `(graderType, name)`, never aggregate pass,
+weights, thresholds, LLM graders, or human graders. One baseline-only
+transition is only a candidate. `VALID_REGRESSION` additionally requires
+conclusive paired confirmation at `p <= 0.05`, at least a 20% objective net
+loss, and correction across multiple tested completion scenarios.
+
+Vally 0.13 supplies `graderType` in raw grader details, but evals do not yet
+declare which deterministic graders are task-completion invariants and compare
+JSONL still exposes only aggregate booleans. Therefore the state remains
+reserved and the aggregate transition remains report-only.
+
+### Vally 0.13 comparison identity
+
+Vally 0.13 comparison trials retain the `(stimulusName, trialIndex)` identity
+used by retry merging. Repeated compare calls over the same persisted inputs
+produce the same indices. Do not treat the index as a durable ID across
+regenerated runs or future Vally versions. An all-errored comparison exits
+nonzero in 0.13 after writing its report; the adapter reads that report so it
+can retry and classify the failure.
 
 ### 7. Quality looks fine but the skill still fails the gate
 The gate is a **preference** comparison, not an absolute score. A high `skilledIsolated.judgeResult.overallScore` that isn't clearly better than `baseline.judgeResult.overallScore` will not pass. Focus on the *delta* over baseline, not the absolute number.

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -1,6 +1,6 @@
 # Investigating Evaluation Results (Vally)
 
-This guide is for AI agents (and humans) investigating skill evaluation failures produced by the **Vally** harness via `eng/vally-adapter/adapt.mjs`. It documents the `results.json` schema, how to reach the raw Vally output, common failure patterns, and recommended fixes.
+This guide is for AI agents (and humans) investigating non-passing, invalid, or warning-bearing skill evaluation results produced by the **Vally** harness via `eng/vally-adapter/adapt.mjs`. It documents the `results.json` schema, how to reach the raw Vally output, common result patterns, and recommended fixes.
 
 Evaluations run through Vally (`@microsoft/vally-cli`): every skill's `tests/<plugin>/<skill>/eval.yaml` is run in up to three variants — **baseline** (no skills), **skilled** (only the skill under test), and **plugin** (the whole plugin loaded). The workflow records the exact expected-eval manifest before execution. The adapter then runs `vally compare` (a debiased, position-swapped head-to-head judgment of skilled vs baseline) and writes one `results.json` per expected skill, including an explicit invalid result when required evidence is missing.
 
@@ -8,35 +8,52 @@ Evaluations run through Vally (`@microsoft/vally-cli`): every skill's `tests/<pl
 
 ## Using this guide with an AI agent
 
-When an evaluation has failures, the PR comment includes a ready-to-use prompt — copy it to your AI agent. The agent downloads the artifacts, reads this guide, analyzes the `results.json` files, and suggests fixes.
+When an evaluation has a non-pass or warning, the PR comment includes a ready-to-use prompt. Copy it to your AI agent. The agent downloads the artifacts, reads this guide, analyzes the `results.json` files, and suggests fixes.
 
 ## Quick start
 
 1. **Download the results artifacts:** `gh run download <run-id> --repo dotnet/skills --pattern "vally-results-*" --dir ./eval-results`
-2. **Skim the run's step summary** (the "Full Results" link) for the consolidated pass/fail table.
+2. **Skim the run's step summary** (the "Full Results" link) for the complete metrics and scenario tables.
 3. **Read `adapter-summary.json` and each `results.json`** (`eval-results/vally-results-*/<plugin>/<skill>/results.json`). The summary proves expected-versus-produced accounting; each skill file gives the compare state and evidence.
-4. **Identify the failure pattern** using the categories below and fix in priority order: infra/errored trials → timeouts → activation → quality/preference.
-5. **Apply the fix** and re-run with `/evaluate`.
+4. **Identify the result pattern** using the categories below and fix in priority order: invalid accounting or judge evidence → timeouts → activation → underpowered design → quality/preference.
+5. **Apply the fix**, push it, and evaluate that exact commit. Submit a PR review containing `/evaluate` (recommended), or comment `/evaluate <new-head-sha>` in the PR conversation.
 
 > The `--pattern "vally-results-*"` flag matters — without it, `gh` also tries to download non-zip artifacts and exits non-zero.
 
 ## The PR comment
 
-`eng/vally-adapter/consolidate.mjs` renders the comment (and the fuller step summary). Its table has these columns:
+`eng/vally-adapter/consolidate.mjs` renders the comment and the fuller step summary. The PR comment starts with:
+
+- the number of unique skills, execution models, and model/skill results;
+- the exact evaluated commit and judge model;
+- expected / observed / written result accounting, with missing, unexpected,
+  invalid, recovered, and unresolved counts; and
+- an explicit notice that the objective completion regression gate is not
+  enabled.
+
+Its compact table has these columns:
 
 | Column | Meaning |
 |--------|---------|
 | `Skill` | Skill under test |
-| `Result` | ✅ `VALID_PASS` / 🔻 objective `VALID_REGRESSION` / ❌ `VALID_NO_CHANGE` / 📉 report-only LLM preference loss / ⚠️ `INVALID_INCONCLUSIVE` |
-| `Net win` | `(wins − losses) / distinct stimulus votes`. Must be at least +20% for a pass |
-| `p` | One-sided exact sign test over discordant (non-tie) stimulus votes. A pass at `p ≤ 0.05` needs at least 5 winning votes |
-| `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |
-| `W/T/L` | Wins / ties / losses after repeated runs collapse to one vote per stimulus |
-| `Quality` (+ `Quality (Plugin)` in the full step summary) / `Baseline` | Mean absolute judge score 0–5 for skilled isolated (and plugin) vs the skill-free control |
+| `Model` | Model used for the baseline and skilled agent runs. This prevents duplicate skill rows from being ambiguous |
+| `Verdict` | ✅ Improved / ➖ Not proven improved / 📉 Preference loss (report only) / ⚠️ Invalid or underpowered / 🔻 Objective regression when that future gate is enabled |
+| `Gate evidence` | `n` distinct-stimulus votes, stimulus W/T/L, `d` discordant votes, exact one-sided `p`, and net win. A pass needs `p ≤ 0.05` and net win ≥20% |
 | `Overfit` | Overfitting-judge severity — ✅ Low, 🟡 Moderate, 🔴 High, — none — with its score |
-| `Skills Loaded` | Of scenarios that expect activation, how many the skill activated / that total (plugin run shown when present); ⚠️ flags a scenario that expected activation but didn't activate |
+| `Warnings` | Activation gaps, timeouts, recovered judge slots, and unresolved comparison errors |
+| `Next action` | A cause-specific repair step. It does not recommend more repeated runs as a power fix |
 
-A collapsible **Column legend** and a per-skill **details** block follow the table. Each details block shows `state`, `stateReason`, comparison-error codes, retry recovery, authoritative stimulus-vote evidence, separate repeated-run reliability evidence, the human-readable `reason`, and a per-scenario table. `--format full` (the step summary) adds the `Quality (Plugin)` column; `--format simple` (the PR comment) omits it.
+A collapsible **How to read this report** block follows the table. The PR
+comment includes details only for non-passing, invalid, or warning-bearing
+results. Each block says why the result did not pass, gives the next repair
+action, names weak or warning scenarios, includes one clearly labeled
+illustrative judge excerpt when available, and separates repeated-run
+reliability from stimulus-vote gate evidence.
+
+`--format full` (the workflow summary) keeps every result and adds `Δ Pref`,
+isolated/plugin quality, and baseline quality. These are triage metrics. They
+are not the gate. The `p` value applies to one model/skill result; the renderer
+does not apply a matrix-wide multiple-comparison correction.
 
 ## Understanding `results.json`
 
@@ -118,7 +135,7 @@ The adapter's `results.json` is a summary. The uploaded artifact also contains t
 
 To see exactly what the agent did for a failing scenario, open its `events.jsonl` (match on `variant` + `stimulusName` in the sibling `metadata.json`).
 
-## Failure patterns and fixes
+## Result patterns and fixes
 
 Work top-down; earlier categories often cause later ones.
 
@@ -197,4 +214,14 @@ The gate is a **preference** comparison, not an absolute score. A high `skilledI
 
 ## Re-running
 
-Push the fix and comment `/evaluate` on the PR (optionally `/evaluate <plugin>` to scope). The workflow re-runs Vally, regenerates the verdicts, and updates the PR comment.
+Push the fix, then bind the new run to its exact commit:
+
+1. **Recommended:** open **Files changed → Review changes**, enter `/evaluate`,
+   and submit the review. GitHub supplies the reviewed commit ID.
+2. **PR conversation:** comment `/evaluate <new-head-sha>`. A bare conversation
+   comment does not run an evaluation because `issue_comment` has no trusted
+   commit identity.
+
+For a transient retry without a code change, use the exact SHA printed in the
+result comment. The workflow regenerates the verdicts and updates the PR
+comment.

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -84,10 +84,10 @@ A verdict carries **both** the head-to-head preference and absolute per-role dat
 | `passed` | **The gate.** `true` only when `conclusive`, at least 5 distinct stimuli were counted, `signTest.pValue <= 0.05`, and `netWin >= 0.20` |
 | `netWin` | `(wins − losses) / stimulus votes` — the effect size the gate reads. Magnitude-free, so an identical stimulus W/T/L record always yields an identical verdict |
 | `practicalSignificance` | `{ netWin, minimum, passed }`. The absolute directional effect must reach 20%; this blocks sparse records such as `5W/95T/0L` |
-| `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over discordant stimulus votes. **This is what decides.** Ties cannot support a win, so they hold `discordant` down |
-| `regressed` / `preferenceRegressed` | Compatibility and explicit fields for a credible LLM preference loss. Under schema version 2 this maps to `VALID_NO_CHANGE`, not `VALID_REGRESSION`, because ordinal LLM preference is not objective completion evidence. Renderers apply the same report-only meaning to legacy records that have `regressed: true` but no `state` |
+| `signTest` | `{ wins, ties, losses, discordant, direction, pValue, alpha }` — exact one-sided binomial tail over discordant stimulus votes. **This is what decides.** Ties cannot support a win, so they hold `discordant` down |
+| `regressed` / `preferenceRegressed` | Compatibility and explicit fields for a credible LLM preference loss. In the current schema version 3 this maps to `VALID_NO_CHANGE`, not `VALID_REGRESSION`, because ordinal LLM preference is not objective completion evidence. Renderers apply the same report-only meaning to legacy records that have `regressed: true` but no `state` |
 | `conclusive` | `false` when the comparison did not complete: errored runs, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
-| `underpowered` | `true` when a *completed* comparison counted fewer than `minCredibleStimuli` distinct stimuli, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. Disjoint from `conclusive` |
+| `underpowered` | `true` only when a completed, `conclusive: true` comparison counted fewer than `minCredibleStimuli` distinct stimuli, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. This is separate from the `conclusive: false` error path |
 | `minCredibleStimuli` | The distinct-stimulus floor in force (5). See `eng/eval-quality/README.md` for why |
 | `minCredibleTrials` | Compatibility alias for `minCredibleStimuli` |
 | `meanScore` | Vally's magnitude-weighted mean preference (`much-better` ±1.0, `slightly-better` ±0.4), −1..1. **Triage only — not the gate**; weighting the statistic by magnitude is what made verdicts flip in dotnet/skills#952 |
@@ -204,14 +204,17 @@ completion invariants, and compare JSONL exposes only aggregate booleans.
 Therefore the state remains reserved and the aggregate transition remains
 report-only.
 
-### Vally 0.13 comparison identity
+### Comparison slot identity
 
-Vally 0.13 comparison trials retain the `(stimulusName, trialIndex)` identity
-used by retry merging. Repeated compare calls over the same persisted inputs
-produce the same indices. Do not treat the index as a durable ID across
-regenerated runs or future Vally versions. An all-errored comparison exits
-nonzero in 0.13 after writing its report; the adapter reads that report so it
-can retry and classify the failure.
+Comparison trials use `(stimulusName, trialIndex)` as the retry slot identity.
+Repeated compare calls over the same persisted inputs must produce the same
+indices. The adapter rejects missing or duplicate identities instead of pairing
+trials by array position. Treat the index as scoped to one persisted experiment,
+not as a durable ID across regenerated runs.
+
+If compare writes a structured report but exits nonzero, the adapter still
+reads the report so it can classify and retry errored slots. A nonzero exit with
+no report remains an invocation failure.
 
 ### 7. Quality looks fine but the skill still fails the gate
 The gate is a **preference** comparison, not an absolute score. A high `skilledIsolated.judgeResult.overallScore` that isn't clearly better than `baseline.judgeResult.overallScore` will not pass. Focus on the *delta* over baseline, not the absolute number.

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -2,7 +2,7 @@
 
 This guide is for AI agents (and humans) investigating skill evaluation failures produced by the **Vally** harness via `eng/vally-adapter/adapt.mjs`. It documents the `results.json` schema, how to reach the raw Vally output, common failure patterns, and recommended fixes.
 
-Evaluations run through Vally (`@microsoft/vally-cli`): every skill's `tests/<plugin>/<skill>/eval.yaml` is run in up to three variants — **baseline** (no skills), **skilled** (only the skill under test), and **plugin** (the whole plugin loaded). The adapter then runs `vally compare` (a debiased, position-swapped head-to-head judgment of skilled vs baseline) and writes one `results.json` per skill.
+Evaluations run through Vally (`@microsoft/vally-cli`): every skill's `tests/<plugin>/<skill>/eval.yaml` is run in up to three variants — **baseline** (no skills), **skilled** (only the skill under test), and **plugin** (the whole plugin loaded). The workflow records the exact expected-eval manifest before execution. The adapter then runs `vally compare` (a debiased, position-swapped head-to-head judgment of skilled vs baseline) and writes one `results.json` per expected skill, including an explicit invalid result when required evidence is missing.
 
 > Note: the linter (`skill-validator check`) is a **separate** workflow (`skill-check.yml`) and is unrelated to these eval results.
 
@@ -14,7 +14,7 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 
 1. **Download the results artifacts:** `gh run download <run-id> --repo dotnet/skills --pattern "vally-results-*" --dir ./eval-results`
 2. **Skim the run's step summary** (the "Full Results" link) for the consolidated pass/fail table.
-3. **Read each `results.json`** (`eval-results/vally-results-*/<plugin>/<skill>/results.json`) for the compare verdict and per-scenario metrics.
+3. **Read `adapter-summary.json` and each `results.json`** (`eval-results/vally-results-*/<plugin>/<skill>/results.json`). The summary proves expected-versus-produced accounting; each skill file gives the compare state and evidence.
 4. **Identify the failure pattern** using the categories below and fix in priority order: infra/errored trials → timeouts → activation → quality/preference.
 5. **Apply the fix** and re-run with `/evaluate`.
 
@@ -27,7 +27,7 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 | Column | Meaning |
 |--------|---------|
 | `Skill` | Skill under test |
-| `Result` | ✅ credible net win / 🔻 credible regression / ❌ no credible change / ⚠️ the gate withheld a verdict (underpowered eval, or a comparison that errored, had unmatched trials, or contradicted itself) |
+| `Result` | ✅ `VALID_PASS` / 🔻 objective `VALID_REGRESSION` / ❌ `VALID_NO_CHANGE` / 📉 report-only LLM preference loss / ⚠️ `INVALID_INCONCLUSIVE` |
 | `Net win` | `(wins − losses) / trials`. **The deciding effect size** |
 | `p` | One-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials |
 | `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |
@@ -36,7 +36,7 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 | `Overfit` | Overfitting-judge severity — ✅ Low, 🟡 Moderate, 🔴 High, — none — with its score |
 | `Skills Loaded` | Of scenarios that expect activation, how many the skill activated / that total (plugin run shown when present); ⚠️ flags a scenario that expected activation but didn't activate |
 
-A collapsible **Column legend** and a per-skill **details** block follow the table. Each details block shows the verdict `reason` and a `Scenario | Mean preference | Trials (W/T/L)` table, so per-scenario detail is one click away in the PR itself. `--format full` (the step summary) adds the `Quality (Plugin)` column; `--format simple` (the PR comment) omits it. Both formats include the Overfit, Skills Loaded, legend, and details.
+A collapsible **Column legend** and a per-skill **details** block follow the table. Each details block shows `state`, `stateReason`, comparison-error codes, retry recovery, report-only effective-scenario evidence, the human-readable `reason`, and a per-scenario table. `--format full` (the step summary) adds the `Quality (Plugin)` column; `--format simple` (the PR comment) omits it.
 
 ## Understanding `results.json`
 
@@ -44,6 +44,8 @@ Each file has a top-level object:
 
 | Field | Description |
 |-------|-------------|
+| `schemaVersion` | Adapter schema version. Version 2 adds explicit states and evidence provenance |
+| `evalFile` / `expectedEval` | Normalized eval path and whether it was in the pre-run manifest |
 | `model` | Model used for agent runs |
 | `judgeModel` | Model used by `vally compare` |
 | `timestamp` | When results were written (UTC) |
@@ -51,15 +53,17 @@ Each file has a top-level object:
 
 ### Verdict structure
 
-A verdict carries **both** the head-to-head preference (what gates the PR) and absolute per-role data (what the dashboard charts).
+A verdict carries **both** the head-to-head preference and absolute per-role data. `state` is authoritative. Boolean fields remain for compatibility with older consumers.
 
 | Field | Description |
 |-------|-------------|
 | `skillName` / `skillPath` | The skill under test |
+| `state` | One of `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or `INVALID_INCONCLUSIVE` |
+| `stateReason` | Machine-readable `{ code, phase }`. Use this field for automation; do not parse `reason` |
 | `passed` | **The gate.** `true` only on a credible net win: more wins than losses at `signTest.pValue <= 0.05`, `conclusive`, and not `underpowered` |
 | `netWin` | `(wins − losses) / trials` — the effect size the gate reads. Magnitude-free, so an identical W/T/L record always yields an identical verdict |
 | `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over the discordant (non-tie) trials. **This is what decides.** Ties can't support a win, so they hold `discordant` down |
-| `regressed` | `true` when the *losses* are credible by the same test — the mirror of `passed` |
+| `regressed` / `preferenceRegressed` | Compatibility and explicit fields for a credible LLM preference loss. Under schema version 2 this maps to `VALID_NO_CHANGE`, not `VALID_REGRESSION`, because ordinal LLM preference is not objective completion evidence. Renderers apply the same report-only meaning to legacy records that have `regressed: true` but no `state` |
 | `conclusive` | `false` when the comparison didn't complete: errored trials, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
 | `underpowered` | `true` when a *completed* comparison counted fewer than `minCredibleTrials` trials, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. Disjoint from `conclusive` |
 | `minCredibleTrials` | The trial floor in force (5). See `eng/eval-quality/README.md` for why |
@@ -67,6 +71,10 @@ A verdict carries **both** the head-to-head preference (what gates the PR) and a
 | `confidenceInterval` | `{ low, high, level: 0.95 }` — the 95% CI on `meanScore`, reported alongside it |
 | `winRate`, `wins`, `ties`, `losses` | Trial-level head-to-head tally as vally reported it |
 | `trialCount`, `erroredCount` | Counted trials (scenarios × `defaults.runs`) and how many errored (errored trials don't count toward either statistic) |
+| `comparisonAttempts` | Retry telemetry. Successful first-attempt slots are frozen; only errored slots can be filled by attempt 2 |
+| `errors[]` / `recoveredErrors[]` | Structured unresolved and recovered comparison failures, with phase, code, stimulus, trial, and attempt provenance |
+| `scenarioEvidence` | One effective vote per stimulus after repeated runs are collapsed. Report-only (`gateEligible: false`) |
+| `completionTransitions` | Baseline/treatment aggregate pass transitions. Report-only because Vally aggregate pass can include LLM grading |
 | `reason` | Human-readable summary of the above |
 | `scenarios[]` | Per-scenario detail (below) |
 
@@ -88,6 +96,14 @@ Each scenario merges the compare preference for that stimulus with the absolute 
 
 `metrics` on each role: `{ wallTimeMs, tokenEstimate, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens }`.
 
+### Adapter summary
+
+`adapter-summary.json` is the result-set accounting record. It contains
+`expectedEvalCount`, `observedEvalCount`, `writtenResultCount`, `missingEvals`,
+`unexpectedEvals`, and `invalidEvals`. The workflow also checks that the number
+of primary result files equals the exact pre-run manifest count. A missing eval
+cannot disappear while unrelated results make the job look complete.
+
 ## Reaching the raw Vally output
 
 The adapter's `results.json` is a summary. The uploaded artifact also contains the full Vally run under `artifacts/TestResults/vally/<entry>/`:
@@ -101,8 +117,15 @@ To see exactly what the agent did for a failing scenario, open its `events.jsonl
 
 Work top-down; earlier categories often cause later ones.
 
-### 1. Errored or missing trials (`erroredCount > 0`, or a variant produced no records)
-The agent crashed, the model was unavailable, or the environment failed. Check the run logs and the variant's `results.jsonl`/session logs. These are usually infra/flake — re-run before treating as a real regression. If the **skilled** or **baseline** variant produced no records, the adapter writes no verdict for that skill (a warning is emitted).
+### 1. Errored or missing trials (`state == "INVALID_INCONCLUSIVE"`)
+The agent crashed, the model was unavailable, evidence was missing, or the comparison judge failed. Check `stateReason`, `errors[]`, `adapter-summary.json`, and the variant's `results.jsonl`/session logs. These are invalid measurements, not skill regressions. If a required variant produced no records, the adapter writes an explicit invalid result with `missing_baseline_records` or `missing_skilled_records`.
+
+For comparison-judge failures, inspect `errors[].code`. Known codes include
+`judge_session_idle_timeout`, `judge_organization_disabled`,
+`judge_rate_limited`, and `judge_service_error`. The adapter makes one targeted retry. It keeps every
+successful first-attempt judgment fixed and replaces only errored slots. A
+recovered transient appears in `recoveredErrors[]`; an unresolved failure stays
+in `errors[]` and makes the state invalid.
 
 ### 2. Timeouts (`scenario.timedOut == true`, `trajectory.endReason == "agent_timeout"`)
 The agent didn't finish within the eval's `config.timeout`. Either the task is too large for the budget or the skill sent the agent down a slow path. Fixes: raise `config.timeout` in `eval.yaml` if the task legitimately needs more time, or tighten the skill so it converges faster.
@@ -111,7 +134,7 @@ The agent didn't finish within the eval's `config.timeout`. Either the task is t
 The skill was available but the agent never invoked it, so "skilled" ≈ "baseline" and no improvement is possible. Fixes: sharpen the skill's `description`/trigger phrasing in `SKILL.md` so the model recognizes when to use it, and make sure the eval prompt actually describes a task the skill targets.
 
 ### 4. Underpowered eval (`underpowered == true`)
-Not a skill problem — an eval problem. The gate is an exact one-sided sign test over the head-to-head trials, and `trials = scenarios × defaults.runs`. That test cannot reach `p ≤ 0.05` on fewer than five discordant trials (`0.5⁴ = 0.0625`), and discordant trials can never exceed counted trials — so below `minCredibleTrials` (5) **no possible record passes**, however good the skill is.
+Not a skill problem — an eval problem. This is `INVALID_INCONCLUSIVE` with `stateReason.code == "underpowered"`. The gate is an exact one-sided sign test over the head-to-head trials, and `trials = scenarios × defaults.runs`. That test cannot reach `p ≤ 0.05` on fewer than five discordant trials (`0.5⁴ = 0.0625`), and discordant trials can never exceed counted trials — so below `minCredibleTrials` (5) **no possible record passes**, however good the skill is.
 
 Do not "fix" the skill in response to this. Fix the eval: add scenarios (strongly preferred — five repeats of one scenario satisfy the arithmetic but still measure the skill on a single task), or declare `defaults: { runs: N }` in its `eval.yaml` so `scenarios × runs >= 5`. If the spec still opens with the deprecated `config:` block, **merge** `runs` into it and rename it `defaults:` — vally's loader throws on a spec declaring both, and that failure surfaces as "Evaluation ran but produced no results", not as a spec error. `eng/eval-quality/check_eval_quality.py` fails any new eval below the floor, rejects the `config:`+`defaults:` combination, and tracks the grandfathered ones in `eng/eval-quality/underpowered-allowlist.txt`.
 
@@ -119,12 +142,21 @@ Clearing the floor is necessary, not sufficient. The sign test conditions on the
 
 ### 5. No credible net win (`passed == false` with `netWin <= 0` or `signTest.pValue > 0.05`)
 The judge didn't consistently prefer the skilled run over baseline.
-- **`netWin <= 0`** — at least as many losses as wins. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. Strengthen the skill's guidance, or reconsider whether the scenario exercises the skill's value. If `regressed` is also `true`, the losses themselves are credible: the skill is actively hurting.
+- **`netWin <= 0`** — at least as many losses as wins. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. If `preferenceRegressed` is `true`, the LLM judge credibly preferred baseline. This is report-only preference evidence, not an objective completion regression.
 - **`netWin > 0` but `signTest.pValue > 0.05`** — a real but inconsistent signal: the skill wins some scenarios and ties or loses others. Ties count against here, because they hold the discordant trial count down. Add more/broader scenarios so there is enough evidence, and make the skill help consistently rather than occasionally.
 - Do **not** read `meanScore` here. It is magnitude-weighted and reported for triage only; a verdict never turns on it (see `eng/eval-quality/README.md`, "Why the gate scores direction, not magnitude").
 - Inspect `scenarios[].trials[].evidence` for the judge's reasoning on losses/ties, and compare the skilled vs baseline `events.jsonl` to see what the skill changed (or failed to change).
 
-### 6. Quality looks fine but the skill still fails the gate
+### 6. Completion-transition telemetry
+
+`completionTransitions` counts aggregate `baselinePassed` and
+`treatmentPassed` transitions from Vally compare. It is not a hard gate:
+Vally's aggregate pass can include LLM grader output, so it is not an objective
+task-completion primitive. `VALID_REGRESSION` is reserved until Vally exposes
+objective per-grader completion evidence. Do not infer an objective regression
+from `completionTransitions.baselineOnly`.
+
+### 7. Quality looks fine but the skill still fails the gate
 The gate is a **preference** comparison, not an absolute score. A high `skilledIsolated.judgeResult.overallScore` that isn't clearly better than `baseline.judgeResult.overallScore` will not pass. Focus on the *delta* over baseline, not the absolute number.
 
 ## Re-running

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -28,15 +28,15 @@ When an evaluation has failures, the PR comment includes a ready-to-use prompt �
 |--------|---------|
 | `Skill` | Skill under test |
 | `Result` | ✅ `VALID_PASS` / 🔻 objective `VALID_REGRESSION` / ❌ `VALID_NO_CHANGE` / 📉 report-only LLM preference loss / ⚠️ `INVALID_INCONCLUSIVE` |
-| `Net win` | `(wins − losses) / trials`. Must be at least +20% for a pass |
-| `p` | One-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials |
+| `Net win` | `(wins − losses) / distinct stimulus votes`. Must be at least +20% for a pass |
+| `p` | One-sided exact sign test over discordant (non-tie) stimulus votes. A pass at `p ≤ 0.05` needs at least 5 winning votes |
 | `Δ Pref` | The same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Triage only; deliberately not gated on |
-| `W/T/L` | Wins / ties / losses across trials |
+| `W/T/L` | Wins / ties / losses after repeated runs collapse to one vote per stimulus |
 | `Quality` (+ `Quality (Plugin)` in the full step summary) / `Baseline` | Mean absolute judge score 0–5 for skilled isolated (and plugin) vs the skill-free control |
 | `Overfit` | Overfitting-judge severity — ✅ Low, 🟡 Moderate, 🔴 High, — none — with its score |
 | `Skills Loaded` | Of scenarios that expect activation, how many the skill activated / that total (plugin run shown when present); ⚠️ flags a scenario that expected activation but didn't activate |
 
-A collapsible **Column legend** and a per-skill **details** block follow the table. Each details block shows `state`, `stateReason`, comparison-error codes, retry recovery, report-only effective-scenario evidence, the human-readable `reason`, and a per-scenario table. `--format full` (the step summary) adds the `Quality (Plugin)` column; `--format simple` (the PR comment) omits it.
+A collapsible **Column legend** and a per-skill **details** block follow the table. Each details block shows `state`, `stateReason`, comparison-error codes, retry recovery, authoritative stimulus-vote evidence, separate repeated-run reliability evidence, the human-readable `reason`, and a per-scenario table. `--format full` (the step summary) adds the `Quality (Plugin)` column; `--format simple` (the PR comment) omits it.
 
 ## Understanding `results.json`
 
@@ -44,7 +44,7 @@ Each file has a top-level object:
 
 | Field | Description |
 |-------|-------------|
-| `schemaVersion` | Adapter schema version. Version 2 adds explicit states and evidence provenance |
+| `schemaVersion` | Adapter schema version. Version 2 adds explicit states; version 3 makes stimulus votes authoritative and separates repeated-run evidence |
 | `evalFile` / `expectedEval` | Normalized eval path and whether it was in the pre-run manifest |
 | `model` | Model used for agent runs |
 | `judgeModel` | Model used by `vally compare` |
@@ -60,21 +60,25 @@ A verdict carries **both** the head-to-head preference and absolute per-role dat
 | `skillName` / `skillPath` | The skill under test |
 | `state` | One of `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or `INVALID_INCONCLUSIVE` |
 | `stateReason` | Machine-readable `{ code, phase }`. Use this field for automation; do not parse `reason` |
-| `passed` | **The gate.** `true` only when `conclusive`, not `underpowered`, `signTest.pValue <= 0.05`, and `netWin >= 0.20` |
-| `netWin` | `(wins − losses) / trials` — the effect size the gate reads. Magnitude-free, so an identical W/T/L record always yields an identical verdict |
+| `passed` | **The gate.** `true` only when `conclusive`, at least 5 distinct stimuli were counted, `signTest.pValue <= 0.05`, and `netWin >= 0.20` |
+| `netWin` | `(wins − losses) / stimulus votes` — the effect size the gate reads. Magnitude-free, so an identical stimulus W/T/L record always yields an identical verdict |
 | `practicalSignificance` | `{ netWin, minimum, passed }`. The absolute directional effect must reach 20%; this blocks sparse records such as `5W/95T/0L` |
-| `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over the discordant (non-tie) trials. **This is what decides.** Ties can't support a win, so they hold `discordant` down |
+| `signTest` | `{ wins, ties, losses, discordant, pValue, alpha }` — exact one-sided binomial tail over discordant stimulus votes. **This is what decides.** Ties cannot support a win, so they hold `discordant` down |
 | `regressed` / `preferenceRegressed` | Compatibility and explicit fields for a credible LLM preference loss. Under schema version 2 this maps to `VALID_NO_CHANGE`, not `VALID_REGRESSION`, because ordinal LLM preference is not objective completion evidence. Renderers apply the same report-only meaning to legacy records that have `regressed: true` but no `state` |
-| `conclusive` | `false` when the comparison didn't complete: errored trials, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
-| `underpowered` | `true` when a *completed* comparison counted fewer than `minCredibleTrials` trials, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. Disjoint from `conclusive` |
-| `minCredibleTrials` | The trial floor in force (5). See `eng/eval-quality/README.md` for why |
+| `conclusive` | `false` when the comparison did not complete: errored runs, unmatched trajectories, or a summary that disagrees with its own `stimuli[].trials` |
+| `underpowered` | `true` when a *completed* comparison counted fewer than `minCredibleStimuli` distinct stimuli, so no record could have reached `p <= 0.05`. Rendered ⚠️ — never a pass, never a regression. Disjoint from `conclusive` |
+| `minCredibleStimuli` | The distinct-stimulus floor in force (5). See `eng/eval-quality/README.md` for why |
+| `minCredibleTrials` | Compatibility alias for `minCredibleStimuli` |
 | `meanScore` | Vally's magnitude-weighted mean preference (`much-better` ±1.0, `slightly-better` ±0.4), −1..1. **Triage only — not the gate**; weighting the statistic by magnitude is what made verdicts flip in dotnet/skills#952 |
 | `confidenceInterval` | `{ low, high, level: 0.95 }` — the 95% CI on `meanScore`, reported alongside it |
-| `winRate`, `wins`, `ties`, `losses` | Trial-level head-to-head tally as vally reported it |
-| `trialCount`, `erroredCount` | Counted trials (scenarios × `defaults.runs`) and how many errored (errored trials don't count toward either statistic) |
+| `winRate`, `wins`, `ties`, `losses` | Authoritative stimulus-vote tally |
+| `stimulusVoteCount` | Number of distinct stimuli that supplied a vote |
+| `trialCount` | Compatibility alias for `stimulusVoteCount`; it no longer means pooled runs in schema version 3 |
+| `erroredCount` | Raw comparison-judge runs that errored. Any unresolved error makes the verdict inconclusive |
+| `comparisonTrialEvidence` | Pooled paired-run W/T/L, marked `gateEligible: false`; use it for reliability, not task breadth |
 | `comparisonAttempts` | Retry telemetry. Successful first-attempt slots are frozen; only errored slots can be filled by attempt 2 |
 | `errors[]` / `recoveredErrors[]` | Structured unresolved and recovered comparison failures, with phase, code, stimulus, trial, and attempt provenance |
-| `scenarioEvidence` | One effective vote per stimulus after repeated runs are collapsed. Report-only (`gateEligible: false`) |
+| `scenarioEvidence` | One effective vote per stimulus after repeated runs are collapsed. Authoritative (`gateEligible: true`) |
 | `completionTransitions` | Baseline/treatment aggregate pass transitions. Report-only because Vally aggregate pass can include LLM grading |
 | `reason` | Human-readable summary of the above |
 | `scenarios[]` | Per-scenario detail (below) |
@@ -140,17 +144,17 @@ The agent didn't finish within the eval's `config.timeout`. Either the task is t
 The skill was available but the agent never invoked it, so "skilled" ≈ "baseline" and no improvement is possible. Fixes: sharpen the skill's `description`/trigger phrasing in `SKILL.md` so the model recognizes when to use it, and make sure the eval prompt actually describes a task the skill targets.
 
 ### 4. Underpowered eval (`underpowered == true`)
-Not a skill problem — an eval problem. This is `INVALID_INCONCLUSIVE` with `stateReason.code == "underpowered"`. The gate is an exact one-sided sign test over the head-to-head trials, and `trials = scenarios × defaults.runs`. That test cannot reach `p ≤ 0.05` on fewer than five discordant trials (`0.5⁴ = 0.0625`), and discordant trials can never exceed counted trials — so below `minCredibleTrials` (5) **no possible record passes**, however good the skill is.
+Not a skill problem — an eval problem. This is `INVALID_INCONCLUSIVE` with `stateReason.code == "underpowered"`. The gate gives each distinct stimulus one vote. Repeated runs collapse by majority direction and remain available as reliability evidence. The exact one-sided sign test cannot reach `p ≤ 0.05` on fewer than five discordant stimulus votes (`0.5⁴ = 0.0625`), so below `minCredibleStimuli` (5) **no possible record passes**, however good the skill is.
 
-Do not "fix" the skill in response to this. Fix the eval: add scenarios (strongly preferred — five repeats of one scenario satisfy the arithmetic but still measure the skill on a single task), or declare `defaults: { runs: N }` in its `eval.yaml` so `scenarios × runs >= 5`. If the spec still opens with the deprecated `config:` block, **merge** `runs` into it and rename it `defaults:` — vally's loader throws on a spec declaring both, and that failure surfaces as "Evaluation ran but produced no results", not as a spec error. `eng/eval-quality/check_eval_quality.py` fails any new eval below the floor, rejects the `config:`+`defaults:` combination, and tracks the grandfathered ones in `eng/eval-quality/underpowered-allowlist.txt`.
+Do not "fix" the skill or raise `defaults.runs` in response to this. Add independent, discriminating stimuli. Vally defines stimuli as test cases and uses runs for pass rate, pass@k, pass^k, and flakiness. Its scoring guide recommends 3 runs for CI and 5–10 for nightly reliability measurement, but does not prescribe a distinct-stimulus count or sign-test alpha. `eng/eval-quality/check_eval_quality.py` fails any new eval below the five-stimulus floor and tracks grandfathered debt in `eng/eval-quality/underpowered-allowlist.txt`.
 
-Clearing the floor is necessary, not sufficient. The sign test conditions on the **discordant** (non-tie) trials, so an eval at exactly 5 counted trials only passes on a flawless 5W/0T/0L sweep — one tie leaves 4 discordant and puts it back below the floor without setting `underpowered`. Check `signTest.discordant`, not `trialCount`, when a record with more wins than losses still fails.
+Clearing the floor is necessary, not sufficient. The sign test conditions on **discordant** (non-tie) stimulus votes, so an eval at exactly 5 stimuli only passes on a flawless 5W/0T/0L sweep. One tie leaves 4 discordant votes. Check `signTest.discordant`, not raw run volume, when a record with more wins than losses still fails.
 
 ### 5. No credible or practical net win
 The judge didn't consistently prefer the skilled run over baseline.
 - **`netWin <= 0`** — at least as many losses as wins. Either the skill isn't helping for these scenarios, or the baseline model is already strong here. If `preferenceRegressed` is `true`, the LLM judge credibly preferred baseline. This is report-only preference evidence, not an objective completion regression.
-- **`netWin > 0` but `signTest.pValue > 0.05`** — a real but inconsistent signal: the skill wins some scenarios and ties or loses others. Ties count against here, because they hold the discordant trial count down. Add more/broader scenarios so there is enough evidence, and make the skill help consistently rather than occasionally.
-- **`signTest.pValue <= 0.05` but `practicalSignificance.passed == false`** — the direction is statistically credible but too sparse to matter across counted trials. For example, `5W/95T/0L` has `p=0.03125` but only a 5% net win. Add discriminating scenarios or improve the skill; do not add repeated ties.
+- **`netWin > 0` but `signTest.pValue > 0.05`** — a real but inconsistent signal: the skill wins some stimuli and ties or loses others. Ties hold the discordant vote count down. Add broader stimuli and make the skill help consistently.
+- **`signTest.pValue <= 0.05` but `practicalSignificance.passed == false`** — the direction is statistically credible but too sparse to matter across tested tasks. For example, 100 distinct stimuli with `5W/95T/0L` have `p=0.03125` but only a 5% net win. Add discriminating stimuli or improve the skill.
 - Do **not** read `meanScore` here. It is magnitude-weighted and reported for triage only; a verdict never turns on it (see `eng/eval-quality/README.md`, "Why the gate scores direction, not magnitude").
 - Inspect `scenarios[].trials[].evidence` for the judge's reasoning on losses/ties, and compare the skilled vs baseline `events.jsonl` to see what the skill changed (or failed to change).
 
@@ -166,16 +170,18 @@ The required objective primitive is tri-state per
 `(eval, stimulus, trialIndex, arm)`: `true` only when all explicitly marked,
 allowlisted deterministic completion graders pass; `false` when one explicitly
 fails and none is missing or errored; otherwise `unknown`. It must use raw
-per-grader details matched by `(graderType, name)`, never aggregate pass,
-weights, thresholds, LLM graders, or human graders. One baseline-only
+per-grader details tied to explicit unique declarations in the parsed eval spec,
+never aggregate pass, weights, thresholds, LLM graders, or human graders. One baseline-only
 transition is only a candidate. `VALID_REGRESSION` additionally requires
 conclusive paired confirmation at `p <= 0.05`, at least a 20% objective net
 loss, and correction across multiple tested completion scenarios.
 
-Vally 0.13 supplies `graderType` in raw grader details, but evals do not yet
-declare which deterministic graders are task-completion invariants and compare
-JSONL still exposes only aggregate booleans. Therefore the state remains
-reserved and the aggregate transition remains report-only.
+Official Vally `GraderResult` records expose broad `kind` taxonomy, not the
+eval spec's grader `type`; `kind: "code"` does not prove deterministic
+task-completion semantics. Evals also do not yet declare which graders are
+completion invariants, and compare JSONL exposes only aggregate booleans.
+Therefore the state remains reserved and the aggregate transition remains
+report-only.
 
 ### Vally 0.13 comparison identity
 

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -162,13 +162,17 @@ collector to distinguish:
 - a malformed or invalid result.
 
 The run fails closed unless expected, observed, and written identities match
-exactly. This proof applies inside each matrix leg. Discovery omits entries with
-no eval specs. The PR collector separately requires the full reusable matrix to
-succeed and requires one downloaded `adapter-summary.json` per declared matrix
-entry before it renders any verdict. Partial artifacts remain available for
-diagnosis, but they are labeled incomplete and are never consolidated into
-quality evidence. A leg that found evals also fails if its primary result
-artifact is missing.
+exactly and no measurement-invalid result remains. Missing execution arms,
+unresolved judge or pairing errors, malformed reports, and unknown invalid
+states fail the matrix leg after diagnostic artifacts are written. The explicit
+`underpowered` eval-design state remains visible as instrument debt but does not
+become an infrastructure failure. This proof applies inside each matrix leg.
+Discovery omits entries with no eval specs. The PR collector separately requires
+the full reusable matrix to succeed and requires one downloaded
+`adapter-summary.json` per declared matrix entry before it renders any verdict.
+Partial artifacts remain available for diagnosis, but they are labeled
+incomplete and are never consolidated into quality evidence. A leg that found
+evals also fails if its primary result artifact is missing.
 
 ### 3. Run three Vally variants
 
@@ -310,7 +314,8 @@ measurement-health layer is valid.
 | --- | --- | --- | --- |
 | Expected / observed / written | Did every planned result appear exactly once and get persisted? | Final exact-commit run `32232320378`: `8 / 8 / 8` | Any mismatch is invalid. Inspect discovery, matrix status, upload, and aggregation. |
 | Missing / unexpected / duplicate | Is result identity complete and unique? | Expected skill A, received skill B, or received skill A twice | Fix manifest or result routing. Do not infer quality from the partial set. |
-| Invalid result count | Did any adapter result fail schema or evidence checks? | One report has no paired trials | Inspect `invalidReason` and raw artifacts. |
+| Invalid result count | Did any adapter result fail schema, evidence, or task-breadth checks? | One report has no paired trials, or an eval is underpowered | Inspect `stateReason` and raw artifacts. |
+| Measurement-invalid eval count | Did execution, judge, pairing, or adapter failure make any result untrustworthy? | The skilled arm produced no records | Must be zero. The matrix leg fails after it preserves diagnostics. Explicit `underpowered` design debt is excluded. |
 | Stable paired slot identity | Can baseline and skilled evidence be paired without guessing? | `(prompt-a, 0)` exists once in both arms | Fix missing, negative, or duplicate `trialIndex` values before comparing. |
 | Comparison judge errors | Did the judge fail independently of the skill? | `session.idle` or disabled organization | Retry the exact slot once; invalidate if it remains errored. |
 | Retry recovery | Did the targeted retry repair failed slots? | `1 attempted / 1 recovered / 0 unresolved` | If unresolved is nonzero, inspect judge diagnostics; do not count it as a loss. |

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -42,13 +42,15 @@ result:
   that a skill regressed.
 - `underpowered` is a separate signal with the same "not evidence of a
   regression" property, but a different cause: the eval counted fewer than
-  `minCredibleTrials` trials, so no possible win/tie/loss record could have
+  `minCredibleStimuli` distinct stimulus votes, so no possible win/tie/loss record could have
   reached the sign test's 5% threshold. It is a property of the eval spec, not
-  of the run, and it is fixed by adding scenarios or raising `defaults.runs` —
-  never by changing the skill. See `eng/eval-quality/README.md`.
+  of the run, and it is fixed by adding independent, discriminating stimuli —
+  never by raising `defaults.runs` or changing the skill. See
+  `eng/eval-quality/README.md`.
 - `scenarioEvidence` collapses repeated runs for one stimulus into one effective
-  scenario vote. This is report-only (`gateEligible: false`) until the repository
-  selects a practical threshold and has enough independent scenarios.
+  stimulus vote. It is authoritative (`gateEligible: true`) for the sign test,
+  net-win floor, and verdict. `comparisonTrialEvidence` keeps the pooled run
+  outcomes as reliability-only evidence (`gateEligible: false`).
 - `completionTransitions` reports aggregate baseline/treatment pass transitions.
   Vally's aggregate pass can include LLM grading, so this signal is also
   report-only (`gateEligible: false`). `VALID_REGRESSION` must not be inferred
@@ -74,25 +76,55 @@ and treats a nonzero invocation with no report as a hard failure.
 ## Practical preference floor
 
 The sign test proves that the direction is unlikely under a 50/50 null, but
-ties are outside its sample. Without an effect-size floor, `5W/95T/0L` has
-`p=0.03125` and passes although the skilled arm improves only 5% of counted
-trials. A preference pass therefore requires both:
+ties are outside its sample. Without an effect-size floor, 100 distinct
+stimulus votes with `5W/95T/0L` have `p=0.03125` and pass although the skilled
+arm improves only 5% of tested tasks. A preference pass therefore requires both:
 
 ```text
 signTest.pValue <= 0.05
-abs((wins - losses) / countedTrials) >= 0.20
+abs((wins - losses) / stimulusVotes) >= 0.20
 ```
 
 The mirrored 20% floor applies to report-only preference regressions. The floor
 uses only win/tie/loss direction; judge magnitude cannot affect it. Exhaustive
-enumeration shows that every record which can pass the sign test at the
-repository's current maximum of 24 trials already clears 20%, so this rule
-protects future larger evals without changing a current possible pass.
+enumeration shows that every sign-test pass through 25 stimulus votes clears
+20%: `5W/20T/0L` is exactly 20%, and 26 votes is the first size where
+`5W/21T/0L` falls below it. The largest current eval has 17 distinct stimuli, so
+the floor does not remove any currently possible pass.
 
-`scenarioEvidence` remains the independence check in shadow mode. Repeated runs
-can stabilize one task, but they do not create new task samples. Moving the
-authoritative sign test to one vote per stimulus requires a separate eval-breadth
-migration because many current evals have fewer than five distinct stimuli.
+Repeated runs can stabilize one task, but they do not create new task samples.
+The adapter therefore gives each stimulus one majority-direction vote. For
+example, five stimuli run three times produce five gate votes, not 15. The
+pooled 15-run W/T/L remains visible under `comparisonTrialEvidence` so reliability
+changes are not hidden.
+
+## Policy provenance and power
+
+Vally defines a [stimulus as a test case](https://microsoft.github.io/vally/concepts/how-it-works/)
+and defines repeated runs as inputs to pass rate, pass@k, pass^k, and flakiness.
+Its [scoring guidance](https://microsoft.github.io/vally/concepts/scoring/)
+recommends three runs for CI and 5–10 for nightly evaluation. Those values
+measure within-stimulus reliability. Vally does not prescribe a number of
+distinct stimuli, a sign-test alpha, or a practical net-win floor.
+
+This repository uses a predeclared one-sided exact sign test at `alpha=0.05`
+for an improvement claim. The five-stimulus floor is derived from that policy:
+`0.5^4=0.0625` cannot pass, while `0.5^5=0.03125` can. It is only an eligibility
+floor. It is not 80% power. Under an idealized no-tie model, the exact number of
+discordant stimulus votes needed for at least 80% power is:
+
+| True conditional win probability | Votes needed |
+|---:|---:|
+| 0.60 | 158 |
+| 0.65 | 69 |
+| 0.70 | 37 |
+| 0.75 | 23 |
+| 0.80 | 18 |
+| 0.90 | 8 |
+
+These are planning values, not Vally requirements. Ties require more total
+stimuli because they do not enter the sign test. A non-pass is therefore not
+proof that the skill has no effect.
 
 ## Objective completion contract
 
@@ -109,8 +141,11 @@ Gate-eligible graders must be explicitly named in the eval, use a frozen
 repository allowlist of deterministic grader types, and have task-completion
 semantics. `kind: "code"` alone is not sufficient. LLM and human graders,
 aggregate scores, thresholds, and Vally's aggregate `gradeResult.passed` are
-prohibited. The adapter must read raw `gradeResult.details`, match grader
-instances by `(graderType, name)`, and pair arms by
+prohibited. The grader `type` must come from the trusted parsed eval spec or a
+generated sidecar; official Vally `GraderResult` records expose broad `kind`
+taxonomy, not the spec's `type`. The harness must prove that explicit unique
+grader identities round-trip to raw `gradeResult.details`, fail closed on any
+missing, duplicate, suffixed, mismatched, or errored result, and pair arms by
 `(stimulusName, trialIndex)`.
 
 A baseline-pass/treatment-fail pair is an objective regression candidate, not a
@@ -118,8 +153,9 @@ hard regression by itself because agent execution is still stochastic.
 `VALID_REGRESSION` requires conclusive predeclared paired confirmations, an
 exact one-sided test at `p <= 0.05`, an objective net-loss rate of at least 20%,
 and multiple-scenario correction when more than one completion scenario is
-tested. Until evals can declare these graders and Vally provides stable raw
-grader provenance, `completionTransitions.gateEligible` remains `false`.
+tested. Until evals can declare these graders and the harness proves a stable
+spec-to-result identity mapping, `completionTransitions.gateEligible` remains
+`false`.
 
 ## Correctness metrics
 
@@ -130,8 +166,9 @@ Track these metrics by model, judge, plugin, skill, and run:
 | Manifest completeness | `expectedEvalCount`, `writtenResultCount`, `unexpectedEvalCount` | Detect silent result loss or extra results |
 | Invalid-result rate and cause | `state`, `stateReason`, `errors[].code` | Keep infrastructure and eval-design failures out of skill verdicts |
 | Judge retry recovery | `comparisonAttempts`, `recoveredErrors[]`, `errors[]` | Measure transient judge failure and persistent failure separately |
-| Effective independent scenarios | `scenarioEvidence.count` and W/T/L | Show when repeated runs give trial volume without task breadth |
-| Preference effect and uncertainty | `netWin`, `signTest`, `practicalSignificance`, trial W/T/L | Require statistical and practical skilled-versus-baseline improvement |
+| Independent task evidence | `scenarioEvidence`, `stimulusVoteCount`, stimulus W/T/L | Gate on one vote per distinct stimulus |
+| Repeated-run reliability | `comparisonTrialEvidence`, `scenarios[].trials` | Show run volume, consistency, and flakiness without manufacturing task breadth |
+| Preference effect and uncertainty | `netWin`, `signTest`, `practicalSignificance` | Require statistical and practical skilled-versus-baseline improvement |
 | Completion transitions | `completionTransitions` | Diagnose possible completion changes without treating aggregate LLM grading as objective |
 | Cross-judge agreement | Explicit `state` plus `preferenceRegressed` | Measure judge robustness without conflating preference loss with objective regression |
 

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -1,201 +1,528 @@
-# Vally shadow evaluation adapter
+# Skill evaluation infrastructure
 
-`adapt.mjs` converts a Vally experiment's baseline and skilled `results.jsonl`
-files into per-skill `results.json` verdicts for the shadow-evaluation
-workflow. The local runner `eng/run-skill-evals.sh` runs the experiment and then
-invokes this adapter; CI invokes `adapt.mjs` directly.
+This document explains how this repository evaluates skills, how it builds on
+[Vally](https://microsoft.github.io/vally/), which measurements affect a
+verdict, and how to repair common failures.
 
-## Reliability signals
+Use these focused references when you need more detail:
 
-The adapter keeps infrastructure reliability distinct from a skill-quality
-result:
+- [Investigating evaluation results](./InvestigatingResults.md) explains every
+  result field and provides artifact investigation scripts.
+- [Eval authoring quality](../eval-quality/README.md) explains the structural
+  defects that the authoring gate detects.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md#evaluating-your-skill) explains how to
+  create an eval and run `/evaluate`.
 
-- `state` is the authoritative four-state result:
+## Why this layer exists
 
-  | State | Meaning |
-  |-------|---------|
-  | `VALID_PASS` | The completed comparison shows a statistically credible preference improvement with at least a 20% net win. |
-  | `VALID_REGRESSION` | Reserved for an objective completion regression. The current Vally compare output does not provide a gate-eligible objective completion primitive, so the adapter does not emit this state yet. |
-  | `VALID_NO_CHANGE` | The completed comparison does not show a credible improvement. A credible LLM preference loss is recorded as `preferenceRegressed: true`, but stays report-only. |
-  | `INVALID_INCONCLUSIVE` | The run cannot support a quality verdict because evidence is missing, underpowered, errored, unmatched, or inconsistent. |
+Vally provides the evaluation engine. It runs test cases, records agent
+trajectories, applies graders, repeats trials, and compares two experiment
+arms. The repository adds the policy needed to answer a different question:
 
-- `stateReason` gives the machine-readable cause and phase. Use it instead of
-  parsing `reason`.
-- Renderers treat legacy `regressed: true` records that have no `state` as
-  report-only preference losses. They do not relabel historical preference data
-  as objective completion regressions.
-- `erroredCount` counts matched baseline/treatment trials whose comparison judge
-  failed. `errors[]` classifies unresolved failures, including
-  `judge_session_idle_timeout`, `judge_organization_disabled`,
-  `judge_rate_limited`, and `judge_service_error`.
-- The adapter retries a comparison once when judgment slots fail. It freezes all
-  successful first-attempt judgments and uses the retry only to fill slots that
-  errored. `comparisonAttempts`, `recoveredErrors[]`, and `errors[]` preserve the
-  attempt history. Recovery requires Vally to emit `trialIndex` for both
-  attempts. If that stable key is absent, the adapter fails closed with
-  `retry_result_missing` instead of pairing trials by array position.
-- `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not
-  be paired, commonly because one arm timed out or failed before grading.
-  `unmatchedTrialCount` is their combined count.
-- `conclusive` is `false` when either signal is nonzero. An inconclusive verdict
-  cannot pass and is rendered as a workflow warning rather than as evidence
-  that a skill regressed.
-- `underpowered` is a separate signal with the same "not evidence of a
-  regression" property, but a different cause: the eval counted fewer than
-  `minCredibleStimuli` distinct stimulus votes, so no possible win/tie/loss record could have
-  reached the sign test's 5% threshold. It is a property of the eval spec, not
-  of the run, and it is fixed by adding independent, discriminating stimuli —
-  never by raising `defaults.runs` or changing the skill. See
-  `eng/eval-quality/README.md`.
-- `scenarioEvidence` collapses repeated runs for one stimulus into one effective
-  stimulus vote. It is authoritative (`gateEligible: true`) for the sign test,
-  net-win floor, and verdict. `comparisonTrialEvidence` keeps the pooled run
-  outcomes as reliability-only evidence (`gateEligible: false`).
-- `completionTransitions` reports aggregate baseline/treatment pass transitions.
-  Vally's aggregate pass can include LLM grading, so this signal is also
-  report-only (`gateEligible: false`). `VALID_REGRESSION` must not be inferred
-  from it. See [Objective completion contract](#objective-completion-contract).
+> Is this result complete, independent, and strong enough to make a merge
+> decision?
 
-CI passes `--expected-evals` with the exact pre-run eval manifest. The adapter
-writes one result file for every expected eval, including explicit invalid
-results when a baseline or skilled variant is missing or comparison invocation
-fails. A parsed comparison record with an invalid shape becomes
-`comparison_report_invalid` for that eval instead of aborting the remaining
-batch. The adapter also writes `adapter-summary.json` with expected, observed,
-missing, unexpected, invalid, and written counts. The workflow requires the
-number of primary result files to equal the manifest count.
+A high score is not enough. An eval can look decisive while it is
+underpowered, repeats one task many times, loses results, or contains
+comparison-judge failures. The repository therefore validates the instrument
+before it evaluates the skill.
 
-The adapter consumes Vally JSONL and CLI output only. Vally 0.9 and 0.13 both
-emit `stimulusName` plus a required `trialIndex` for comparison trials. The
-index is stable when `compare` is repeated over the same persisted inputs, but
-Vally does not promise a global ID across regenerated runs or future versions.
-Vally 0.13 exits nonzero when every judge slot errors while still writing the
-comparison report. The adapter reads that report, retries the identified slots,
-and treats a nonzero invocation with no report as a hard failure.
+## How the repository builds on Vally
 
-## Reporting contract
+The design follows these official Vally concepts:
 
-`consolidate.mjs --format simple` produces the PR decision and repair view. It
-preserves the execution model on every row, reports unique skill and
-model/skill-result counts, aggregates `adapter-summary.json` accounting, keeps
-Overfit visible, and uses distinct labels for improved, not proven improved,
-report-only preference loss, and invalid evidence. It states that objective
-regression is not enabled while `completionTransitions.gateEligible` is false.
+- [How it works](https://microsoft.github.io/vally/concepts/how-it-works/):
+  eval spec -> agent run -> trajectory -> graders -> metrics.
+- [Scoring](https://microsoft.github.io/vally/concepts/scoring/): scores,
+  pass rates, repeated-trial reliability, and confidence intervals.
+- [`vally compare`](https://microsoft.github.io/vally/reference/cli/compare/):
+  paired baseline and treatment comparison.
+- [Grader taxonomy](https://microsoft.github.io/vally/concepts/grader-taxonomy/):
+  static, agent, and other grader classes have different trust properties.
 
-The compact table keeps only gate evidence, warnings, and the next action.
-`--format full` adds magnitude-weighted preference and absolute quality metrics
-and includes every result detail. Compact details are limited to non-passing,
-invalid, or warning-bearing results. Repeated-run W/T/L is shown only as
-reliability evidence, never beside the distinct-stimulus sign test as if both
-used the same inference unit.
+| Responsibility | Vally | Repository policy |
+| --- | --- | --- |
+| Define a test case | `stimuli` in `eval.yaml` | Require unique names, valid fixtures, and at least five distinct stimuli for new gated evals |
+| Repeat a test | `defaults.runs` | Treat repeats as reliability evidence, not new independent task breadth |
+| Run the agent | Copilot SDK executor | Run baseline, isolated-skill, and full-plugin variants at one exact commit |
+| Grade output | Static and LLM graders | Preserve grader evidence, but do not treat a mixed aggregate as objective completion |
+| Compare arms | Paired comparison judge | Check stable slot identity and retry only failed comparison slots |
+| Report scores | Scores, confidence intervals, pass metrics | Use scores for diagnosis, not as the improvement gate |
+| Decide improvement | Comparison report | Collapse repeats to one vote per stimulus, apply an exact sign test, and require a practical net win |
+| Handle failures | Error fields and process status | Reconcile expected, observed, and written results; fail closed on any mismatch |
+| Publish results | Raw Vally artifacts | Emit schema-versioned results, one consolidated PR report, and repair actions |
 
-## Practical preference floor
+This extra policy addresses three different risks:
 
-The sign test proves that the direction is unlikely under a 50/50 null, but
-ties are outside its sample. Without an effect-size floor, 100 distinct
-stimulus votes with `5W/95T/0L` have `p=0.03125` and pass although the skilled
-arm improves only 5% of tested tasks. A preference pass therefore requires both:
+1. **Instrument validity:** Did the intended tests run, and can every output be
+   matched to the intended input?
+2. **Statistical validity:** Does the result contain enough independent task
+   evidence to support the claim?
+3. **Operational validity:** Are judge failures, missing files, and workflow
+   faults separated from skill behavior?
 
-```text
-signTest.pValue <= 0.05
-abs((wins - losses) / stimulusVotes) >= 0.20
+## End-to-end architecture
+
+```mermaid
+flowchart TD
+    A["/evaluate or PR evaluation request"] --> B["Bind request to one PR head SHA"]
+    B --> C["Discover changed skills and build expected-result manifest"]
+    C --> D["Build or restore trusted skill-validator archive"]
+    D --> E["Upload one same-run validator artifact"]
+    C --> F["Start model x shard matrix"]
+    E --> F
+
+    subgraph R["One matrix job"]
+        F --> G["Download exact validator artifact"]
+        G --> H["Run Vally baseline variant"]
+        G --> I["Run Vally isolated-skill variant"]
+        G --> J["Run Vally full-plugin variant"]
+        H --> K["Vally compare: baseline vs isolated skill"]
+        I --> K
+        J --> M
+        K --> L["Retry errored judge slots by stimulusName + trialIndex"]
+        L --> M["Adapter validates identity and computes verdict"]
+        M --> N["Write verdict plus plugin telemetry to results.json"]
+        N --> N2["Write adapter-summary.json"]
+    end
+
+    N2 --> O["Reconcile expected, observed, and written results"]
+    O --> P["Consolidate all model/shard outputs"]
+    P --> Q["Publish Skill Evaluation Results PR comment"]
+    P --> S["Upload raw evidence and rendered report artifacts"]
 ```
 
-The mirrored 20% floor applies to report-only preference regressions. The floor
-uses only win/tie/loss direction; judge magnitude cannot affect it. Exhaustive
-enumeration shows that every sign-test pass through 25 stimulus votes clears
-20%: `5W/20T/0L` is exactly 20%, and 26 votes is the first size where
-`5W/21T/0L` falls below it. The largest current eval has 17 distinct stimuli, so
-the floor does not remove any currently possible pass.
+The implementation is split across these main components:
 
-Repeated runs can stabilize one task, but they do not create new task samples.
-The adapter therefore gives each stimulus one majority-direction vote. For
-example, five stimuli run three times produce five gate votes, not 15. The
-pooled 15-run W/T/L remains visible under `comparisonTrialEvidence` so reliability
-changes are not hidden.
+| Component | Purpose |
+| --- | --- |
+| [`.github/workflows/evaluation.yml`](../../.github/workflows/evaluation.yml) | Authorizes a request, binds it to an exact commit, discovers work, starts the reusable workflow, consolidates results, and publishes the PR comment |
+| [`.github/workflows/evaluation-run.yml`](../../.github/workflows/evaluation-run.yml) | Builds the trusted validator artifact, runs the model/shard matrix, invokes Vally, applies fault injection in tests, and uploads artifacts |
+| [`adapt.mjs`](./adapt.mjs) | Validates Vally comparison data, retries failed judge slots, computes schema-version-3 evidence, and assigns repository verdicts |
+| [`consolidate.mjs`](./consolidate.mjs) | Combines model/shard result sets and produces the decision-first PR comment |
+| [`check_eval_quality.py`](../eval-quality/check_eval_quality.py) | Blocks structurally invalid or newly underpowered eval instruments before they run |
 
-## Policy provenance and power
+## Trust boundaries
 
-Vally defines a [stimulus as a test case](https://microsoft.github.io/vally/concepts/how-it-works/)
-and defines repeated runs as inputs to pass rate, pass@k, pass^k, and flakiness.
-Its [scoring guidance](https://microsoft.github.io/vally/concepts/scoring/)
-recommends three runs for CI and 5–10 for nightly evaluation. Those values
-measure within-stimulus reliability. Vally does not prescribe a number of
-distinct stimuli, a sign-test alpha, or a practical net-win floor.
+Evaluation can execute content from the commit being tested. The workflow must
+not let that content replace the validator that decides whether the result is
+valid.
 
-This repository uses a predeclared one-sided exact sign test at `alpha=0.05`
-for an improvement claim. The five-stimulus floor is derived from that policy:
-`0.5^4=0.0625` cannot pass, while `0.5^5=0.03125` can. It is only an eligibility
-floor. It is not 80% power. Under an idealized no-tie model, the exact number of
-discordant stimulus votes needed for at least 80% power is:
+```mermaid
+flowchart LR
+    subgraph T["Trusted control plane"]
+        W["Workflow from trusted ref"]
+        V["skill-validator package"]
+        A["Adapter and result schema"]
+        W --> V
+        W --> A
+        V --> X["Same-run immutable artifact"]
+    end
 
-| True conditional win probability | Votes needed |
-|---:|---:|
-| 0.60 | 158 |
-| 0.65 | 69 |
-| 0.70 | 37 |
-| 0.75 | 23 |
-| 0.80 | 18 |
-| 0.90 | 8 |
+    subgraph U["Evaluated data plane"]
+        P["PR skill, eval, and fixtures"]
+        B["Baseline trajectories"]
+        S["Skilled trajectories"]
+        P --> B
+        P --> S
+    end
 
-These are planning values, not Vally requirements. Ties require more total
-stimuli because they do not enter the sign test. A non-pass is therefore not
-proof that the skill has no effect.
+    X --> C["Matrix jobs"]
+    B --> C
+    S --> C
+    C --> A
+    A --> R["Validated result"]
+```
 
-The table is sign-test power before the 20% practical floor. At a true 60%
-conditional win rate, 158 votes give the sign test 80.6% power, but the combined
-gate passes about 52.2% of records because the expected effect sits exactly on
-the floor. The gate is intended to certify effects above that practical
-threshold.
+The same-run artifact is important. A previous issue-comment run could not save
+its validator cache. Each matrix job then attempted its own fallback build,
+which required access to a restricted feed. One cache permission fault became a
+matrix-wide infrastructure failure. The current design produces one archive
+before evaluated content is used, then every matrix job downloads that exact
+archive.
 
-## Objective completion contract
+## Execution lifecycle
 
-`VALID_REGRESSION` stays reserved until the harness can compute this tri-state
-primitive for each `(eval, stimulus, trialIndex, arm)`:
+### 1. Bind the request to an exact commit
 
-| Value | Definition |
-|-------|------------|
-| `true` | Every explicitly designated objective-completion grader passed. |
-| `false` | At least one designated grader explicitly failed, and none was missing or errored. |
-| `unknown` | No grader was designated, or any designated result was missing, errored, duplicated, or mismatched. |
+The request records the PR head SHA. Discovery, execution, result collection,
+and the final report all use that identity. If the PR moves, the old run is not
+reported as evidence for the new commit.
 
-Gate-eligible graders must be explicitly named in the eval, use a frozen
-repository allowlist of deterministic grader types, and have task-completion
-semantics. `kind: "code"` alone is not sufficient. LLM and human graders,
-aggregate scores, thresholds, and Vally's aggregate `gradeResult.passed` are
-prohibited. The grader `type` must come from the trusted parsed eval spec or a
-generated sidecar; official Vally `GraderResult` records expose broad `kind`
-taxonomy, not the spec's `type`. The harness must prove that explicit unique
-grader identities round-trip to raw `gradeResult.details`, fail closed on any
-missing, duplicate, suffixed, mismatched, or errored result, and pair arms by
-`(stimulusName, trialIndex)`.
+### 2. Discover the matrix and declare expected outputs
 
-A baseline-pass/treatment-fail pair is an objective regression candidate, not a
-hard regression by itself because agent execution is still stochastic.
-`VALID_REGRESSION` requires conclusive predeclared paired confirmations, an
-exact one-sided test at `p <= 0.05`, an objective net-loss rate of at least 20%,
-and multiple-scenario correction when more than one completion scenario is
-tested. Until evals can declare these graders and the harness proves a stable
-spec-to-result identity mapping, `completionTransitions.gateEligible` remains
-`false`.
+Discovery finds affected skills and creates the model/shard matrix. The workflow
+also writes an expected-result manifest before execution. This allows the
+collector to distinguish:
 
-## Correctness metrics
+- a result that was expected and written;
+- a result that was expected but missing;
+- a result that appeared without being expected;
+- a duplicate result;
+- a malformed or invalid result.
 
-Track these metrics by model, judge, plugin, skill, and run:
+The run fails closed unless expected, observed, and written identities match
+exactly.
 
-| Metric | Source | Use |
-|--------|--------|-----|
-| Manifest completeness | `expectedEvalCount`, `writtenResultCount`, `unexpectedEvalCount` | Detect silent result loss or extra results |
-| Invalid-result rate and cause | `state`, `stateReason`, `errors[].code` | Keep infrastructure and eval-design failures out of skill verdicts |
-| Judge retry recovery | `comparisonAttempts`, `recoveredErrors[]`, `errors[]` | Measure transient judge failure and persistent failure separately |
-| Independent task evidence | `scenarioEvidence`, `stimulusVoteCount`, stimulus W/T/L | Gate on one vote per distinct stimulus |
-| Repeated-run reliability | `comparisonTrialEvidence`, `scenarios[].trials` | Show run volume, consistency, and flakiness without manufacturing task breadth |
-| Preference effect and uncertainty | `netWin`, `signTest`, `practicalSignificance` | Require statistical and practical skilled-versus-baseline improvement |
-| Completion transitions | `completionTransitions` | Diagnose possible completion changes without treating aggregate LLM grading as objective |
-| Cross-judge agreement | Explicit `state` plus `preferenceRegressed` | Measure judge robustness without conflating preference loss with objective regression |
+### 3. Run three Vally variants
 
-Inspect the raw variant `results.jsonl` before changing a skill. A
-`status: "error"` agent timeout is different from a successful pair whose
-comparison evidence says `Comparison judge failed`. Do not add fixture setup,
-SDK pinning, or skill instructions unless the failure occurred during that
-phase.
+- **Baseline:** the tested skill is unavailable.
+- **Skilled:** only the tested skill is available.
+- **Plugin:** the full plugin is available, which can expose routing conflicts
+  and interactions with sibling skills.
+
+The paired preference gate compares baseline only to the isolated-skill
+variant. The plugin variant contributes absolute activation and quality
+telemetry. It can expose routing conflicts and sibling-skill interference, but
+it does not receive a separate sign-test or practical-effect verdict.
+
+### 4. Preserve raw Vally evidence
+
+Each Vally run produces trajectories, grader output, metrics, and trial
+metadata. The adapter keeps the raw report available for diagnosis. It does not
+replace Vally's evidence; it adds repository-specific validity and decision
+fields.
+
+### 5. Retry only failed comparison-judge slots
+
+The paired identity is `(stimulusName, trialIndex)`. If a comparison judge
+times out or its organization is disabled, the adapter builds a retry report
+for only the errored slots. Successful first-attempt judgments are not rerun.
+The merged report keeps retry diagnostics even when no slot recovers.
+
+Retry is bounded to one additional attempt. Remaining judge errors make the
+result invalid. They are not counted as skill losses.
+
+### 6. Convert repeated trials into independent stimulus votes
+
+Repeated runs answer "does this task behave consistently?" They do not answer
+"does this work on more kinds of tasks?" The adapter therefore gives each
+distinct stimulus one gate vote:
+
+```mermaid
+flowchart LR
+    A["Stimulus A<br/>3 paired runs: W, W, L"] --> AV["One A vote: W"]
+    B["Stimulus B<br/>3 paired runs: T, T, W"] --> BV["One B vote: W"]
+    C["Stimulus C<br/>3 paired runs: L, T, L"] --> CV["One C vote: L"]
+    D["Stimulus D<br/>3 paired runs: T, T, T"] --> DV["One D vote: T"]
+
+    AV --> G["Gate evidence: 2W / 1T / 1L over 4 stimuli"]
+    BV --> G
+    CV --> G
+    DV --> G
+
+    A --> R["Reliability evidence: all 12 paired runs"]
+    B --> R
+    C --> R
+    D --> R
+```
+
+This prevents a four-task eval with three repetitions from pretending to have
+twelve independent test cases.
+
+### 7. Apply the repository decision rule
+
+For one model and skill's baseline-versus-isolated comparison:
+
+1. Require complete and well-formed result identity.
+2. Require at least five distinct stimuli.
+3. Collapse all repeated runs to one W/T/L direction per stimulus.
+4. Remove ties for the exact one-sided sign test.
+5. Require `p <= 0.05`.
+6. Require positive aggregate direction.
+7. Require `(wins - losses) / all stimuli >= 0.20`.
+
+The statistical test and practical floor answer different questions:
+
+- The sign test asks whether the observed direction is unlikely under an even
+  win/loss process.
+- The practical floor asks whether the gain is large enough across the task
+  surface to matter.
+
+Example: `5W / 95T / 0L` has `p = 0.03125`, but its net win is only 5%. It is
+statistically significant and practically sparse, so it does not pass.
+
+```mermaid
+flowchart TD
+    A["Comparison report"] --> B{"Identity, accounting, and judge health valid?"}
+    B -- No --> X["INVALID_INCONCLUSIVE<br/>fix measurement first"]
+    B -- Yes --> C{"At least 5 distinct stimuli?"}
+    C -- No --> X
+    C -- Yes --> D["Collapse repeated runs to one vote per stimulus"]
+    D --> E{"Positive direction and one-sided p <= 0.05?"}
+    E -- No --> N["VALID_NO_CHANGE"]
+    E -- Yes --> F{"Net win >= 20% of all stimuli?"}
+    F -- No --> N
+    F -- Yes --> P["VALID_PASS"]
+    N --> G{"Credible reverse preference?"}
+    G -- Yes --> H["Report preference loss<br/>do not call it objective regression"]
+    G -- No --> I["Report not proven improved"]
+```
+
+`VALID_REGRESSION` is reserved. It will require a trusted mapping from an
+explicit deterministic grader declaration in the eval spec to that grader's
+result in both arms. Vally 0.13 raw results do not provide that stable
+spec-to-result identity. The current aggregate pass signal can mix static and
+LLM graders, so it cannot safely prove objective completion regression.
+
+## Verdicts shown on pull requests
+
+| State | PR label | Meaning | Merge effect |
+| --- | --- | --- | --- |
+| `VALID_PASS` | Improved | Complete, adequately powered, statistically significant, and at least a 20% task-level net win | Passes the result |
+| `VALID_NO_CHANGE` | Not proven improved | Measurement is valid, but improvement did not satisfy the full decision rule | Does not claim improvement |
+| `VALID_NO_CHANGE` with reverse preference | Preference loss, report-only | The comparison judge credibly preferred baseline | Diagnostic only; it is not objective completion proof |
+| `INVALID_INCONCLUSIVE` | Invalid or underpowered | Result identity, accounting, judge health, or task breadth is not trustworthy | Fails closed; repair or rerun |
+| `VALID_REGRESSION` | Objective regression | Reserved for a future deterministic completion gate | Not emitted today |
+
+The PR report keeps **Overfit** separate from the verdict. A result can improve
+and still be too tailored to known eval wording. A result can also have low
+overfit and fail because it did not improve.
+
+## Metrics that matter
+
+Read the metrics in layers. Do not interpret effect metrics until the
+measurement-health layer is valid.
+
+### Measurement and instrument validity
+
+| Metric | What it answers | Example | Required action |
+| --- | --- | --- | --- |
+| Expected / observed / written | Did every planned result appear exactly once and get persisted? | Final exact-commit run `32232320378`: `8 / 8 / 8` | Any mismatch is invalid. Inspect discovery, matrix status, upload, and aggregation. |
+| Missing / unexpected / duplicate | Is result identity complete and unique? | Expected skill A, received skill B, or received skill A twice | Fix manifest or result routing. Do not infer quality from the partial set. |
+| Invalid result count | Did any adapter result fail schema or evidence checks? | One report has no paired trials | Inspect `invalidReason` and raw artifacts. |
+| Stable paired slot identity | Can baseline and skilled evidence be paired without guessing? | `(prompt-a, 0)` exists once in both arms | Fix missing, negative, or duplicate `trialIndex` values before comparing. |
+| Comparison judge errors | Did the judge fail independently of the skill? | `session.idle` or disabled organization | Retry the exact slot once; invalidate if it remains errored. |
+| Retry recovery | Did the targeted retry repair failed slots? | `1 attempted / 1 recovered / 0 unresolved` | If unresolved is nonzero, inspect judge diagnostics; do not count it as a loss. |
+| Distinct stimulus names | Can one task identity be matched across arms? | Two stimuli both named `Generate tests` | Rename them uniquely. Duplicate names are an authoring error. |
+| Fixture integrity | Did both arms receive the same intended input? | Cobertura attributes say 50%, payload says 80% | Repair the fixture and any prompt/rubric claims that quote it. |
+
+### Improvement evidence
+
+| Metric | What it answers | Example | Interpretation |
+| --- | --- | --- | --- |
+| Distinct stimuli | How many independent task cases vote in the gate? | 4 stimuli x 3 runs = 4 votes, not 12 | Fewer than five cannot pass the exact 5% test. |
+| Stimulus W/T/L | On how many tasks did skilled beat, tie, or lose to baseline? | `5W / 1T / 1L` | This is the primary task-level effect summary. |
+| Discordant votes | How many stimulus votes were wins or losses? | `5W / 95T / 0L` has 5 discordant votes | Ties do not enter the sign-test numerator or denominator. |
+| One-sided exact p-value | Is the positive W/L direction unlikely under a 50/50 null? | `5W / 0L` gives `p = 0.03125` | Applies to one model/skill result. It is not corrected across the full matrix. |
+| Aggregate net win | Is the improvement broad enough across all stimuli? | `(5 - 0) / 100 = 5%` | Must be at least 20% to pass, even when the p-value passes. |
+| Mean score and confidence interval | Did absolute grader scores move, and how uncertain is the mean? | Both arms can score highly while the paired preference is inconclusive | Triage only. It is not the pass statistic. |
+| Model identity | Which executor model produced the trajectories? | Claude Sonnet and GPT can disagree | Never pool different executor models into one vote. |
+| Judge identity | Which comparison model made the preference decision? | Cross-family executor/judge combinations | Treat correlated combinations as sensitivity evidence, not independent task breadth. |
+
+The five-stimulus floor is repository policy, not a Vally recommendation.
+Four all-win discordant votes give `0.5^4 = 0.0625`, which cannot meet
+`alpha = 0.05`. Five all-win votes give `0.5^5 = 0.03125`, so five is the
+smallest eligible sample. It is an eligibility floor, not a power target. At
+exactly five stimuli, one tie or one loss prevents a pass.
+
+### Reliability, behavior, and resource diagnostics
+
+| Metric | What it answers | Example | How to use it |
+| --- | --- | --- | --- |
+| Repeated-run W/T/L | Does the comparison direction repeat within one task? | One stimulus produces `W, W, L` | Investigate instability, but keep one task-level vote. |
+| Vally pass rate | How often did the arm satisfy its graders? | 4 of 5 repeated runs pass | Diagnose absolute reliability. Do not substitute it for paired improvement. |
+| Vally pass@k | Is at least one of `k` attempts likely to pass? | Useful when retry is part of product behavior | Use only when "one success is enough" matches the user experience. |
+| Vally pass^k | Are all `k` attempts likely to pass? | Useful for strict repeatability | Prefer this view when every invocation must work. |
+| Activation | Did the skill load when it should and stay dormant when it should not? | `6 / 9` isolated activation | Fix routing text, prompt realism, or dormancy cases. |
+| Timeouts | Did the skill complete within the configured limit? | Skilled arm times out while baseline completes | Inspect excessive tool calls or scope. Raise timeout only for legitimate work. |
+| Error count | Did the executor, tool, grader, or harness fail? | Missing dependency in one fixture | Classify the source before editing skill guidance. |
+| Overfit | Does the skill appear tailored to eval wording or fixture details? | High improvement with `Overfit = 0.57` | Generalize the skill and test with unseen prompts. It is not a statistical gate. |
+| Tokens, turns, and wall time | What resource cost did the skill add? | Same quality with 2x wall time | Use as optimization evidence after correctness is established. |
+| Tool behavior | Did the skill use expected tools and avoid unsafe ones? | A research skill answers without opening its required source | Add deterministic tool-use graders where possible. |
+| Objective completion transitions | Did deterministic completion move baseline-only, skilled-only, both, or neither? | `baselineOnly = 1` | Telemetry only until grader identity is trustworthy. |
+
+## Real failures and what fixed them
+
+### Repeated runs manufactured a false sample size
+
+[Issue #986](https://github.com/dotnet/skills/issues/986) showed the core
+independence failure. Four stimuli with three runs could be reported as
+`12W / 0L`. If all twelve were treated as independent, the p-value looked
+decisive. The true task record was only `4W / 0L`, with
+`p = 0.0625`.
+
+**Fix:** keep all twelve paired outcomes for reliability, but give the gate only
+four stimulus votes. Mark the eval underpowered.
+
+**Do not fix it by:** increasing `runs`. Add independent task cases that cover
+new decisions, inputs, or failure modes.
+
+### A statistically significant result had little practical coverage
+
+[Issue #970](https://github.com/dotnet/skills/issues/970) identified the
+`5W / 95T / 0L` case. The exact sign test passes because all five discordant
+votes are wins. The change affects only 5% of the task surface.
+
+**Fix:** require a 20% net win over all distinct stimuli in addition to
+statistical significance.
+
+**Why 20%:** it is a repository policy for a practically visible task-level
+effect, not a Vally default. It blocks sparse wins while allowing ordinary
+small evals to pass when their evidence is broad. The full reachable result
+space through the repository's current 24-trial maximum was enumerated when the
+rule was added.
+
+### Judge outages looked like skill reliability failures
+
+[Issue #909](https://github.com/dotnet/skills/issues/909) tracks run
+[`29228914412`](https://github.com/dotnet/skills/actions/runs/29228914412),
+which contained 11 errored comparison trials across eight skills. The errors
+were `session.idle` timeouts and disabled organizations in the comparison
+judge, not fixture or skill failures.
+
+**Fix:** classify judge failures separately, retry only their stable slots, and
+invalidate any result with unresolved comparison errors.
+
+**Do not fix it by:** changing the skill, weakening its rubric, or counting the
+judge errors as losses.
+
+### Eval YAML parsed but enforced the wrong test
+
+Historical authoring defects included:
+
+- duplicate YAML keys that silently overwrote a stimulus prompt or rubric;
+- an empty grader `config` block that parsed but enforced nothing;
+- both deprecated `config:` and `defaults:` in one spec, which Vally rejects;
+- untracked fixture files that existed locally but not in CI;
+- Cobertura summary attributes that contradicted their line payload;
+- a dormancy guard with `reject_skills: ["*"]`, which made the skilled arm
+  equivalent to baseline;
+- duplicate stimulus names, which made comparison identity ambiguous.
+
+**Fix:** run the authoring gate before dispatch. It blocks eleven structural
+defect classes and checks the underpowered-eval debt ledger. See
+[Eval authoring quality](../eval-quality/README.md) for each pattern and repair.
+
+### A cache fault became a matrix-wide validator failure
+
+An issue-comment run could not save the validator cache. Every matrix job then
+attempted a restricted-feed build and failed for a reason unrelated to the
+tested skills.
+
+**Fix:** produce or restore one validator archive in a trusted job, upload it
+as a same-run artifact, and require every matrix job to use that artifact.
+
+## Troubleshooting from the PR report
+
+```mermaid
+flowchart TD
+    A["Read the verdict and Measurement health"] --> B{"Invalid or underpowered?"}
+    B -- Yes --> C{"Accounting mismatch?"}
+    C -- Yes --> C1["Inspect expected manifest, matrix jobs, and artifact upload"]
+    C -- No --> D{"Judge errors?"}
+    D -- Yes --> D1["Inspect retry diagnostics; rerun exact SHA if transient"]
+    D -- No --> E{"Fewer than 5 stimuli?"}
+    E -- Yes --> E1["Add independent discriminating stimuli, not runs"]
+    E -- No --> E2["Inspect invalidReason and raw paired identities"]
+
+    B -- No --> F{"Preference loss?"}
+    F -- Yes --> F1["Read losing stimulus excerpts and compare baseline/skilled trajectories"]
+    F -- No --> G{"Not proven improved?"}
+    G -- Yes --> G1["Check ties, losses, p-value, and 20% net-win floor"]
+    G -- No --> H["Improved: inspect activation, Overfit, timeout, and cost warnings"]
+```
+
+| PR symptom | First evidence to inspect | Common repair |
+| --- | --- | --- |
+| Missing or unexpected result | Measurement health counts and matrix job list | Fix discovery identity, failed job, or artifact path |
+| Invalid comparison | `invalidReason`, comparison errors, retry summary | Repair slot identity or rerun a transient judge failure |
+| Underpowered | Distinct stimuli and power note | Add independent, discriminating stimuli |
+| Many ties | Weak scenarios and evidence excerpts | Make tasks expose behavior the skill is meant to change |
+| Preference loss | Losing stimulus excerpts and trajectories | Fix the skill behavior; do not infer objective regression |
+| Low activation | Baseline/skilled/plugin activation table | Improve skill description and realistic trigger prompts |
+| High Overfit | Overfit column and grader evidence | Remove fixture-specific instructions and test unseen inputs |
+| Timeout or high cost | Trial diagnostics, turns, tools, and duration | Reduce unnecessary exploration or narrow the skill workflow |
+| Objective completion concern | Deterministic grader evidence in both raw arms | Investigate manually; the hard gate is intentionally reserved |
+
+The compact PR comment includes only non-passing or warning-bearing detail.
+Download the artifacts when you need every passing scenario or full trajectory.
+
+## Investigation workflow
+
+1. Confirm that the report commit matches the PR head commit you intend to
+   evaluate.
+2. Read **Measurement health** before quality metrics.
+3. Identify the affected model, skill, and isolated/plugin comparison.
+4. Use weak-scenario excerpts to find the first failing stimulus.
+5. Download `results.json`, `adapter-summary.json`, and raw Vally experiment
+   files for that matrix leg.
+6. Follow [Investigating evaluation results](./InvestigatingResults.md) to
+   inspect schema fields, paired slots, errors, and trajectories.
+7. Rerun the exact same SHA only when the evidence shows a transient
+   infrastructure or judge failure.
+
+Do not rerun until a noisy result turns green. Repeated optional stopping
+inflates false-positive risk. A skill change should produce a new commit and a
+new exact-commit evaluation.
+
+## Authoring and local validation
+
+Create or edit evals according to
+[CONTRIBUTING.md](../../CONTRIBUTING.md#evaluating-your-skill). Use
+`defaults:` for new specs. `config:` remains a deprecated Vally alias only for
+existing specs; declaring both is invalid.
+
+Run the structural quality checks before evaluation:
+
+```powershell
+python eng\eval-quality\check_eval_quality.py
+python eng\eval-quality\selftest_eval_quality.py
+```
+
+Run adapter and report tests after changing result policy:
+
+```powershell
+node --test eng\vally-adapter\adapt.test.mjs eng\vally-adapter\consolidate.test.mjs
+```
+
+The adapter tests include fault-injection paths for judge timeouts, disabled
+organizations, partial retry recovery, missing and unexpected results, and an
+entirely invalid run. The consolidation tests cover the PR and full-results
+rendering contracts.
+
+When a workflow file changes, also run `actionlint` because valid YAML is not
+proof of a valid GitHub Actions workflow.
+
+## Current limitations and debt
+
+As of the eval-correctness rollout in August 2026:
+
+- 48 existing evals remain grandfathered below the five-stimulus floor. Their
+  results are underpowered and cannot pass or fail the gate.
+- 25 evals have only five to seven stimuli. They are eligible, but one loss is
+  fatal and ties can leave too few discordant votes.
+- Unique stimulus names do not prove semantic independence. Eval authors must
+  not satisfy the floor with trivial prompt rewrites that test the same task.
+- No matrix-wide multiple-comparison correction is applied. Every p-value
+  describes one model/skill/comparison result.
+- Executor/judge combinations are sensitivity views. They are not independent
+  task replications.
+- Position swapping reduces comparison-judge order bias, but it cannot remove
+  every judge preference for output length, formatting, or style.
+- Result reconciliation proves completeness against the discovery manifest. It
+  cannot prove that discovery selected every skill that is semantically
+  affected by a change.
+- Objective completion transitions are telemetry only because Vally 0.13 does
+  not expose trusted spec-to-result grader identity.
+- Coverage management still needs explicit suite or tag policy. Adding more
+  trials does not by itself improve task coverage.
+
+Keep debt repair separate from correctness-policy changes. First make the
+measurement honest; then improve the affected eval instruments in focused
+changes.
+
+## Policy summary
+
+1. **Validate before interpreting.** Missing, duplicate, malformed, or errored
+   evidence fails closed.
+2. **Count tasks, not repetitions.** Distinct stimuli are the inference unit;
+   repeated runs measure reliability.
+3. **Require statistical and practical evidence.** A pass needs `p <= 0.05`
+   and at least a 20% net win over all stimuli.
+4. **Separate preference from completion.** LLM comparison losses are
+   diagnostic; deterministic objective regressions need stronger identity.
+5. **Preserve exact identity.** Commit, model, skill, variant, stimulus, and
+   trial index must remain traceable from request through report.
+6. **Fix the correct layer.** Repair judge and workflow faults as measurement
+   faults; repair skill behavior only when valid evidence shows a skill issue.

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -14,7 +14,7 @@ result:
 
   | State | Meaning |
   |-------|---------|
-  | `VALID_PASS` | The completed comparison shows a credible preference improvement. |
+  | `VALID_PASS` | The completed comparison shows a statistically credible preference improvement with at least a 20% net win. |
   | `VALID_REGRESSION` | Reserved for an objective completion regression. The current Vally compare output does not provide a gate-eligible objective completion primitive, so the adapter does not emit this state yet. |
   | `VALID_NO_CHANGE` | The completed comparison does not show a credible improvement. A credible LLM preference loss is recorded as `preferenceRegressed: true`, but stays report-only. |
   | `INVALID_INCONCLUSIVE` | The run cannot support a quality verdict because evidence is missing, underpowered, errored, unmatched, or inconsistent. |
@@ -52,18 +52,74 @@ result:
 - `completionTransitions` reports aggregate baseline/treatment pass transitions.
   Vally's aggregate pass can include LLM grading, so this signal is also
   report-only (`gateEligible: false`). `VALID_REGRESSION` must not be inferred
-  from it.
+  from it. See [Objective completion contract](#objective-completion-contract).
 
 CI passes `--expected-evals` with the exact pre-run eval manifest. The adapter
 writes one result file for every expected eval, including explicit invalid
 results when a baseline or skilled variant is missing or comparison invocation
-fails. It also writes `adapter-summary.json` with expected, observed, missing,
-unexpected, invalid, and written counts. The workflow requires the number of
-primary result files to equal the manifest count.
+fails. A parsed comparison record with an invalid shape becomes
+`comparison_report_invalid` for that eval instead of aborting the remaining
+batch. The adapter also writes `adapter-summary.json` with expected, observed,
+missing, unexpected, invalid, and written counts. The workflow requires the
+number of primary result files to equal the manifest count.
 
-The adapter consumes Vally JSONL and CLI output only. It does not depend on
-Vally package internals, so the result-accounting contract remains compatible
-with the separate Vally 0.13 dependency update.
+The adapter consumes Vally JSONL and CLI output only. Vally 0.9 and 0.13 both
+emit `stimulusName` plus a required `trialIndex` for comparison trials. The
+index is stable when `compare` is repeated over the same persisted inputs, but
+Vally does not promise a global ID across regenerated runs or future versions.
+Vally 0.13 exits nonzero when every judge slot errors while still writing the
+comparison report. The adapter reads that report, retries the identified slots,
+and treats a nonzero invocation with no report as a hard failure.
+
+## Practical preference floor
+
+The sign test proves that the direction is unlikely under a 50/50 null, but
+ties are outside its sample. Without an effect-size floor, `5W/95T/0L` has
+`p=0.03125` and passes although the skilled arm improves only 5% of counted
+trials. A preference pass therefore requires both:
+
+```text
+signTest.pValue <= 0.05
+abs((wins - losses) / countedTrials) >= 0.20
+```
+
+The mirrored 20% floor applies to report-only preference regressions. The floor
+uses only win/tie/loss direction; judge magnitude cannot affect it. Exhaustive
+enumeration shows that every record which can pass the sign test at the
+repository's current maximum of 24 trials already clears 20%, so this rule
+protects future larger evals without changing a current possible pass.
+
+`scenarioEvidence` remains the independence check in shadow mode. Repeated runs
+can stabilize one task, but they do not create new task samples. Moving the
+authoritative sign test to one vote per stimulus requires a separate eval-breadth
+migration because many current evals have fewer than five distinct stimuli.
+
+## Objective completion contract
+
+`VALID_REGRESSION` stays reserved until the harness can compute this tri-state
+primitive for each `(eval, stimulus, trialIndex, arm)`:
+
+| Value | Definition |
+|-------|------------|
+| `true` | Every explicitly designated objective-completion grader passed. |
+| `false` | At least one designated grader explicitly failed, and none was missing or errored. |
+| `unknown` | No grader was designated, or any designated result was missing, errored, duplicated, or mismatched. |
+
+Gate-eligible graders must be explicitly named in the eval, use a frozen
+repository allowlist of deterministic grader types, and have task-completion
+semantics. `kind: "code"` alone is not sufficient. LLM and human graders,
+aggregate scores, thresholds, and Vally's aggregate `gradeResult.passed` are
+prohibited. The adapter must read raw `gradeResult.details`, match grader
+instances by `(graderType, name)`, and pair arms by
+`(stimulusName, trialIndex)`.
+
+A baseline-pass/treatment-fail pair is an objective regression candidate, not a
+hard regression by itself because agent execution is still stochastic.
+`VALID_REGRESSION` requires conclusive predeclared paired confirmations, an
+exact one-sided test at `p <= 0.05`, an objective net-loss rate of at least 20%,
+and multiple-scenario correction when more than one completion scenario is
+tested. Until evals can declare these graders and Vally provides stable raw
+grader provenance, `completionTransitions.gateEligible` remains `false`.
 
 ## Correctness metrics
 
@@ -75,7 +131,7 @@ Track these metrics by model, judge, plugin, skill, and run:
 | Invalid-result rate and cause | `state`, `stateReason`, `errors[].code` | Keep infrastructure and eval-design failures out of skill verdicts |
 | Judge retry recovery | `comparisonAttempts`, `recoveredErrors[]`, `errors[]` | Measure transient judge failure and persistent failure separately |
 | Effective independent scenarios | `scenarioEvidence.count` and W/T/L | Show when repeated runs give trial volume without task breadth |
-| Preference effect and uncertainty | `netWin`, `signTest`, trial W/T/L | Measure credible skilled-versus-baseline preference |
+| Preference effect and uncertainty | `netWin`, `signTest`, `practicalSignificance`, trial W/T/L | Require statistical and practical skilled-versus-baseline improvement |
 | Completion transitions | `completionTransitions` | Diagnose possible completion changes without treating aggregate LLM grading as objective |
 | Cross-judge agreement | Explicit `state` plus `preferenceRegressed` | Measure judge robustness without conflating preference loss with objective regression |
 

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -73,6 +73,22 @@ Vally 0.13 exits nonzero when every judge slot errors while still writing the
 comparison report. The adapter reads that report, retries the identified slots,
 and treats a nonzero invocation with no report as a hard failure.
 
+## Reporting contract
+
+`consolidate.mjs --format simple` produces the PR decision and repair view. It
+preserves the execution model on every row, reports unique skill and
+model/skill-result counts, aggregates `adapter-summary.json` accounting, keeps
+Overfit visible, and uses distinct labels for improved, not proven improved,
+report-only preference loss, and invalid evidence. It states that objective
+regression is not enabled while `completionTransitions.gateEligible` is false.
+
+The compact table keeps only gate evidence, warnings, and the next action.
+`--format full` adds magnitude-weighted preference and absolute quality metrics
+and includes every result detail. Compact details are limited to non-passing,
+invalid, or warning-bearing results. Repeated-run W/T/L is shown only as
+reliability evidence, never beside the distinct-stimulus sign test as if both
+used the same inference unit.
+
 ## Practical preference floor
 
 The sign test proves that the direction is unlikely under a 50/50 null, but

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -162,7 +162,13 @@ collector to distinguish:
 - a malformed or invalid result.
 
 The run fails closed unless expected, observed, and written identities match
-exactly.
+exactly. This proof applies inside each matrix leg. Discovery omits entries with
+no eval specs. The PR collector separately requires the full reusable matrix to
+succeed and requires one downloaded `adapter-summary.json` per declared matrix
+entry before it renders any verdict. Partial artifacts remain available for
+diagnosis, but they are labeled incomplete and are never consolidated into
+quality evidence. A leg that found evals also fails if its primary result
+artifact is missing.
 
 ### 3. Run three Vally variants
 
@@ -241,6 +247,20 @@ The statistical test and practical floor answer different questions:
 
 Example: `5W / 95T / 0L` has `p = 0.03125`, but its net win is only 5%. It is
 statistically significant and practically sparse, so it does not pass.
+
+The 20% floor does not make small or niche instruments harder to pass. For
+every instrument from 5 through 25 stimuli, any record that can pass the exact
+sign test already has a net win of at least 20%. The first record changed by the
+floor is `5W / 21T / 0L` at 26 stimuli: `p = 0.03125`, but net win is only
+`5 / 26 = 19.2%`. `adapt.test.mjs` exhaustively checks this boundary.
+
+Per-eval overrides are intentionally unsupported. An override would matter
+only for a larger instrument with a statistically credible but sparse effect,
+which is the exact false-positive class the floor prevents. It would also let
+authors tune a threshold after seeing results. If repository evidence later
+shows that 20% is wrong, change the versioned repository policy with a
+predeclared rationale and apply it consistently; do not create result-specific
+exceptions.
 
 ```mermaid
 flowchart TD

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -126,6 +126,12 @@ These are planning values, not Vally requirements. Ties require more total
 stimuli because they do not enter the sign test. A non-pass is therefore not
 proof that the skill has no effect.
 
+The table is sign-test power before the 20% practical floor. At a true 60%
+conditional win rate, 158 votes give the sign test 80.6% power, but the combined
+gate passes about 52.2% of records because the expected effect sits exactly on
+the floor. The gate is intended to certify effects above that practical
+threshold.
+
 ## Objective completion contract
 
 `VALID_REGRESSION` stays reserved until the harness can compute this tri-state

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -10,10 +10,30 @@ invokes this adapter; CI invokes `adapt.mjs` directly.
 The adapter keeps infrastructure reliability distinct from a skill-quality
 result:
 
+- `state` is the authoritative four-state result:
+
+  | State | Meaning |
+  |-------|---------|
+  | `VALID_PASS` | The completed comparison shows a credible preference improvement. |
+  | `VALID_REGRESSION` | Reserved for an objective completion regression. The current Vally compare output does not provide a gate-eligible objective completion primitive, so the adapter does not emit this state yet. |
+  | `VALID_NO_CHANGE` | The completed comparison does not show a credible improvement. A credible LLM preference loss is recorded as `preferenceRegressed: true`, but stays report-only. |
+  | `INVALID_INCONCLUSIVE` | The run cannot support a quality verdict because evidence is missing, underpowered, errored, unmatched, or inconsistent. |
+
+- `stateReason` gives the machine-readable cause and phase. Use it instead of
+  parsing `reason`.
+- Renderers treat legacy `regressed: true` records that have no `state` as
+  report-only preference losses. They do not relabel historical preference data
+  as objective completion regressions.
 - `erroredCount` counts matched baseline/treatment trials whose comparison judge
-  failed. The adapter retries a comparison once because model or transport
-  timeouts can be transient. If the retry does not reduce errors, the original
-  report remains visible.
+  failed. `errors[]` classifies unresolved failures, including
+  `judge_session_idle_timeout`, `judge_organization_disabled`,
+  `judge_rate_limited`, and `judge_service_error`.
+- The adapter retries a comparison once when judgment slots fail. It freezes all
+  successful first-attempt judgments and uses the retry only to fill slots that
+  errored. `comparisonAttempts`, `recoveredErrors[]`, and `errors[]` preserve the
+  attempt history. Recovery requires Vally to emit `trialIndex` for both
+  attempts. If that stable key is absent, the adapter fails closed with
+  `retry_result_missing` instead of pairing trials by array position.
 - `unmatchedBaseline` and `unmatchedTreatment` list trajectories that could not
   be paired, commonly because one arm timed out or failed before grading.
   `unmatchedTrialCount` is their combined count.
@@ -26,6 +46,38 @@ result:
   reached the sign test's 5% threshold. It is a property of the eval spec, not
   of the run, and it is fixed by adding scenarios or raising `defaults.runs` —
   never by changing the skill. See `eng/eval-quality/README.md`.
+- `scenarioEvidence` collapses repeated runs for one stimulus into one effective
+  scenario vote. This is report-only (`gateEligible: false`) until the repository
+  selects a practical threshold and has enough independent scenarios.
+- `completionTransitions` reports aggregate baseline/treatment pass transitions.
+  Vally's aggregate pass can include LLM grading, so this signal is also
+  report-only (`gateEligible: false`). `VALID_REGRESSION` must not be inferred
+  from it.
+
+CI passes `--expected-evals` with the exact pre-run eval manifest. The adapter
+writes one result file for every expected eval, including explicit invalid
+results when a baseline or skilled variant is missing or comparison invocation
+fails. It also writes `adapter-summary.json` with expected, observed, missing,
+unexpected, invalid, and written counts. The workflow requires the number of
+primary result files to equal the manifest count.
+
+The adapter consumes Vally JSONL and CLI output only. It does not depend on
+Vally package internals, so the result-accounting contract remains compatible
+with the separate Vally 0.13 dependency update.
+
+## Correctness metrics
+
+Track these metrics by model, judge, plugin, skill, and run:
+
+| Metric | Source | Use |
+|--------|--------|-----|
+| Manifest completeness | `expectedEvalCount`, `writtenResultCount`, `unexpectedEvalCount` | Detect silent result loss or extra results |
+| Invalid-result rate and cause | `state`, `stateReason`, `errors[].code` | Keep infrastructure and eval-design failures out of skill verdicts |
+| Judge retry recovery | `comparisonAttempts`, `recoveredErrors[]`, `errors[]` | Measure transient judge failure and persistent failure separately |
+| Effective independent scenarios | `scenarioEvidence.count` and W/T/L | Show when repeated runs give trial volume without task breadth |
+| Preference effect and uncertainty | `netWin`, `signTest`, trial W/T/L | Measure credible skilled-versus-baseline preference |
+| Completion transitions | `completionTransitions` | Diagnose possible completion changes without treating aggregate LLM grading as objective |
+| Cross-judge agreement | Explicit `state` plus `preferenceRegressed` | Measure judge robustness without conflating preference loss with objective regression |
 
 Inspect the raw variant `results.jsonl` before changing a skill. A
 `status: "error"` agent timeout is different from a successful pair whose

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -569,8 +569,53 @@ function classifyComparisonError(evidence) {
 
 function comparisonTrialKey(stimulusName, trial) {
   const trialIndex = trial?.trialIndex;
-  if (trialIndex == null) return null;
-  return JSON.stringify([stimulusName ?? "", trialIndex]);
+  if (!stimulusName || !Number.isInteger(trialIndex) || trialIndex < 0) return null;
+  return JSON.stringify([stimulusName, trialIndex]);
+}
+
+function comparisonTrialIdentityErrors(report) {
+  const seen = new Set();
+  const duplicates = new Set();
+  const errors = [];
+  for (const stimulus of report.stimuli ?? []) {
+    for (const trial of stimulus.trials ?? []) {
+      const key = comparisonTrialKey(stimulus.stimulusName, trial);
+      if (key === null) {
+        errors.push({
+          phase: "comparison_pairing",
+          kind: "permanent",
+          code: "comparison_trial_identity_missing",
+          message: "Comparison trial is missing trialIndex",
+          stimulusName: stimulus.stimulusName,
+          trialIndex: null,
+        });
+      } else if (seen.has(key) && !duplicates.has(key)) {
+        duplicates.add(key);
+        errors.push({
+          phase: "comparison_pairing",
+          kind: "permanent",
+          code: "comparison_trial_identity_duplicate",
+          message: "Comparison report contains a duplicate (stimulusName, trialIndex) slot",
+          stimulusName: stimulus.stimulusName,
+          trialIndex: trial.trialIndex,
+        });
+      } else {
+        seen.add(key);
+      }
+    }
+  }
+  return errors;
+}
+
+function comparisonTrialKeyCounts(report) {
+  const counts = new Map();
+  for (const stimulus of report.stimuli ?? []) {
+    for (const trial of stimulus.trials ?? []) {
+      const key = comparisonTrialKey(stimulus.stimulusName, trial);
+      if (key !== null) counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return counts;
 }
 
 function summarizeComparisonTrials(report, invalidateInterval = false) {
@@ -611,11 +656,13 @@ function summarizeComparisonTrials(report, invalidateInterval = false) {
  */
 function mergeComparisonReports(primaryReport, retryReport) {
   const report = structuredClone(primaryReport);
+  const primaryKeyCounts = comparisonTrialKeyCounts(primaryReport);
+  const retryKeyCounts = comparisonTrialKeyCounts(retryReport);
   const retryTrials = new Map();
   for (const stimulus of retryReport?.stimuli ?? []) {
     for (const trial of stimulus.trials ?? []) {
       const key = comparisonTrialKey(stimulus.stimulusName, trial);
-      if (key !== null) retryTrials.set(key, trial);
+      if (key !== null && retryKeyCounts.get(key) === 1) retryTrials.set(key, trial);
     }
   }
 
@@ -633,7 +680,9 @@ function mergeComparisonReports(primaryReport, retryReport) {
       retriedSlots++;
       const error = classifyComparisonError(trial.evidence);
       const retryKey = comparisonTrialKey(stimulus.stimulusName, trial);
-      const retry = retryKey === null ? undefined : retryTrials.get(retryKey);
+      const primaryIdentityIsUnique =
+        retryKey !== null && primaryKeyCounts.get(retryKey) === 1;
+      const retry = primaryIdentityIsUnique ? retryTrials.get(retryKey) : undefined;
       if (retry && !retry.errored) {
         recoveredErrors.push({
           stimulusName: stimulus.stimulusName,
@@ -648,14 +697,34 @@ function mergeComparisonReports(primaryReport, retryReport) {
         };
       }
 
-      const retryError = retry?.errored
-        ? classifyComparisonError(retry.evidence)
-        : {
-            phase: "comparison_judge",
-            kind: "unknown",
-            code: "retry_result_missing",
-            message: "Comparison retry did not return the planned trial slot",
-          };
+      const retryError = !primaryIdentityIsUnique
+        ? {
+            phase: "comparison_pairing",
+            kind: "permanent",
+            code:
+              retryKey === null
+                ? "comparison_trial_identity_missing"
+                : "comparison_trial_identity_duplicate",
+            message:
+              retryKey === null
+                ? "Original comparison trial is missing trialIndex"
+                : "Original comparison report contains a duplicate trial slot",
+          }
+        : retryKey !== null && (retryKeyCounts.get(retryKey) ?? 0) > 1
+          ? {
+              phase: "comparison_pairing",
+              kind: "permanent",
+              code: "retry_result_ambiguous",
+              message: "Comparison retry returned a duplicate trial slot",
+            }
+          : retry?.errored
+            ? classifyComparisonError(retry.evidence)
+            : {
+                phase: "comparison_judge",
+                kind: "unknown",
+                code: "retry_result_missing",
+                message: "Comparison retry did not return the planned trial slot",
+              };
       persistentErrors.push({
         stimulusName: stimulus.stimulusName,
         trialIndex: trial.trialIndex ?? index,
@@ -809,6 +878,7 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   const unmatchedBaseline = report.unmatchedBaseline ?? [];
   const unmatchedTreatment = report.unmatchedTreatment ?? [];
   const unmatchedTrialCount = unmatchedBaseline.length + unmatchedTreatment.length;
+  const identityErrors = comparisonTrialIdentityErrors(report);
 
   // Raw paired trials remain authoritative for report-integrity checks, retry
   // accounting, and within-stimulus reliability. They are not independent task
@@ -836,7 +906,11 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     );
   }
 
-  const conclusive = s.erroredCount === 0 && unmatchedTrialCount === 0 && summaryAgrees;
+  const conclusive =
+    s.erroredCount === 0 &&
+    unmatchedTrialCount === 0 &&
+    summaryAgrees &&
+    identityErrors.length === 0;
 
   // Collapse repeated runs to one vote per stimulus. A stimulus votes in the
   // direction supported by more of its successful runs; an even split or all
@@ -1074,11 +1148,13 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   if (!conclusive) {
     state = VERDICT_STATES.INVALID_INCONCLUSIVE;
     stateReason =
-      unresolvedErrors.length > 0
-        ? { code: "comparison_judge_error", phase: "comparison_judge" }
-        : unmatchedTrialCount > 0
-          ? { code: "unmatched_trajectories", phase: "comparison_pairing" }
-          : { code: "comparison_summary_mismatch", phase: "adapter" };
+      identityErrors.length > 0
+        ? { code: identityErrors[0].code, phase: "comparison_pairing" }
+        : unresolvedErrors.length > 0
+          ? { code: "comparison_judge_error", phase: "comparison_judge" }
+          : unmatchedTrialCount > 0
+            ? { code: "unmatched_trajectories", phase: "comparison_pairing" }
+            : { code: "comparison_summary_mismatch", phase: "adapter" };
   } else if (underpowered) {
     state = VERDICT_STATES.INVALID_INCONCLUSIVE;
     stateReason = { code: "underpowered", phase: "eval_design" };
@@ -1168,7 +1244,7 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
       recoveredErrors: [],
       persistentErrors: [],
     },
-    errors: unresolvedErrors,
+    errors: [...identityErrors, ...unresolvedErrors],
     recoveredErrors,
     scenarios,
     reason,

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -76,6 +76,11 @@ const { values: opts } = parseArgs({
     // by `skill-validator overfitting`. When provided, each verdict is annotated
     // with its matching overfittingResult (keyed by `${plugin}/${skill}`).
     overfitting: { type: "string" },
+    // Optional newline-delimited or JSON-array manifest of eval files selected by
+    // the workflow before execution. When supplied, every listed eval receives a
+    // results.json, including an explicit invalid verdict if a variant or compare
+    // result is missing.
+    "expected-evals": { type: "string" },
     help: { type: "boolean", default: false },
   },
   strict: true,
@@ -103,6 +108,8 @@ Options:
   --overfitting <file>      Optional JSON file from 'skill-validator overfitting'
                             (array of {plugin, skill, overfittingResult}). Merged
                             onto each verdict as verdict.overfittingResult.
+  --expected-evals <file>   Optional newline-delimited or JSON-array manifest of
+                            eval files that must each produce an explicit verdict.
   --help                    Show this help`);
   process.exit(opts.help ? 0 : 1);
 }
@@ -149,6 +156,34 @@ const SIGN_TEST_ALPHA = 0.05;
 // considerably more. eng/eval-quality/check_eval_quality.py enforces the same
 // number against eval specs before they are ever run.
 const MIN_CREDIBLE_TRIALS = 5;
+
+const VERDICT_STATES = Object.freeze({
+  VALID_PASS: "VALID_PASS",
+  VALID_REGRESSION: "VALID_REGRESSION",
+  VALID_NO_CHANGE: "VALID_NO_CHANGE",
+  INVALID_INCONCLUSIVE: "INVALID_INCONCLUSIVE",
+});
+
+function normalizeEvalFile(file) {
+  return String(file ?? "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "");
+}
+
+function loadExpectedEvalFiles(file) {
+  if (!file) return [];
+  const text = readFileSync(resolve(file), "utf-8").trim();
+  if (!text) return [];
+  let values;
+  if (text.startsWith("[")) {
+    values = JSON.parse(text);
+    if (!Array.isArray(values)) throw new Error("--expected-evals JSON must be an array");
+  } else {
+    values = text.split(/\r?\n/);
+  }
+  return [...new Set(values.map(normalizeEvalFile).filter(Boolean))].sort();
+}
 
 // ---------------------------------------------------------------------------
 // JSONL loading + provenance
@@ -290,7 +325,7 @@ function readNonActivationStimuli(evalFile, repoRoot) {
 }
 
 function evalFileOf(record) {
-  return record.experiment?.evalFile ?? record.evalFilePath ?? "";
+  return normalizeEvalFile(record.experiment?.evalFile ?? record.evalFilePath ?? "");
 }
 
 function groupByEval(records) {
@@ -483,6 +518,170 @@ function trialDirection(trial) {
   return typeof score === "number" ? Math.sign(score) : 0;
 }
 
+function classifyComparisonError(evidence) {
+  const text = String(evidence ?? "");
+  if (/session\.idle|waiting for session\.idle/i.test(text)) {
+    return {
+      phase: "comparison_judge",
+      kind: "transient",
+      code: "judge_session_idle_timeout",
+      message: text,
+    };
+  }
+  if (/organization.{0,80}disabled|disabled.{0,80}organization/i.test(text)) {
+    return {
+      phase: "comparison_judge",
+      kind: "permanent",
+      code: "judge_organization_disabled",
+      message: text,
+    };
+  }
+  if (/\b429\b|rate.?limit|throttl/i.test(text)) {
+    return {
+      phase: "comparison_judge",
+      kind: "transient",
+      code: "judge_rate_limited",
+      message: text,
+    };
+  }
+  if (/\b5\d\d\b|service unavailable|internal server error/i.test(text)) {
+    return {
+      phase: "comparison_judge",
+      kind: "transient",
+      code: "judge_service_error",
+      message: text,
+    };
+  }
+  return {
+    phase: "comparison_judge",
+    kind: "unknown",
+    code: "comparison_judge_error",
+    message: text || "Comparison judge failed without error evidence",
+  };
+}
+
+function comparisonTrialKey(stimulusName, trial) {
+  const trialIndex = trial?.trialIndex;
+  if (trialIndex == null) return null;
+  return JSON.stringify([stimulusName ?? "", trialIndex]);
+}
+
+function summarizeComparisonTrials(report, invalidateInterval = false) {
+  const counted = [];
+  let erroredCount = 0;
+  for (const stimulus of report.stimuli ?? []) {
+    const trials = stimulus.trials ?? [];
+    const stimulusCounted = trials.filter((trial) => !trial.errored);
+    erroredCount += trials.length - stimulusCounted.length;
+    counted.push(...stimulusCounted);
+    stimulus.meanScore = mean(stimulusCounted.map((trial) => trial.score)) ?? 0;
+  }
+  const wins = counted.filter((trial) => trialDirection(trial) > 0).length;
+  const losses = counted.filter((trial) => trialDirection(trial) < 0).length;
+  const ties = counted.length - wins - losses;
+  report.summary = {
+    ...(report.summary ?? {}),
+    trialCount: counted.length,
+    erroredCount,
+    meanScore: mean(counted.map((trial) => trial.score)) ?? 0,
+    wins,
+    ties,
+    losses,
+    winRate: counted.length ? wins / counted.length : 0,
+    ...(invalidateInterval
+      ? { ciLow: null, ciHigh: null, mcnemar: null, metricDeltas: null }
+      : {}),
+  };
+  return report;
+}
+
+/**
+ * Merge a retry without replacing successful first-attempt judgments.
+ *
+ * Vally compares a full slice at a time, so a retry necessarily returns another
+ * full report. Only errored first-attempt slots are eligible for replacement;
+ * every successful first-attempt slot remains frozen.
+ */
+function mergeComparisonReports(primaryReport, retryReport) {
+  const report = structuredClone(primaryReport);
+  const retryTrials = new Map();
+  for (const stimulus of retryReport?.stimuli ?? []) {
+    for (const trial of stimulus.trials ?? []) {
+      const key = comparisonTrialKey(stimulus.stimulusName, trial);
+      if (key !== null) retryTrials.set(key, trial);
+    }
+  }
+
+  const recoveredErrors = [];
+  const persistentErrors = [];
+  let frozenSuccesses = 0;
+  let retriedSlots = 0;
+  for (const stimulus of report.stimuli ?? []) {
+    stimulus.trials = (stimulus.trials ?? []).map((trial, index) => {
+      if (!trial.errored) {
+        frozenSuccesses++;
+        return { ...trial, comparisonAttempt: trial.comparisonAttempt ?? 1 };
+      }
+
+      retriedSlots++;
+      const error = classifyComparisonError(trial.evidence);
+      const retryKey = comparisonTrialKey(stimulus.stimulusName, trial);
+      const retry = retryKey === null ? undefined : retryTrials.get(retryKey);
+      if (retry && !retry.errored) {
+        recoveredErrors.push({
+          stimulusName: stimulus.stimulusName,
+          trialIndex: trial.trialIndex ?? index,
+          attempts: 2,
+          ...error,
+        });
+        return {
+          ...retry,
+          comparisonAttempt: 2,
+          recoveredFrom: error,
+        };
+      }
+
+      const retryError = retry?.errored
+        ? classifyComparisonError(retry.evidence)
+        : {
+            phase: "comparison_judge",
+            kind: "unknown",
+            code: "retry_result_missing",
+            message: "Comparison retry did not return the planned trial slot",
+          };
+      persistentErrors.push({
+        stimulusName: stimulus.stimulusName,
+        trialIndex: trial.trialIndex ?? index,
+        attempts: 2,
+        attemptHistory: [
+          { attempt: 1, ...error },
+          { attempt: 2, ...retryError },
+        ],
+      });
+      return {
+        ...trial,
+        comparisonAttempt: 2,
+        retryError,
+      };
+    });
+  }
+
+  report.retrySummary = {
+    attempts: 2,
+    retriedSlots,
+    recoveredSlots: recoveredErrors.length,
+    frozenSuccesses,
+    recoveredErrors,
+    persistentErrors,
+  };
+  // Retry-only unmatched records are ignored because no successful first-attempt
+  // slot can be invalidated by a retry. An original errored slot that the retry
+  // cannot match remains errored through `retry_result_missing`.
+  report.unmatchedBaseline = [...new Set(primaryReport.unmatchedBaseline ?? [])];
+  report.unmatchedTreatment = [...new Set(primaryReport.unmatchedTreatment ?? [])];
+  return summarizeComparisonTrials(report, recoveredErrors.length > 0);
+}
+
 /**
  * Run `vally compare` in two-run mode over one eval's baseline vs skilled
  * slices and return the parsed comparison record (or null on failure).
@@ -508,8 +707,19 @@ function runCompare(baselineSlice, skilledSlice, outFile) {
 
 function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
   const report = runCompare(baselineSlice, skilledSlice, outFile);
-  const errorCount = report?.summary?.erroredCount ?? 0;
-  if (errorCount === 0) return report;
+  if (!report) return null;
+  const errorCount = report.summary?.erroredCount ?? 0;
+  if (errorCount === 0) {
+    report.retrySummary = {
+      attempts: 1,
+      retriedSlots: 0,
+      recoveredSlots: 0,
+      frozenSuccesses: report?.summary?.trialCount ?? 0,
+      recoveredErrors: [],
+      persistentErrors: [],
+    };
+    return report;
+  }
 
   warn(`vally compare returned ${errorCount} errored trial(s); retrying once`);
 
@@ -517,18 +727,53 @@ function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
   try {
     retryReport = runCompare(baselineSlice, skilledSlice, `${outFile}.retry`);
   } catch (err) {
-    warn(`vally compare retry failed; keeping the original result (${err instanceof Error ? err.message : String(err)})`);
+    const detail = err instanceof Error ? err.message : String(err);
+    warn(`vally compare retry failed; keeping the original result (${detail})`);
+    const retryError = {
+      phase: "comparison_judge",
+      kind: "unknown",
+      code: "comparison_retry_invocation_failed",
+      message: detail,
+    };
+    const persistentErrors = [];
+    for (const stimulus of report.stimuli ?? []) {
+      for (const [index, trial] of (stimulus.trials ?? []).entries()) {
+        if (!trial.errored) continue;
+        const firstAttempt = classifyComparisonError(trial.evidence);
+        trial.comparisonAttempt = 2;
+        trial.retryError = retryError;
+        persistentErrors.push({
+          stimulusName: stimulus.stimulusName,
+          trialIndex: trial.trialIndex ?? index,
+          attempts: 2,
+          attemptHistory: [
+            { attempt: 1, ...firstAttempt },
+            { attempt: 2, ...retryError },
+          ],
+        });
+      }
+    }
+    report.retrySummary = {
+      attempts: 2,
+      retriedSlots: errorCount,
+      recoveredSlots: 0,
+      frozenSuccesses: report?.summary?.trialCount ?? 0,
+      recoveredErrors: [],
+      persistentErrors,
+      retryInvocationError: detail,
+    };
     return report;
   }
 
-  const retryErrorCount = retryReport?.summary?.erroredCount ?? Number.POSITIVE_INFINITY;
-  if (retryErrorCount < errorCount) {
-    warn(`vally compare retry reduced errored trials from ${errorCount} to ${retryErrorCount}`);
-    return retryReport;
+  const merged = mergeComparisonReports(report, retryReport);
+  const mergedErrorCount = merged?.summary?.erroredCount ?? errorCount;
+  if (mergedErrorCount < errorCount) {
+    warn(`vally compare retry reduced errored trials from ${errorCount} to ${mergedErrorCount} without replacing successful judgments`);
+    return merged;
   }
 
   warn(`vally compare retry did not reduce errored trials; keeping the original result`);
-  return report;
+  return merged;
 }
 
 // ---------------------------------------------------------------------------
@@ -536,6 +781,7 @@ function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
 // ---------------------------------------------------------------------------
 
 function pct(x) {
+  if (typeof x !== "number" || !Number.isFinite(x)) return "—";
   return `${(x * 100).toFixed(1)}%`;
 }
 
@@ -629,6 +875,8 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
 
     const scenario = {
       scenarioName: name,
+      runCount: counted.length,
+      direction: sWins > sLosses ? "better" : sLosses > sWins ? "worse" : "none",
       // The scenario's contribution to the verdict, on the gate's own basis.
       netWin: counted.length ? (sWins - sLosses) / counted.length : 0,
       wins: sWins,
@@ -661,6 +909,64 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     }
     return scenario;
   });
+
+  // Repeated runs measure within-stimulus reliability, not independent task
+  // breadth. This report-only statistic gives every stimulus one directional
+  // vote so consumers can see the effective cross-scenario evidence without
+  // changing the current trial-level gate.
+  const scenarioDirections = scenarios
+    .filter((scenario) => scenario.runCount > 0)
+    .map((scenario) => (scenario.direction === "better" ? 1 : scenario.direction === "worse" ? -1 : 0));
+  const scenarioWins = scenarioDirections.filter((value) => value > 0).length;
+  const scenarioLosses = scenarioDirections.filter((value) => value < 0).length;
+  const scenarioTies = scenarioDirections.length - scenarioWins - scenarioLosses;
+  const scenarioDirection =
+    scenarioWins > scenarioLosses ? "better" : scenarioLosses > scenarioWins ? "worse" : "none";
+  const scenarioPValue =
+    scenarioDirection === "worse"
+      ? signTestPValue(scenarioLosses, scenarioWins)
+      : signTestPValue(scenarioWins, scenarioLosses);
+  const scenarioEvidence = {
+    gateEligible: false,
+    reason: "Report-only: repeated runs are collapsed to one directional vote per stimulus",
+    count: scenarioDirections.length,
+    wins: scenarioWins,
+    ties: scenarioTies,
+    losses: scenarioLosses,
+    discordant: scenarioWins + scenarioLosses,
+    direction: scenarioDirection,
+    netWin: scenarioDirections.length
+      ? (scenarioWins - scenarioLosses) / scenarioDirections.length
+      : 0,
+    pValue: scenarioPValue,
+    alpha: SIGN_TEST_ALPHA,
+  };
+
+  // Vally compare currently exposes aggregate per-arm pass booleans. They are
+  // useful telemetry, but may include LLM grader results, so they are explicitly
+  // not eligible for a hard completion gate.
+  const completionTransitions = {
+    gateEligible: false,
+    source: "vally_compare_aggregate_pass",
+    bothPassed: 0,
+    baselineOnly: 0,
+    treatmentOnly: 0,
+    neitherPassed: 0,
+    unknown: 0,
+  };
+  for (const trial of (report.stimuli ?? []).flatMap((stimulus) => stimulus.trials ?? [])) {
+    if (trial.errored || typeof trial.baselinePassed !== "boolean" || typeof trial.treatmentPassed !== "boolean") {
+      completionTransitions.unknown++;
+    } else if (trial.baselinePassed && trial.treatmentPassed) {
+      completionTransitions.bothPassed++;
+    } else if (trial.baselinePassed) {
+      completionTransitions.baselineOnly++;
+    } else if (trial.treatmentPassed) {
+      completionTransitions.treatmentOnly++;
+    } else {
+      completionTransitions.neitherPassed++;
+    }
+  }
 
   const sweep = directions.length > 0 && wins === directions.length;
   // The sign test conditions on the discordant (non-tie) trials, so this — not
@@ -705,14 +1011,71 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     `${s.erroredCount ? `, ${s.erroredCount} errored` : ""}` +
     `${unmatchedTrialCount ? `, ${unmatchedTrialCount} unmatched` : ""} — ${credibility}`;
 
+  const unresolvedErrors = (report.stimuli ?? []).flatMap((stimulus) =>
+    (stimulus.trials ?? [])
+      .map((trial, index) => ({ trial, index }))
+      .filter(({ trial }) => trial.errored)
+      .map(({ trial, index }) => ({
+        ...(() => {
+          const firstAttempt = classifyComparisonError(trial.evidence);
+          const finalAttempt = trial.retryError ?? firstAttempt;
+          const attempts = trial.comparisonAttempt ?? report.retrySummary?.attempts ?? 1;
+          return {
+            stimulusName: stimulus.stimulusName,
+            trialIndex: trial.trialIndex ?? index,
+            attempts,
+            ...finalAttempt,
+            attemptHistory:
+              attempts > 1
+                ? [
+                    { attempt: 1, ...firstAttempt },
+                    { attempt: 2, ...finalAttempt },
+                  ]
+                : [{ attempt: 1, ...firstAttempt }],
+          };
+        })(),
+      })),
+  );
+  const recoveredErrors = report.retrySummary?.recoveredErrors ?? [];
+
+  let state;
+  let stateReason;
+  if (!conclusive) {
+    state = VERDICT_STATES.INVALID_INCONCLUSIVE;
+    stateReason =
+      unresolvedErrors.length > 0
+        ? { code: "comparison_judge_error", phase: "comparison_judge" }
+        : unmatchedTrialCount > 0
+          ? { code: "unmatched_trajectories", phase: "comparison_pairing" }
+          : { code: "comparison_summary_mismatch", phase: "adapter" };
+  } else if (underpowered) {
+    state = VERDICT_STATES.INVALID_INCONCLUSIVE;
+    stateReason = { code: "underpowered", phase: "eval_design" };
+  } else if (passed) {
+    state = VERDICT_STATES.VALID_PASS;
+    stateReason = { code: "credible_preference_improvement", phase: "decision" };
+  } else if (regressed) {
+    // A credible ordinal preference loss is useful triage evidence, but it is
+    // not an objective task-completion regression. Keep the legacy `regressed`
+    // field for compatibility and make the new state explicit about that limit.
+    state = VERDICT_STATES.VALID_NO_CHANGE;
+    stateReason = { code: "preference_regression_report_only", phase: "decision" };
+  } else {
+    state = VERDICT_STATES.VALID_NO_CHANGE;
+    stateReason = { code: "no_credible_preference_change", phase: "decision" };
+  }
+
   return {
     skillName: identity.skill,
     skillPath: identity.skillPath,
+    state,
+    stateReason,
     conclusive,
     underpowered,
     minCredibleTrials: MIN_CREDIBLE_TRIALS,
     passed,
     regressed,
+    preferenceRegressed: regressed,
     // The deciding statistic: (wins - losses) / trials as the effect size, and
     // an exact one-sided sign test over the discordant trials as its
     // credibility. Magnitude-free, so it cannot reverse when the judge upgrades
@@ -743,13 +1106,34 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     unmatchedTreatment,
     mcnemar: s.mcnemar,
     metricDeltas: s.metricDeltas,
+    scenarioEvidence,
+    completionTransitions,
+    comparisonAttempts: report.retrySummary ?? {
+      attempts: 1,
+      retriedSlots: 0,
+      recoveredSlots: 0,
+      frozenSuccesses: directions.length,
+      recoveredErrors: [],
+      persistentErrors: [],
+    },
+    errors: unresolvedErrors,
+    recoveredErrors,
     scenarios,
     reason,
   };
 }
 
 function verdictSummaryLine(v) {
-  const icon = !v.conclusive || v.underpowered ? "⚠️" : v.passed ? "✅" : "❌";
+  const icon =
+    v.state === VERDICT_STATES.INVALID_INCONCLUSIVE || !v.conclusive || v.underpowered
+      ? "⚠️"
+      : v.state === VERDICT_STATES.VALID_REGRESSION
+        ? "🔻"
+        : v.passed
+          ? "✅"
+          : v.preferenceRegressed
+            ? "📉"
+            : "❌";
   // Ordered and signed by net win, on the same basis as the verdict, so a line
   // can never point ▼ for a scenario contributing a positive net win.
   const scenarios = v.scenarios
@@ -760,6 +1144,102 @@ function verdictSummaryLine(v) {
     )
     .join("\n");
   return `${icon} ${v.skillName}: ${v.reason}${scenarios ? "\n" + scenarios : ""}`;
+}
+
+function invalidVerdict(identity, cause, message, accounting = {}) {
+  const error = {
+    phase: cause.phase,
+    kind: cause.kind ?? "permanent",
+    code: cause.code,
+    message,
+  };
+  return {
+    skillName: identity.skill,
+    skillPath: identity.skillPath,
+    state: VERDICT_STATES.INVALID_INCONCLUSIVE,
+    stateReason: { code: cause.code, phase: cause.phase },
+    conclusive: false,
+    underpowered: false,
+    minCredibleTrials: MIN_CREDIBLE_TRIALS,
+    passed: false,
+    regressed: false,
+    preferenceRegressed: false,
+    netWin: 0,
+    signTest: {
+      wins: 0,
+      ties: 0,
+      losses: 0,
+      discordant: 0,
+      direction: "none",
+      pValue: 1,
+      alpha: SIGN_TEST_ALPHA,
+    },
+    scenarioEvidence: {
+      gateEligible: false,
+      reason: "No complete comparison was available",
+      count: 0,
+      wins: 0,
+      ties: 0,
+      losses: 0,
+      discordant: 0,
+      direction: "none",
+      netWin: 0,
+      pValue: 1,
+      alpha: SIGN_TEST_ALPHA,
+    },
+    completionTransitions: {
+      gateEligible: false,
+      source: "vally_compare_aggregate_pass",
+      bothPassed: 0,
+      baselineOnly: 0,
+      treatmentOnly: 0,
+      neitherPassed: 0,
+      unknown: 0,
+    },
+    comparisonAttempts: {
+      attempts: 0,
+      retriedSlots: 0,
+      recoveredSlots: 0,
+      frozenSuccesses: 0,
+      recoveredErrors: [],
+      persistentErrors: [],
+    },
+    meanScore: null,
+    confidenceInterval: { low: null, high: null, level: 0.95 },
+    winRate: 0,
+    wins: 0,
+    ties: 0,
+    losses: 0,
+    trialCount: 0,
+    erroredCount: 0,
+    unmatchedTrialCount: 0,
+    unmatchedBaseline: [],
+    unmatchedTreatment: [],
+    mcnemar: null,
+    metricDeltas: [],
+    scenarios: [],
+    errors: [error],
+    recoveredErrors: [],
+    accounting,
+    reason: message,
+  };
+}
+
+function writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval) {
+  const results = {
+    schemaVersion: 2,
+    evalFile,
+    model: opts.model,
+    judgeModel: opts["judge-model"],
+    timestamp: new Date().toISOString(),
+    expectedEval,
+    verdicts: [verdict],
+  };
+  const evalOutDir = join(outputRoot, identity.plugin, identity.skill);
+  mkdirSync(evalOutDir, { recursive: true });
+  const outputPath = join(evalOutDir, "results.json");
+  writeFileSync(outputPath, JSON.stringify(results, null, 2));
+  return outputPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -773,8 +1253,8 @@ function main() {
   const skilledFile = join(runDir, opts["skilled-variant"], "results.jsonl");
   const pluginFile = join(runDir, opts["plugin-variant"], "results.jsonl");
 
-  const baselineRecords = loadJsonlFile(baselineFile);
-  const skilledRecords = loadJsonlFile(skilledFile);
+  const baselineRecords = existsSync(baselineFile) ? loadJsonlFile(baselineFile) : [];
+  const skilledRecords = existsSync(skilledFile) ? loadJsonlFile(skilledFile) : [];
   const hasPlugin = existsSync(pluginFile);
   const pluginRecords = hasPlugin ? loadJsonlFile(pluginFile) : [];
   console.log(
@@ -791,27 +1271,80 @@ function main() {
   // empty map => verdict.overfittingResult stays null (byte-identical output).
   const overfittingMap = loadOverfittingMap(opts.overfitting);
 
-  // Union of evals seen in either variant so an eval that dropped out of one is
-  // surfaced rather than silently disappearing.
-  const allEvals = [...new Set([...baselineByEval.keys(), ...skilledByEval.keys()])].sort();
+  const expectedManifestProvided = Boolean(opts["expected-evals"]);
+  const expectedEvals = loadExpectedEvalFiles(opts["expected-evals"]);
+  const expectedSet = new Set(expectedEvals);
+  const observedEvals = [...new Set([...baselineByEval.keys(), ...skilledByEval.keys()])].map(
+    normalizeEvalFile,
+  );
+  const observedSet = new Set(observedEvals);
+  const missingEvals = expectedEvals.filter((evalFile) => !observedSet.has(evalFile));
+  // Include the declared manifest first so an eval missing from both variants
+  // still receives an explicit invalid result instead of disappearing.
+  const allEvals = [...new Set([...expectedEvals, ...observedEvals])].sort();
 
   const workDir = mkdtempSync(join(tmpdir(), "vally-adapt-"));
   let written = 0;
   let incomplete = 0;
+  const invalidEvals = [];
+  const unexpectedEvals = [];
   try {
     for (const evalFile of allEvals) {
       const { skill, plugin, skillPath } = evalIdentity(evalFile);
+      const identity = { skill, plugin, skillPath };
+      const expectedEval = !expectedManifestProvided || expectedSet.has(normalizeEvalFile(evalFile));
       const skilled = skilledByEval.get(evalFile) ?? [];
       const baseline = baselineByEval.get(evalFile) ?? [];
       const pluginRecs = pluginByEval.get(evalFile) ?? [];
 
+      if (!expectedEval) {
+        unexpectedEvals.push(evalFile);
+      }
+      if (skilled.length === 0 && baseline.length === 0) {
+        const message = `${plugin}/${skill}: baseline and skilled variants produced no records`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "missing_baseline_and_skilled_records", phase: "executor" },
+          message,
+          { baselineRecords: 0, skilledRecords: 0, pluginRecords: pluginRecs.length },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
+        incomplete++;
+        continue;
+      }
       if (skilled.length === 0) {
-        warn(`${plugin}/${skill}: skilled variant produced no records — no verdict written`);
+        const message = `${plugin}/${skill}: skilled variant produced no records`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "missing_skilled_records", phase: "executor" },
+          message,
+          { baselineRecords: baseline.length, skilledRecords: 0, pluginRecords: pluginRecs.length },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
         incomplete++;
         continue;
       }
       if (baseline.length === 0) {
-        warn(`${plugin}/${skill}: baseline variant produced no records — cannot compare, no verdict written`);
+        const message = `${plugin}/${skill}: baseline variant produced no records — cannot compare`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "missing_baseline_records", phase: "executor" },
+          message,
+          { baselineRecords: 0, skilledRecords: skilled.length, pluginRecords: pluginRecs.length },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
         incomplete++;
         continue;
       }
@@ -826,12 +1359,35 @@ function main() {
       try {
         report = runCompareWithRetry(baselineSlice, skilledSlice, compareOut);
       } catch (err) {
-        warn(`${plugin}/${skill}: vally compare failed — no verdict written (${err instanceof Error ? err.message : String(err)})`);
+        const detail = err instanceof Error ? err.message : String(err);
+        const message = `${plugin}/${skill}: vally compare failed (${detail})`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "comparison_invocation_failed", phase: "comparison_judge", kind: "unknown" },
+          message,
+          { baselineRecords: baseline.length, skilledRecords: skilled.length, pluginRecords: pluginRecs.length },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
         incomplete++;
         continue;
       }
       if (!report) {
-        warn(`${plugin}/${skill}: vally compare produced no comparison record — no verdict written`);
+        const message = `${plugin}/${skill}: vally compare produced no comparison record`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "comparison_record_missing", phase: "comparison_judge", kind: "unknown" },
+          message,
+          { baselineRecords: baseline.length, skilledRecords: skilled.length, pluginRecords: pluginRecs.length },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
         incomplete++;
         continue;
       }
@@ -853,27 +1409,36 @@ function main() {
 
       const verdict = comparisonToVerdict(
         report,
-        { skill, plugin, skillPath },
+        identity,
         roles,
         readNonActivationStimuli(evalFile, opts["repo-root"]),
       );
+      if (!expectedEval) {
+        verdict.state = VERDICT_STATES.INVALID_INCONCLUSIVE;
+        verdict.stateReason = { code: "unexpected_eval", phase: "adapter" };
+        verdict.conclusive = false;
+        verdict.passed = false;
+        verdict.regressed = false;
+        verdict.preferenceRegressed = false;
+        verdict.errors.push({
+          phase: "adapter",
+          kind: "permanent",
+          code: "unexpected_eval",
+          message: `${evalFile} was observed but was not in the expected-eval manifest`,
+        });
+        verdict.reason = `${verdict.reason}; observed eval was not in the expected-eval manifest`;
+      }
       // Only annotate when --overfitting was supplied, so output is
       // byte-identical to before when the flag is absent.
       if (opts.overfitting) {
         verdict.overfittingResult = overfittingMap.get(`${plugin}/${skill}`) ?? null;
       }
-      const results = {
-        model: opts.model,
-        judgeModel: opts["judge-model"],
-        timestamp: new Date().toISOString(),
-        verdicts: [verdict],
-      };
-
-      const evalOutDir = join(outputRoot, plugin, skill);
-      mkdirSync(evalOutDir, { recursive: true });
-      const outputPath = join(evalOutDir, "results.json");
-      writeFileSync(outputPath, JSON.stringify(results, null, 2));
+      const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
       written++;
+      if (verdict.state === VERDICT_STATES.INVALID_INCONCLUSIVE) {
+        invalidEvals.push(evalFile);
+        incomplete++;
+      }
 
       console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
     }
@@ -882,6 +1447,27 @@ function main() {
   }
 
   const incompleteNote = incomplete > 0 ? ` (${incomplete} eval(s) incomplete — see warnings above)` : "";
+  mkdirSync(outputRoot, { recursive: true });
+  writeFileSync(
+    join(outputRoot, "adapter-summary.json"),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        expectedManifestProvided,
+        expectedEvalCount: expectedEvals.length,
+        observedEvalCount: observedEvals.length,
+        writtenResultCount: written,
+        missingEvalCount: missingEvals.length,
+        unexpectedEvalCount: unexpectedEvals.length,
+        invalidEvalCount: invalidEvals.length,
+        missingEvals,
+        invalidEvals,
+        unexpectedEvals,
+      },
+      null,
+      2,
+    ),
+  );
   console.log(`\nWrote ${written} results.json file(s) under ${outputRoot}${incompleteNote}`);
 }
 
@@ -907,6 +1493,10 @@ export {
   splitVallyCommand,
   signTestPValue,
   trialDirection,
+  classifyComparisonError,
+  mergeComparisonReports,
+  loadExpectedEvalFiles,
+  VERDICT_STATES,
   MIN_CREDIBLE_TRIALS,
   SIGN_TEST_ALPHA,
 };

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -1426,7 +1426,16 @@ function main() {
   let written = 0;
   let incomplete = 0;
   const invalidEvals = [];
+  const measurementInvalidEvals = [];
   const unexpectedEvals = [];
+  const recordInvalidEval = (evalFile, verdict) => {
+    invalidEvals.push(evalFile);
+    // Underpowered instruments are tracked separately as design debt. Every
+    // other invalid state is measurement failure and must fail the matrix leg.
+    if (verdict.stateReason?.code !== "underpowered") {
+      measurementInvalidEvals.push(evalFile);
+    }
+  };
   try {
     for (const evalFile of allEvals) {
       const { skill, plugin, skillPath } = evalIdentity(evalFile);
@@ -1450,7 +1459,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1466,7 +1475,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1482,7 +1491,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1509,7 +1518,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1525,7 +1534,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1570,7 +1579,7 @@ function main() {
         );
         const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
         console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         written++;
         incomplete++;
         continue;
@@ -1598,7 +1607,7 @@ function main() {
       const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
       written++;
       if (verdict.state === VERDICT_STATES.INVALID_INCONCLUSIVE) {
-        invalidEvals.push(evalFile);
+        recordInvalidEval(evalFile, verdict);
         incomplete++;
       }
 
@@ -1622,8 +1631,10 @@ function main() {
         missingEvalCount: missingEvals.length,
         unexpectedEvalCount: unexpectedEvals.length,
         invalidEvalCount: invalidEvals.length,
+        measurementInvalidEvalCount: measurementInvalidEvals.length,
         missingEvals,
         invalidEvals,
+        measurementInvalidEvals,
         unexpectedEvals,
       },
       null,

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -144,6 +144,12 @@ Options:
 // discordant count down and a tie-heavy record simply fails to reach 5%.
 const SIGN_TEST_ALPHA = 0.05;
 
+// Statistical significance alone can approve a negligible effect when ties
+// dominate: 5W/95T/0L has p=0.031 but improves only 5% of counted trials. Keep
+// the effect-size floor magnitude-free so stronger judge adjectives cannot
+// reintroduce the variance reversal fixed in dotnet/skills#952.
+const MIN_PRACTICAL_NET_WIN = 0.2;
+
 // Minimum counted trials behind a verdict. This is not a chosen constant: the
 // sign test cannot reach 5% on fewer than five discordant trials
 // (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5), and discordant trials can never
@@ -700,9 +706,21 @@ function runCompare(baselineSlice, skilledSlice, outFile) {
     "--output",
     outFile,
   ];
-  execFileSync(bin, args, { stdio: ["ignore", "ignore", "inherit"] });
-  const records = loadJsonlFile(outFile);
-  return records[0] ?? null;
+  let invocationError;
+  try {
+    execFileSync(bin, args, { stdio: ["ignore", "ignore", "inherit"] });
+  } catch (error) {
+    invocationError = error;
+  }
+
+  // Vally 0.13 exits nonzero when every comparison trial errors, but it writes
+  // the structured comparison report first. That report is exactly what the
+  // adapter needs to classify the failures and retry their stable trial slots.
+  // A nonzero invocation with no report remains a hard invocation failure.
+  const records = existsSync(outFile) ? loadJsonlFile(outFile) : [];
+  if (records[0]) return records[0];
+  if (invocationError) throw invocationError;
+  return null;
 }
 
 function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
@@ -836,8 +854,11 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     direction === "worse" ? signTestPValue(losses, wins) : signTestPValue(wins, losses);
   const netWin = directions.length ? (wins - losses) / directions.length : 0;
   const credible = pValue <= SIGN_TEST_ALPHA;
-  const passed = conclusive && !underpowered && direction === "better" && credible;
-  const regressed = conclusive && !underpowered && direction === "worse" && credible;
+  const practicallyMeaningful = Math.abs(netWin) >= MIN_PRACTICAL_NET_WIN;
+  const passed =
+    conclusive && !underpowered && direction === "better" && credible && practicallyMeaningful;
+  const regressed =
+    conclusive && !underpowered && direction === "worse" && credible && practicallyMeaningful;
   const nonActivation = nonActivationStims ?? new Set();
 
   // Compare's per-stimulus preference (meanScore + trials), keyed by name so we
@@ -988,6 +1009,10 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
             ? `underpowered (${directions.length} counted trial(s); a credible verdict needs at ` +
               `least ${MIN_CREDIBLE_TRIALS}${sweep ? ", and this eval won every one of them" : ""}) — ` +
               `raise the eval's trial count with more scenarios or defaults.runs`
+            : credible && direction !== "none" && !practicallyMeaningful
+            ? `statistically credible ${direction === "better" ? "improvement" : "preference loss"}, ` +
+              `but |net win| ${pct(Math.abs(netWin))} is below the practical floor ` +
+              `${pct(MIN_PRACTICAL_NET_WIN)}`
             : passed
               ? "credibly better"
               : regressed
@@ -1051,6 +1076,9 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   } else if (underpowered) {
     state = VERDICT_STATES.INVALID_INCONCLUSIVE;
     stateReason = { code: "underpowered", phase: "eval_design" };
+  } else if (credible && direction !== "none" && !practicallyMeaningful) {
+    state = VERDICT_STATES.VALID_NO_CHANGE;
+    stateReason = { code: "practical_effect_below_floor", phase: "decision" };
   } else if (passed) {
     state = VERDICT_STATES.VALID_PASS;
     stateReason = { code: "credible_preference_improvement", phase: "decision" };
@@ -1073,6 +1101,11 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     conclusive,
     underpowered,
     minCredibleTrials: MIN_CREDIBLE_TRIALS,
+    practicalSignificance: {
+      netWin: Math.abs(netWin),
+      minimum: MIN_PRACTICAL_NET_WIN,
+      passed: practicallyMeaningful,
+    },
     passed,
     regressed,
     preferenceRegressed: regressed,
@@ -1407,12 +1440,35 @@ function main() {
         warn(`${plugin}/${skill}: plugin variant produced no records — Plugin columns omitted for this skill`);
       }
 
-      const verdict = comparisonToVerdict(
-        report,
-        identity,
-        roles,
-        readNonActivationStimuli(evalFile, opts["repo-root"]),
-      );
+      let verdict;
+      try {
+        verdict = comparisonToVerdict(
+          report,
+          identity,
+          roles,
+          readNonActivationStimuli(evalFile, opts["repo-root"]),
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const message = `${plugin}/${skill}: vally comparison report is invalid (${detail})`;
+        warn(message);
+        verdict = invalidVerdict(
+          identity,
+          { code: "comparison_report_invalid", phase: "adapter", kind: "permanent" },
+          message,
+          {
+            baselineRecords: baseline.length,
+            skilledRecords: skilled.length,
+            pluginRecords: pluginRecs.length,
+          },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        invalidEvals.push(evalFile);
+        written++;
+        incomplete++;
+        continue;
+      }
       if (!expectedEval) {
         verdict.state = VERDICT_STATES.INVALID_INCONCLUSIVE;
         verdict.stateReason = { code: "unexpected_eval", phase: "adapter" };
@@ -1498,5 +1554,6 @@ export {
   loadExpectedEvalFiles,
   VERDICT_STATES,
   MIN_CREDIBLE_TRIALS,
+  MIN_PRACTICAL_NET_WIN,
   SIGN_TEST_ALPHA,
 };

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -16,8 +16,9 @@
  *      than differencing two independently-graded absolute scores. This drives
  *      the PR gate/comment: a skill passes only on a credible *net win* (more
  *      wins than losses by an exact one-sided sign test at 5%) over at least
- *      MIN_CREDIBLE_TRIALS trials. Below that floor the verdict is reported as
- *      underpowered rather than as a pass or a failure.
+ *      MIN_CREDIBLE_STIMULI distinct stimulus votes. Repeated runs measure
+ *      within-stimulus reliability and do not increase that sample. Below the
+ *      floor the verdict is reported as underpowered rather than as a failure.
  *   4. Emit a per-skill results.json that is a SUPERSET carrying BOTH:
  *        - the compare-based preference verdict (for gating + PR comment), and
  *        - absolute per-role dashboard fields (baseline / skilledIsolated /
@@ -145,15 +146,15 @@ Options:
 const SIGN_TEST_ALPHA = 0.05;
 
 // Statistical significance alone can approve a negligible effect when ties
-// dominate: 5W/95T/0L has p=0.031 but improves only 5% of counted trials. Keep
+// dominate: 5W/95T/0L has p=0.031 but improves only 5% of tested stimuli. Keep
 // the effect-size floor magnitude-free so stronger judge adjectives cannot
 // reintroduce the variance reversal fixed in dotnet/skills#952.
 const MIN_PRACTICAL_NET_WIN = 0.2;
 
-// Minimum counted trials behind a verdict. This is not a chosen constant: the
-// sign test cannot reach 5% on fewer than five discordant trials
+// Minimum distinct stimulus votes behind a verdict. This is not a chosen
+// constant: the sign test cannot reach 5% on fewer than five discordant votes
 // (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5), and discordant trials can never
-// exceed counted trials — so at four or fewer, no possible record produces a
+// exceed stimulus votes — so at four or fewer, no possible record produces a
 // pass. Reporting those as "underpowered" rather than as a failure is what
 // stops "won every trial, failed anyway" from being rediagnosed every run.
 //
@@ -161,7 +162,7 @@ const MIN_PRACTICAL_NET_WIN = 0.2;
 // not a guarantee of adequate power for a realistic effect, which needs
 // considerably more. eng/eval-quality/check_eval_quality.py enforces the same
 // number against eval specs before they are ever run.
-const MIN_CREDIBLE_TRIALS = 5;
+const MIN_CREDIBLE_STIMULI = 5;
 
 const VERDICT_STATES = Object.freeze({
   VALID_PASS: "VALID_PASS",
@@ -809,41 +810,59 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   const unmatchedTreatment = report.unmatchedTreatment ?? [];
   const unmatchedTrialCount = unmatchedBaseline.length + unmatchedTreatment.length;
 
-  // Every counted trial, as a direction. Errored trials are excluded from every
-  // statistic (matching compare's own `summarize`) so a flaky judge can't
-  // register as a run of genuine ties.
-  const directions = (report.stimuli ?? [])
+  // Raw paired trials remain authoritative for report-integrity checks, retry
+  // accounting, and within-stimulus reliability. They are not independent task
+  // samples, so repeated runs do not enter the cross-stimulus gate directly.
+  const trialDirections = (report.stimuli ?? [])
     .flatMap((st) => st.trials ?? [])
     .filter((t) => !t.errored)
     .map(trialDirection);
-  const wins = directions.filter((d) => d > 0).length;
-  const losses = directions.filter((d) => d < 0).length;
-  const ties = directions.length - wins - losses;
+  const trialWins = trialDirections.filter((d) => d > 0).length;
+  const trialLosses = trialDirections.filter((d) => d < 0).length;
+  const trialTies = trialDirections.length - trialWins - trialLosses;
 
-  // The gate reads the enumerated trials; the summary is what humans read. If
-  // they disagree, the report is malformed and neither can be trusted — that is
-  // a comparison that didn't complete, not a small eval, so it must not be
-  // routed to the contributor as "add more scenarios".
+  // The summary is what humans read. If it disagrees with the enumerated raw
+  // trials, neither representation can be trusted.
   const summaryAgrees =
-    directions.length === (s.trialCount ?? 0) &&
-    wins === (s.wins ?? 0) &&
-    ties === (s.ties ?? 0) &&
-    losses === (s.losses ?? 0);
+    trialDirections.length === (s.trialCount ?? 0) &&
+    trialWins === (s.wins ?? 0) &&
+    trialTies === (s.ties ?? 0) &&
+    trialLosses === (s.losses ?? 0);
   if (!summaryAgrees) {
     warn(
       `${identity.plugin}/${identity.skill}: compare summary reports ` +
         `${s.trialCount} trial(s) ${s.wins}W/${s.ties}T/${s.losses}L but stimuli[].trials shows ` +
-        `${directions.length} trial(s) ${wins}W/${ties}T/${losses}L — verdict marked inconclusive`,
+        `${trialDirections.length} trial(s) ${trialWins}W/${trialTies}T/${trialLosses}L — verdict marked inconclusive`,
     );
   }
 
   const conclusive = s.erroredCount === 0 && unmatchedTrialCount === 0 && summaryAgrees;
-  // Too few counted trials for any record to reach significance — see
-  // MIN_CREDIBLE_TRIALS. This is a property of the eval spec, not of the run, so
-  // it is only claimed when the comparison actually completed: a trial count
-  // depressed by errored, unmatched or unreadable trials is an infrastructure
-  // problem and is already reported as inconclusive.
-  const underpowered = conclusive && directions.length < MIN_CREDIBLE_TRIALS;
+
+  // Collapse repeated runs to one vote per stimulus. A stimulus votes in the
+  // direction supported by more of its successful runs; an even split or all
+  // ties contributes one stimulus-level tie.
+  const stimulusVotes = (report.stimuli ?? []).map((stimulus) => {
+    const counted = (stimulus.trials ?? []).filter((trial) => !trial.errored);
+    const stimulusWins = counted.filter((trial) => trialDirection(trial) > 0).length;
+    const stimulusLosses = counted.filter((trial) => trialDirection(trial) < 0).length;
+    return {
+      stimulusName: stimulus.stimulusName,
+      runCount: counted.length,
+      wins: stimulusWins,
+      ties: counted.length - stimulusWins - stimulusLosses,
+      losses: stimulusLosses,
+      direction: stimulusWins > stimulusLosses ? 1 : stimulusLosses > stimulusWins ? -1 : 0,
+    };
+  });
+  const directions = stimulusVotes.filter((vote) => vote.runCount > 0).map((vote) => vote.direction);
+  const wins = directions.filter((value) => value > 0).length;
+  const losses = directions.filter((value) => value < 0).length;
+  const ties = directions.length - wins - losses;
+
+  // Too few distinct stimulus votes for any record to reach significance is an
+  // eval-design problem. A stimulus count depressed by comparison errors or
+  // unmatched trajectories remains an infrastructure failure instead.
+  const underpowered = conclusive && directions.length < MIN_CREDIBLE_STIMULI;
 
   // The p-value is always the one-sided tail *in the direction the record
   // actually points*, so a reported p never describes the opposite hypothesis
@@ -867,6 +886,7 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   for (const st of report.stimuli ?? []) {
     compareByStim.set(st.stimulusName, st);
   }
+  const voteByStim = new Map(stimulusVotes.map((vote) => [vote.stimulusName, vote]));
 
   const { baselineByStim, skilledByStim, pluginByStim, hasPlugin } = roles;
 
@@ -891,8 +911,9 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     // scenario row can never point the opposite way to the verdict it feeds.
     // Computed once here rather than re-derived by each renderer.
     const counted = (st?.trials ?? []).filter((t) => !t.errored);
-    const sWins = counted.filter((t) => trialDirection(t) > 0).length;
-    const sLosses = counted.filter((t) => trialDirection(t) < 0).length;
+    const vote = voteByStim.get(name);
+    const sWins = vote?.wins ?? 0;
+    const sLosses = vote?.losses ?? 0;
 
     const scenario = {
       scenarioName: name,
@@ -931,35 +952,19 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     return scenario;
   });
 
-  // Repeated runs measure within-stimulus reliability, not independent task
-  // breadth. This report-only statistic gives every stimulus one directional
-  // vote so consumers can see the effective cross-scenario evidence without
-  // changing the current trial-level gate.
-  const scenarioDirections = scenarios
-    .filter((scenario) => scenario.runCount > 0)
-    .map((scenario) => (scenario.direction === "better" ? 1 : scenario.direction === "worse" ? -1 : 0));
-  const scenarioWins = scenarioDirections.filter((value) => value > 0).length;
-  const scenarioLosses = scenarioDirections.filter((value) => value < 0).length;
-  const scenarioTies = scenarioDirections.length - scenarioWins - scenarioLosses;
-  const scenarioDirection =
-    scenarioWins > scenarioLosses ? "better" : scenarioLosses > scenarioWins ? "worse" : "none";
-  const scenarioPValue =
-    scenarioDirection === "worse"
-      ? signTestPValue(scenarioLosses, scenarioWins)
-      : signTestPValue(scenarioWins, scenarioLosses);
+  // This is the authoritative gate evidence. Raw repeated-run outcomes remain
+  // available in scenarios[].trials and comparisonTrialEvidence.
   const scenarioEvidence = {
-    gateEligible: false,
-    reason: "Report-only: repeated runs are collapsed to one directional vote per stimulus",
-    count: scenarioDirections.length,
-    wins: scenarioWins,
-    ties: scenarioTies,
-    losses: scenarioLosses,
-    discordant: scenarioWins + scenarioLosses,
-    direction: scenarioDirection,
-    netWin: scenarioDirections.length
-      ? (scenarioWins - scenarioLosses) / scenarioDirections.length
-      : 0,
-    pValue: scenarioPValue,
+    gateEligible: true,
+    reason: "Authoritative: repeated runs are collapsed to one directional vote per stimulus",
+    count: directions.length,
+    wins,
+    ties,
+    losses,
+    discordant: wins + losses,
+    direction,
+    netWin,
+    pValue,
     alpha: SIGN_TEST_ALPHA,
   };
 
@@ -990,9 +995,9 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
   }
 
   const sweep = directions.length > 0 && wins === directions.length;
-  // The sign test conditions on the discordant (non-tie) trials, so this — not
-  // the counted trial count — is what decides whether any record could have
-  // reached alpha. An eval can clear MIN_CREDIBLE_TRIALS on counted trials and
+  // The sign test conditions on discordant (non-tie) stimulus votes, so this —
+  // not the total stimulus-vote count — decides whether any record could have
+  // reached alpha. An eval can clear MIN_CREDIBLE_STIMULI on stimulus votes and
   // still be unwinnable once ties are removed, which is the case the plain
   // "not credible (p > alpha)" wording used to misdescribe as a measured null.
   const discordant = wins + losses;
@@ -1006,9 +1011,9 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
             `${s.wins}W/${s.ties}T/${s.losses}L, trials show ${directions.length} ` +
             `${wins}W/${ties}T/${losses}L)`
           : underpowered
-            ? `underpowered (${directions.length} counted trial(s); a credible verdict needs at ` +
-              `least ${MIN_CREDIBLE_TRIALS}${sweep ? ", and this eval won every one of them" : ""}) — ` +
-              `raise the eval's trial count with more scenarios or defaults.runs`
+            ? `underpowered (${directions.length} counted stimulus vote(s); a credible verdict needs at ` +
+              `least ${MIN_CREDIBLE_STIMULI}${sweep ? ", and this eval won every one of them" : ""}) — ` +
+              `add distinct, discriminating stimuli; repeated runs do not increase task breadth`
             : credible && direction !== "none" && !practicallyMeaningful
             ? `statistically credible ${direction === "better" ? "improvement" : "preference loss"}, ` +
               `but |net win| ${pct(Math.abs(netWin))} is below the practical floor ` +
@@ -1019,20 +1024,21 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
                 ? "credibly worse"
                 : wins <= losses
                   ? "no improvement"
-                  : discordant < MIN_CREDIBLE_TRIALS
+                  : discordant < MIN_CREDIBLE_STIMULI
                     ? `not credible — ${ties} of ${directions.length} trial(s) tied, leaving only ` +
                       `${discordant} discordant trial(s). The sign test conditions on non-tie ` +
-                      `trials and cannot reach ${SIGN_TEST_ALPHA} below ${MIN_CREDIBLE_TRIALS}, so ` +
+                      `stimulus votes and cannot reach ${SIGN_TEST_ALPHA} below ${MIN_CREDIBLE_STIMULI}, so ` +
                       `no record could have passed here — this is not a measured null. Either the ` +
                       `skill is inert on these scenarios (make them discriminate) or the eval ` +
-                      `needs more trials to clear the ties (more scenarios or defaults.runs)`
+                      `needs more distinct stimuli to clear the ties`
                     : `not credible (sign test p=${pValue.toFixed(3)} > ${SIGN_TEST_ALPHA})`;
 
   const reason =
     `Net win ${netWin >= 0 ? "+" : ""}${pct(netWin)} ` +
-    `(${wins}W/${ties}T/${losses}L over ${directions.length} trial(s), ` +
+    `(${wins}W/${ties}T/${losses}L over ${directions.length} stimulus vote(s), ` +
     `sign test p=${pValue.toFixed(3)}), ` +
     `mean preference ${s.meanScore >= 0 ? "+" : ""}${pct(s.meanScore)}` +
+    ` across ${trialDirections.length} paired run(s)` +
     `${s.erroredCount ? `, ${s.erroredCount} errored` : ""}` +
     `${unmatchedTrialCount ? `, ${unmatchedTrialCount} unmatched` : ""} — ${credibility}`;
 
@@ -1100,7 +1106,9 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     stateReason,
     conclusive,
     underpowered,
-    minCredibleTrials: MIN_CREDIBLE_TRIALS,
+    minCredibleStimuli: MIN_CREDIBLE_STIMULI,
+    // Compatibility alias retained for schema-version-2 consumers.
+    minCredibleTrials: MIN_CREDIBLE_STIMULI,
     practicalSignificance: {
       netWin: Math.abs(netWin),
       minimum: MIN_PRACTICAL_NET_WIN,
@@ -1109,8 +1117,8 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     passed,
     regressed,
     preferenceRegressed: regressed,
-    // The deciding statistic: (wins - losses) / trials as the effect size, and
-    // an exact one-sided sign test over the discordant trials as its
+    // The deciding statistic: one vote per distinct stimulus, with repeated
+    // runs collapsed before the exact one-sided sign test.
     // credibility. Magnitude-free, so it cannot reverse when the judge upgrades
     // a win from "slightly-better" to "much-better".
     netWin,
@@ -1128,11 +1136,22 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
     // Vally's magnitude-weighted preference, reported for triage. NOT the gate.
     meanScore: s.meanScore,
     confidenceInterval: { low: s.ciLow, high: s.ciHigh, level: 0.95 },
-    winRate: s.winRate,
-    wins: s.wins,
-    ties: s.ties,
-    losses: s.losses,
-    trialCount: s.trialCount,
+    winRate: directions.length ? wins / directions.length : 0,
+    wins,
+    ties,
+    losses,
+    stimulusVoteCount: directions.length,
+    // Compatibility alias retained for schema-version-2 consumers.
+    trialCount: directions.length,
+    comparisonTrialEvidence: {
+      gateEligible: false,
+      reason: "Reliability only: repeated runs are not independent task samples",
+      count: trialDirections.length,
+      wins: trialWins,
+      ties: trialTies,
+      losses: trialLosses,
+      winRate: s.winRate,
+    },
     erroredCount: s.erroredCount,
     unmatchedTrialCount,
     unmatchedBaseline,
@@ -1145,7 +1164,7 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
       attempts: 1,
       retriedSlots: 0,
       recoveredSlots: 0,
-      frozenSuccesses: directions.length,
+      frozenSuccesses: trialDirections.length,
       recoveredErrors: [],
       persistentErrors: [],
     },
@@ -1193,7 +1212,8 @@ function invalidVerdict(identity, cause, message, accounting = {}) {
     stateReason: { code: cause.code, phase: cause.phase },
     conclusive: false,
     underpowered: false,
-    minCredibleTrials: MIN_CREDIBLE_TRIALS,
+    minCredibleStimuli: MIN_CREDIBLE_STIMULI,
+    minCredibleTrials: MIN_CREDIBLE_STIMULI,
     passed: false,
     regressed: false,
     preferenceRegressed: false,
@@ -1243,7 +1263,17 @@ function invalidVerdict(identity, cause, message, accounting = {}) {
     wins: 0,
     ties: 0,
     losses: 0,
+    stimulusVoteCount: 0,
     trialCount: 0,
+    comparisonTrialEvidence: {
+      gateEligible: false,
+      reason: "No complete comparison was available",
+      count: 0,
+      wins: 0,
+      ties: 0,
+      losses: 0,
+      winRate: 0,
+    },
     erroredCount: 0,
     unmatchedTrialCount: 0,
     unmatchedBaseline: [],
@@ -1260,7 +1290,7 @@ function invalidVerdict(identity, cause, message, accounting = {}) {
 
 function writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval) {
   const results = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     evalFile,
     model: opts.model,
     judgeModel: opts["judge-model"],
@@ -1553,7 +1583,7 @@ export {
   mergeComparisonReports,
   loadExpectedEvalFiles,
   VERDICT_STATES,
-  MIN_CREDIBLE_TRIALS,
+  MIN_CREDIBLE_STIMULI,
   MIN_PRACTICAL_NET_WIN,
   SIGN_TEST_ALPHA,
 };

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -153,7 +153,7 @@ const MIN_PRACTICAL_NET_WIN = 0.2;
 
 // Minimum distinct stimulus votes behind a verdict. This is not a chosen
 // constant: the sign test cannot reach 5% on fewer than five discordant votes
-// (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5), and discordant trials can never
+// (0.5^4 = 0.0625 > 0.05 >= 0.031 = 0.5^5), and discordant stimulus votes can never
 // exceed stimulus votes — so at four or fewer, no possible record produces a
 // pass. Reporting those as "underpowered" rather than as a failure is what
 // stops "won every trial, failed anyway" from being rediagnosed every run.
@@ -1099,8 +1099,8 @@ function comparisonToVerdict(report, identity, roles, nonActivationStims) {
                 : wins <= losses
                   ? "no improvement"
                   : discordant < MIN_CREDIBLE_STIMULI
-                    ? `not credible — ${ties} of ${directions.length} trial(s) tied, leaving only ` +
-                      `${discordant} discordant trial(s). The sign test conditions on non-tie ` +
+                    ? `not credible — ${ties} of ${directions.length} stimulus vote(s) tied, leaving only ` +
+                      `${discordant} discordant stimulus vote(s). The sign test conditions on non-tie ` +
                       `stimulus votes and cannot reach ${SIGN_TEST_ALPHA} below ${MIN_CREDIBLE_STIMULI}, so ` +
                       `no record could have passed here — this is not a measured null. Either the ` +
                       `skill is inert on these scenarios (make them discriminate) or the eval ` +

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -860,7 +860,7 @@ function runCompareWithRetry(baselineSlice, skilledSlice, outFile) {
     return merged;
   }
 
-  warn(`vally compare retry did not reduce errored trials; keeping the original result`);
+  warn(`vally compare retry did not reduce errored trials; returning the merged report with original judgments and retry diagnostics`);
   return merged;
 }
 

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -533,7 +533,64 @@ test("does not pair retry slots by array position when trialIndex is absent", ()
   assert.equal(merged.retrySummary.recoveredSlots, 0);
   assert.equal(
     merged.retrySummary.persistentErrors[0].attemptHistory[1].code,
-    "retry_result_missing",
+    "comparison_trial_identity_missing",
+  );
+});
+
+test("does not recover an ambiguous duplicate retry slot", () => {
+  const primary = reportFromRepeatedScores([null]);
+  primary.stimuli[0].trials[0] = {
+    trialIndex: 0,
+    score: 0,
+    winner: "tie",
+    errored: true,
+    evidence: "Comparison judge failed: Timeout after 120000ms waiting for session.idle",
+  };
+  primary.summary.trialCount = 0;
+  primary.summary.erroredCount = 1;
+  primary.summary.wins = 0;
+
+  const retry = reportFromRepeatedScores([0.4, 0.4]);
+  retry.stimuli[0].trials[1].trialIndex = 0;
+  const merged = mergeComparisonReports(primary, retry);
+
+  assert.equal(merged.summary.erroredCount, 1);
+  assert.equal(merged.retrySummary.recoveredSlots, 0);
+  assert.equal(
+    merged.retrySummary.persistentErrors[0].attemptHistory[1].code,
+    "retry_result_ambiguous",
+  );
+});
+
+test("missing or duplicate comparison slot identities invalidate a verdict", () => {
+  const missing = reportFromScores([0.4, 0.4, 0.4, 0.4, 0.4]);
+  delete missing.stimuli[0].trials[0].trialIndex;
+  const missingVerdict = comparisonToVerdict(
+    missing,
+    IDENTITY,
+    EMPTY_ROLES,
+    new Set(),
+  );
+  assert.equal(missingVerdict.conclusive, false);
+  assert.equal(missingVerdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+  assert.equal(
+    missingVerdict.stateReason.code,
+    "comparison_trial_identity_missing",
+  );
+
+  const duplicate = reportFromStimulusRuns([[0.4, 0.4], [0.4], [0.4], [0.4]]);
+  duplicate.stimuli[0].trials[1].trialIndex = 0;
+  const duplicateVerdict = comparisonToVerdict(
+    duplicate,
+    IDENTITY,
+    EMPTY_ROLES,
+    new Set(),
+  );
+  assert.equal(duplicateVerdict.conclusive, false);
+  assert.equal(duplicateVerdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+  assert.equal(
+    duplicateVerdict.stateReason.code,
+    "comparison_trial_identity_duplicate",
   );
 });
 

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -15,6 +15,7 @@ import {
   trialDirection,
   VERDICT_STATES,
   MIN_CREDIBLE_TRIALS,
+  MIN_PRACTICAL_NET_WIN,
   SIGN_TEST_ALPHA,
 } from "./adapt.mjs";
 
@@ -40,6 +41,12 @@ function createExperiment(root) {
   return runDir;
 }
 
+function createEmptyExperiment(root) {
+  const runDir = join(root, "experiment");
+  mkdirSync(runDir, { recursive: true });
+  return runDir;
+}
+
 function createFakeVally(root, mode, trialCount) {
   const scriptPath = join(root, "fake-vally.mjs");
   const statePath = join(root, "compare-count.txt");
@@ -58,41 +65,70 @@ if (mode === "empty") {
   writeFileSync(output, "");
   process.exit(0);
 }
-const errored = mode === "persistent" || (mode === "recover" && count === 1);
 const unmatched = mode === "unmatched";
 // One winning trial per run of the single stimulus, all scored "slightly
 // better". Errored trials are excluded from every statistic by vally, so the
-// errored modes report zero counted trials.
-const trials = Array.from({ length: trialCount }, (_, trialIndex) => ({
-  trialIndex,
-  winner: errored ? "tie" : "treatment",
-  magnitude: errored ? "equal" : "slightly-better",
-  score: errored ? 0 : 0.4,
-  evidence: errored ? "Comparison judge failed: timeout" : "Treatment was better",
-  baselinePassed: true,
-  treatmentPassed: true,
-  errored
-}));
+// all-errored modes report zero counted trials.
+const trials = Array.from({ length: trialCount }, (_, trialIndex) => {
+  const errored =
+    mode === "persistent" ||
+    mode === "organization-disabled" ||
+    mode === "all-errored-exit-persistent" ||
+    ((mode === "recover" || mode === "all-errored-exit-recover") && count === 1) ||
+    (mode === "partial-recover" && count === 1 && trialIndex === 0);
+  // On the partial retry, deliberately reverse the four already-successful
+  // slots. The adapter must freeze them and take only the recovered slot 0.
+  const retryDisagrees = mode === "partial-recover" && count === 2 && trialIndex > 0;
+  const evidence = errored
+    ? mode === "organization-disabled"
+      ? "Comparison judge failed: CAPIError 400 This organization has been disabled"
+      : "Comparison judge failed: Timeout after 120000ms waiting for session.idle"
+    : retryDisagrees
+      ? "Baseline was better on the retry"
+      : "Treatment was better";
+  return {
+    trialIndex,
+    winner: errored ? "tie" : retryDisagrees ? "baseline" : "treatment",
+    magnitude: errored ? "equal" : retryDisagrees ? "slightly-worse" : "slightly-better",
+    score: errored ? 0 : retryDisagrees ? -0.4 : 0.4,
+    evidence,
+    baselinePassed: true,
+    treatmentPassed: true,
+    errored
+  };
+});
+const counted = trials.filter((trial) => !trial.errored);
+const wins = counted.filter((trial) => trial.winner === "treatment").length;
+const losses = counted.filter((trial) => trial.winner === "baseline").length;
+const ties = counted.length - wins - losses;
 const report = {
-  type: "comparison-report",
+  type: "comparison",
   summary: {
-    trialCount: errored ? 0 : trialCount,
-    erroredCount: errored ? trialCount : 0,
-    meanScore: errored ? 0 : 0.4,
-    ciLow: errored ? 0 : 0.4,
-    ciHigh: errored ? 0 : 0.4,
-    wins: errored ? 0 : trialCount,
-    ties: 0,
-    losses: 0,
-    winRate: errored ? 0 : 1,
-    mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: trialCount, pValue: 1, exact: true },
+    trialCount: counted.length,
+    erroredCount: trialCount - counted.length,
+    meanScore: counted.length ? counted.reduce((sum, trial) => sum + trial.score, 0) / counted.length : 0,
+    ciLow: 0,
+    ciHigh: 0,
+    wins,
+    ties,
+    losses,
+    winRate: counted.length ? wins / counted.length : 0,
+    mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: counted.length, pValue: 1, exact: true },
     metricDeltas: []
   },
-  stimuli: [{ stimulusName: "Scenario", meanScore: errored ? 0 : 0.4, trials }],
+  stimuli: [{ stimulusName: "Scenario", meanScore: 0, trials }],
   unmatchedBaseline: unmatched ? ["Baseline only (trial 0)"] : [],
   unmatchedTreatment: unmatched ? ["Treatment only (trial 0)"] : []
 };
+if (mode === "malformed") delete report.summary;
 writeFileSync(output, JSON.stringify(report) + "\\n");
+if (
+  (mode === "all-errored-exit-recover" && count === 1) ||
+  mode === "all-errored-exit-persistent" ||
+  mode === "organization-disabled"
+) {
+  process.exit(1);
+}
 `,
   );
   return {
@@ -103,8 +139,14 @@ writeFileSync(output, JSON.stringify(report) + "\\n");
 
 // Default to a trial count at the credibility floor so a test that isn't about
 // statistical power gets a verdict that can actually pass.
-function runAdapter(root, mode, trialCount = 5, expectedEvalFiles = [evalFile]) {
-  const runDir = createExperiment(root);
+function runAdapter(
+  root,
+  mode,
+  trialCount = 5,
+  expectedEvalFiles = [evalFile],
+  experimentFactory = createExperiment,
+) {
+  const runDir = experimentFactory(root);
   const outputRoot = join(root, "output");
   const expectedEvalsPath = join(root, "expected-evals.txt");
   writeFileSync(expectedEvalsPath, `${expectedEvalFiles.join("\n")}\n`);
@@ -166,6 +208,31 @@ test("retries a transient comparison error once", () => {
   });
 });
 
+test("Vally 0.13 all-errored exit still reaches slot-preserving retry", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "all-errored-exit-recover");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.state, VERDICT_STATES.VALID_PASS);
+    assert.equal(verdict.comparisonAttempts.recoveredSlots, 5);
+    assert.equal(verdict.errors.length, 0);
+  });
+});
+
+test("recovers one session.idle slot and freezes four successful judgments", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "partial-recover");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.state, VERDICT_STATES.VALID_PASS);
+    assert.equal(verdict.wins, 5);
+    assert.equal(verdict.losses, 0);
+    assert.equal(verdict.comparisonAttempts.recoveredSlots, 1);
+    assert.equal(verdict.comparisonAttempts.frozenSuccesses, 4);
+    assert.equal(verdict.recoveredErrors[0].code, "judge_session_idle_timeout");
+  });
+});
+
 test("preserves adapter diagnostics when compare fails", () => {
   withTempDir((root) => {
     const { result, verdict } = runAdapter(root, "fails");
@@ -177,6 +244,29 @@ test("preserves adapter diagnostics when compare fails", () => {
   });
 });
 
+test("keeps a Vally 0.13 all-errored report invalid when retry also errors", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "all-errored-exit-persistent");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.erroredCount, 5);
+    assert.equal(verdict.errors.length, 5);
+  });
+});
+
+test("classifies a persistent organization-disabled judge failure", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict } = runAdapter(root, "organization-disabled");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, 2);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.errors.length, 5);
+    assert.ok(verdict.errors.every((error) => error.code === "judge_organization_disabled"));
+    assert.ok(verdict.errors.every((error) => error.attempts === 2));
+  });
+});
+
 test("classifies an empty compare output as a missing record", () => {
   withTempDir((root) => {
     const { result, verdict } = runAdapter(root, "empty");
@@ -184,6 +274,20 @@ test("classifies an empty compare output as a missing record", () => {
     assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
     assert.equal(verdict.stateReason.code, "comparison_record_missing");
     assert.doesNotMatch(verdict.errors[0].message, /Cannot set properties/);
+  });
+});
+
+test("a malformed comparison report becomes one explicit invalid result", () => {
+  withTempDir((root) => {
+    const { result, verdict, outputRoot } = runAdapter(root, "malformed");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "comparison_report_invalid");
+    assert.equal(verdict.errors[0].phase, "adapter");
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.equal(summary.writtenResultCount, 1);
+    assert.deepEqual(summary.invalidEvals, [evalFile]);
   });
 });
 
@@ -277,6 +381,48 @@ test("writes an explicit invalid verdict for every expected eval", () => {
     assert.equal(summary.writtenResultCount, 2);
     assert.deepEqual(summary.missingEvals, [missingEval]);
     assert.deepEqual(summary.invalidEvals, [missingEval]);
+  });
+});
+
+test("records an observed eval that is absent from the expected manifest", () => {
+  withTempDir((root) => {
+    const expectedEval = "tests/dotnet-test/missing-skill/eval.yaml";
+    const { result, outputRoot } = runAdapter(root, "clean", 5, [expectedEval]);
+    assert.equal(result.status, 0, result.stderr);
+
+    const unexpectedResult = JSON.parse(
+      readFileSync(
+        join(outputRoot, "dotnet-diag", "analyzing-dotnet-performance", "results.json"),
+        "utf8",
+      ),
+    );
+    assert.equal(unexpectedResult.expectedEval, false);
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.deepEqual(summary.unexpectedEvals, [evalFile]);
+    assert.equal(summary.unexpectedEvalCount, 1);
+  });
+});
+
+test("writes an explicit invalid result when the entire eval run is empty", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict, outputRoot } = runAdapter(
+      root,
+      "clean",
+      5,
+      [evalFile],
+      createEmptyExperiment,
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, undefined);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "missing_baseline_and_skilled_records");
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.equal(summary.expectedEvalCount, 1);
+    assert.equal(summary.writtenResultCount, 1);
+    assert.deepEqual(summary.missingEvals, [evalFile]);
+    assert.deepEqual(summary.invalidEvals, [evalFile]);
   });
 });
 
@@ -631,6 +777,39 @@ test("the credibility floor is the smallest count that can reach the alpha", () 
   // never exceed counted trials.
   assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS, 0) <= SIGN_TEST_ALPHA);
   assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS - 1, 0) > SIGN_TEST_ALPHA);
+});
+
+test("the practical net-win floor rejects sparse wins among many ties", () => {
+  const sparse = gate([...Array(5).fill(0.4), ...Array(95).fill(0)]);
+  assert.ok(sparse.signTest.pValue <= SIGN_TEST_ALPHA);
+  assert.equal(sparse.netWin, 0.05);
+  assert.equal(sparse.practicalSignificance.passed, false);
+  assert.equal(sparse.passed, false);
+  assert.equal(sparse.state, VERDICT_STATES.VALID_NO_CHANGE);
+  assert.equal(sparse.stateReason.code, "practical_effect_below_floor");
+
+  const boundary = gate([...Array(5).fill(0.4), ...Array(20).fill(0)]);
+  assert.equal(boundary.netWin, MIN_PRACTICAL_NET_WIN);
+  assert.equal(boundary.practicalSignificance.passed, true);
+  assert.equal(boundary.passed, true);
+});
+
+test("the practical floor preserves every possible pass through 24 trials", () => {
+  for (let trialCount = MIN_CREDIBLE_TRIALS; trialCount <= 24; trialCount++) {
+    for (let wins = 0; wins <= trialCount; wins++) {
+      for (let losses = 0; losses <= trialCount - wins; losses++) {
+        const ties = trialCount - wins - losses;
+        const statisticallyPassed =
+          wins > losses && signTestPValue(wins, losses) <= SIGN_TEST_ALPHA;
+        if (!statisticallyPassed) continue;
+        const netWin = (wins - losses) / trialCount;
+        assert.ok(
+          netWin >= MIN_PRACTICAL_NET_WIN,
+          `${wins}W/${ties}T/${losses}L at n=${trialCount} would change`,
+        );
+      }
+    }
+  }
 });
 
 // --- CLI tokenizer ----------------------------------------------------------

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -6,7 +6,17 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { comparisonToVerdict, splitVallyCommand, signTestPValue, trialDirection, MIN_CREDIBLE_TRIALS, SIGN_TEST_ALPHA } from "./adapt.mjs";
+import {
+  comparisonToVerdict,
+  classifyComparisonError,
+  mergeComparisonReports,
+  splitVallyCommand,
+  signTestPValue,
+  trialDirection,
+  VERDICT_STATES,
+  MIN_CREDIBLE_TRIALS,
+  SIGN_TEST_ALPHA,
+} from "./adapt.mjs";
 
 const adapterPath = fileURLToPath(new URL("./adapt.mjs", import.meta.url));
 
@@ -44,6 +54,10 @@ const count = existsSync(statePath) ? Number(readFileSync(statePath, "utf8")) + 
 writeFileSync(statePath, String(count));
 if (mode === "fails") process.exit(3);
 const output = args[args.indexOf("--output") + 1];
+if (mode === "empty") {
+  writeFileSync(output, "");
+  process.exit(0);
+}
 const errored = mode === "persistent" || (mode === "recover" && count === 1);
 const unmatched = mode === "unmatched";
 // One winning trial per run of the single stimulus, all scored "slightly
@@ -89,9 +103,11 @@ writeFileSync(output, JSON.stringify(report) + "\\n");
 
 // Default to a trial count at the credibility floor so a test that isn't about
 // statistical power gets a verdict that can actually pass.
-function runAdapter(root, mode, trialCount = 5) {
+function runAdapter(root, mode, trialCount = 5, expectedEvalFiles = [evalFile]) {
   const runDir = createExperiment(root);
   const outputRoot = join(root, "output");
+  const expectedEvalsPath = join(root, "expected-evals.txt");
+  writeFileSync(expectedEvalsPath, `${expectedEvalFiles.join("\n")}\n`);
   const fakeVally = createFakeVally(root, mode, trialCount);
   const result = spawnSync(
     process.execPath,
@@ -103,6 +119,8 @@ function runAdapter(root, mode, trialCount = 5) {
       outputRoot,
       "--vally",
       fakeVally.command,
+      "--expected-evals",
+      expectedEvalsPath,
     ],
     { encoding: "utf8" },
   );
@@ -114,6 +132,7 @@ function runAdapter(root, mode, trialCount = 5) {
   );
   return {
     result,
+    outputRoot,
     compareCount: existsSync(fakeVally.statePath)
       ? Number(readFileSync(fakeVally.statePath, "utf8"))
       : undefined,
@@ -141,7 +160,9 @@ test("retries a transient comparison error once", () => {
     assert.equal(verdict.conclusive, true);
     assert.equal(verdict.underpowered, false);
     assert.equal(verdict.passed, true);
-    assert.match(result.stderr, /reduced errored trials from 5 to 0/);
+    assert.equal(verdict.state, VERDICT_STATES.VALID_PASS);
+    assert.equal(verdict.recoveredErrors.length, 5);
+    assert.match(result.stderr, /without replacing successful judgments/);
   });
 });
 
@@ -149,8 +170,20 @@ test("preserves adapter diagnostics when compare fails", () => {
   withTempDir((root) => {
     const { result, verdict } = runAdapter(root, "fails");
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(verdict, undefined);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "comparison_invocation_failed");
+    assert.equal(verdict.errors[0].phase, "comparison_judge");
     assert.match(result.stderr, /vally compare failed/);
+  });
+});
+
+test("classifies an empty compare output as a missing record", () => {
+  withTempDir((root) => {
+    const { result, verdict } = runAdapter(root, "empty");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "comparison_record_missing");
+    assert.doesNotMatch(verdict.errors[0].message, /Cannot set properties/);
   });
 });
 
@@ -162,6 +195,15 @@ test("keeps a persistent comparison error visible after one retry", () => {
     assert.equal(verdict.erroredCount, 5);
     assert.equal(verdict.conclusive, false);
     assert.equal(verdict.passed, false);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.errors.length, 5);
+    assert.equal(verdict.errors[0].phase, "comparison_judge");
+    assert.equal(verdict.errors[0].attempts, 2);
+    assert.deepEqual(
+      verdict.errors[0].attemptHistory.map((attempt) => attempt.attempt),
+      [1, 2],
+    );
+    assert.equal(verdict.comparisonAttempts.persistentErrors.length, 5);
     assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
     assert.match(result.stderr, /did not reduce errored trials/);
   });
@@ -177,6 +219,8 @@ test("surfaces unmatched trajectories in the verdict", () => {
     assert.deepEqual(verdict.unmatchedTreatment, ["Treatment only (trial 0)"]);
     assert.equal(verdict.conclusive, false);
     assert.equal(verdict.passed, false);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "unmatched_trajectories");
     assert.match(verdict.reason, /2 unmatched.*inconclusive \(unmatched trajectories\)/);
   });
 });
@@ -191,6 +235,8 @@ test("reports a below-floor eval as underpowered rather than as a pass", () => {
     assert.equal(verdict.conclusive, true, "the comparison itself completed");
     assert.equal(verdict.underpowered, true);
     assert.equal(verdict.passed, false);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "underpowered");
     assert.equal(verdict.minCredibleTrials, 5);
     assert.match(verdict.reason, /underpowered \(1 counted trial\(s\); a credible verdict needs at least 5/);
     assert.match(verdict.reason, /won every one of them/);
@@ -204,8 +250,33 @@ test("passes once the eval reaches the credibility floor", () => {
     const { verdict } = runAdapter(root, "clean", 5);
     assert.equal(verdict.underpowered, false);
     assert.equal(verdict.passed, true);
+    assert.equal(verdict.state, VERDICT_STATES.VALID_PASS);
     assert.equal(verdict.trialCount, 5);
     assert.match(verdict.reason, /credibly better/);
+  });
+});
+
+test("writes an explicit invalid verdict for every expected eval", () => {
+  withTempDir((root) => {
+    const missingEval = "tests/dotnet-test/missing-skill/eval.yaml";
+    const { result, outputRoot } = runAdapter(root, "clean", 5, [evalFile, missingEval]);
+    assert.equal(result.status, 0, result.stderr);
+    const missingResult = JSON.parse(
+      readFileSync(join(outputRoot, "dotnet-test", "missing-skill", "results.json"), "utf8"),
+    );
+    assert.equal(missingResult.evalFile, missingEval);
+    assert.equal(missingResult.expectedEval, true);
+    assert.equal(missingResult.verdicts[0].state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(
+      missingResult.verdicts[0].stateReason.code,
+      "missing_baseline_and_skilled_records",
+    );
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.equal(summary.expectedEvalCount, 2);
+    assert.equal(summary.writtenResultCount, 2);
+    assert.deepEqual(summary.missingEvals, [missingEval]);
+    assert.deepEqual(summary.invalidEvals, [missingEval]);
   });
 });
 
@@ -256,6 +327,95 @@ function reportFromScores(scores, summaryOverrides = {}) {
 
 const gate = (scores, summaryOverrides) =>
   comparisonToVerdict(reportFromScores(scores, summaryOverrides), IDENTITY, EMPTY_ROLES, new Set());
+
+test("a retry fills only errored slots and freezes successful judgments", () => {
+  const primary = reportFromScores([null, 0.4, 0.4, 0.4, 0.4]);
+  primary.stimuli[0].trials[0] = {
+    trialIndex: 0,
+    score: 0,
+    winner: "tie",
+    errored: true,
+    evidence: "Comparison judge failed: Timeout after 120000ms waiting for session.idle",
+  };
+  primary.summary.trialCount = 4;
+  primary.summary.erroredCount = 1;
+  primary.summary.wins = 4;
+
+  // The retry recovers slot 0 but disagrees with every successful first-attempt
+  // slot. Only slot 0 may be taken from this report.
+  const retry = reportFromScores([0.4, -0.4, -0.4, -0.4, -0.4]);
+  const merged = mergeComparisonReports(primary, retry);
+  const directions = merged.stimuli[0].trials.map(trialDirection);
+
+  assert.deepEqual(directions, [1, 1, 1, 1, 1]);
+  assert.equal(merged.summary.erroredCount, 0);
+  assert.equal(merged.retrySummary.recoveredSlots, 1);
+  assert.equal(merged.retrySummary.frozenSuccesses, 4);
+  assert.equal(merged.summary.mcnemar, null);
+  assert.equal(merged.summary.metricDeltas, null);
+  assert.equal(
+    merged.retrySummary.recoveredErrors[0].code,
+    "judge_session_idle_timeout",
+  );
+});
+
+test("does not pair retry slots by array position when trialIndex is absent", () => {
+  const primary = reportFromScores([null, 0.4]);
+  primary.stimuli[0].trials[0].errored = true;
+  primary.summary.trialCount = 1;
+  primary.summary.erroredCount = 1;
+  primary.summary.wins = 1;
+  for (const trial of primary.stimuli[0].trials) delete trial.trialIndex;
+
+  const retry = reportFromScores([-0.4, 0.4]);
+  for (const trial of retry.stimuli[0].trials) delete trial.trialIndex;
+
+  const merged = mergeComparisonReports(primary, retry);
+  assert.equal(merged.summary.erroredCount, 1);
+  assert.equal(merged.retrySummary.recoveredSlots, 0);
+  assert.equal(
+    merged.retrySummary.persistentErrors[0].attemptHistory[1].code,
+    "retry_result_missing",
+  );
+});
+
+test("classifies the known judge-side failures that must not become skill losses", () => {
+  assert.equal(
+    classifyComparisonError("Timeout after 120000ms waiting for session.idle").code,
+    "judge_session_idle_timeout",
+  );
+  assert.equal(
+    classifyComparisonError("This organization has disabled this personal access token").code,
+    "judge_organization_disabled",
+  );
+  assert.equal(
+    classifyComparisonError("Request failed with status code 429: Too Many Requests").code,
+    "judge_rate_limited",
+  );
+});
+
+test("scenario evidence collapses repeated runs to one report-only vote", () => {
+  const verdict = gate([0.4, 0.4, 0.4, 0.4, 0.4]);
+  assert.equal(verdict.trialCount, 5);
+  assert.equal(verdict.scenarioEvidence.count, 1);
+  assert.equal(verdict.scenarioEvidence.wins, 1);
+  assert.equal(verdict.scenarioEvidence.pValue, 0.5);
+  assert.equal(verdict.scenarioEvidence.gateEligible, false);
+});
+
+test("aggregate completion transitions are telemetry, not a hard gate", () => {
+  const report = reportFromScores([-0.4, -0.4, -0.4, -0.4, -0.4]);
+  for (const trial of report.stimuli[0].trials) {
+    trial.baselinePassed = true;
+    trial.treatmentPassed = false;
+  }
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+  assert.equal(verdict.completionTransitions.baselineOnly, 5);
+  assert.equal(verdict.completionTransitions.gateEligible, false);
+  assert.equal(verdict.preferenceRegressed, true);
+  assert.equal(verdict.state, VERDICT_STATES.VALID_NO_CHANGE);
+  assert.equal(verdict.stateReason.code, "preference_regression_report_only");
+});
 
 // The defect behind dotnet/skills#952: weighting the statistic by how decisive
 // each win was let the SAME win/tie/loss record reverse the verdict when the
@@ -341,6 +501,7 @@ test("a tie-starved record says no record could have passed, not that none did",
 
 test("the smallest record that does pass is five wins and no losses", () => {  const v = gate([0.4, 0.4, 0.4, 0.4, 0.4]);
   assert.equal(v.passed, true);
+  assert.equal(v.state, VERDICT_STATES.VALID_PASS);
   assert.equal(v.underpowered, false);
   assert.ok(v.signTest.pValue <= SIGN_TEST_ALPHA);
   assert.match(v.reason, /credibly better/);
@@ -363,6 +524,8 @@ test("losses sink a verdict, and a clean sweep of them is a credible regression"
   const swept = gate([-0.4, -0.4, -0.4, -0.4, -0.4]);
   assert.equal(swept.passed, false);
   assert.equal(swept.regressed, true);
+  assert.equal(swept.preferenceRegressed, true);
+  assert.equal(swept.state, VERDICT_STATES.VALID_NO_CHANGE);
   assert.match(swept.reason, /credibly worse/);
   assert.equal(gate([0.4, 0.4, 0.4, 0, 0, -1.0]).passed, false, "one loss among ties");
 });
@@ -393,6 +556,7 @@ test("a summary whose tie count is wrong is inconclusive", () => {
   report.summary.ties = 0;
   const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
   assert.equal(verdict.conclusive, false);
+  assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
   assert.match(verdict.reason, /compare report inconsistent/);
 });
 
@@ -419,6 +583,7 @@ test("a summary that disagrees with its own trials is inconclusive, not underpow
   report.stimuli = [];
   const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
   assert.equal(verdict.conclusive, false);
+  assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
   assert.equal(verdict.underpowered, false);
   assert.equal(verdict.passed, false);
   assert.match(verdict.reason, /compare report inconsistent/);
@@ -433,6 +598,7 @@ test("errored trials are excluded from the deciding statistic", () => {
   const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
   assert.equal(verdict.signTest.wins, 4, "the errored trial is not counted");
   assert.equal(verdict.conclusive, false);
+  assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
   assert.equal(
     verdict.underpowered,
     false,

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -14,7 +14,7 @@ import {
   signTestPValue,
   trialDirection,
   VERDICT_STATES,
-  MIN_CREDIBLE_TRIALS,
+  MIN_CREDIBLE_STIMULI,
   MIN_PRACTICAL_NET_WIN,
   SIGN_TEST_ALPHA,
 } from "./adapt.mjs";
@@ -116,7 +116,11 @@ const report = {
     mcnemar: { baselineOnly: 0, treatmentOnly: 0, concordant: counted.length, pValue: 1, exact: true },
     metricDeltas: []
   },
-  stimuli: [{ stimulusName: "Scenario", meanScore: 0, trials }],
+  stimuli: trials.map((trial, stimulusIndex) => ({
+    stimulusName: "Scenario " + (stimulusIndex + 1),
+    meanScore: trial.score,
+    trials: [{ ...trial, trialIndex: 0 }],
+  })),
   unmatchedBaseline: unmatched ? ["Baseline only (trial 0)"] : [],
   unmatchedTreatment: unmatched ? ["Treatment only (trial 0)"] : []
 };
@@ -333,9 +337,8 @@ test("surfaces unmatched trajectories in the verdict", () => {
   });
 });
 
-// An eval with too few trials cannot clear the 95% CI bar at any effect size:
-// at one trial vally reports no interval at all (ciLow == mean), so before the
-// floor existed a single lucky judgment passed outright.
+// An eval with too few distinct stimuli cannot clear the exact sign-test bar at
+// any effect size, so one lucky task must not pass outright.
 test("reports a below-floor eval as underpowered rather than as a pass", () => {
   withTempDir((root) => {
     const { result, verdict } = runAdapter(root, "clean", 1);
@@ -346,9 +349,9 @@ test("reports a below-floor eval as underpowered rather than as a pass", () => {
     assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
     assert.equal(verdict.stateReason.code, "underpowered");
     assert.equal(verdict.minCredibleTrials, 5);
-    assert.match(verdict.reason, /underpowered \(1 counted trial\(s\); a credible verdict needs at least 5/);
+    assert.match(verdict.reason, /underpowered \(1 counted stimulus vote\(s\); a credible verdict needs at least 5/);
     assert.match(verdict.reason, /won every one of them/);
-    assert.match(verdict.reason, /defaults\.runs/);
+    assert.match(verdict.reason, /repeated runs do not increase task breadth/);
     assert.match(result.stdout, /⚠️/);
   });
 });
@@ -440,10 +443,12 @@ const EMPTY_ROLES = {
   hasPlugin: false,
 };
 
-// Build a compare report from raw trial scores, spreading them over one
-// stimulus. `summaryOverrides` lets a test assert that a field is NOT read.
-function reportFromScores(scores, summaryOverrides = {}) {
-  const counted = scores.filter((s) => s !== null);
+// Build a compare report from arrays of repeated-run scores, one array per
+// distinct stimulus. `summaryOverrides` lets a test assert that a field is NOT
+// read.
+function reportFromStimulusRuns(stimulusRuns, summaryOverrides = {}) {
+  const scores = stimulusRuns.flat();
+  const counted = scores.filter((score) => score !== null);
   const winnerOf = (s) => (s > 0 ? "treatment" : s < 0 ? "baseline" : "tie");
   return {
     summary: {
@@ -458,28 +463,31 @@ function reportFromScores(scores, summaryOverrides = {}) {
       winRate: counted.filter((s) => s > 0).length / (counted.length || 1),
       ...summaryOverrides,
     },
-    stimuli: [
-      {
-        stimulusName: "Scenario",
+    stimuli: stimulusRuns.map((runs, stimulusIndex) => ({
+        stimulusName: `Scenario ${stimulusIndex + 1}`,
         meanScore: 0,
-        trials: scores.map((score, trialIndex) => ({
+        trials: runs.map((score, trialIndex) => ({
           trialIndex,
           score,
           winner: winnerOf(score),
           errored: false,
         })),
-      },
-    ],
+      })),
     unmatchedBaseline: [],
     unmatchedTreatment: [],
   };
 }
 
+const reportFromScores = (scores, summaryOverrides = {}) =>
+  reportFromStimulusRuns(scores.map((score) => [score]), summaryOverrides);
+const reportFromRepeatedScores = (scores, summaryOverrides = {}) =>
+  reportFromStimulusRuns([scores], summaryOverrides);
+
 const gate = (scores, summaryOverrides) =>
   comparisonToVerdict(reportFromScores(scores, summaryOverrides), IDENTITY, EMPTY_ROLES, new Set());
 
 test("a retry fills only errored slots and freezes successful judgments", () => {
-  const primary = reportFromScores([null, 0.4, 0.4, 0.4, 0.4]);
+  const primary = reportFromRepeatedScores([null, 0.4, 0.4, 0.4, 0.4]);
   primary.stimuli[0].trials[0] = {
     trialIndex: 0,
     score: 0,
@@ -493,7 +501,7 @@ test("a retry fills only errored slots and freezes successful judgments", () => 
 
   // The retry recovers slot 0 but disagrees with every successful first-attempt
   // slot. Only slot 0 may be taken from this report.
-  const retry = reportFromScores([0.4, -0.4, -0.4, -0.4, -0.4]);
+  const retry = reportFromRepeatedScores([0.4, -0.4, -0.4, -0.4, -0.4]);
   const merged = mergeComparisonReports(primary, retry);
   const directions = merged.stimuli[0].trials.map(trialDirection);
 
@@ -510,14 +518,14 @@ test("a retry fills only errored slots and freezes successful judgments", () => 
 });
 
 test("does not pair retry slots by array position when trialIndex is absent", () => {
-  const primary = reportFromScores([null, 0.4]);
+  const primary = reportFromRepeatedScores([null, 0.4]);
   primary.stimuli[0].trials[0].errored = true;
   primary.summary.trialCount = 1;
   primary.summary.erroredCount = 1;
   primary.summary.wins = 1;
   for (const trial of primary.stimuli[0].trials) delete trial.trialIndex;
 
-  const retry = reportFromScores([-0.4, 0.4]);
+  const retry = reportFromRepeatedScores([-0.4, 0.4]);
   for (const trial of retry.stimuli[0].trials) delete trial.trialIndex;
 
   const merged = mergeComparisonReports(primary, retry);
@@ -544,18 +552,68 @@ test("classifies the known judge-side failures that must not become skill losses
   );
 });
 
-test("scenario evidence collapses repeated runs to one report-only vote", () => {
-  const verdict = gate([0.4, 0.4, 0.4, 0.4, 0.4]);
-  assert.equal(verdict.trialCount, 5);
+test("scenario evidence collapses repeated runs to one authoritative vote", () => {
+  const verdict = comparisonToVerdict(
+    reportFromRepeatedScores([0.4, 0.4, 0.4, 0.4, 0.4]),
+    IDENTITY,
+    EMPTY_ROLES,
+    new Set(),
+  );
+  assert.equal(verdict.comparisonTrialEvidence.count, 5);
+  assert.equal(verdict.comparisonTrialEvidence.gateEligible, false);
   assert.equal(verdict.scenarioEvidence.count, 1);
   assert.equal(verdict.scenarioEvidence.wins, 1);
   assert.equal(verdict.scenarioEvidence.pValue, 0.5);
-  assert.equal(verdict.scenarioEvidence.gateEligible, false);
+  assert.equal(verdict.scenarioEvidence.gateEligible, true);
+  assert.equal(verdict.stimulusVoteCount, 1);
+  assert.equal(verdict.trialCount, verdict.stimulusVoteCount, "legacy alias remains coherent");
+  assert.equal(verdict.minCredibleStimuli, 5);
+  assert.equal(verdict.minCredibleTrials, verdict.minCredibleStimuli, "legacy alias remains coherent");
+  assert.equal(verdict.underpowered, true);
+  assert.equal(verdict.passed, false);
+});
+
+test("repeated runs cannot manufacture significance from four of five stimuli", () => {
+  const report = reportFromStimulusRuns([
+    [0.4, 0.4, 0.4],
+    [0.4, 0.4, 0.4],
+    [0.4, 0.4, 0.4],
+    [0.4, 0.4, 0.4],
+    [-0.4, -0.4, -0.4],
+  ]);
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+
+  assert.equal(verdict.comparisonTrialEvidence.wins, 12);
+  assert.equal(verdict.comparisonTrialEvidence.losses, 3);
+  assert.ok(signTestPValue(12, 3) <= SIGN_TEST_ALPHA, "pooled pseudo-replicates look significant");
+  assert.equal(verdict.signTest.wins, 4);
+  assert.equal(verdict.signTest.losses, 1);
+  assert.ok(verdict.signTest.pValue > SIGN_TEST_ALPHA);
+  assert.equal(verdict.passed, false);
+});
+
+test("repeated runs cannot hide agreement across all five stimuli", () => {
+  const report = reportFromStimulusRuns([
+    [0.4, 0.4, -0.4],
+    [0.4, 0.4, -0.4],
+    [0.4, 0.4, -0.4],
+    [0.4, 0.4, -0.4],
+    [0.4, 0.4, -0.4],
+  ]);
+  const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
+
+  assert.equal(verdict.comparisonTrialEvidence.wins, 10);
+  assert.equal(verdict.comparisonTrialEvidence.losses, 5);
+  assert.ok(signTestPValue(10, 5) > SIGN_TEST_ALPHA, "pooled pseudo-replicates look inconclusive");
+  assert.equal(verdict.signTest.wins, 5);
+  assert.equal(verdict.signTest.losses, 0);
+  assert.ok(verdict.signTest.pValue <= SIGN_TEST_ALPHA);
+  assert.equal(verdict.passed, true);
 });
 
 test("aggregate completion transitions are telemetry, not a hard gate", () => {
   const report = reportFromScores([-0.4, -0.4, -0.4, -0.4, -0.4]);
-  for (const trial of report.stimuli[0].trials) {
+  for (const trial of report.stimuli.flatMap((stimulus) => stimulus.trials)) {
     trial.baselinePassed = true;
     trial.treatmentPassed = false;
   }
@@ -614,8 +672,8 @@ test("records that miss 5% by the exact test do not pass", () => {
   }
 });
 
-// A record can clear the counted-trial floor and still be unwinnable, because
-// the sign test only ever sees the discordant trials. Run 30611635547 reported
+// A record can clear the distinct-stimulus floor and still be unwinnable,
+// because the sign test only sees discordant stimulus votes. Run 30611635547 reported
 // five such evals as plain failures; `code-testing-agent` won its single
 // discordant trial (1W/4T/0L) and read as "not credible p=0.500 > 0.05", which
 // describes a measured null rather than a test that could not be run. The
@@ -623,8 +681,8 @@ test("records that miss 5% by the exact test do not pass", () => {
 // so this must NOT be relabelled `underpowered` — but the reason has to say that
 // no record could have passed.
 test("a tie-starved record says no record could have passed, not that none did", () => {
-  const v = gate([0.4, 0, 0, 0, 0]); // 1W/4T/0L over 5 counted trials
-  assert.equal(v.trialCount, 5, "clears the counted-trial floor");
+  const v = gate([0.4, 0, 0, 0, 0]); // 1W/4T/0L over 5 stimulus votes
+  assert.equal(v.stimulusVoteCount, 5, "clears the distinct-stimulus floor");
   assert.equal(v.underpowered, false, "not a spec-size problem: the trials exist");
   assert.equal(v.signTest.discordant, 1);
   assert.equal(v.passed, false);
@@ -714,7 +772,7 @@ test("each scenario carries its own record on the gate's basis", () => {
   // Two "slightly-better" wins and one "much-better" loss: magnitude-weighted
   // this scenario reads negative, but it contributes a positive net win, and a
   // renderer keyed on magnitude would point the opposite way to the verdict.
-  const report = reportFromScores([0.4, 0.4, -1.0, 0.4, 0.4, 0.4]);
+  const report = reportFromRepeatedScores([0.4, 0.4, -1.0, 0.4, 0.4, 0.4]);
   report.stimuli[0].meanScore = -0.06;
   const verdict = comparisonToVerdict(report, IDENTITY, EMPTY_ROLES, new Set());
   const scenario = verdict.scenarios[0];
@@ -777,10 +835,10 @@ test("signTestPValue is the exact one-sided binomial tail", () => {
 
 test("the credibility floor is the smallest count that can reach the alpha", () => {
   // Stated as the property that fixes the constant, so changing it needs a
-  // reason: 0.5^5 = 0.031 <= 0.05 < 0.0625 = 0.5^4, and discordant trials can
-  // never exceed counted trials.
-  assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS, 0) <= SIGN_TEST_ALPHA);
-  assert.ok(signTestPValue(MIN_CREDIBLE_TRIALS - 1, 0) > SIGN_TEST_ALPHA);
+  // reason: 0.5^5 = 0.031 <= 0.05 < 0.0625 = 0.5^4, and discordant votes can
+  // never exceed counted stimulus votes.
+  assert.ok(signTestPValue(MIN_CREDIBLE_STIMULI, 0) <= SIGN_TEST_ALPHA);
+  assert.ok(signTestPValue(MIN_CREDIBLE_STIMULI - 1, 0) > SIGN_TEST_ALPHA);
 });
 
 test("the practical net-win floor rejects sparse wins among many ties", () => {
@@ -798,22 +856,28 @@ test("the practical net-win floor rejects sparse wins among many ties", () => {
   assert.equal(boundary.passed, true);
 });
 
-test("the practical floor preserves every possible pass through 24 trials", () => {
-  for (let trialCount = MIN_CREDIBLE_TRIALS; trialCount <= 24; trialCount++) {
-    for (let wins = 0; wins <= trialCount; wins++) {
-      for (let losses = 0; losses <= trialCount - wins; losses++) {
-        const ties = trialCount - wins - losses;
+test("the practical floor preserves every possible pass through its 25-vote boundary", () => {
+  for (let stimulusCount = MIN_CREDIBLE_STIMULI; stimulusCount <= 25; stimulusCount++) {
+    for (let wins = 0; wins <= stimulusCount; wins++) {
+      for (let losses = 0; losses <= stimulusCount - wins; losses++) {
+        const ties = stimulusCount - wins - losses;
         const statisticallyPassed =
           wins > losses && signTestPValue(wins, losses) <= SIGN_TEST_ALPHA;
         if (!statisticallyPassed) continue;
-        const netWin = (wins - losses) / trialCount;
+        const netWin = (wins - losses) / stimulusCount;
         assert.ok(
           netWin >= MIN_PRACTICAL_NET_WIN,
-          `${wins}W/${ties}T/${losses}L at n=${trialCount} would change`,
+          `${wins}W/${ties}T/${losses}L at n=${stimulusCount} would change`,
         );
       }
     }
   }
+
+  const firstExcluded = gate([...Array(5).fill(0.4), ...Array(21).fill(0)]);
+  assert.ok(firstExcluded.signTest.pValue <= SIGN_TEST_ALPHA);
+  assert.ok(firstExcluded.netWin < MIN_PRACTICAL_NET_WIN);
+  assert.equal(firstExcluded.practicalSignificance.passed, false);
+  assert.equal(firstExcluded.passed, false);
 });
 
 // --- CLI tokenizer ----------------------------------------------------------

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -317,7 +317,11 @@ test("keeps a persistent comparison error visible after one retry", () => {
     );
     assert.equal(verdict.comparisonAttempts.persistentErrors.length, 5);
     assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
-    assert.match(processOutput(result), /did not reduce errored trials/);
+    assert.match(
+      processOutput(result),
+      /returning the merged report with original judgments and retry diagnostics/,
+    );
+    assert.doesNotMatch(processOutput(result), /keeping the original result/);
   });
 });
 

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -193,6 +193,10 @@ function withTempDir(action) {
   }
 }
 
+function processOutput(result) {
+  return `${result.stdout}\n${result.stderr}`;
+}
+
 test("retries a transient comparison error once", () => {
   withTempDir((root) => {
     const { result, compareCount, verdict } = runAdapter(root, "recover");
@@ -204,7 +208,7 @@ test("retries a transient comparison error once", () => {
     assert.equal(verdict.passed, true);
     assert.equal(verdict.state, VERDICT_STATES.VALID_PASS);
     assert.equal(verdict.recoveredErrors.length, 5);
-    assert.match(result.stderr, /without replacing successful judgments/);
+    assert.match(processOutput(result), /without replacing successful judgments/);
   });
 });
 
@@ -240,7 +244,7 @@ test("preserves adapter diagnostics when compare fails", () => {
     assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
     assert.equal(verdict.stateReason.code, "comparison_invocation_failed");
     assert.equal(verdict.errors[0].phase, "comparison_judge");
-    assert.match(result.stderr, /vally compare failed/);
+    assert.match(processOutput(result), /vally compare failed/);
   });
 });
 
@@ -309,7 +313,7 @@ test("keeps a persistent comparison error visible after one retry", () => {
     );
     assert.equal(verdict.comparisonAttempts.persistentErrors.length, 5);
     assert.match(verdict.reason, /inconclusive \(comparison errors\)/);
-    assert.match(result.stderr, /did not reduce errored trials/);
+    assert.match(processOutput(result), /did not reduce errored trials/);
   });
 });
 

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -28,7 +28,7 @@ function writeJsonl(path, records) {
   writeFileSync(path, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
 }
 
-function createExperiment(root) {
+function createExperimentWithVariants(root, variants) {
   const runDir = join(root, "experiment");
   const record = {
     type: "trial-result",
@@ -36,9 +36,22 @@ function createExperiment(root) {
     status: "success",
     stimulus: "Scenario",
   };
-  writeJsonl(join(runDir, "baseline", "results.jsonl"), [{ ...record, variant: "baseline" }]);
-  writeJsonl(join(runDir, "skilled", "results.jsonl"), [{ ...record, variant: "skilled" }]);
+  for (const variant of variants) {
+    writeJsonl(join(runDir, variant, "results.jsonl"), [{ ...record, variant }]);
+  }
   return runDir;
+}
+
+function createExperiment(root) {
+  return createExperimentWithVariants(root, ["baseline", "skilled"]);
+}
+
+function createBaselineOnlyExperiment(root) {
+  return createExperimentWithVariants(root, ["baseline"]);
+}
+
+function createSkilledOnlyExperiment(root) {
+  return createExperimentWithVariants(root, ["skilled"]);
 }
 
 function createEmptyExperiment(root) {
@@ -296,6 +309,7 @@ test("a malformed comparison report becomes one explicit invalid result", () => 
     const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
     assert.equal(summary.writtenResultCount, 1);
     assert.deepEqual(summary.invalidEvals, [evalFile]);
+    assert.deepEqual(summary.measurementInvalidEvals, [evalFile]);
   });
 });
 
@@ -343,9 +357,9 @@ test("surfaces unmatched trajectories in the verdict", () => {
 
 // An eval with too few distinct stimuli cannot clear the exact sign-test bar at
 // any effect size, so one lucky task must not pass outright.
-test("reports a below-floor eval as underpowered rather than as a pass", () => {
+test("reports a below-floor eval as underpowered rather than as a measurement failure", () => {
   withTempDir((root) => {
-    const { result, verdict } = runAdapter(root, "clean", 1);
+    const { result, verdict, outputRoot } = runAdapter(root, "clean", 1);
     assert.equal(result.status, 0, result.stderr);
     assert.equal(verdict.conclusive, true, "the comparison itself completed");
     assert.equal(verdict.underpowered, true);
@@ -357,6 +371,11 @@ test("reports a below-floor eval as underpowered rather than as a pass", () => {
     assert.match(verdict.reason, /won every one of them/);
     assert.match(verdict.reason, /repeated runs do not increase task breadth/);
     assert.match(result.stdout, /⚠️/);
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.equal(summary.invalidEvalCount, 1);
+    assert.equal(summary.measurementInvalidEvalCount, 0);
+    assert.deepEqual(summary.measurementInvalidEvals, []);
   });
 });
 
@@ -392,6 +411,7 @@ test("writes an explicit invalid verdict for every expected eval", () => {
     assert.equal(summary.writtenResultCount, 2);
     assert.deepEqual(summary.missingEvals, [missingEval]);
     assert.deepEqual(summary.invalidEvals, [missingEval]);
+    assert.deepEqual(summary.measurementInvalidEvals, [missingEval]);
   });
 });
 
@@ -434,7 +454,35 @@ test("writes an explicit invalid result when the entire eval run is empty", () =
     assert.equal(summary.writtenResultCount, 1);
     assert.deepEqual(summary.missingEvals, [evalFile]);
     assert.deepEqual(summary.invalidEvals, [evalFile]);
+    assert.equal(summary.measurementInvalidEvalCount, 1);
+    assert.deepEqual(summary.measurementInvalidEvals, [evalFile]);
   });
+});
+
+test("marks either missing comparison arm as measurement-invalid", () => {
+  const cases = [
+    [createBaselineOnlyExperiment, "missing_skilled_records"],
+    [createSkilledOnlyExperiment, "missing_baseline_records"],
+  ];
+  for (const [experimentFactory, expectedCode] of cases) {
+    withTempDir((root) => {
+      const { result, verdict, outputRoot } = runAdapter(
+        root,
+        "clean",
+        5,
+        [evalFile],
+        experimentFactory,
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(verdict.stateReason.code, expectedCode);
+
+      const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+      assert.equal(summary.missingEvalCount, 0);
+      assert.equal(summary.invalidEvalCount, 1);
+      assert.equal(summary.measurementInvalidEvalCount, 1);
+      assert.deepEqual(summary.measurementInvalidEvals, [evalFile]);
+    });
+  }
 });
 
 // --- the gate itself --------------------------------------------------------

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -732,7 +732,7 @@ test("records that miss 5% by the exact test do not pass", () => {
 // A record can clear the distinct-stimulus floor and still be unwinnable,
 // because the sign test only sees discordant stimulus votes. Run 30611635547 reported
 // five such evals as plain failures; `code-testing-agent` won its single
-// discordant trial (1W/4T/0L) and read as "not credible p=0.500 > 0.05", which
+// discordant stimulus vote (1W/4T/0L) and read as "not credible p=0.500 > 0.05", which
 // describes a measured null rather than a test that could not be run. The
 // verdict stays a failure — ties are evidence of inertness, not of a small eval,
 // so this must NOT be relabelled `underpowered` — but the reason has to say that
@@ -744,18 +744,18 @@ test("a tie-starved record says no record could have passed, not that none did",
   assert.equal(v.signTest.discordant, 1);
   assert.equal(v.passed, false);
   assert.equal(v.regressed, false);
-  assert.match(v.reason, /4 of 5 trial\(s\) tied, leaving only 1 discordant trial\(s\)/);
+  assert.match(v.reason, /4 of 5 stimulus vote\(s\) tied, leaving only 1 discordant stimulus vote\(s\)/);
   assert.match(v.reason, /no record could have passed here — this is not a measured null/);
   assert.match(v.reason, /inert/);
 
-  // 4W/1T/0L: four discordant trials, one short. Same class of unwinnable
+  // 4W/1T/0L: four discordant stimulus votes, one short. Same class of unwinnable
   // record, and the wording must not collapse to the bare p-value again.
   const four = gate([0.4, 0.4, 0.4, 0.4, 0]);
   assert.equal(four.signTest.discordant, 4);
   assert.equal(four.passed, false);
   assert.match(four.reason, /no record could have passed here/);
 
-  // Five discordant trials is where the test becomes winnable, so a record that
+  // Five discordant stimulus votes is where the test becomes winnable, so a record that
   // merely loses on the evidence keeps the plain p-value wording.
   const winnable = gate([0.4, 0.4, 0.4, 0.4, -0.4]);
   assert.equal(winnable.signTest.discordant, 5);

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -491,8 +491,8 @@ if (verdicts.length === 0) {
   lines.push(`|${header.map(() => "---").join("|")}|`);
   for (const verdict of verdicts) {
     const common = [
-      verdict.skillName,
-      verdict.model,
+      html(verdict.skillName),
+      html(verdict.model),
       resultLabel(verdict),
       gateEvidence(verdict),
     ];

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -491,8 +491,8 @@ if (verdicts.length === 0) {
   lines.push(`|${header.map(() => "---").join("|")}|`);
   for (const verdict of verdicts) {
     const common = [
-      td(verdict.skillName),
-      td(verdict.model),
+      verdict.skillName,
+      verdict.model,
       resultLabel(verdict),
       gateEvidence(verdict),
     ];

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -7,7 +7,8 @@
  *
  * Each results.json (written by adapt.mjs) has:
  *   { model, judgeModel, timestamp, verdicts: [ {
- *       skillName, passed, conclusive, underpowered, regressed,
+ *       skillName, state, stateReason, passed, conclusive, underpowered,
+ *       preferenceRegressed,
  *       netWin, signTest:{wins,ties,losses,discordant,pValue,alpha},  // the gate
  *       meanScore, confidenceInterval:{low,high},  // magnitude, triage only
  *       winRate, wins, ties, losses, trialCount, erroredCount, reason,
@@ -16,10 +17,10 @@
  *                      baseline:{judgeResult:{overallScore}} } ]
  *   } ] }
  *
- * A skill's verdict is head-to-head preference of skilled vs baseline (judged by
- * `vally compare`): it PASSES only on a credible net win — more wins than
- * losses by an exact one-sided sign test at 5% — over enough trials for any
- * record to reach that bar. Absolute per-role quality is shown for context.
+ * A skill passes only on a credible head-to-head preference improvement.
+ * Objective regression, no-change, and invalid evidence use distinct states.
+ * Absolute per-role quality and report-only reliability evidence are shown for
+ * context.
  *
  * Both formats render a table (Overfit + Skills Loaded columns included),
  * followed by a legend and a collapsible <details> per skill that carries the
@@ -112,6 +113,29 @@ function pct(x) {
   return `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)}%`;
 }
 
+const STATE = Object.freeze({
+  PASS: "VALID_PASS",
+  REGRESSION: "VALID_REGRESSION",
+  NO_CHANGE: "VALID_NO_CHANGE",
+  INVALID: "INVALID_INCONCLUSIVE",
+});
+
+function verdictState(verdict) {
+  if (Object.values(STATE).includes(verdict.state)) return verdict.state;
+  if (verdict.conclusive === false || verdict.underpowered === true) return STATE.INVALID;
+  if (verdict.passed === true) return STATE.PASS;
+  return STATE.NO_CHANGE;
+}
+
+function isPreferenceRegression(verdict) {
+  return verdict.preferenceRegressed === true
+    || (verdict.regressed === true && (verdict.state == null || verdict.state === STATE.NO_CHANGE));
+}
+
+function isObjectiveRegression(verdict) {
+  return verdictState(verdict) === STATE.REGRESSION;
+}
+
 // Escape a value for safe use inside a markdown table cell: literal pipes would
 // otherwise inject extra columns, and newlines would split the row.
 function td(x) {
@@ -198,29 +222,36 @@ for (const file of uniqueFiles) {
 
 verdicts.sort((a, b) => (a.skillName ?? "").localeCompare(b.skillName ?? ""));
 
-// A verdict is ⚠️ when it can't support a pass/fail either because the
-// comparison couldn't complete (errored/unmatched trials) or because the eval
-// has too few trials for any result to reach the alpha (`underpowered`).
-// Otherwise it improved (✅), got credibly worse (🔻), or changed nothing the
-// gate can call (❌). Mirrors adapt.mjs and the evaluation-run.yml summary.
+// Prefer schema-version-2 states. The fallback keeps historical result
+// artifacts readable.
 function isIndeterminate(v) {
-  return v.conclusive === false || v.underpowered === true;
+  return verdictState(v) === STATE.INVALID;
 }
 
 function resultIcon(v) {
   if (isIndeterminate(v)) return "⚠️";
-  if (v.passed) return "✅";
-  return v.regressed === true ? "🔻" : "❌";
+  if (verdictState(v) === STATE.PASS) return "✅";
+  if (isObjectiveRegression(v)) return "🔻";
+  return isPreferenceRegression(v) ? "📉" : "❌";
 }
 
-const passedCount = verdicts.filter((v) => v.passed).length;
+const passedCount = verdicts.filter((v) => verdictState(v) === STATE.PASS).length;
 const underpoweredCount = verdicts.filter(
-  (v) => v.conclusive !== false && v.underpowered === true,
+  (v) => isIndeterminate(v) && v.underpowered === true,
 ).length;
-const incompleteCount = verdicts.filter((v) => v.conclusive === false).length;
+const incompleteCount = verdicts.filter(
+  (v) => isIndeterminate(v) && v.underpowered !== true,
+).length;
 const indeterminateCount = underpoweredCount + incompleteCount;
-const regressedCount = verdicts.filter((v) => v.regressed === true).length;
-const failedCount = verdicts.length - passedCount - indeterminateCount - regressedCount;
+const regressedCount = verdicts.filter(isObjectiveRegression).length;
+const preferenceRegressedCount = verdicts.filter(
+  (v) => !isIndeterminate(v) && !isObjectiveRegression(v) && isPreferenceRegression(v),
+).length;
+const failedCount = verdicts.length
+  - passedCount
+  - indeterminateCount
+  - regressedCount
+  - preferenceRegressedCount;
 
 const isFull = opts.format === "full";
 
@@ -235,11 +266,12 @@ lines.push("");
 // the gate refused to judge because no possible result at its size can reach
 // p <= 0.05. Reporting those next to real failures reads as a wall of
 // regressions, which is the opposite of what happened — the skill was never
-// measured. `regressed` is called out separately for the same reason: "did
-// anything get worse?" should be answerable from the first line.
+// measured. Objective regressions and report-only preference losses are called
+// out separately.
 lines.push(
   `${verdicts.length} skill(s) evaluated — ✅ **${passedCount} improved**, ` +
-    `❌ **${failedCount} no credible change**, 🔻 **${regressedCount} regressed**.`,
+    `❌ **${failedCount} no credible change**, 🔻 **${regressedCount} objective regressions**, ` +
+    `📉 **${preferenceRegressedCount} preference losses (report only)**.`,
 );
 if (indeterminateCount > 0) {
   const parts = [];
@@ -259,7 +291,7 @@ if (indeterminateCount > 0) {
 lines.push("");
 lines.push(
   `A skill passes only on a credible net win over baseline: more wins than losses, by an exact ` +
-    `one-sided sign test at \`p ≤ 0.05\`.`,
+    `one-sided sign test at \`p ≤ 0.05\`. LLM preference losses are reported separately from objective completion regressions.`,
 );
 lines.push("");
 
@@ -302,7 +334,8 @@ if (verdicts.length === 0) {
   lines.push("- **Δ Pref** — the same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Reported for triage only: weighting the statistic by magnitude made a skill fail for winning *harder*, which is why the gate deliberately ignores this column.");
   lines.push("- **W/T/L** — wins / ties / losses across trials.");
   lines.push("- **⚠️** — the gate withheld a verdict. Either the eval has fewer trials than any result needs to reach `p ≤ 0.05` (**underpowered** — the skill was never actually measured, so this is not a regression; add scenarios or raise `defaults.runs`), or the comparison didn't complete.");
-  lines.push("- **🔻** — a credible *regression*: the losses themselves clear the same bar the gate uses for wins.");
+  lines.push("- **🔻** — an objective completion regression. This state is reserved for objective completion evidence.");
+  lines.push("- **📉** — a credible LLM preference loss. It is report-only and is not an objective completion regression.");
   lines.push("- **Quality / Baseline** — mean absolute judge score 0–5 (skilled isolated vs skill-free control).");
   if (isFull) {
     lines.push("- **Quality (Plugin)** — mean absolute judge score 0–5 for the whole-plugin run.");
@@ -325,14 +358,34 @@ if (verdicts.length === 0) {
   // eval-size problem.
   const COMMENT_BUDGET = 63000; // leave headroom for links the workflow appends
   const rank = (v) =>
-    isIndeterminate(v) ? 2 : v.passed ? 3 : v.regressed === true ? 0 : 1;
+    isIndeterminate(v) ? 2 : verdictState(v) === STATE.PASS ? 3 : isObjectiveRegression(v) ? 0 : 1;
   const detailBlocks = verdicts.map((v) => {
     const icon = resultIcon(v);
+    const errorCounts = new Map();
+    for (const error of v.errors ?? []) {
+      const code = error.code ?? "unknown_comparison_error";
+      errorCounts.set(code, (errorCounts.get(code) ?? 0) + 1);
+    }
     const block = [
       `<details><summary>${icon} ${td(v.skillName)} — details</summary>`,
       "",
+      `**State:** \`${verdictState(v)}\`${v.stateReason?.code ? ` (\`${td(v.stateReason.code)}\`)` : ""}`,
+      "",
       ...(v.reason ? [`**Reason:** ${td(v.reason)}`] : []),
       "",
+      ...(errorCounts.size > 0
+        ? [`**Comparison errors:** ${[...errorCounts.entries()].map(([code, count]) => `\`${td(code)}\`=${count}`).join(", ")}`, ""]
+        : []),
+      ...((v.recoveredErrors?.length ?? 0) > 0
+        ? [`**Retry recovery:** ${v.recoveredErrors.length} errored judgment slot(s) recovered; successful first-attempt judgments stayed fixed.`, ""]
+        : []),
+      ...(v.scenarioEvidence
+        ? [
+            `**Effective scenarios (report only):** ${v.scenarioEvidence.count} ` +
+              `(${v.scenarioEvidence.wins}W/${v.scenarioEvidence.ties}T/${v.scenarioEvidence.losses}L).`,
+            "",
+          ]
+        : []),
       ...scenarioTable(v),
       "",
       "</details>",
@@ -343,15 +396,12 @@ if (verdicts.length === 0) {
   let used = lines.join("\n").length;
   const keep = new Set();
   // Two-phase selection so a passing (✅) detail can never be shown while a
-  // higher-priority failing (❌) or inconclusive (⚠️) detail was dropped for size:
-  // fit as many high-priority blocks as possible first, and only surface passing
-  // blocks if every high-priority block fit. Within the high-priority set, failing
-  // (❌, rank 0) blocks are considered before inconclusive (⚠️, rank 1) ones so a
-  // ⚠️ block can't consume budget that a later ❌ block needs.
+  // higher-priority non-pass detail was dropped for size. Objective regressions
+  // come first, followed by no-change/preference-loss and invalid records.
   const highPriority = detailBlocks
-    .filter((d) => rank(d.v) < 2)
+    .filter((d) => rank(d.v) < 3)
     .sort((a, b) => rank(a.v) - rank(b.v));
-  const lowPriority = detailBlocks.filter((d) => rank(d.v) === 2);
+  const lowPriority = detailBlocks.filter((d) => rank(d.v) === 3);
   let droppedHighPriority = false;
   for (const d of highPriority) {
     if (used + d.len > COMMENT_BUDGET) {

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -11,7 +11,8 @@
  *       preferenceRegressed,
  *       netWin, signTest:{wins,ties,losses,discordant,pValue,alpha},  // the gate
  *       meanScore, confidenceInterval:{low,high},  // magnitude, triage only
- *       winRate, wins, ties, losses, trialCount, erroredCount, reason,
+ *       winRate, wins, ties, losses, stimulusVoteCount, trialCount,
+ *       comparisonTrialEvidence, erroredCount, reason,
  *       scenarios: [ { scenarioName, skilledIsolated:{judgeResult:{overallScore}},
  *                      skilledPlugin?:{judgeResult:{overallScore}},
  *                      baseline:{judgeResult:{overallScore}} } ]
@@ -39,8 +40,8 @@ import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
-// Reuse the adapter's trial-direction rule so the PR comment and the gate can
-// never disagree about who won a trial.
+// Reuse the adapter's run-direction rule so the PR comment and the gate can
+// never disagree about who won a repeated run.
 import { trialDirection } from "./adapt.mjs";
 
 const { values: opts, positionals } = parseArgs({
@@ -189,7 +190,7 @@ function activationCell(verdict) {
 // adapt.mjs computes these per scenario; the fallback re-derives them from the
 // trials for results.json files written before it did.
 function scenarioTable(verdict) {
-  const rows = ["| Scenario | Net win | Δ Pref | Trials (W/T/L) |", "|---|---|---|---|"];
+  const rows = ["| Scenario | Net win | Δ Pref | Runs (W/T/L) |", "|---|---|---|---|"];
   for (const s of verdict.scenarios ?? []) {
     let { netWin, wins, ties, losses } = s;
     if (typeof netWin !== "number") {
@@ -277,9 +278,9 @@ if (indeterminateCount > 0) {
   const parts = [];
   if (underpoweredCount > 0) {
     parts.push(
-      `**${underpoweredCount} underpowered** — the eval has fewer trials than any result needs ` +
+      `**${underpoweredCount} underpowered** — the eval has fewer distinct stimuli than any result needs ` +
         `to reach \`p ≤ 0.05\`, so no verdict was possible. This is the eval's size, **not a ` +
-        `skill regression**; fix it by adding scenarios or raising \`defaults.runs\``,
+        `skill regression**; fix it by adding independent, discriminating stimuli`,
     );
   }
   if (incompleteCount > 0) {
@@ -290,8 +291,9 @@ if (indeterminateCount > 0) {
 }
 lines.push("");
 lines.push(
-  `A skill passes only on a credible net win over baseline: more wins than losses, by an exact ` +
-    `one-sided sign test at \`p ≤ 0.05\`. LLM preference losses are reported separately from objective completion regressions.`,
+  `A skill passes only when one vote per distinct stimulus gives a net win of at least 20% ` +
+    `and an exact one-sided sign test at \`p ≤ 0.05\`. Repeated runs report reliability only. ` +
+    `LLM preference losses are separate from objective completion regressions.`,
 );
 lines.push("");
 
@@ -329,11 +331,11 @@ if (verdicts.length === 0) {
   // Legend / glossary — kept out of table cells so it renders reliably.
   lines.push("<details><summary>ℹ️ Column legend</summary>");
   lines.push("");
-  lines.push("- **Net win** — `(wins − losses) / trials` for skilled vs baseline, judged head-to-head by `vally compare`. **This is the effect the gate decides on.**");
-  lines.push("- **p** — one-sided exact sign test over the discordant (non-tie) trials. A skill passes only at `p ≤ 0.05`, which needs at least 5 winning trials.");
+  lines.push("- **Net win** — `(wins − losses) / distinct stimulus votes` for skilled vs baseline. Repeated runs for each stimulus collapse to one majority-direction vote. A pass also needs an absolute net win of at least 20%.");
+  lines.push("- **p** — one-sided exact sign test over discordant (non-tie) stimulus votes. A pass needs `p ≤ 0.05`, which requires at least 5 winning stimulus votes.");
   lines.push("- **Δ Pref** — the same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Reported for triage only: weighting the statistic by magnitude made a skill fail for winning *harder*, which is why the gate deliberately ignores this column.");
-  lines.push("- **W/T/L** — wins / ties / losses across trials.");
-  lines.push("- **⚠️** — the gate withheld a verdict. Either the eval has fewer trials than any result needs to reach `p ≤ 0.05` (**underpowered** — the skill was never actually measured, so this is not a regression; add scenarios or raise `defaults.runs`), or the comparison didn't complete.");
+  lines.push("- **W/T/L** — wins / ties / losses after each distinct stimulus contributes one vote.");
+  lines.push("- **⚠️** — the gate withheld a verdict. Either the eval has fewer than 5 distinct stimuli (**underpowered** — not a skill regression; repeated runs cannot fix it), or the comparison did not complete.");
   lines.push("- **🔻** — an objective completion regression. This state is reserved for objective completion evidence.");
   lines.push("- **📉** — a credible LLM preference loss. It is report-only and is not an objective completion regression.");
   lines.push("- **Quality / Baseline** — mean absolute judge score 0–5 (skilled isolated vs skill-free control).");
@@ -379,10 +381,18 @@ if (verdicts.length === 0) {
       ...((v.recoveredErrors?.length ?? 0) > 0
         ? [`**Retry recovery:** ${v.recoveredErrors.length} errored judgment slot(s) recovered; successful first-attempt judgments stayed fixed.`, ""]
         : []),
-      ...(v.scenarioEvidence
+      ...(v.scenarioEvidence?.gateEligible === true
         ? [
-            `**Effective scenarios (report only):** ${v.scenarioEvidence.count} ` +
+            `**Gate evidence (stimulus votes):** ${v.scenarioEvidence.count} ` +
               `(${v.scenarioEvidence.wins}W/${v.scenarioEvidence.ties}T/${v.scenarioEvidence.losses}L).`,
+            "",
+          ]
+        : []),
+      ...((v.comparisonTrialEvidence?.count ?? 0) > 0
+        ? [
+            `**Repeated-run reliability (not used by the gate):** ${v.comparisonTrialEvidence.count} ` +
+              `paired run(s) (${v.comparisonTrialEvidence.wins}W/${v.comparisonTrialEvidence.ties}T/` +
+              `${v.comparisonTrialEvidence.losses}L).`,
             "",
           ]
         : []),

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -244,7 +244,7 @@ function scenarioTable(verdict, weakOnly = false) {
     const icon = netWin > 0 ? "▲" : netWin < 0 ? "▼" : "=";
     const magnitude = typeof scenario.meanScore === "number" ? scenario.meanScore : 0;
     rows.push(
-      `| ${icon} ${td(scenario.scenarioName)} | ${pct(netWin)} | ${pct(magnitude)} | ${wins}/${ties}/${losses} |`,
+      `| ${icon} ${td(html(scenario.scenarioName))} | ${pct(netWin)} | ${pct(magnitude)} | ${wins}/${ties}/${losses} |`,
     );
   }
   return rows;

--- a/eng/vally-adapter/consolidate.mjs
+++ b/eng/vally-adapter/consolidate.mjs
@@ -1,47 +1,15 @@
 #!/usr/bin/env node
 
 /**
- * consolidate — turn the adapter's per-skill results.json files into the PR
- * summary markdown, replacing `skill-validator evaluate consolidate` plus the
- * downstream Python column-stripper.
- *
- * Each results.json (written by adapt.mjs) has:
- *   { model, judgeModel, timestamp, verdicts: [ {
- *       skillName, state, stateReason, passed, conclusive, underpowered,
- *       preferenceRegressed,
- *       netWin, signTest:{wins,ties,losses,discordant,pValue,alpha},  // the gate
- *       meanScore, confidenceInterval:{low,high},  // magnitude, triage only
- *       winRate, wins, ties, losses, stimulusVoteCount, trialCount,
- *       comparisonTrialEvidence, erroredCount, reason,
- *       scenarios: [ { scenarioName, skilledIsolated:{judgeResult:{overallScore}},
- *                      skilledPlugin?:{judgeResult:{overallScore}},
- *                      baseline:{judgeResult:{overallScore}} } ]
- *   } ] }
- *
- * A skill passes only on a credible head-to-head preference improvement.
- * Objective regression, no-change, and invalid evidence use distinct states.
- * Absolute per-role quality and report-only reliability evidence are shown for
- * context.
- *
- * Both formats render a table (Overfit + Skills Loaded columns included),
- * followed by a legend and a collapsible <details> per skill that carries the
- * verdict reason and a per-scenario preference table.
- *
- * Two formats:
- *   --format full    every column incl. Quality (Plugin)  — for the step summary
- *   --format simple  drops Quality (Plugin)                — for the PR comment
- *
- * Usage:
- *   node consolidate.mjs --format simple --output body.md <results.json...>
- *   node consolidate.mjs --format full --root all-results/ --output summary.md
+ * Consolidate per-skill adapter results into either a compact PR comment or a
+ * complete workflow summary. The compact view answers what happened, why, and
+ * what to do next. The full view keeps the triage metrics and every detail.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
-// Reuse the adapter's run-direction rule so the PR comment and the gate can
-// never disagree about who won a repeated run.
 import { trialDirection } from "./adapt.mjs";
 
 const { values: opts, positionals } = parseArgs({
@@ -49,6 +17,7 @@ const { values: opts, positionals } = parseArgs({
     format: { type: "string", default: "full" },
     output: { type: "string" },
     root: { type: "string" },
+    commit: { type: "string" },
     help: { type: "boolean", default: false },
   },
   allowPositionals: true,
@@ -57,61 +26,104 @@ const { values: opts, positionals } = parseArgs({
 
 if (opts.help || (opts.format !== "full" && opts.format !== "simple")) {
   console.log(`Usage:
-  node consolidate.mjs --format <full|simple> [--output <file>] [--root <dir>] [<results.json>...]
+  node consolidate.mjs --format <full|simple> [--output <file>] [--root <dir>] [--commit <sha>] [<results.json>...]
 
 Consolidates per-skill results.json into a markdown summary table.
 
 Options:
-  --format <full|simple>  full: all columns (step summary). simple: drop Quality
-                          (Plugin) column (PR comment). (required)
+  --format <full|simple>  full: all metrics and details (workflow summary).
+                          simple: decision and repair view (PR comment).
   --output <file>         Write markdown here (default: stdout).
-  --root <dir>            Recursively discover results.json under <dir> (in
-                          addition to any explicit file arguments).
+  --root <dir>            Recursively discover results.json and
+                          adapter-summary.json under this directory.
+  --commit <sha>          Show the exact evaluated commit in the report.
   --help                  Show this help`);
   process.exit(opts.help ? 0 : 1);
 }
 
-function findResultsJson(dir) {
+function findNamedFiles(dir, fileName) {
   const out = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...findResultsJson(full));
-    else if (entry.name === "results.json") out.push(full);
+    if (entry.isDirectory()) out.push(...findNamedFiles(full, fileName));
+    else if (entry.name === fileName) out.push(full);
   }
   return out;
 }
 
-const files = [...positionals];
+const resultFiles = [...positionals];
+const summaryFiles = [];
 if (opts.root) {
   try {
-    if (statSync(opts.root).isDirectory()) files.push(...findResultsJson(opts.root));
+    if (statSync(opts.root).isDirectory()) {
+      resultFiles.push(...findNamedFiles(opts.root, "results.json"));
+      summaryFiles.push(...findNamedFiles(opts.root, "adapter-summary.json"));
+    }
   } catch {
-    /* missing root dir — treated as no files */
+    // A missing root is reported as an empty result set below.
   }
 }
 
-// Dedupe while preserving order.
-const uniqueFiles = [...new Set(files)];
-
-function mean(nums) {
-  const xs = nums.filter((n) => typeof n === "number" && Number.isFinite(n));
-  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null;
+function readJson(file, label) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    console.error(
+      `::warning::consolidate: failed to read ${label} ${file}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
 }
 
-// Mean absolute quality (0-5) across a verdict's scenarios for one role.
+const verdicts = [];
+for (const file of [...new Set(resultFiles)]) {
+  const data = readJson(file, "result");
+  if (!data) continue;
+  for (const verdict of data.verdicts ?? []) {
+    verdicts.push({
+      ...verdict,
+      model: verdict.model ?? data.model ?? "unknown",
+      judgeModel: verdict.judgeModel ?? data.judgeModel ?? "unknown",
+    });
+  }
+}
+
+const adapterSummaries = [...new Set(summaryFiles)]
+  .map((file) => readJson(file, "adapter summary"))
+  .filter(Boolean);
+
+verdicts.sort(
+  (a, b) =>
+    String(a.skillName ?? "").localeCompare(String(b.skillName ?? ""))
+    || String(a.model ?? "").localeCompare(String(b.model ?? "")),
+);
+
+function mean(nums) {
+  const values = nums.filter((n) => typeof n === "number" && Number.isFinite(n));
+  return values.length
+    ? values.reduce((sum, value) => sum + value, 0) / values.length
+    : null;
+}
+
 function roleQuality(verdict, role) {
   return mean(
-    (verdict.scenarios ?? []).map((s) => s?.[role]?.judgeResult?.overallScore),
+    (verdict.scenarios ?? []).map((scenario) => scenario?.[role]?.judgeResult?.overallScore),
   );
 }
 
-function fmtQuality(q) {
-  return q === null ? "—" : `${q.toFixed(1)}/5`;
+function fmtQuality(value) {
+  return value === null ? "—" : `${value.toFixed(1)}/5`;
 }
 
-function pct(x) {
-  if (typeof x !== "number" || !Number.isFinite(x)) return "—";
-  return `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)}%`;
+function pct(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  return `${value >= 0 ? "+" : ""}${(value * 100).toFixed(1)}%`;
+}
+
+function countNoun(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 const STATE = Object.freeze({
@@ -128,172 +140,347 @@ function verdictState(verdict) {
   return STATE.NO_CHANGE;
 }
 
-function isPreferenceRegression(verdict) {
-  return verdict.preferenceRegressed === true
-    || (verdict.regressed === true && (verdict.state == null || verdict.state === STATE.NO_CHANGE));
+function isIndeterminate(verdict) {
+  return verdictState(verdict) === STATE.INVALID;
 }
 
 function isObjectiveRegression(verdict) {
   return verdictState(verdict) === STATE.REGRESSION;
 }
 
-// Escape a value for safe use inside a markdown table cell: literal pipes would
-// otherwise inject extra columns, and newlines would split the row.
-function td(x) {
-  return String(x ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+function isPreferenceRegression(verdict) {
+  return verdict.preferenceRegressed === true
+    || (verdict.regressed === true
+      && (verdict.state == null || verdict.state === STATE.NO_CHANGE));
 }
 
-// Overfitting-judge severity → icon + score, mirroring the old Reporter.cs
-// FormatOverfitCell (Low=✅, Moderate=🟡, High=🔴, missing=—).
+function td(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function html(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function fmtOverfit(verdict) {
-  const r = verdict.overfittingResult;
-  if (!r || !r.severity) return "—";
-  const icon =
-    { Low: "✅", Moderate: "🟡", High: "🔴" }[r.severity] ?? "—";
-  const score = typeof r.score === "number" ? ` ${r.score.toFixed(2)}` : "";
+  const result = verdict.overfittingResult;
+  if (!result?.severity) return "—";
+  const icon = { Low: "✅", Moderate: "🟡", High: "🔴" }[result.severity] ?? "—";
+  const score = typeof result.score === "number" ? ` ${result.score.toFixed(2)}` : "";
   return `${icon}${score}`;
 }
 
-// Skill-activation coverage from scenarios: "activated/total" for the isolated
-// run (plus the plugin run when present), with a ⚠️ when a scenario that
-// expected activation didn't activate. Only scenarios that expect activation
-// count toward coverage — scenarios marked expectActivation:false are meant to
-// stay dormant, so including them would under-report (e.g. a correct dormant
-// scenario showing as "0/1").
-function activationCell(verdict) {
-  const scenarios = verdict.scenarios ?? [];
-  const expected = scenarios.filter((s) => s?.expectActivation !== false);
-  if (expected.length === 0) return "—";
-  const total = expected.length;
-  const isoActive = expected.filter((s) => s?.skillActivationIsolated?.activated).length;
-  const hasPlugin = expected.some((s) => s?.skillActivationPlugin != null);
-  const missingExpected = expected.some(
-    (s) =>
-      !s?.skillActivationIsolated?.activated ||
-      (s?.skillActivationPlugin != null && !s.skillActivationPlugin.activated),
+function activationStats(verdict) {
+  const expected = (verdict.scenarios ?? []).filter(
+    (scenario) => scenario?.expectActivation !== false,
   );
-  let cell = `${isoActive}/${total}`;
-  if (hasPlugin) {
-    const plugActive = expected.filter((s) => s?.skillActivationPlugin?.activated).length;
-    cell += ` · ${plugActive}/${total} (plugin)`;
-  }
-  return missingExpected ? `⚠️ ${cell}` : cell;
+  if (expected.length === 0) return null;
+  const total = expected.length;
+  const isolated = expected.filter(
+    (scenario) => scenario?.skillActivationIsolated?.activated,
+  ).length;
+  const hasPlugin = expected.some((scenario) => scenario?.skillActivationPlugin != null);
+  const plugin = hasPlugin
+    ? expected.filter((scenario) => scenario?.skillActivationPlugin?.activated).length
+    : null;
+  return {
+    total,
+    isolated,
+    plugin,
+    hasMissing: isolated < total || (plugin !== null && plugin < total),
+  };
 }
 
-// Per-scenario table (mirrors evaluation-run.yml's step summary).
-//
-// The arrow and the leading number follow the scenario's *net win*, so a
-// scenario's row can never point the opposite way to the verdict it feeds.
-// Ranking by magnitude instead let two `slightly-better` wins and one
-// `much-better` loss display ▼ while contributing a positive net win.
-//
-// adapt.mjs computes these per scenario; the fallback re-derives them from the
-// trials for results.json files written before it did.
-function scenarioTable(verdict) {
-  const rows = ["| Scenario | Net win | Δ Pref | Runs (W/T/L) |", "|---|---|---|---|"];
-  for (const s of verdict.scenarios ?? []) {
-    let { netWin, wins, ties, losses } = s;
-    if (typeof netWin !== "number") {
-      const counted = (s.trials ?? []).filter((tr) => !tr.errored);
-      wins = counted.filter((tr) => trialDirection(tr) > 0).length;
-      losses = counted.filter((tr) => trialDirection(tr) < 0).length;
-      ties = counted.length - wins - losses;
-      netWin = counted.length ? (wins - losses) / counted.length : 0;
-    }
+function activationCell(verdict) {
+  const stats = activationStats(verdict);
+  if (!stats) return "—";
+  const plugin = stats.plugin === null ? "" : `; plugin ${stats.plugin}/${stats.total}`;
+  return `isolated ${stats.isolated}/${stats.total}${plugin}`;
+}
+
+function scenarioStats(scenario) {
+  let { netWin, wins, ties, losses } = scenario;
+  if (typeof netWin !== "number") {
+    const trials = (scenario.trials ?? []).filter((trial) => !trial.errored);
+    wins = trials.filter((trial) => trialDirection(trial) > 0).length;
+    losses = trials.filter((trial) => trialDirection(trial) < 0).length;
+    ties = trials.length - wins - losses;
+    netWin = trials.length ? (wins - losses) / trials.length : 0;
+  }
+  return {
+    netWin,
+    wins: wins ?? 0,
+    ties: ties ?? 0,
+    losses: losses ?? 0,
+  };
+}
+
+function isWeakOrWarningScenario(scenario) {
+  const { netWin } = scenarioStats(scenario);
+  return netWin <= 0
+    || scenario?.timedOut === true
+    || (scenario?.expectActivation !== false
+      && (!scenario?.skillActivationIsolated?.activated
+        || (scenario?.skillActivationPlugin != null
+          && !scenario.skillActivationPlugin.activated)));
+}
+
+function scenarioTable(verdict, weakOnly = false) {
+  const scenarios = (verdict.scenarios ?? []).filter(
+    (scenario) => !weakOnly || isWeakOrWarningScenario(scenario),
+  );
+  if (scenarios.length === 0) return [];
+  const rows = [
+    weakOnly ? "**Weak or warning scenarios:**" : "**Scenario evidence:**",
+    "",
+    "| Scenario | Net win | Δ Pref | Runs (W/T/L) |",
+    "|---|---|---|---|",
+  ];
+  for (const scenario of scenarios) {
+    const { netWin, wins, ties, losses } = scenarioStats(scenario);
     const icon = netWin > 0 ? "▲" : netWin < 0 ? "▼" : "=";
-    const m = typeof s.meanScore === "number" ? s.meanScore : 0;
+    const magnitude = typeof scenario.meanScore === "number" ? scenario.meanScore : 0;
     rows.push(
-      `| ${icon} ${td(s.scenarioName)} | ${pct(netWin)} | ${pct(m)} | ${wins}/${ties}/${losses} |`,
+      `| ${icon} ${td(scenario.scenarioName)} | ${pct(netWin)} | ${pct(magnitude)} | ${wins}/${ties}/${losses} |`,
     );
   }
   return rows;
 }
 
-const verdicts = [];
-for (const file of uniqueFiles) {
-  let data;
-  try {
-    data = JSON.parse(readFileSync(file, "utf-8"));
-  } catch (err) {
-    console.error(`::warning::consolidate: failed to read ${file}: ${err instanceof Error ? err.message : String(err)}`);
-    continue;
+function representativeEvidence(verdict) {
+  for (const scenario of verdict.scenarios ?? []) {
+    if (!isWeakOrWarningScenario(scenario)) continue;
+    const trials = (scenario.trials ?? []).filter((trial) => !trial.errored);
+    const trial = trials.find((candidate) => trialDirection(candidate) < 0)
+      ?? trials.find((candidate) => trialDirection(candidate) === 0);
+    const evidence = trial?.evidence;
+    if (typeof evidence !== "string" || evidence.trim().length === 0) continue;
+    const compact = evidence.replace(/\s+/g, " ").trim();
+    const excerpt = compact.length > 280 ? `${compact.slice(0, 277)}...` : compact;
+    return [
+      "**Illustrative judge evidence:**",
+      "",
+      `- <code>${html(scenario.scenarioName)}</code>: <code>${html(excerpt)}</code>`,
+      "",
+      "_This is one example, not the aggregate verdict. Open Full Results for every judgment._",
+    ];
   }
-  for (const v of data.verdicts ?? []) verdicts.push(v);
+  return [];
 }
 
-verdicts.sort((a, b) => (a.skillName ?? "").localeCompare(b.skillName ?? ""));
-
-// Prefer schema-version-2 states. The fallback keeps historical result
-// artifacts readable.
-function isIndeterminate(v) {
-  return verdictState(v) === STATE.INVALID;
+function resultLabel(verdict) {
+  if (isIndeterminate(verdict)) {
+    return verdict.underpowered === true
+      ? "⚠️ Underpowered"
+      : "⚠️ Invalid / inconclusive";
+  }
+  if (verdictState(verdict) === STATE.PASS) return "✅ Improved";
+  if (isObjectiveRegression(verdict)) return "🔻 Objective regression";
+  if (isPreferenceRegression(verdict)) return "📉 Preference loss (report only)";
+  return "➖ Not proven improved";
 }
 
-function resultIcon(v) {
-  if (isIndeterminate(v)) return "⚠️";
-  if (verdictState(v) === STATE.PASS) return "✅";
-  if (isObjectiveRegression(v)) return "🔻";
-  return isPreferenceRegression(v) ? "📉" : "❌";
+function gateEvidence(verdict) {
+  const evidence = verdict.scenarioEvidence ?? verdict.signTest;
+  const wins = verdict.signTest?.wins ?? evidence?.wins ?? verdict.wins ?? 0;
+  const ties = verdict.signTest?.ties ?? evidence?.ties ?? verdict.ties ?? 0;
+  const losses = verdict.signTest?.losses ?? evidence?.losses ?? verdict.losses ?? 0;
+  const count = verdict.stimulusVoteCount ?? evidence?.count ?? wins + ties + losses;
+  if (!count) return "No gate-eligible evidence";
+  const discordant = verdict.signTest?.discordant ?? wins + losses;
+  const pValue = typeof verdict.signTest?.pValue === "number"
+    ? verdict.signTest.pValue.toFixed(3)
+    : "—";
+  return `n=${count}; ${wins}W/${ties}T/${losses}L; d=${discordant}; p=${pValue}; net ${pct(verdict.netWin)}`;
 }
 
-const passedCount = verdicts.filter((v) => verdictState(v) === STATE.PASS).length;
+function warningParts(verdict) {
+  const warnings = [];
+  const activation = activationStats(verdict);
+  if (activation?.hasMissing) warnings.push(`Activation: ${activationCell(verdict)}`);
+  const timeoutCount = (verdict.scenarios ?? []).filter(
+    (scenario) => scenario?.timedOut === true,
+  ).length;
+  if (timeoutCount > 0) warnings.push(countNoun(timeoutCount, "timeout"));
+  const recovered = verdict.recoveredErrors?.length ?? 0;
+  if (recovered > 0) warnings.push(`${countNoun(recovered, "judge slot")} recovered`);
+  const unresolved = verdict.errors?.length ?? 0;
+  if (unresolved > 0) warnings.push(`${countNoun(unresolved, "unresolved error")}`);
+  return warnings;
+}
+
+function warningCell(verdict) {
+  const warnings = warningParts(verdict);
+  return warnings.length ? warnings.join("; ") : "—";
+}
+
+function hasActionableWarning(verdict) {
+  return warningParts(verdict).length > 0
+    || ["Moderate", "High"].includes(verdict.overfittingResult?.severity);
+}
+
+function nextAction(verdict) {
+  const state = verdictState(verdict);
+  const reasonCode = verdict.stateReason?.code ?? "";
+  if (state === STATE.INVALID) {
+    if (verdict.underpowered === true) {
+      return "Predeclare more independent, discriminating stimuli; repeated runs do not add power.";
+    }
+    if (/judge|organization|rate_limit|session_idle/.test(reasonCode)
+        || (verdict.errors ?? []).some((error) => /judge|organization|rate_limit|session_idle/.test(error.code ?? ""))) {
+      return "Fix the listed judge or service error, then rerun the exact commit.";
+    }
+    if (/missing|unexpected|accounting|identity|malformed|duplicate/.test(reasonCode)) {
+      return "Fix result production or identity accounting before judging skill quality.";
+    }
+    return "Inspect the comparison errors and restore complete paired evidence before rerunning.";
+  }
+  if (state === STATE.REGRESSION) {
+    return "Inspect objective completion losses and fix them before merge.";
+  }
+  if (isPreferenceRegression(verdict)) {
+    return "Inspect losing stimuli and fix skill behavior; this is not objective completion proof.";
+  }
+  if (state === STATE.NO_CHANGE) {
+    if (reasonCode === "practical_effect_below_floor") {
+      return "Improve the skill across more tested tasks; the credible effect is too sparse.";
+    }
+    if ((verdict.signTest?.discordant ?? 0) < 5) {
+      return "Inspect tied or lost stimuli; predeclare added breadth before a new experiment.";
+    }
+    return "Inspect tied or lost stimuli and fix inconsistent skill behavior.";
+  }
+
+  const actions = [];
+  const activation = activationStats(verdict);
+  if (activation?.hasMissing) actions.push("Fix activation gaps");
+  if ((verdict.scenarios ?? []).some((scenario) => scenario?.timedOut === true)) {
+    actions.push("Inspect timeouts");
+  }
+  if (["Moderate", "High"].includes(verdict.overfittingResult?.severity)) {
+    actions.push("Review overfit evidence");
+  }
+  if ((verdict.recoveredErrors?.length ?? 0) > 0) actions.push("Review recovered judge slots");
+  return actions.length ? `${actions.join("; ")}.` : "None.";
+}
+
+function sumSummaryField(field) {
+  return adapterSummaries.reduce(
+    (sum, summary) => sum + (Number.isFinite(summary?.[field]) ? summary[field] : 0),
+    0,
+  );
+}
+
+const passedCount = verdicts.filter((verdict) => verdictState(verdict) === STATE.PASS).length;
 const underpoweredCount = verdicts.filter(
-  (v) => isIndeterminate(v) && v.underpowered === true,
+  (verdict) => isIndeterminate(verdict) && verdict.underpowered === true,
 ).length;
-const incompleteCount = verdicts.filter(
-  (v) => isIndeterminate(v) && v.underpowered !== true,
+const invalidCount = verdicts.filter(
+  (verdict) => isIndeterminate(verdict) && verdict.underpowered !== true,
 ).length;
-const indeterminateCount = underpoweredCount + incompleteCount;
 const regressedCount = verdicts.filter(isObjectiveRegression).length;
 const preferenceRegressedCount = verdicts.filter(
-  (v) => !isIndeterminate(v) && !isObjectiveRegression(v) && isPreferenceRegression(v),
+  (verdict) =>
+    !isIndeterminate(verdict)
+    && !isObjectiveRegression(verdict)
+    && isPreferenceRegression(verdict),
 ).length;
-const failedCount = verdicts.length
+const noChangeCount = verdicts.length
   - passedCount
-  - indeterminateCount
+  - underpoweredCount
+  - invalidCount
   - regressedCount
   - preferenceRegressedCount;
-
+const skillCount = new Set(verdicts.map((verdict) => verdict.skillName)).size;
+const models = [...new Set(verdicts.map((verdict) => verdict.model))];
+const judges = [...new Set(verdicts.map((verdict) => verdict.judgeModel))];
+const objectiveGateEnabled = regressedCount > 0
+  || verdicts.some((verdict) => verdict.completionTransitions?.gateEligible === true);
 const isFull = opts.format === "full";
 
-const header = isFull
-  ? ["Skill", "Result", "Net win", "p", "Δ Pref", "W/T/L", "Quality (Isolated)", "Quality (Plugin)", "Baseline", "Overfit", "Skills Loaded"]
-  : ["Skill", "Result", "Net win", "p", "Δ Pref", "W/T/L", "Quality", "Baseline", "Overfit", "Skills Loaded"];
+const compactHeader = [
+  "Skill",
+  "Model",
+  "Verdict",
+  "Gate evidence",
+  "Overfit",
+  "Warnings",
+  "Next action",
+];
+const fullHeader = [
+  "Skill",
+  "Model",
+  "Verdict",
+  "Gate evidence",
+  "Δ Pref",
+  "Quality (Isolated)",
+  "Quality (Plugin)",
+  "Baseline",
+  "Overfit",
+  "Warnings",
+  "Next action",
+];
+const header = isFull ? fullHeader : compactHeader;
+const lines = ["## 📊 Skill Evaluation Results", ""];
 
-const lines = [];
-lines.push(`## 📊 Skill Evaluation Results`);
-lines.push("");
-// Headline. Kept explicit about what ⚠️ is *not*: an underpowered eval is one
-// the gate refused to judge because no possible result at its size can reach
-// p <= 0.05. Reporting those next to real failures reads as a wall of
-// regressions, which is the opposite of what happened — the skill was never
-// measured. Objective regressions and report-only preference losses are called
-// out separately.
 lines.push(
-  `${verdicts.length} skill(s) evaluated — ✅ **${passedCount} improved**, ` +
-    `❌ **${failedCount} no credible change**, 🔻 **${regressedCount} objective regressions**, ` +
-    `📉 **${preferenceRegressedCount} preference losses (report only)**.`,
+  `${countNoun(verdicts.length, "model/skill result")} across `
+  + `${countNoun(skillCount, "skill")} and ${countNoun(models.length, "model")} — `
+  + `✅ **${passedCount} improved**, ➖ **${noChangeCount} not proven improved**, `
+  + `⚠️ **${underpoweredCount + invalidCount} invalid or underpowered**, `
+  + `📉 **${preferenceRegressedCount} preference losses (report only)**`
+  + `${regressedCount > 0 ? `, 🔻 **${regressedCount} objective regressions**` : ""}.`,
 );
-if (indeterminateCount > 0) {
-  const parts = [];
-  if (underpoweredCount > 0) {
-    parts.push(
-      `**${underpoweredCount} underpowered** — the eval has fewer distinct stimuli than any result needs ` +
-        `to reach \`p ≤ 0.05\`, so no verdict was possible. This is the eval's size, **not a ` +
-        `skill regression**; fix it by adding independent, discriminating stimuli`,
-    );
-  }
-  if (incompleteCount > 0) {
-    parts.push(`**${incompleteCount} inconclusive** — the comparison didn't complete (errored, unmatched, or self-contradictory trials)`);
-  }
+
+const metadata = [];
+if (opts.commit) metadata.push(`evaluated commit \`${td(opts.commit)}\``);
+if (judges.length === 1) metadata.push(`judge \`${td(judges[0])}\``);
+else if (judges.length > 1) metadata.push(`${judges.length} judge models`);
+if (metadata.length > 0) {
   lines.push("");
-  lines.push(`⚠️ **${indeterminateCount} could not be judged**: ${parts.join("; ")}.`);
+  lines.push(`**Measurement identity:** ${metadata.join("; ")}.`);
+}
+
+if (adapterSummaries.length > 0) {
+  const recovered = verdicts.reduce(
+    (sum, verdict) => sum + (verdict.recoveredErrors?.length ?? 0),
+    0,
+  );
+  const unresolved = verdicts.reduce(
+    (sum, verdict) => sum + (verdict.errors?.length ?? 0),
+    0,
+  );
+  lines.push("");
+  lines.push(
+    `**Measurement health:** ${sumSummaryField("expectedEvalCount")} expected / `
+    + `${sumSummaryField("observedEvalCount")} observed / `
+    + `${sumSummaryField("writtenResultCount")} written; `
+    + `${sumSummaryField("missingEvalCount")} missing, `
+    + `${sumSummaryField("unexpectedEvalCount")} unexpected, `
+    + `${sumSummaryField("invalidEvalCount")} invalid; `
+    + `${countNoun(recovered, "recovered comparison error slot")} and `
+    + `${countNoun(unresolved, "unresolved comparison error slot")}.`,
+  );
+}
+
+lines.push("");
+if (objectiveGateEnabled) {
+  lines.push(
+    `**Objective completion gate:** enabled; ${countNoun(regressedCount, "result")} `
+    + `${regressedCount === 1 ? "shows" : "show"} a proven objective regression.`,
+  );
+} else {
+  lines.push(
+    "**Objective completion gate:** not enabled. Aggregate completion transitions are telemetry only, so this report does not claim that zero objective regressions were proven.",
+  );
 }
 lines.push("");
 lines.push(
-  `A skill passes only when one vote per distinct stimulus gives a net win of at least 20% ` +
-    `and an exact one-sided sign test at \`p ≤ 0.05\`. Repeated runs report reliability only. ` +
-    `LLM preference losses are separate from objective completion regressions.`,
+  "A result passes only when the aggregate net win across distinct-stimulus votes is at least 20% "
+  + "and an exact one-sided sign-test result of `p ≤ 0.05`. Repeated runs measure reliability only.",
 );
 lines.push("");
 
@@ -302,140 +489,153 @@ if (verdicts.length === 0) {
 } else {
   lines.push(`| ${header.join(" | ")} |`);
   lines.push(`|${header.map(() => "---").join("|")}|`);
-  for (const v of verdicts) {
-    const result = resultIcon(v);
-    // The deciding statistic is the net win and its sign-test p. Older
-    // results.json files predate both, so fall back to the magnitude-weighted
-    // mean and interval they were actually gated on at the time.
-    const hasNetWin = typeof v.netWin === "number";
-    const netWin = hasNetWin
-      ? pct(v.netWin)
-      : `${pct(v.meanScore)}${v.confidenceInterval ? ` [${pct(v.confidenceInterval.low)}, ${pct(v.confidenceInterval.high)}]` : ""}`;
-    const pv = v.signTest && typeof v.signTest.pValue === "number"
-      ? v.signTest.pValue.toFixed(3)
-      : "—";
-    const pref = pct(v.meanScore);
-    const wtl = `${v.wins ?? 0}/${v.ties ?? 0}/${v.losses ?? 0}`;
-    const isolated = fmtQuality(roleQuality(v, "skilledIsolated"));
-    const plugin = fmtQuality(roleQuality(v, "skilledPlugin"));
-    const baseline = fmtQuality(roleQuality(v, "baseline"));
-    const overfit = fmtOverfit(v);
-    const activation = activationCell(v);
+  for (const verdict of verdicts) {
+    const common = [
+      td(verdict.skillName),
+      td(verdict.model),
+      resultLabel(verdict),
+      gateEvidence(verdict),
+    ];
     const cells = isFull
-      ? [td(v.skillName), result, netWin, pv, pref, wtl, isolated, plugin, baseline, overfit, activation]
-      : [td(v.skillName), result, netWin, pv, pref, wtl, isolated, baseline, overfit, activation];
-    lines.push(`| ${cells.join(" | ")} |`);
+      ? [
+          ...common,
+          pct(verdict.meanScore),
+          fmtQuality(roleQuality(verdict, "skilledIsolated")),
+          fmtQuality(roleQuality(verdict, "skilledPlugin")),
+          fmtQuality(roleQuality(verdict, "baseline")),
+          fmtOverfit(verdict),
+          warningCell(verdict),
+          nextAction(verdict),
+        ]
+      : [
+          ...common,
+          fmtOverfit(verdict),
+          warningCell(verdict),
+          nextAction(verdict),
+        ];
+    lines.push(`| ${cells.map(td).join(" | ")} |`);
   }
   lines.push("");
 
-  // Legend / glossary — kept out of table cells so it renders reliably.
-  lines.push("<details><summary>ℹ️ Column legend</summary>");
+  lines.push("<details><summary>ℹ️ How to read this report</summary>");
   lines.push("");
-  lines.push("- **Net win** — `(wins − losses) / distinct stimulus votes` for skilled vs baseline. Repeated runs for each stimulus collapse to one majority-direction vote. A pass also needs an absolute net win of at least 20%.");
-  lines.push("- **p** — one-sided exact sign test over discordant (non-tie) stimulus votes. A pass needs `p ≤ 0.05`, which requires at least 5 winning stimulus votes.");
-  lines.push("- **Δ Pref** — the same comparison weighted by how decisive each win was (`much-better` ±100%, `slightly-better` ±40%). Reported for triage only: weighting the statistic by magnitude made a skill fail for winning *harder*, which is why the gate deliberately ignores this column.");
-  lines.push("- **W/T/L** — wins / ties / losses after each distinct stimulus contributes one vote.");
-  lines.push("- **⚠️** — the gate withheld a verdict. Either the eval has fewer than 5 distinct stimuli (**underpowered** — not a skill regression; repeated runs cannot fix it), or the comparison did not complete.");
-  lines.push("- **🔻** — an objective completion regression. This state is reserved for objective completion evidence.");
-  lines.push("- **📉** — a credible LLM preference loss. It is report-only and is not an objective completion regression.");
-  lines.push("- **Quality / Baseline** — mean absolute judge score 0–5 (skilled isolated vs skill-free control).");
+  lines.push("- **✅ Improved** — the result passed both the statistical gate and the 20% practical net-win floor.");
+  lines.push("- **➖ Not proven improved** — the result is valid but did not pass both gates. This is not automatically a regression.");
+  lines.push("- **⚠️ Invalid / underpowered** — the gate withheld a quality verdict. Fix the measurement before judging the skill.");
+  lines.push("- **📉 Preference loss** — the LLM judge credibly preferred baseline. It is report-only, not objective completion proof.");
+  lines.push("- **Gate evidence** — `n` distinct-stimulus votes, W/T/L stimulus votes, `d` discordant votes, exact one-sided `p`, and net win. The `p` value applies to one model/skill result; no matrix-wide multiple-comparison correction is applied.");
+  lines.push("- **Overfit** — overfitting-judge severity (✅ Low, 🟡 Moderate, 🔴 High, — none) and score.");
+  lines.push("- **Warnings** — activation, timeout, retry recovery, or unresolved comparison conditions that need attention.");
   if (isFull) {
-    lines.push("- **Quality (Plugin)** — mean absolute judge score 0–5 for the whole-plugin run.");
+    lines.push("- **Δ Pref** — magnitude-weighted LLM preference, shown for triage only and not used by the gate.");
+    lines.push("- **Quality / Baseline** — mean absolute judge score from 0–5. These are triage metrics, not the pass statistic.");
   }
-  lines.push("- **Overfit** — overfitting-judge severity (✅ Low, 🟡 Moderate, 🔴 High, — none) with its score.");
-  lines.push("- **Skills Loaded** — of the scenarios that expect activation, how many actually activated / that total (plugin run shown when present); ⚠️ marks a scenario that expected activation but didn't activate.");
+  lines.push("- Do not add repeated runs to increase statistical power. Do not add stimuli after seeing a near-pass unless the new breadth is predeclared for a new experiment.");
   lines.push("</details>");
   lines.push("");
 
-  // Per-skill detail: verdict reason + per-scenario preference table, one click
-  // away. Budgeted so the whole comment stays under GitHub's 65,536-character
-  // comment limit; when it can't all fit, the details that matter most for triage
-  // (failing, then inconclusive) are kept and the rest are omitted with a pointer.
-  // Two-phase selection so a passing (✅) detail can never be shown while a
-  // higher-priority detail was dropped for size: fit as many high-priority
-  // blocks as possible first, and only surface passing blocks if every
-  // high-priority block fit. Within the high-priority set, a credible
-  // regression (🔻) is considered before a no-change (❌) and both before an
-  // unjudgeable (⚠️) one, so a real regression can't lose its budget to an
-  // eval-size problem.
-  const COMMENT_BUDGET = 63000; // leave headroom for links the workflow appends
-  const rank = (v) =>
-    isIndeterminate(v) ? 2 : verdictState(v) === STATE.PASS ? 3 : isObjectiveRegression(v) ? 0 : 1;
-  const detailBlocks = verdicts.map((v) => {
-    const icon = resultIcon(v);
-    const errorCounts = new Map();
-    for (const error of v.errors ?? []) {
-      const code = error.code ?? "unknown_comparison_error";
-      errorCounts.set(code, (errorCounts.get(code) ?? 0) + 1);
-    }
-    const block = [
-      `<details><summary>${icon} ${td(v.skillName)} — details</summary>`,
-      "",
-      `**State:** \`${verdictState(v)}\`${v.stateReason?.code ? ` (\`${td(v.stateReason.code)}\`)` : ""}`,
-      "",
-      ...(v.reason ? [`**Reason:** ${td(v.reason)}`] : []),
-      "",
-      ...(errorCounts.size > 0
-        ? [`**Comparison errors:** ${[...errorCounts.entries()].map(([code, count]) => `\`${td(code)}\`=${count}`).join(", ")}`, ""]
-        : []),
-      ...((v.recoveredErrors?.length ?? 0) > 0
-        ? [`**Retry recovery:** ${v.recoveredErrors.length} errored judgment slot(s) recovered; successful first-attempt judgments stayed fixed.`, ""]
-        : []),
-      ...(v.scenarioEvidence?.gateEligible === true
-        ? [
-            `**Gate evidence (stimulus votes):** ${v.scenarioEvidence.count} ` +
-              `(${v.scenarioEvidence.wins}W/${v.scenarioEvidence.ties}T/${v.scenarioEvidence.losses}L).`,
-            "",
-          ]
-        : []),
-      ...((v.comparisonTrialEvidence?.count ?? 0) > 0
-        ? [
-            `**Repeated-run reliability (not used by the gate):** ${v.comparisonTrialEvidence.count} ` +
-              `paired run(s) (${v.comparisonTrialEvidence.wins}W/${v.comparisonTrialEvidence.ties}T/` +
-              `${v.comparisonTrialEvidence.losses}L).`,
-            "",
-          ]
-        : []),
-      ...scenarioTable(v),
-      "",
-      "</details>",
-    ];
-    return { v, block, len: block.join("\n").length + 1 };
-  });
+  const COMMENT_BUDGET = 63000;
+  const candidates = isFull
+    ? verdicts
+    : verdicts.filter(
+        (verdict) => verdictState(verdict) !== STATE.PASS || hasActionableWarning(verdict),
+      );
+  const rank = (verdict) => {
+    if (isObjectiveRegression(verdict)) return 0;
+    if (isIndeterminate(verdict)) return 1;
+    if (isPreferenceRegression(verdict)) return 2;
+    if (verdictState(verdict) === STATE.NO_CHANGE) return 3;
+    return 4;
+  };
+  const detailBlocks = candidates
+    .map((verdict) => {
+      const errorCounts = new Map();
+      for (const error of verdict.errors ?? []) {
+        const code = error.code ?? "unknown_comparison_error";
+        errorCounts.set(code, (errorCounts.get(code) ?? 0) + 1);
+      }
+      const scenarioLines = scenarioTable(verdict, !isFull);
+      const evidenceLines = representativeEvidence(verdict);
+      const block = [
+        `<details><summary>${resultLabel(verdict)} — ${html(verdict.skillName)} (${html(verdict.model)})</summary>`,
+        "",
+        `**Why:** ${html(verdict.reason ?? "No adapter reason was supplied.")}`,
+        "",
+        `**Next action:** ${html(nextAction(verdict))}`,
+        "",
+        `**State:** <code>${html(verdictState(verdict))}</code>${verdict.stateReason?.code ? ` (<code>${html(verdict.stateReason.code)}</code>)` : ""}`,
+        "",
+        `**Gate evidence:** ${html(gateEvidence(verdict))}`,
+        "",
+        ...(warningParts(verdict).length > 0
+          ? [`**Warnings:** ${html(warningCell(verdict))}`, ""]
+          : []),
+        ...(verdict.overfittingResult?.severity
+          ? [
+              `**Overfit:** ${html(verdict.overfittingResult.severity)}`
+              + `${typeof verdict.overfittingResult.score === "number"
+                ? ` (score ${verdict.overfittingResult.score.toFixed(2)})`
+                : ""}`,
+              "",
+            ]
+          : []),
+        ...(errorCounts.size > 0
+          ? [
+              `**Comparison errors:** ${[...errorCounts.entries()]
+                .map(([code, count]) => `<code>${html(code)}</code>=${count}`)
+                .join(", ")}`,
+              "",
+            ]
+          : []),
+        ...((verdict.recoveredErrors?.length ?? 0) > 0
+          ? [
+              `**Retry recovery:** ${countNoun(verdict.recoveredErrors.length, "errored judgment slot")} recovered; successful first-attempt judgments stayed fixed.`,
+              "",
+            ]
+          : []),
+        ...((verdict.comparisonTrialEvidence?.count ?? 0) > 0
+          ? [
+              `**Repeated-run reliability (not used by the gate):** ${countNoun(verdict.comparisonTrialEvidence.count, "paired run")} `
+              + `(${verdict.comparisonTrialEvidence.wins}W/`
+              + `${verdict.comparisonTrialEvidence.ties}T/`
+              + `${verdict.comparisonTrialEvidence.losses}L).`,
+              "",
+            ]
+          : []),
+        ...scenarioLines,
+        ...(scenarioLines.length > 0 ? [""] : []),
+        ...evidenceLines,
+        ...(evidenceLines.length > 0 ? [""] : []),
+        "</details>",
+      ];
+      return { verdict, block, len: block.join("\n").length + 1 };
+    })
+    .sort((a, b) => rank(a.verdict) - rank(b.verdict));
 
   let used = lines.join("\n").length;
-  const keep = new Set();
-  // Two-phase selection so a passing (✅) detail can never be shown while a
-  // higher-priority non-pass detail was dropped for size. Objective regressions
-  // come first, followed by no-change/preference-loss and invalid records.
-  const highPriority = detailBlocks
-    .filter((d) => rank(d.v) < 3)
-    .sort((a, b) => rank(a.v) - rank(b.v));
-  const lowPriority = detailBlocks.filter((d) => rank(d.v) === 3);
-  let droppedHighPriority = false;
-  for (const d of highPriority) {
-    if (used + d.len > COMMENT_BUDGET) {
-      droppedHighPriority = true;
+  let omittedForBudget = 0;
+  for (const detail of detailBlocks) {
+    if (used + detail.len > COMMENT_BUDGET) {
+      omittedForBudget++;
       continue;
     }
-    keep.add(d);
-    used += d.len;
+    lines.push(...detail.block);
+    used += detail.len;
   }
-  if (!droppedHighPriority) {
-    for (const d of lowPriority) {
-      if (used + d.len > COMMENT_BUDGET) continue;
-      keep.add(d);
-      used += d.len;
+
+  if (!isFull) {
+    const routinePasses = verdicts.length - candidates.length;
+    if (routinePasses > 0) {
+      lines.push("");
+      lines.push(
+        `_Routine passing details for ${countNoun(routinePasses, "result")} are in Full Results._`,
+      );
     }
   }
-  for (const d of detailBlocks) {
-    if (keep.has(d)) lines.push(...d.block);
-  }
-  const omitted = detailBlocks.length - keep.size;
-  if (omitted > 0) {
+  if (omittedForBudget > 0) {
     lines.push("");
     lines.push(
-      `_Per-scenario details for ${omitted} skill(s) were omitted to keep this comment under GitHub's 65,536-character limit — open the job's step summary or Full Results for the complete breakdown._`,
+      `_Details for ${countNoun(omittedForBudget, "result")} were omitted to keep this comment under GitHub's limit. Open the workflow summary or Full Results for the complete breakdown._`,
     );
   }
 }
@@ -444,7 +644,9 @@ lines.push("");
 const markdown = lines.join("\n");
 if (opts.output) {
   writeFileSync(opts.output, markdown);
-  console.error(`Wrote ${opts.format} summary (${verdicts.length} skill(s)) to ${opts.output}`);
+  console.error(
+    `Wrote ${opts.format} summary (${countNoun(verdicts.length, "model/skill result")}) to ${opts.output}`,
+  );
 } else {
-  process.stdout.write(markdown + "\n");
+  process.stdout.write(`${markdown}\n`);
 }

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -180,6 +180,23 @@ test("preserves execution model identity and aggregates measurement health", () 
   assert.match(markdown, /0 missing, 0 unexpected, 0 invalid/);
 });
 
+test("escapes table identity cells exactly once", () => {
+  const markdown = render([
+    {
+      skillName: "skill|name\nnext",
+      model: "model|name\nvariant",
+      state: "VALID_PASS",
+      passed: true,
+      conclusive: true,
+      scenarios: [],
+    },
+  ]);
+
+  assert.ok(markdown.includes("| skill\\|name next | model\\|name variant |"));
+  assert.equal(markdown.includes("skill\\\\|name"), false);
+  assert.equal(markdown.includes("model\\\\|name"), false);
+});
+
 test("keeps Overfit visible and gives actionable evidence for a non-pass", () => {
   const markdown = render([
     {

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -183,8 +183,8 @@ test("preserves execution model identity and aggregates measurement health", () 
 test("escapes table identity cells exactly once", () => {
   const markdown = render([
     {
-      skillName: "skill|name\nnext",
-      model: "model|name\nvariant",
+      skillName: "skill<T> & name|next\nline",
+      model: "model<U> & name|next\nline",
       state: "VALID_PASS",
       passed: true,
       conclusive: true,
@@ -192,9 +192,16 @@ test("escapes table identity cells exactly once", () => {
     },
   ]);
 
-  assert.ok(markdown.includes("| skill\\|name next | model\\|name variant |"));
-  assert.equal(markdown.includes("skill\\\\|name"), false);
-  assert.equal(markdown.includes("model\\\\|name"), false);
+  assert.ok(
+    markdown.includes(
+      "| skill&lt;T&gt; &amp; name\\|next line | model&lt;U&gt; &amp; name\\|next line |",
+    ),
+  );
+  assert.equal(markdown.includes("skill<T>"), false);
+  assert.equal(markdown.includes("model<U>"), false);
+  assert.equal(markdown.includes("&amp;lt;"), false);
+  assert.equal(markdown.includes("&amp;amp;"), false);
+  assert.equal(markdown.includes("name\\\\|next"), false);
 });
 
 test("escapes scenario names in markdown tables exactly once", () => {

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const script = join(dirname(fileURLToPath(import.meta.url)), "consolidate.mjs");
+
+function render(verdicts) {
+  const root = mkdtempSync(join(tmpdir(), "vally-consolidate-"));
+  try {
+    const input = join(root, "results.json");
+    const output = join(root, "summary.md");
+    writeFileSync(input, JSON.stringify({ verdicts }));
+    const result = spawnSync(
+      process.execPath,
+      [script, "--format", "simple", "--output", output, input],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    return readFileSync(output, "utf8");
+  } finally {
+    for (const file of ["results.json", "summary.md"]) {
+      try {
+        unlinkSync(join(root, file));
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+      }
+    }
+    rmdirSync(root);
+  }
+}
+
+test("renders new states and reliability evidence without calling preference loss an objective regression", () => {
+  const markdown = render([
+    {
+      skillName: "preference-loss",
+      state: "VALID_NO_CHANGE",
+      stateReason: { code: "preference_regression_report_only" },
+      preferenceRegressed: true,
+      regressed: true,
+      passed: false,
+      conclusive: true,
+      reason: "credible preference loss",
+      recoveredErrors: [{ code: "judge_session_idle_timeout" }],
+      scenarioEvidence: { count: 1, wins: 0, ties: 0, losses: 1 },
+      scenarios: [],
+    },
+    {
+      skillName: "judge-failure",
+      state: "INVALID_INCONCLUSIVE",
+      stateReason: { code: "comparison_errors" },
+      passed: false,
+      conclusive: false,
+      underpowered: false,
+      reason: "comparison failed",
+      errors: [
+        { code: "judge_organization_disabled" },
+        { code: "judge_organization_disabled" },
+      ],
+      scenarios: [],
+    },
+  ]);
+
+  assert.match(markdown, /\*\*0 objective regressions\*\*/);
+  assert.match(markdown, /\*\*1 preference losses \(report only\)\*\*/);
+  assert.match(markdown, /`VALID_NO_CHANGE` \(`preference_regression_report_only`\)/);
+  assert.match(markdown, /`judge_organization_disabled`=2/);
+  assert.match(markdown, /successful first-attempt judgments stayed fixed/);
+  assert.match(markdown, /Effective scenarios \(report only\):\*\* 1 \(0W\/0T\/1L\)/);
+});
+
+test("renders legacy preference regressions as report-only", () => {
+  const markdown = render([
+    {
+      skillName: "legacy-regression",
+      regressed: true,
+      passed: false,
+      conclusive: true,
+      reason: "legacy credible loss",
+      scenarios: [],
+    },
+  ]);
+
+  assert.match(markdown, /\*\*0 objective regressions\*\*/);
+  assert.match(markdown, /\*\*1 preference losses \(report only\)\*\*/);
+  assert.match(markdown, /`VALID_NO_CHANGE`/);
+});
+
+test("keeps passing detail blocks when the comment budget permits", () => {
+  const markdown = render([
+    {
+      skillName: "passing-skill",
+      state: "VALID_PASS",
+      passed: true,
+      conclusive: true,
+      reason: "credible preference improvement",
+      scenarios: [],
+    },
+  ]);
+
+  assert.match(markdown, /passing-skill — details/);
+  assert.match(markdown, /`VALID_PASS`/);
+});

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -197,6 +197,36 @@ test("escapes table identity cells exactly once", () => {
   assert.equal(markdown.includes("model\\\\|name"), false);
 });
 
+test("escapes scenario names in markdown tables exactly once", () => {
+  const markdown = render(
+    [
+      {
+        skillName: "scenario-escaping",
+        state: "VALID_NO_CHANGE",
+        passed: false,
+        conclusive: true,
+        reason: "not proven improved",
+        scenarios: [
+          {
+            scenarioName: "List<T> & map|next\nline",
+            netWin: 0,
+            meanScore: 0,
+            wins: 0,
+            ties: 1,
+            losses: 0,
+          },
+        ],
+      },
+    ],
+    { format: "full" },
+  );
+
+  assert.ok(markdown.includes("| = List&lt;T&gt; &amp; map\\|next line |"));
+  assert.equal(markdown.includes("List<T>"), false);
+  assert.equal(markdown.includes("&amp;lt;"), false);
+  assert.equal(markdown.includes("&amp;amp;"), false);
+});
+
 test("keeps Overfit visible and gives actionable evidence for a non-pass", () => {
   const markdown = render([
     {

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,32 +14,46 @@ import { spawnSync } from "node:child_process";
 
 const script = join(dirname(fileURLToPath(import.meta.url)), "consolidate.mjs");
 
-function render(verdicts) {
+function render(verdicts, options = {}) {
+  const documents = options.documents ?? [
+    {
+      model: "test-model",
+      judgeModel: "test-judge",
+      verdicts,
+    },
+  ];
   const root = mkdtempSync(join(tmpdir(), "vally-consolidate-"));
   try {
-    const input = join(root, "results.json");
+    documents.forEach((document, index) => {
+      const directory = join(root, `result-${index}`);
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(join(directory, "results.json"), JSON.stringify(document));
+    });
+    (options.summaries ?? []).forEach((summary, index) => {
+      const directory = join(root, `summary-${index}`);
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(join(directory, "adapter-summary.json"), JSON.stringify(summary));
+    });
     const output = join(root, "summary.md");
-    writeFileSync(input, JSON.stringify({ verdicts }));
-    const result = spawnSync(
-      process.execPath,
-      [script, "--format", "simple", "--output", output, input],
-      { encoding: "utf8" },
-    );
+    const args = [
+      script,
+      "--format",
+      options.format ?? "simple",
+      "--output",
+      output,
+      "--root",
+      root,
+    ];
+    if (options.commit) args.push("--commit", options.commit);
+    const result = spawnSync(process.execPath, args, { encoding: "utf8" });
     assert.equal(result.status, 0, result.stderr);
     return readFileSync(output, "utf8");
   } finally {
-    for (const file of ["results.json", "summary.md"]) {
-      try {
-        unlinkSync(join(root, file));
-      } catch (error) {
-        if (error?.code !== "ENOENT") throw error;
-      }
-    }
-    rmdirSync(root);
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
-test("renders new states and reliability evidence without calling preference loss an objective regression", () => {
+test("separates preference loss from the disabled objective regression gate", () => {
   const markdown = render([
     {
       skillName: "preference-loss",
@@ -41,19 +61,28 @@ test("renders new states and reliability evidence without calling preference los
       stateReason: { code: "preference_regression_report_only" },
       preferenceRegressed: true,
       regressed: true,
-      passed: false,
-      conclusive: true,
       reason: "credible preference loss",
       recoveredErrors: [{ code: "judge_session_idle_timeout" }],
-      scenarioEvidence: { gateEligible: true, count: 1, wins: 0, ties: 0, losses: 1 },
-      comparisonTrialEvidence: { gateEligible: false, count: 3, wins: 0, ties: 1, losses: 2 },
+      scenarioEvidence: {
+        gateEligible: true,
+        count: 1,
+        wins: 0,
+        ties: 0,
+        losses: 1,
+      },
+      comparisonTrialEvidence: {
+        gateEligible: false,
+        count: 3,
+        wins: 0,
+        ties: 1,
+        losses: 2,
+      },
       scenarios: [],
     },
     {
       skillName: "judge-failure",
       state: "INVALID_INCONCLUSIVE",
       stateReason: { code: "comparison_errors" },
-      passed: false,
       conclusive: false,
       underpowered: false,
       reason: "comparison failed",
@@ -65,13 +94,13 @@ test("renders new states and reliability evidence without calling preference los
     },
   ]);
 
-  assert.match(markdown, /\*\*0 objective regressions\*\*/);
+  assert.match(markdown, /Objective completion gate:\*\* not enabled/);
+  assert.doesNotMatch(markdown, /0 objective regressions/);
   assert.match(markdown, /\*\*1 preference losses \(report only\)\*\*/);
-  assert.match(markdown, /`VALID_NO_CHANGE` \(`preference_regression_report_only`\)/);
-  assert.match(markdown, /`judge_organization_disabled`=2/);
+  assert.match(markdown, /<code>VALID_NO_CHANGE<\/code> \(<code>preference_regression_report_only<\/code>\)/);
+  assert.match(markdown, /<code>judge_organization_disabled<\/code>=2/);
   assert.match(markdown, /successful first-attempt judgments stayed fixed/);
-  assert.match(markdown, /Gate evidence \(stimulus votes\):\*\* 1 \(0W\/0T\/1L\)/);
-  assert.match(markdown, /Repeated-run reliability \(not used by the gate\):\*\* 3 paired run\(s\) \(0W\/1T\/2L\)/);
+  assert.match(markdown, /Repeated-run reliability \(not used by the gate\):\*\* 3 paired runs/);
 });
 
 test("renders legacy preference regressions as report-only", () => {
@@ -86,23 +115,131 @@ test("renders legacy preference regressions as report-only", () => {
     },
   ]);
 
-  assert.match(markdown, /\*\*0 objective regressions\*\*/);
   assert.match(markdown, /\*\*1 preference losses \(report only\)\*\*/);
-  assert.match(markdown, /`VALID_NO_CHANGE`/);
+  assert.match(markdown, /<code>VALID_NO_CHANGE<\/code>/);
 });
 
-test("keeps passing detail blocks when the comment budget permits", () => {
+test("keeps routine passing details out of the PR comment but in Full Results", () => {
+  const verdict = {
+    skillName: "passing-skill",
+    state: "VALID_PASS",
+    passed: true,
+    conclusive: true,
+    reason: "credible preference improvement",
+    scenarios: [],
+  };
+
+  const compact = render([verdict]);
+  assert.doesNotMatch(compact, /passing-skill \(test-model\)<\/summary>/);
+  assert.match(compact, /Routine passing details for 1 result are in Full Results/);
+
+  const full = render([verdict], { format: "full" });
+  assert.match(full, /passing-skill \(test-model\)<\/summary>/);
+  assert.match(full, /<code>VALID_PASS<\/code>/);
+});
+
+test("preserves execution model identity and aggregates measurement health", () => {
+  const verdict = {
+    skillName: "same-skill",
+    state: "VALID_PASS",
+    passed: true,
+    conclusive: true,
+    scenarios: [],
+  };
+  const markdown = render([], {
+    documents: [
+      { model: "model-a", judgeModel: "judge-a", verdicts: [verdict] },
+      { model: "model-b", judgeModel: "judge-a", verdicts: [verdict] },
+    ],
+    summaries: [
+      {
+        expectedEvalCount: 1,
+        observedEvalCount: 1,
+        writtenResultCount: 1,
+        missingEvalCount: 0,
+        unexpectedEvalCount: 0,
+        invalidEvalCount: 0,
+      },
+      {
+        expectedEvalCount: 1,
+        observedEvalCount: 1,
+        writtenResultCount: 1,
+        missingEvalCount: 0,
+        unexpectedEvalCount: 0,
+        invalidEvalCount: 0,
+      },
+    ],
+    commit: "abc123",
+  });
+
+  assert.match(markdown, /2 model\/skill results across 1 skill and 2 models/);
+  assert.match(markdown, /\| same-skill \| model-a \| ✅ Improved \|/);
+  assert.match(markdown, /\| same-skill \| model-b \| ✅ Improved \|/);
+  assert.match(markdown, /evaluated commit `abc123`; judge `judge-a`/);
+  assert.match(markdown, /2 expected \/ 2 observed \/ 2 written/);
+  assert.match(markdown, /0 missing, 0 unexpected, 0 invalid/);
+});
+
+test("keeps Overfit visible and gives actionable evidence for a non-pass", () => {
   const markdown = render([
     {
-      skillName: "passing-skill",
-      state: "VALID_PASS",
-      passed: true,
-      conclusive: true,
-      reason: "credible preference improvement",
+      skillName: "tie-sensitive",
+      state: "VALID_NO_CHANGE",
+      stateReason: { code: "insufficient_discordant_stimulus_votes" },
+      reason: "not credible",
+      netWin: 0.4,
+      signTest: {
+        wins: 4,
+        ties: 1,
+        losses: 0,
+        discordant: 4,
+        pValue: 0.0625,
+      },
+      stimulusVoteCount: 5,
+      overfittingResult: { severity: "Moderate", score: 0.51 },
+      scenarios: [
+        {
+          scenarioName: "tied-case",
+          expectActivation: true,
+          skillActivationIsolated: { activated: false },
+          netWin: 0,
+          wins: 0,
+          ties: 1,
+          losses: 0,
+          trials: [{ evidence: "tie evidence <unsafe>", score: "tie" }],
+        },
+      ],
+    },
+  ]);
+
+  assert.match(markdown, /\| Skill \| Model \| Verdict \| Gate evidence \| Overfit \| Warnings \| Next action \|/);
+  assert.match(markdown, /n=5; 4W\/1T\/0L; d=4; p=0.063; net \+40.0%/);
+  assert.match(markdown, /🟡 0.51/);
+  assert.match(markdown, /Activation: isolated 0\/1/);
+  assert.match(markdown, /predeclare added breadth before a new experiment/);
+  assert.match(markdown, /\| = tied-case \|/);
+  assert.match(markdown, /tie evidence &lt;unsafe&gt;/);
+});
+
+test("explains that repeated runs cannot repair an underpowered eval", () => {
+  const markdown = render([
+    {
+      skillName: "too-small",
+      state: "INVALID_INCONCLUSIVE",
+      underpowered: true,
+      reason: "fewer than five distinct stimuli",
+      stimulusVoteCount: 4,
+      signTest: {
+        wins: 4,
+        ties: 0,
+        losses: 0,
+        discordant: 4,
+        pValue: 0.0625,
+      },
       scenarios: [],
     },
   ]);
 
-  assert.match(markdown, /passing-skill — details/);
-  assert.match(markdown, /`VALID_PASS`/);
+  assert.match(markdown, /⚠️ Underpowered/);
+  assert.match(markdown, /Predeclare more independent, discriminating stimuli; repeated runs do not add power/);
 });

--- a/eng/vally-adapter/consolidate.test.mjs
+++ b/eng/vally-adapter/consolidate.test.mjs
@@ -45,7 +45,8 @@ test("renders new states and reliability evidence without calling preference los
       conclusive: true,
       reason: "credible preference loss",
       recoveredErrors: [{ code: "judge_session_idle_timeout" }],
-      scenarioEvidence: { count: 1, wins: 0, ties: 0, losses: 1 },
+      scenarioEvidence: { gateEligible: true, count: 1, wins: 0, ties: 0, losses: 1 },
+      comparisonTrialEvidence: { gateEligible: false, count: 3, wins: 0, ties: 1, losses: 2 },
       scenarios: [],
     },
     {
@@ -69,7 +70,8 @@ test("renders new states and reliability evidence without calling preference los
   assert.match(markdown, /`VALID_NO_CHANGE` \(`preference_regression_report_only`\)/);
   assert.match(markdown, /`judge_organization_disabled`=2/);
   assert.match(markdown, /successful first-attempt judgments stayed fixed/);
-  assert.match(markdown, /Effective scenarios \(report only\):\*\* 1 \(0W\/0T\/1L\)/);
+  assert.match(markdown, /Gate evidence \(stimulus votes\):\*\* 1 \(0W\/0T\/1L\)/);
+  assert.match(markdown, /Repeated-run reliability \(not used by the gate\):\*\* 3 paired run\(s\) \(0W\/1T\/2L\)/);
 });
 
 test("renders legacy preference regressions as report-only", () => {

--- a/tests/dotnet-test/coverage-analysis/eval.yaml
+++ b/tests/dotnet-test/coverage-analysis/eval.yaml
@@ -2,17 +2,13 @@ name: coverage-analysis
 description: Evaluates the dotnet-test/coverage-analysis skill
 type: capability
 executionShard: risk-coverage
-# Raised above the 5-trial eligibility floor deliberately.
+# Nine distinct stimuli clear the eligibility floor.
 #
-# At exactly 5 trials the ONLY record that reaches p <= 0.05 is a clean 5W/0T/0L
-# sweep: the sign test conditions on the discordant (non-tie) trials, so a single
-# tie drops it to 4 and no record can pass. Run 30611635547 measured a 32% tie
-# rate across this plugin, which gives a genuinely-helping skill roughly a 1-in-10
-# chance of being certified. Nine distinct scenarios remain; two expensive
-# near-ties were replaced by focused no-tool stimuli that preserve branch-gap
-# and multi-member threshold arithmetic coverage, and one protects SDK 10
-# VSTest-mode command syntax. Two runs provide 18 trials;
-# the other six scenarios measured 16W/1T/1L across three runs.
+# Repeated runs collapse to one majority-direction vote per stimulus, so they do
+# not increase the sign-test sample. The two runs below measure reliability.
+# The nine stimuli cover distinct branch-gap, threshold-arithmetic, no-data, and
+# SDK 10 command cases. Add a discriminating stimulus, not more runs, to improve
+# statistical power.
 #
 defaults:
   timeout: 6m

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -2,19 +2,14 @@ name: find-untested-sources
 executionShard: b
 description: Evaluates the dotnet-test/find-untested-sources skill
 type: capability
-# Raised above the 5-trial eligibility floor deliberately.
+# Six distinct stimuli clear the eligibility floor.
 #
-# At exactly 5 trials the ONLY record that reaches p <= 0.05 is a clean 5W/0T/0L
-# sweep: the sign test conditions on the discordant (non-tie) trials, so a single
-# tie drops it to 4 and no record can pass. Run 30611635547 measured a 32% tie
-# rate across this plugin, which gives a genuinely-helping skill roughly a 1-in-10
-# chance of being certified. Three runs over the same five discriminating
-# scenarios lifts that to ~9-in-10 without inventing content.
+# Repeated runs collapse to one majority-direction vote per stimulus, so they do
+# not increase the sign-test sample. The three runs below measure reliability and
+# reduce the chance that one noisy execution decides a stimulus vote.
 #
-# This is the "genuinely expensive to add" exemption in eng/eval-quality/README.md:
-# the scenarios here already cover five distinct properties, so the shortfall is
-# repetition against judge noise (one trial in that run was decided by a
-# position-swap disagreement), not task diversity.
+# These tasks are expensive and cover distinct source-discovery cases. Add a new
+# discriminating stimulus, not more runs, to improve statistical power.
 defaults:
   timeout: 5m
   runs: 3

--- a/tests/dotnet-test/generate-testability-wrappers/eval.yaml
+++ b/tests/dotnet-test/generate-testability-wrappers/eval.yaml
@@ -1,19 +1,15 @@
 name: generate-testability-wrappers
 description: Evaluates the dotnet-test/generate-testability-wrappers skill
 type: capability
-# Raised above the 5-trial eligibility floor deliberately.
+# Five distinct stimuli meet the eligibility floor, but remain fragile.
 #
-# At exactly 5 trials the ONLY record that reaches p <= 0.05 is a clean 5W/0T/0L
-# sweep: the sign test conditions on the discordant (non-tie) trials, so a single
-# tie drops it to 4 and no record can pass. Run 30611635547 measured a 32% tie
-# rate across this plugin, which gives a genuinely-helping skill roughly a 1-in-10
-# chance of being certified. Three runs over the same five discriminating
-# scenarios lifts that to ~9-in-10 without inventing content.
+# At exactly 5 stimulus votes, only a clean 5W/0T/0L sweep reaches p <= 0.05.
+# Repeated runs collapse to one majority-direction vote per stimulus, so they do
+# not increase the sign-test sample. The three runs below measure reliability and
+# reduce the chance that one noisy execution decides a stimulus vote.
 #
-# This is the "genuinely expensive to add" exemption in eng/eval-quality/README.md:
-# the scenarios here already cover five distinct properties, so the shortfall is
-# repetition against judge noise (one trial in that run was decided by a
-# position-swap disagreement), not task diversity.
+# These tasks are expensive and already cover five distinct properties. Add a
+# new discriminating stimulus, not more runs, to improve statistical power.
 defaults:
   timeout: 4m
   runs: 3

--- a/tests/dotnet-test/grade-tests/eval.yaml
+++ b/tests/dotnet-test/grade-tests/eval.yaml
@@ -2,19 +2,14 @@ name: grade-tests
 executionShard: c
 description: Evaluates the dotnet-test/grade-tests skill
 type: capability
-# Raised above the 5-trial eligibility floor deliberately.
+# Six distinct stimuli clear the eligibility floor.
 #
-# At exactly 5 trials the ONLY record that reaches p <= 0.05 is a clean 5W/0T/0L
-# sweep: the sign test conditions on the discordant (non-tie) trials, so a single
-# tie drops it to 4 and no record can pass. Run 30611635547 measured a 32% tie
-# rate across this plugin, which gives a genuinely-helping skill roughly a 1-in-10
-# chance of being certified. Three runs over the same five discriminating
-# scenarios lifts that to ~9-in-10 without inventing content.
+# Repeated runs collapse to one majority-direction vote per stimulus, so they do
+# not increase the sign-test sample. The three runs below measure reliability and
+# reduce the chance that one noisy execution decides a stimulus vote.
 #
-# This is the "genuinely expensive to add" exemption in eng/eval-quality/README.md:
-# the scenarios here already cover five distinct properties, so the shortfall is
-# repetition against judge noise (one trial in that run was decided by a
-# position-swap disagreement), not task diversity.
+# These tasks are expensive and cover distinct grading cases. Add a new
+# discriminating stimulus, not more runs, to improve statistical power.
 defaults:
   timeout: 5m
   runs: 3


### PR DESCRIPTION
## Why this is needed

The old gate could mistake three different things for skill quality:

1. Repeated runs of one task were pooled as if they were independent tasks.
2. A judge timeout or disabled organization could be counted as a skill loss or disappear as a missing result.
3. A statistically significant but tiny preference difference could pass, while aggregate completion data could mix deterministic checks with LLM grades.

This PR makes the inference unit, failure accounting, and verdict contract explicit.

## Example for #986: repeated runs manufactured significance

Assume an eval has **4 distinct stimuli** and `runs: 3`. The treatment wins all 12 paired runs.

- **Old pooled calculation:** `12W/0L`, exact one-sided sign-test `p = 1/4096`, so the eval could pass.
- **Correct task-level calculation:** each stimulus supplies one majority-direction vote, so the record is `4W/0L`, `p = 1/16 = 0.0625`. It cannot pass at `alpha = 0.05`.

The 12 runs show repeatability on four tasks. They do not create 12 independent task samples. This PR therefore makes four stimulus votes authoritative and keeps the 12 paired runs as reliability evidence.

## Example for #909: one judge timeout is not a regression

Assume five comparison slots. Four judge calls succeed, but one returns `Timeout after 120000ms waiting for session.idle`.

This PR:

1. Identifies the failed slot by `(stimulusName, trialIndex)`.
2. Retries the comparison once.
3. Freezes all successful first-attempt judgments.
4. Uses retry output only for the failed slot.
5. Returns `INVALID_INCONCLUSIVE` with a classified cause if recovery fails.
6. Requires an explicit result for every selected eval, so missing or unexpected output cannot disappear.

A disabled organization, rate limit, service failure, missing result, malformed report, or empty run now fails closed. None can become `VALID_PASS`, `VALID_NO_CHANGE`, or `VALID_REGRESSION`.

## Example for #970: significance alone is not enough

Assume **100 distinct stimuli** produce `5W/95T/0L`.

- The exact sign test conditions on the five non-ties, so `p = 1/32 = 0.03125`.
- The practical net win is only `(5 - 0) / 100 = 5%`.

Statistical significance says the direction is unlikely under a 50/50 null among non-ties. It does not say the effect is large enough to matter. This PR also requires an absolute task-level net win of at least **20%**, so this sparse result does not pass.

The completion hard gate is not enabled. Vally's aggregate `passed` value can combine weighted deterministic and LLM graders. Treating that mixed value as objective completion could manufacture a P0 regression. `VALID_REGRESSION` stays reserved until the harness can prove deterministic grader provenance.

## Decision flow

```mermaid
flowchart LR
    A[Distinct stimulus] --> B[Repeated Vally runs]
    B --> C[Pair by stimulusName and trialIndex]
    C --> D{Judge slot failed?}
    D -- Yes --> E[Retry once; freeze successes]
    D -- No --> F[Run-level W/T/L]
    E --> F
    F --> G[One majority-direction vote per stimulus]
    F --> H[Reliability evidence only]
    G --> I[Exact sign test at alpha 0.05]
    G --> J[Absolute net-win floor at 20%]
    I --> K[Verdict state]
    J --> K
    H --> L[Report pass rate, retries, and flakiness]
```

## What is implemented

| Issue | State | Result |
|---|---|---|
| #986 — independent inference unit | **Done** | One majority-direction vote per distinct stimulus. Repeated runs cannot create or hide significance. |
| #986 — authoring floor | **Done** | New and expanded evals need at least five distinct stimuli. Extra runs cannot clear the floor. |
| #986 — current underpowered debt | **Deferred** | The 48 grandfathered evals below five distinct stimuli remain a separate repair project, as requested. |
| #909 — judge-side transient failures | **Done** | One targeted retry, stable slot identity, frozen successes, classified failure provenance, and fail-closed verdicts. |
| #909 — result-set integrity | **Done** | Expected, observed, missing, unexpected, invalid, and written results are reconciled exactly. |
| #970 — statistical gate | **Done** | Exact one-sided sign test at `alpha = 0.05`, based on distinct stimulus votes. |
| #970 — practical net-win floor | **Done** | A pass also needs `abs((wins - losses) / stimulusVotes) >= 0.20`. |
| #970 — objective completion primitive | **Partial** | The required deterministic provenance contract is defined and mixed aggregate completion remains telemetry-only. |
| #970 — objective completion hard gate | **Deferred** | `VALID_REGRESSION` stays reserved until the harness supplies trusted spec-to-result grader identity. |
| Coverage suites/tags | **Deferred** | Coverage management is separate from verdict correctness and is not mixed into this PR. |

## Vally guidance versus repository policy

Vally documents that:

- a stimulus is a **test case**;
- repeated runs measure pass rate, `pass@k`, `pass^k`, and flakiness;
- three runs are a practical CI recommendation and five to ten runs are an outer-loop recommendation;
- comparisons pair trajectories by **stimulus name and trial index**;
- grader taxonomy distinguishes deterministic `static`/`complex-static` graders from non-deterministic `llm` graders.

Vally does **not** prescribe a distinct-stimulus minimum, a sign-test alpha, or a practical net-win floor. Those are repository policies:

- `alpha = 0.05`;
- five distinct stimuli as the smallest eligibility floor at which any exact sign-test record can pass;
- a 20% practical net-win floor.

Five is not a general power target. Under a no-tie model, exact calculations show that the **sign test alone** reaches 80% power at about 158 discordant votes for a 60% conditional win rate, 37 for 70%, 18 for 80%, and 8 for 90%. The 20% practical floor is intentionally binding at a 60% conditional win rate: at 158 votes the combined gate passes about 52% of records and approaches 50% as the sample grows. The gate is designed to certify effects above its practical threshold. Eval authors must choose breadth from the smallest effect they need to detect; they must not treat five as "well powered."

Official references:

- [How It Works](https://microsoft.github.io/vally/concepts/how-it-works/)
- [Scoring and multi-trial metrics](https://microsoft.github.io/vally/concepts/scoring/)
- [Grader taxonomy](https://microsoft.github.io/vally/concepts/grader-taxonomy/)
- [`vally compare`](https://microsoft.github.io/vally/reference/cli/compare/)

## Objective completion contract

A future `VALID_REGRESSION` hard gate must have all of these properties:

1. The eval spec declares which graders are objective completion graders.
2. Each declaration has a stable identity that maps uniquely to one result.
3. Only a frozen allowlist of Vally `static` and `complex-static` grader types is eligible.
4. Each paired arm yields `pass`, `fail`, or `unknown`; missing, duplicate, ambiguous, or LLM-backed evidence becomes `unknown`.
5. Every selected completion grader is present for both arms.
6. A hard regression requires conclusive paired objective losses plus the repository's statistical and practical thresholds.

Current Vally comparison output exposes aggregate pass transitions, but not a trusted unique mapping from each eval-spec grader declaration to each result. The PR reports those transitions but does not overstate them as objective proof.

## Output and compatibility

- Result schema version 3 separates authoritative `scenarioEvidence` from non-gating `comparisonTrialEvidence`.
- `stimulusVoteCount` and `minCredibleStimuli` are the canonical fields.
- `trialCount` and `minCredibleTrials` remain compatibility aliases for current consumers.
- The branch now includes Vally CLI 0.13 from current `main`.
- A live Vally 0.13 raw comparison produced six required and unique `(stimulusName, trialIndex)` keys, with no missing index and no duplicate slot.
- Vally 0.13 all-errored comparisons, which write a report and then exit nonzero, are handled and tested.

## PR result UI and trusted validator handoff

The old PR comment could show the same skill twice without naming the model, label a positive but unproven result with a red cross, say "zero objective regressions" while that gate was disabled, and call all non-passes failures. It also hid exact result accounting and judge retry health.

The new comment:

- reports model/skill results separately from unique skills;
- names the execution model, evaluated commit, and judge identity;
- distinguishes **Improved**, **Not proven improved**, **Invalid / inconclusive**, and **Preference loss (report only)**;
- keeps **Overfit** in the main table;
- shows expected / observed / written / missing / unexpected / invalid result accounting and recovered / unresolved judge slots;
- shows gate evidence on the correct unit: distinct-stimulus `n`, W/T/L, discordant votes, one-result `p`, and aggregate net win;
- gives a cause-specific next action and limits PR details to non-passing or warning-bearing results; and
- states that the objective completion gate is not enabled instead of claiming that zero objective regressions were proven.

For example, `7W/0T/2L` over nine stimuli has a strong `+55.6%` net win but `p=0.090`. It now appears as **➖ Not proven improved**, with the two losing stimuli and the next action, rather than as a generic red failure.

The validator transport also no longer depends on a writable cache. The trusted `prepare-validator` job builds or restores one archive before PR content is checked out, uploads it as a same-run artifact, and every matrix job downloads that exact archive. The cache remains an optimization only. This removes the issue-comment path where cache save failed and every matrix job then tried to rebuild against the restricted evaluation package sources.

## Validation

- 47 adapter and report tests.
- 25 eval-quality self-tests.
- 15 evaluation workflow behavior tests.
- The full 99-spec quality scan.
- Workflow structure validation with `actionlint` 1.7.7.
- Deterministic fault injection for:
  - `session.idle` timeout;
  - organization-disabled judge;
  - successful failed-slot recovery;
  - persistent retry failure;
  - missing and unexpected eval results;
  - malformed comparison output;
  - missing or duplicate comparison slot identity;
  - duplicate stimulus names at authoring time;
  - an entirely invalid empty run.
- A live Vally 0.13 comparison on persisted trajectories, plus a schema-version-3 adapter run.
- The final default-profile matrix passed all eight current shard/model legs in run [32206910590](https://github.com/dotnet/skills/actions/runs/32206910590), bound to exact commit `780c999546a4007bde9742f511c29adb65c67cd8`.
- Its artifacts contain eight schema-version-3 verdicts: all are conclusive and none are underpowered.
- Exact result accounting was `8 expected / 8 observed / 8 written`, with zero missing, unexpected, or invalid evals.
- Across all raw Vally 0.13 baseline/skilled reports, every `trialIndex` was present and non-negative, each `(stimulusName, trialIndex)` key was unique, and paired key sets had zero differences.
- Every verdict has `scenarioEvidence.gateEligible=true`, `comparisonTrialEvidence.gateEligible=false`, zero unmatched trials, and zero errors.
- The final UI and validator-handoff run [32232320378](https://github.com/dotnet/skills/actions/runs/32232320378) passed on exact commit `0434d9e58437e6beda3f27814cf9bed996eb57c9`.
- Its trusted producer uploaded one same-run validator archive. All eight matrix legs downloaded and extracted that archive; no matrix job used a cache or fallback build.
- Its final artifacts again contain eight schema-version-3 verdicts with exact `8 expected / 8 observed / 8 written` accounting, zero missing, unexpected, invalid, underpowered, or unresolved-error results.
- Across 276 raw baseline/skilled Vally 0.13 trials, every `trialIndex` was present and non-negative, every arm key was unique, and paired key sets had zero differences.
- The rendered PR comment identifies four skills across two models, includes model-specific gate evidence and Overfit, states that the objective gate is disabled, and gives repair actions for each non-passing or warning result.

## Related issues

- #986
- #909
- #970