### PR TITLE
Pin min-threads and env-var ground truth in migrate-dotnet8-to-dotnet9 rubric

### DIFF
--- a/tests/dotnet-upgrade/migrate-dotnet8-to-dotnet9/eval.yaml
+++ b/tests/dotnet-upgrade/migrate-dotnet8-to-dotnet9/eval.yaml
@@ -343,8 +343,8 @@ stimuli:
       - type: prompt
     rubric:
       - Identifies zlib is no longer installed in .NET 9 images; recommends adding apt-get install
-      - Explains environment variables now take precedence over runtimeconfig.json — GC and ThreadPool settings will use
-        env var values
+      - "Explains that in .NET 9 environment variables now take precedence over runtimeconfig.json for GC and
+        ThreadPool settings (a response claiming runtimeconfig still wins, as it did in .NET 8, is wrong)"
       - Warns about .NET Monitor image tag format changes
       - Notes global.json should be updated to 9.0.x SDK
     constraints:
@@ -455,8 +455,9 @@ stimuli:
     rubric:
       - Correctly states environment variables now take precedence in .NET 9 — all three settings (GC Server,
         Concurrent, ThreadPool) will use env var values instead of runtimeconfig
-      - "Explains the concrete impact: app switches from server GC to workstation GC, concurrent GC disabled, min
-        threads drop from 25 to 4"
+      - "States the correct concrete impact: server GC becomes workstation GC, concurrent GC is disabled, and the
+        minimum ThreadPool thread count drops from 25 to 4 (a response claiming any of these values are unchanged —
+        for example that min threads stay at 25 — is factually wrong, however confidently it is stated)"
       - Identifies zlib no longer installed in .NET 9 container images; SkiaSharp/image processing will fail; recommends
         adding apt-get install zlib1g
       - Recommends either removing conflicting env vars or updating runtimeconfig to match desired values

--- a/tests/dotnet-upgrade/migrate-dotnet8-to-dotnet9/eval.yaml
+++ b/tests/dotnet-upgrade/migrate-dotnet8-to-dotnet9/eval.yaml
@@ -317,7 +317,8 @@ stimuli:
     prompt: |
       Migrate this containerized .NET 8 app to .NET 9.
       In our Kubernetes deployment, we set DOTNET_gcServer=0 (to reduce memory on small pods)
-      and DOTNET_ThreadPool_MinThreads=4. In .NET 8, the runtimeconfig.json values took precedence.
+      and DOTNET_ThreadPool_MinThreads=4. The .NET 8 app uses server GC with a minimum ThreadPool
+      thread count of 50 from runtimeconfig.json.
       The app uses .NET Monitor with specific image tags.
       Identify all breaking changes and provide the exact fixes.
     environment:
@@ -343,8 +344,10 @@ stimuli:
       - type: prompt
     rubric:
       - Identifies zlib is no longer installed in .NET 9 images; recommends adding apt-get install
-      - "Explains that in .NET 9 environment variables now take precedence over runtimeconfig.json for GC and
-        ThreadPool settings (a response claiming runtimeconfig still wins, as it did in .NET 8, is wrong)"
+      - "Explains that in .NET 9 DOTNET_gcServer=0 takes precedence over System.GC.Server=true in runtimeconfig.json,
+        so the app switches from server GC to workstation GC"
+      - "Identifies that DOTNET_ThreadPool_MinThreads is not a supported runtime configuration environment variable
+        and has no effect, so the minimum ThreadPool thread count remains 50 from runtimeconfig.json"
       - Warns about .NET Monitor image tag format changes
       - Notes global.json should be updated to 9.0.x SDK
     constraints:
@@ -427,8 +430,8 @@ stimuli:
         DOTNET_gcServer=0 (save memory on small pods)
         DOTNET_gcConcurrent=0
         DOTNET_ThreadPool_MinThreads=4
-      In .NET 8, the runtimeconfig.json values (Server=true, Concurrent=true, MinThreads=25)
-      took precedence and our app used server GC with 25 min threads.
+      The .NET 8 app uses server GC with concurrent GC and 25 minimum ThreadPool threads from
+      runtimeconfig.json (Server=true, Concurrent=true, MinThreads=25).
       The app uses SkiaSharp for image processing which depends on system zlib.
       Identify all breaking changes and their exact impact on this deployment.
     environment:
@@ -450,17 +453,17 @@ stimuli:
           pattern: (zlib|no longer install|apt-get|zlib1g|SkiaSharp)
       - type: output-matches
         config:
-          pattern: (workstation|server GC|GC.*mode|MinThreads.*4)
+          pattern: (workstation|server GC|GC.*mode)
       - type: prompt
     rubric:
-      - Correctly states environment variables now take precedence in .NET 9 — all three settings (GC Server,
-        Concurrent, ThreadPool) will use env var values instead of runtimeconfig
+      - "Correctly states that the supported GC environment variables now take precedence in .NET 9, while
+        DOTNET_ThreadPool_MinThreads is unsupported and does not override runtimeconfig.json"
       - "States the correct concrete impact: server GC becomes workstation GC, concurrent GC is disabled, and the
-        minimum ThreadPool thread count drops from 25 to 4 (a response claiming any of these values are unchanged —
-        for example that min threads stay at 25 — is factually wrong, however confidently it is stated)"
+        minimum ThreadPool thread count remains 25 from runtimeconfig.json"
       - Identifies zlib no longer installed in .NET 9 container images; SkiaSharp/image processing will fail; recommends
         adding apt-get install zlib1g
-      - Recommends either removing conflicting env vars or updating runtimeconfig to match desired values
+      - Recommends removing or updating conflicting GC environment variables, removing the unsupported
+        DOTNET_ThreadPool_MinThreads variable, and configuring the minimum thread count in runtimeconfig.json
     constraints:
       reject_skills:
         - "*"


### PR DESCRIPTION
## What

Corrects two container stimuli in `migrate-dotnet8-to-dotnet9/eval.yaml` so the judge has explicit and consistent ground truth for .NET 9 runtime configuration.

In .NET 9, the supported GC environment variables take precedence over `runtimeconfig.json`. `DOTNET_ThreadPool_MinThreads` is not a supported counterpart for `System.Threading.ThreadPool.MinThreads`, so it has no effect.

The two fixture outcomes are:
- `DOTNET_gcServer=0` switches the first app from server GC to workstation GC; its minimum ThreadPool thread count remains `50` from `runtimeconfig.json`.
- `DOTNET_gcServer=0` and `DOTNET_gcConcurrent=0` switch the second app to workstation GC and disable concurrent GC; its minimum ThreadPool thread count remains `25` from `runtimeconfig.json`.

The prompts and rubrics now state those outcomes. The misleading `MinThreads.*4` output-matches alternative was removed, and the mitigation now tells users to remove the unsupported variable and configure MinThreads in `runtimeconfig.json`.

## Why

The previous rubric treated `DOTNET_ThreadPool_MinThreads` as a supported override and required the judge to reward an incorrect 25-to-4 change. This update keeps the supported GC precedence behavior while making the ThreadPool ground truth match the runtime and both fixtures.

## Design note

The prompt grader checks the ThreadPool distinction semantically. A numeric regex cannot distinguish a correct statement such as "remains 25" from an incorrect statement such as "drops from 25 to 4."

## Scope and validation

- One eval file; no skill-content change.
- `python eng/eval-quality/check_eval_quality.py` passes with no errors.
- The `dotnet-upgrade` plugin validator passes for all six skills.
- The PR's automatic eval-quality, skill-check, skill-coverage, skill-validator, CODEOWNERS, and CLA checks pass.

## Verification still needed

The manual `/evaluate` status is pending. A live eval run is needed to measure the rubric's effect on judge consistency.

/cc @AbhitejJohn