### PR TITLE
Improve MSTest skill routing and eval quality

### DIFF
--- a/plugins/dotnet-test/skills/assertion-quality/SKILL.md
+++ b/plugins/dotnet-test/skills/assertion-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assertion-quality
-description: "MANDATORY for reviewing assertion strength, depth, and variety in existing tests. Invoke when the user asks whether individual assertions are weak, shallow, trivial, always true, self-referential, or diverse; asks which tests are assertion-free or rely only on presence/truthiness checks; or requests assertion quality/depth/variety metrics. Polyglot: .NET, Python/pytest, TS/JS/Jest, Java, Go, Ruby, Rust, Swift, Kotlin, PowerShell, C++. DO NOT USE FOR: writing or fixing tests/assertions (use code-testing-agent or writing-mstest-tests), mutation reasoning (use test-gap-analysis), or a general severity-ranked anti-pattern audit (use test-anti-patterns)."
+description: "Produce an assertion-quality report or metrics for existing tests. ALWAYS USE when asked whether assertions are weak, shallow, trivial, always true, self-referential, or diverse; which tests are assertion-free or use only presence/truthiness checks; or for depth/variety metrics. Polyglot. DO NOT USE for direct fixes: use writing-mstest-tests for supplied MSTest assertions, or code-testing-agent when new cases must be designed. Do not use for mutation reasoning (test-gap-analysis) or a general severity-ranked audit (test-anti-patterns)."
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: code-testing-agent
 description: >-
-  Generate or add unit tests for existing code, from one function to a complete
-  project-wide suite. ALWAYS USE when asked to "write unit tests", "add tests",
-  "generate tests", "cover this untested method", scaffold tests where none
-  exist, or create comprehensive tests across multiple modules or packages.
-  Polyglot: C#/.NET, Python/pytest, TS/JS, Go, Rust, Java, Ruby. Handles classic
-  non-SDK/packages.config MSTest projects, explicit Compile registration, sparse
-  workspaces, existing-suite extension, and proportional focused work. DO NOT USE
-  for only running/diagnosing tests, analyzing a coverage report, auditing test
-  quality, or answering an MSTest API question without writing tests.
+  Generate or add unit tests for existing code, from one function to a
+  project-wide suite. ALWAYS USE for "write/add/generate tests", "cover this
+  untested method", scaffolding tests where none exist, or comprehensive suites.
+  Polyglot; supports classic packages.config MSTest, sparse workspaces, and
+  proportional focused work. DO NOT USE for only running/diagnosing tests,
+  coverage/audits, or correcting supplied MSTest assertions, attributes,
+  lifecycle, or configuration without designing new cases
+  (writing-mstest-tests).
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scaffold-dotnet-test-project
 description: >-
-  Create the first .NET test project. USE FOR: "solution has no tests",
-  xUnit tests, Tests.csproj/ProjectReference, add an omitted test project to
-  .sln/.slnx/.slnf, central packages, or tests missing from CI. DO NOT USE FOR:
-  a suitable project already registered in the requested build entry point
-  (stop) or migration.
+  Create and wire the first .NET test project. USE FOR: "solution has no tests",
+  Tests.csproj/ProjectReference, solution registration, central packages, or
+  tests missing from CI. DO NOT USE when a suitable project exists, for
+  migration, or for MSTest API/attribute/MSTest.Sdk/parallelization advice
+  without a request to create and wire files (writing-mstest-tests).
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
+++ b/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
@@ -1,21 +1,14 @@
 ---
 name: test-anti-patterns
 description: >
-  Audits an existing test file or suite in any language for anti-patterns
-  and quality issues — produces a severity-ranked report
-  (Critical/Warning/Info). INVOKE whenever asked to audit or review tests,
-  find what's wrong with a suite, judge whether tests are any good, or
-  check for: tests that pass but verify nothing, missing assertions,
-  swallowed exceptions, self-comparing / tautological assertions,
-  coverage-touching tests, broad exceptions, flaky or order-dependent tests
-  (Thread.Sleep, DateTime.Now, shared state), duplicated tests, or magic
-  values — in .NET, Python/pytest, TS/Jest, Java, Go, Ruby or C++. DO NOT
-  USE FOR: writing new tests (use code-testing-agent, or writing-mstest-tests
-  for MSTest); running tests (use
-  run-tests); migration; assertion-diversity metrics (use assertion-quality);
-  coverage/CRAP metrics (use coverage-analysis); the testsmells.org academic
-  catalog (use test-smell-detection); fixing or modernizing MSTest tests,
-  assertions, attributes, or lifecycle (use writing-mstest-tests).
+  Audit an existing test file or suite and produce a severity-ranked diagnostic
+  report. ALWAYS USE for findings about tests that verify nothing, missing or
+  tautological assertions, swallowed/broad exceptions, flaky or order-dependent
+  tests, duplication, or magic values. Polyglot. DO NOT USE for direct edits:
+  use writing-mstest-tests for supplied MSTest assertions, attributes, or
+  lifecycle, and code-testing-agent for new tests. Do not use for running tests,
+  migration, assertion metrics (assertion-quality), coverage/CRAP metrics, or
+  the testsmells.org catalog (test-smell-detection).
 license: MIT
 ---
 
@@ -31,11 +24,11 @@ Quick, pragmatic analysis of test code in any supported language for anti-patter
 - User wants to know why tests are flaky or unreliable
 - User asks "are my tests good?" or "what's wrong with my tests?"
 - User requests a test audit or test code review
-- User wants to improve existing test code
+- User wants diagnostic findings before deciding what to improve
 
 ## When Not to Use
 
-- User wants to write new tests from scratch (use `code-testing-agent` for any language, or `writing-mstest-tests` for MSTest specifically)
+- User wants to write new tests from scratch (use `code-testing-agent`)
 - User wants direct implementation fixes rather than a diagnostic review (use the relevant write/edit skill)
 - User asks to fix swapped `Assert.AreEqual` argument order in MSTest (use `writing-mstest-tests`)
 - User asks to convert MSTest `DynamicData` from `IEnumerable<object[]>` to `ValueTuple` (use `writing-mstest-tests`)

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: writing-mstest-tests
 description: >
-  Review, modernize, fix, or explain MSTest APIs using the installed version,
-  including classic non-SDK packages.config projects and older MSTest 3.x.
-  ALWAYS USE to "fix swapped Assert.AreEqual arguments", "replace
-  ExpectedException with Assert.Throws/ThrowsExactly", choose specific assertions,
-  fix StringAssert/CollectionAssert/IsInstanceOfType, modernize DataRow or
-  DynamicData, configure lifecycle/TestContext/cancellation/retry/parallelization,
-  set up MSTest.Sdk, or fix MSTESTxxxx diagnostics. Preserves FixtureBase,
-  Moq/NBuilder, project format, and package versions unless migration is requested.
-  DO NOT USE for generating new tests (code-testing-agent), audits, running tests,
-  framework migration, xUnit/NUnit/TUnit, or non-.NET.
+  Fix, modernize, review, or explain supplied MSTest code and MSTest-specific
+  configuration while honoring installed versions and project style. ALWAYS USE
+  for direct corrections: expected/actual order; generic/manual assertions;
+  exception, hard-cast, or object[] patterns; TestContext/lifecycle;
+  timeout/cancellation; condition/retry/cleanup; parallelization; MSTest.Sdk
+  setup; or MSTESTxxxx. Use for "review" only when corrected code or edits are
+  wanted. DO NOT USE for new test-case design (code-testing-agent), report-only
+  audits/metrics (test-anti-patterns or assertion-quality), creating/wiring a
+  first test project (scaffold-dotnet-test-project), running tests, migration,
+  non-MSTest frameworks, or non-.NET.
 license: MIT
 ---
 

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -13,10 +13,11 @@ defaults:
   # gives transient model stalls recovery room without changing skill behavior.
   timeout: 6m
 stimuli:
-  - name: Modernize an async test with cooperative cancellation
+  - name: Stop in-flight work when a timed test expires
     prompt: |
-      Review and modernize this existing MSTest test so its timeout is
-      cooperative and it flows the test framework's cancellation token:
+      When this test reaches its timeout, the awaited operation keeps running.
+      Update the existing MSTest code so timing out also stops the in-flight
+      operation. Show the corrected test and explain why the old code did not:
 
       ```csharp
       [TestClass]
@@ -34,8 +35,7 @@ stimuli:
       }
       ```
 
-      Show the corrected test and explain the relevant MSTest APIs. Do not run
-      tools or add another test suite.
+      Do not run tools or add another test suite.
     graders:
       - type: output-matches
         config:
@@ -48,19 +48,20 @@ stimuli:
           pattern: CancellationToken
       - type: prompt
     rubric:
-      - Uses async Task test methods (not async void)
-      - Uses TestContext.CancellationToken or mentions its importance for cooperative timeout
-      - Uses a valid [Timeout(milliseconds, CooperativeCancellation = true)] attribute
-      - Does not use CancellationToken.None when TestContext.CancellationToken is available
-      - Seals the test class
+      - The corrected test remains awaitable by the test runner rather than becoming fire-and-forget
+      - Reaching the framework timeout requests cancellation of the work still in progress
+      - The token controlled by the test framework is passed to the production call instead of an uncancelable token
+      - The explanation connects the timeout configuration and token flow to the observed runaway operation
+      - The class declaration follows current MSTest requirements without changing the behavior under test
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Fix swapped Assert.AreEqual arguments
+  - name: Correct expected and actual failure labels
     prompt: |
-      Review and fix these MSTest assertions following MSTest best practices. Leave anything that is already correct untouched.
+      These tests pass, but their failure output labels the calculated value as
+      "Expected" and the constants as "Actual". Correct only that problem:
 
       ```csharp
       [TestClass]
@@ -90,16 +91,16 @@ stimuli:
           pattern: Assert\.AreEqual\(0
       - type: prompt
     rubric:
-      - Identifies the swapped arguments in Assert.AreEqual — expected should be first, actual second
-      - Fixes to Assert.AreEqual(5, result) and Assert.AreEqual(0, result)
-      - "Explains why argument order matters (failure messages show 'Expected: X, Actual: Y')"
+      - Both equality checks report the constants 5 and 0 as the expected values and the calculated results as the actual values
+      - No unrelated test logic or production behavior is changed
+      - The explanation connects argument order to accurate Expected/Actual failure diagnostics
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Modernize legacy test patterns
-    prompt: Can you review these MSTest tests and modernize them to use current MSTest best practices like sealed classes and Assert.ThrowsExactly?
+  - name: Modernize legacy MSTest code safely
+    prompt: Review the attached legacy MSTest tests, apply current patterns that improve safety and failure diagnostics, and preserve the installed package version and tested behavior.
     environment:
       files:
         - src: fixtures/legacy-antipatterns/TestProject.csproj
@@ -122,18 +123,18 @@ stimuli:
           pattern: IsInstanceOfType
       - type: prompt
     rubric:
-      - Seals the test class (adds 'sealed' keyword)
-      - Replaces [ExpectedException] with Assert.ThrowsExactly or Assert.Throws
-      - Fixes the swapped Assert.AreEqual arguments (expected first, actual second)
-      - Moves synchronous setup from [TestInitialize] into the constructor, enabling readonly fields and satisfying
-        nullability analyzers
-      - Removes nullable annotation from TestContext property or switches to constructor injection
-      - Improves test naming to be descriptive (replaces 'Test1', 'TestNegativeQuantity')
-      - Replaces hard cast with Assert.IsInstanceOfType
-      - Replaces manual foreach test data loop with [DataRow] or [DynamicData] attributes
-  - name: Replace ExpectedException with Assert.Throws
+      - The revised class cannot be inherited accidentally
+      - Exception behavior is asserted at the exact call site so the thrown object can be inspected
+      - Equality failures label the intended value and calculated value correctly
+      - Synchronous per-test dependencies are guaranteed initialized after construction without null-forgiving workarounds
+      - Test names describe the behavior and expected result
+      - A failed runtime type check produces an assertion failure rather than an invalid-cast exception
+      - Repeated input cases are independently discoverable and reported by the test runner
+  - name: Verify an exception at the throwing call
     prompt: |
-      Modernize this MSTest test to replace [ExpectedException] with Assert.ThrowsExactly, following MSTest best practices.
+      Update this MSTest test so the exception is verified at the call that should
+      throw and the returned exception can be inspected. The project uses MSTest
+      3.8:
 
       ```csharp
       [TestMethod]
@@ -153,17 +154,16 @@ stimuli:
           substring: "[ExpectedException]"
       - type: prompt
     rubric:
-      - Replaces [ExpectedException] with Assert.ThrowsExactly<ArgumentNullException> or
-        Assert.Throws<ArgumentNullException>
-      - 'Wraps the call in a lambda: Assert.ThrowsExactly<ArgumentNullException>(() => service.CreateUser(null, "John"))'
-      - Mentions that Assert.Throws/ThrowsExactly allows asserting on the exception properties (message, param name)
-      - Explains the difference between Throws (matches derived types) and ThrowsExactly (exact type only)
+      - Only the CreateUser call is inside the exception assertion, so an earlier failure cannot satisfy the test
+      - The test requires ArgumentNullException and makes an intentional choice about whether derived exception types are accepted
+      - The thrown exception is available for checking behavior such as the parameter name or message
+      - The explanation accurately distinguishes exact-type matching from assignable-type matching
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Keep exception assertions compatible with the installed MSTest version
+  - name: Respect a pinned framework version
     prompt: |
       Our classic net472 test project is pinned to MSTest.TestFramework 3.5.2
       in packages.config. This existing test does not compile because it uses a
@@ -187,19 +187,19 @@ stimuli:
           pattern: (?i)(MSTest(?:\.TestFramework)?\s*)?3\.5\.2
       - type: prompt
     rubric:
-      - Uses Assert.ThrowsException<ArgumentNullException>, which is available in the pinned MSTest version
-      - Does not recommend Assert.ThrowsExactly, unified modern assertions, or a package upgrade
-      - Keeps the answer focused on a compatible test for the null guard
-      - Optionally asserts the ArgumentNullException parameter name without requiring newer APIs
+      - The corrected test compiles against MSTest.TestFramework 3.5.2 and verifies ArgumentNullException at the throwing call
+      - The response does not depend on an API introduced after the pinned version or propose changing dependencies
+      - The explanation identifies version compatibility as the reason for the correction
+      - Any optional check of exception details also uses APIs available to this project
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Use proper collection assertions
+  - name: Improve collection failure diagnostics
     prompt: >
       I'm writing MSTest tests and I'm using Assert.IsTrue for all my collection checks. Are there more specific MSTest
-      assertions I should use instead, following MSTest best practices? Here's what I have:
+      assertions that would make failures explain what was wrong? The project uses MSTest 3.8. Here's what I have:
 
 
       ```csharp
@@ -229,20 +229,22 @@ stimuli:
           pattern: ContainsSingle|Assert\.IsNotNull
       - type: prompt
     rubric:
-      - Replaces Assert.IsTrue(users.Count > 0) with Assert.IsNotEmpty(users) or similar
-      - Replaces Assert.IsTrue(users.Count() == 3) with Assert.HasCount(3, users)
-      - Replaces users.Single() with Assert.ContainsSingle for better failure messages
-      - Uses Assert.IsNotNull instead of Assert.IsTrue(x != null)
-      - Uses Assert.Contains for checking specific items in collections
-      - Explains that specialized assertions give better failure messages than generic Assert.IsTrue
+      - A failure clearly distinguishes an empty collection from the expected non-empty result
+      - The exact expected count is represented directly in the assertion failure
+      - Requiring one matching administrator reports zero or multiple matches as assertion failures
+      - Presence checks report a null-specific failure instead of a generic false condition
+      - The explanation connects each correction to more diagnostic failure output
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Use proper type assertions instead of casts
+  - name: Report runtime type mismatches as assertion failures
     prompt: |
-      Rewrite this MSTest test for a factory method to replace the hard cast with a proper type-checking assertion, following MSTest best practices.
+      If this factory returns the wrong handler, this test currently throws
+      InvalidCastException before MSTest can explain the mismatch. Rewrite it so
+      the failure reports the expected and actual runtime types. Our repositories
+      include both MSTest 3.x and 4.x, so call out the syntax difference:
 
       ```csharp
       [TestMethod]
@@ -262,19 +264,20 @@ stimuli:
           pattern: IsInstanceOfType
       - type: prompt
     rubric:
-      - Replaces hard cast (EmailHandler)result with Assert.IsInstanceOfType<EmailHandler>(result)
-      - Shows how to use the typed result from IsInstanceOfType for further assertions
-      - Explains that IsInstanceOfType provides a clear failure message showing actual vs expected type
-      - Distinguishes MSTest 3.x (out parameter) vs 4.x (direct return) syntax
+      - A wrong factory result fails as an assertion that reports expected and actual runtime types
+      - The value proven to be an EmailHandler is then used for the Type behavior check without another unsafe cast
+      - The answer does not present MSTest v4-only syntax as valid for MSTest v3
+      - The explanation makes the syntax difference between installed major versions actionable
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Set up test lifecycle correctly
+  - name: Initialize test state in lifecycle order
     prompt: >
-      I need to set up my MSTest test lifecycle with both synchronous and asynchronous initialization. I want to inject
-      TestContext via the constructor. What's the recommended way to do this in modern MSTest?
+      This project uses MSTest 3.8. Each test needs synchronous dependency construction, asynchronous database seeding,
+      and access to the current test context. Show a class structure that guarantees fields are initialized, supports the
+      async work, and explain the order in which setup, the test, and cleanup run.
     environment:
       files:
         - src: fixtures/modern-mstest/TestProject.csproj
@@ -293,17 +296,16 @@ stimuli:
           pattern: \[TestInitialize\]|TestInitialize
       - type: prompt
     rubric:
-      - Always initializes in the constructor — enables readonly fields and satisfies nullability analyzers (fields
-        guaranteed non-null after construction)
-      - Uses [TestInitialize] only for async initialization, combined with constructor for sync parts
-      - Injects TestContext via constructor parameter (MSTest 3.6+) rather than property
-      - "Mentions the execution order: Constructor → TestContext property → [TestInitialize] → Test → [TestCleanup] →
-        Dispose"
-      - Seals the test class
-      - If TestContext property is used, does not add nullable annotation or = null! initializer
-  - name: Use DynamicData with ValueTuples over object arrays
+      - Synchronous dependencies and the test context are available immediately after construction without nullable placeholders
+      - Asynchronous database seeding completes before each test method begins
+      - Cleanup is placed where it still runs after a test failure
+      - The stated execution order is accurate for the injection form shown
+      - The class structure does not introduce an unintended inheritance point
+  - name: Make a data source compile-time safe
     prompt: |
-      Rewrite this data-driven MSTest test to use type-safe ValueTuples instead of object arrays, following modern MSTest best practices.
+      This MSTest 3.8 data source can put values in the wrong position without a
+      compiler error. Rewrite it so the source has compile-time element names and
+      types while each row remains independently discoverable:
 
       ```csharp
       [TestMethod]
@@ -330,15 +332,15 @@ stimuli:
           pattern: IEnumerable<\(
       - type: prompt
     rubric:
-      - Recommends switching from IEnumerable<object[]> to IEnumerable<(string input, bool expected)> ValueTuples
-      - Explains that ValueTuples provide compile-time type safety
-      - Shows the correct ValueTuple syntax with named elements
-      - Mentions TestDataRow<T> as an option when custom DisplayName or metadata is needed
-      - Notes this requires MSTest 3.7+
-  - name: Replace manual string checks with MSTest 3.10 assertions
+      - The data source exposes string input and Boolean expectation as compile-time checked elements
+      - Element names make the relationship between each supplied value and method parameter clear
+      - The rewritten source remains compatible with the installed MSTest 3.8 version
+      - The response distinguishes the simple typed-row case from rows that need custom display names or metadata
+  - name: Diagnose failed string conditions
     prompt: |
-      This project uses MSTest 3.10. Rewrite these assertions with the most
-      specific MSTest APIs. Do not add tests or run tools.
+      This project uses MSTest 3.10. Rewrite these checks so a failure identifies
+      the unmet string condition instead of only saying a Boolean was false. Do
+      not add tests or run tools.
 
       ```csharp
       Assert.IsTrue(greeting.StartsWith("Dear "));
@@ -357,18 +359,19 @@ stimuli:
           pattern: Assert\.MatchesRegex
       - type: prompt
     rubric:
-      - Replaced each manual boolean check with the corresponding MSTest 3.10 string assertion
-      - Preserved the expected/actual argument meaning and regex pattern
-      - Did not fall back to StringAssert or Assert.IsTrue
+      - Each failure directly identifies whether the prefix, suffix, or regular-expression condition was unmet
+      - The expected text or pattern and the actual string retain their original meaning and order
+      - The correction uses APIs available in MSTest 3.10 rather than retaining generic Boolean checks or legacy helpers
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Replace manual numeric bounds with MSTest 3.10 assertions
+  - name: Diagnose failed numeric boundaries
     prompt: |
-      This project uses MSTest 3.10. Rewrite these checks with specific MSTest
-      comparison assertions. Do not add tests or run tools.
+      This project uses MSTest 3.10. Rewrite these checks so failures report the
+      expected numeric bound or range and the actual score, rather than only a
+      false Boolean. Do not add tests or run tools.
 
       ```csharp
       Assert.IsTrue(score > 0);
@@ -387,15 +390,16 @@ stimuli:
           pattern: Assert\.IsInRange\(60,\s*90,\s*score\)
       - type: prompt
     rubric:
-      - Used IsGreaterThan and IsLessThan for strict bounds
-      - Used Assert.IsInRange(60, 90, score) with minimum, maximum, then actual value
-      - Did not retain manual Assert.IsTrue comparisons
+      - The lower and upper strict-bound checks preserve their original exclusive semantics
+      - The inclusive 60-through-90 check preserves both endpoints and reports the actual score
+      - Argument order yields accurate expected-bound and actual-value failure diagnostics
+      - No generic Boolean comparison remains
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Configure conditional execution, retry, and cleanup
+  - name: Apply environment retry and cleanup policies
     prompt: |
       I have MSTest tests that:
       1. Only work on Windows because they use the Windows registry
@@ -403,7 +407,8 @@ stimuli:
       3. Sometimes fail due to a flaky external weather API
       4. Create temporary files that need to be deleted even if the test fails
 
-      How should I handle all of these using MSTest attributes and patterns following MSTest best practices?
+      Show how to express each requirement in MSTest 3.10 without putting
+      environment checks or cleanup control flow inside the test bodies.
     graders:
       - type: output-matches
         config:
@@ -419,19 +424,21 @@ stimuli:
           pattern: TestCleanup|IDisposable
       - type: prompt
     rubric:
-      - Uses an OS condition attribute to restrict the registry test to Windows only
-      - Uses a CICondition attribute to exclude the GPU test from CI environments
-      - Uses a retry attribute for the flaky weather API test with a small retry count
-      - Uses [TestCleanup] or IDisposable/IAsyncDisposable for deleting temporary files to ensure cleanup runs even on
-        test failure
+      - The registry test is discoverable everywhere but executes only on Windows
+      - The GPU test is excluded in CI without embedding an environment branch in its body
+      - The external-service test has a small, bounded retry policy rather than an unbounded loop
+      - Temporary files are removed through lifecycle cleanup that still runs after test failure
+      - The response does not use retry to conceal deterministic race conditions or shared-state defects
     constraints:
       reject_tools:
         - bash
         - edit
         - create
-  - name: Replace generic IsTrue checks for null, identity, emptiness, and absence
+  - name: Diagnose identity null absence and emptiness
     prompt: |
-      Every check in this MSTest test is written with Assert.IsTrue. Rewrite it so each check uses the most specific MSTest assertion available for what it is actually verifying, following MSTest best practices.
+      Every check in this MSTest 3.8 test is written as a generic Boolean
+      assertion. Rewrite it so each failure reports the condition that was
+      actually expected:
 
       ```csharp
       [TestMethod]
@@ -465,27 +472,23 @@ stimuli:
           pattern: Assert\.IsEmpty
       - type: prompt
     rubric:
-      - Replaced the ReferenceEquals check with an assertion dedicated to verifying that two references are the same
-        object, not merely equal values
-      - Replaced the '== null' comparison with a null-specific assertion
-      - Replaced the negated Contains check with an assertion for an item being absent from a collection
-      - Replaced the 'Count == 0' check with a dedicated empty-collection assertion
-      - Explained that the specific assertions report what actually differed on failure, whereas the generic boolean form
-        can only report that a condition was false
+      - The identity check verifies that both expressions refer to the same object rather than merely equal values
+      - The missing-session check reports null as the expected condition
+      - The ended session check reports unexpected collection membership directly
+      - The purge check reports that the collection was expected to be empty
+      - The explanation connects each correction to failure output that states what differed
     constraints:
       reject_tools:
         - bash
         - edit
         - create
 
-  - name: Configure test parallelization and MSTest.Sdk project
+  - name: Configure concurrent execution with a serial exception
     prompt: |
-      I'm setting up a new MSTest.Sdk project from scratch. I want test parallelization:
-      1. The simplest possible project file using MSTest.Sdk
-      2. Tests to run in parallel using Parallelize
-      3. But my database integration tests must use DoNotParallelize
-
-      What's the recommended MSTest setup?
+      Show the smallest recommended project file for a new MSTest project. Most
+      tests should execute concurrently, but database integration tests share
+      state and must run serially. Include where the SDK version belongs and the
+      assembly/class configuration needed for those two execution policies.
     graders:
       - type: output-matches
         config:
@@ -498,10 +501,10 @@ stimuli:
           pattern: DoNotParallelize
       - type: prompt
     rubric:
-      - Recommends MSTest.Sdk for the simplest possible project file
-      - Shows assembly-level Parallelize attribute configuration with Workers and Scope
-      - Uses [DoNotParallelize] on the database integration test class to opt it out of parallel execution
-      - Suggests putting the MSTest.Sdk version in global.json so all test projects stay in sync
+      - The project file uses the minimal MSTest-specific SDK form without redundant package references
+      - Parallel execution is enabled once at assembly scope with an explicit worker count and scheduling scope
+      - The database integration class opts out because its tests share state
+      - The SDK version is centralized so multiple test projects can stay aligned
     constraints:
       reject_tools:
         - bash

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -17,7 +17,8 @@ stimuli:
     prompt: |
       When this test reaches its timeout, the awaited operation keeps running.
       Update the existing MSTest code so timing out also stops the in-flight
-      operation. Show the corrected test and explain why the old code did not:
+      operation. Show the corrected test and explain why the old code did not
+      stop the operation:
 
       ```csharp
       [TestClass]
@@ -52,7 +53,7 @@ stimuli:
       - Reaching the framework timeout requests cancellation of the work still in progress
       - The token controlled by the test framework is passed to the production call instead of an uncancelable token
       - The explanation connects the timeout configuration and token flow to the observed runaway operation
-      - The class declaration follows current MSTest requirements without changing the behavior under test
+      - The corrected test remains valid MSTest code and preserves the behavior being verified
     constraints:
       reject_tools:
         - bash
@@ -434,7 +435,7 @@ stimuli:
         - bash
         - edit
         - create
-  - name: Diagnose identity null absence and emptiness
+  - name: Diagnose identity, null, absence, and emptiness
     prompt: |
       Every check in this MSTest 3.8 test is written as a generic Boolean
       assertion. Rewrite it so each failure reports the condition that was


### PR DESCRIPTION
## Summary

Dashboard evidence showed 24/140 isolated and 36/140 plugin activation misses for `writing-mstest-tests`, concentrated in direct assertion and API transformations, while six model families flagged the eval as highly overfit. The root causes were overlapping sibling descriptions that partitioned by topic instead of requested outcome, plus prompts and rubrics that repeated the exact APIs being rewarded.

This change sharpens the handoffs between direct MSTest fixes, report-only audits, new-test design, and first-project scaffolding. It preserves all 14 stimuli and their deterministic API checks, but rewrites stimulus titles, prompts, and rubrics around observable outcomes. Skill body guidance remains unchanged because there was no losing-trial evidence of a content defect.

## Related issue

N/A

## Validation

- `python eng/eval-quality/check_eval_quality.py` - passed with no errors; repository-wide pre-existing warnings remain
- `skill-validator check --plugin ./plugins/dotnet-test` - passed all 22 skills, 10 agents, and plugin checks
- Confirmed 14 unique stimuli and prompt grading on all 14

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content. (N/A: no owned content added or moved.)
- [x] I updated all marketplace manifests when plugin metadata changed. (N/A: plugin metadata unchanged.)
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content. (N/A: no new domains.)