### PR TITLE
Enable daemon mode for Roslyn LSP

### DIFF
--- a/plugins/dotnet/.lsp.json
+++ b/plugins/dotnet/.lsp.json
@@ -8,6 +8,7 @@
       "--prerelease",
       "--",
       "--stdio",
+      "--daemon-mode",
       "--autoLoadProjects"
     ],
     "extensionToLanguage": {

--- a/plugins/dotnet/lsp.json
+++ b/plugins/dotnet/lsp.json
@@ -8,6 +8,7 @@
         "--prerelease",
         "--",
         "--stdio",
+        "--daemon-mode",
         "--autoLoadProjects"
       ],
       "cwd": "${PLUGIN_ROOT}",


### PR DESCRIPTION
## Summary
- launch the Roslyn language server with `--daemon-mode`
- keep the standard and Codex LSP configurations aligned

## Validation
- parsed both LSP configuration files as JSON
- verified `--daemon-mode` follows `--stdio` in both argument lists

`skill-validator check` was blocked while downloading `@github/copilot-win32-x64` by a TLS handshake failure.