### PR TITLE
Surface skill preference regressions via a separate non-required CI status

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1438,6 +1438,73 @@ jobs:
             -f description="$DESC" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Download evaluation artifacts for regression scan
+        id: reg_artifacts
+        if: needs.evaluate.result != 'skipped'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: vally-results-*
+          path: all-results/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Set preference-regression commit status
+        # Separate, ADVISORY, NON-required status context. It surfaces a credible
+        # preference regression without touching the required `evaluation-status`,
+        # so it is non-blocking until a maintainer opts to make it required.
+        #
+        # The adapter records a credible ordinal preference loss as
+        # `preferenceRegressed: true` (state stays VALID_NO_CHANGE — see
+        # eng/vally-adapter/adapt.mjs; VALID_REGRESSION is reserved and not
+        # emitted today). We therefore key on `preferenceRegressed` and require
+        # the verdict to be conclusive and adequately powered, which keeps the
+        # false-positive rate down. It is deliberately advisory: the signal is
+        # judge-based and, on dual-judge cadences, the primary judge's preference
+        # regressions are not always corroborated by the second judge.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVALUATE_RESULT: ${{ needs.evaluate.result }}
+          DL_OUTCOME: ${{ steps.reg_artifacts.outcome }}
+        run: |
+          mkdir -p all-results
+          REG_FILE="$(mktemp)"
+          while IFS= read -r f; do
+            if [[ -z "$f" ]]; then continue; fi
+            plugin="$(basename "$(dirname "$(dirname "$f")")")"
+            jq -r --arg plugin "$plugin" '
+              (.model // "?") as $m | (.judgeModel // "?") as $jm |
+              (.verdicts // [])[]
+              | select((.preferenceRegressed == true)
+                       and (.conclusive == true)
+                       and ((.underpowered // false) != true))
+              | "\($plugin)/\(.skillName) [executor \($m), judge \($jm)]"
+            ' "$f" 2>/dev/null || true
+          done < <(find all-results/ -name results.json 2>/dev/null || true) > "$REG_FILE"
+
+          REG_COUNT="$(grep -c . "$REG_FILE" 2>/dev/null || true)"
+          REG_COUNT="${REG_COUNT:-0}"
+          if [[ "$REG_COUNT" -gt 0 ]]; then
+            STATE="failure"
+            SUMMARY="$(head -n 5 "$REG_FILE" | paste -sd ';' -)"
+            DESC="Preference regression (advisory) in ${REG_COUNT} verdict(s): ${SUMMARY}"
+          elif [[ "$EVALUATE_RESULT" == "success" && "$DL_OUTCOME" != "success" ]]; then
+            STATE="success"
+            DESC="No preference regression detected (artifact scan incomplete - see run logs)"
+          elif [[ "$EVALUATE_RESULT" == "success" ]]; then
+            STATE="success"
+            DESC="No credible preference regression detected"
+          else
+            STATE="success"
+            DESC="No preference regression detected (evaluation incomplete - see evaluation-status)"
+          fi
+          DESC="$(printf '%s' "$DESC" | tr '\n' ' ' | cut -c1-140)"
+
+          gh api "repos/${{ github.repository }}/statuses/${{ needs.gate.outputs.head_sha }}" \
+            -f state="$STATE" \
+            -f context="evaluation-regression" \
+            -f description="$DESC" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Post completion comment for skipped evaluation
         if: needs.evaluate.result == 'skipped'
         continue-on-error: true


### PR DESCRIPTION
## What

Adds an advisory, **non-required** `evaluation-regression` commit status to the `report-status` job. It downloads the `vally-results-*` artifacts and posts red only when a verdict is a credible, conclusive, adequately-powered preference regression. It never touches the required `evaluation-status`, so it is non-blocking by default; a maintainer can opt to make it required later.

## Why

The required `evaluation-status` check is verdict-blind: it reports success whenever the `evaluate` job ran, regardless of whether a skill regressed. The verdict aggregation that knows about regressions runs only on the scheduled publish path, so a PR author never sees a regression signal on the PR itself.

## Design notes

- **Keyed on `preferenceRegressed`, not a `VALID_REGRESSION` state.** The adapter records a credible ordinal preference loss as `preferenceRegressed: true` while the verdict `state` stays `VALID_NO_CHANGE` (`VALID_REGRESSION` is reserved and not emitted today). Keying on the state would be a permanent no-op. The filter also requires `conclusive == true` and `underpowered != true` to keep the false-positive rate down.
- **Advisory on purpose.** The signal is judge-based. On dual-judge cadences, a primary-judge preference regression is not always corroborated by the second judge, so this must not gate merge until the judge signal is more reliable.
- **Partial-download aware.** If the artifact scan does not complete, the status stays green with an explicit "scan incomplete - see run logs" note instead of failing silently.

## Expected behavior against the corpus

- On a recent full-plugin run across 92 skills, there were 0 regressions, so on normal PRs the advisory almost never fires.
- On three curated dual-judge runs the primary judge flagged a regression in all three; the second judge corroborated none. This is exactly why the status is non-required: had it gated merge, it would have blocked all three with no corroboration.

## Known limitation

A malformed `results.json` makes its per-file `jq` error be swallowed, so the advisory could miss a regression in a corrupt file. This is acceptable for an advisory status; the required `evaluation-status` still covers hard failures.

## Validation

- `actionlint` 1.7.7 exits 0.
- The `jq` filter was tested against real verdict JSON and selects only the credible, powered regression.

/cc @AbhitejJohn