### PR TITLE
Stabilize skill menu and evaluation retries

### DIFF
--- a/.github/workflows/evaluation-run.yml
+++ b/.github/workflows/evaluation-run.yml
@@ -765,6 +765,26 @@ jobs:
             exit 1
           fi
 
+          # A single agent session can time out transiently while every other
+          # trial succeeds. Retry only that eval/variant once, then replace only
+          # the matching failed slots. Persistent or non-timeout failures remain
+          # in the original JSONL and fail the measurement-validity gate below.
+          set +e
+          timeout --signal=TERM --kill-after=30s 30m \
+            node "$RUNNER_TEMP/trusted-validator-src/eng/vally-adapter/retry-executor-timeouts.mjs" \
+              --experiment-file "$EXPERIMENT_FILE" \
+              --experiment-dir "$RUN_DIR" \
+              --retry-output-dir "$RESULTS_DIR/_executor-retry" \
+              --summary "$RESULTS_DIR/executor-retry-summary.json" \
+              --vally "vally" \
+              --workers 5 \
+              --max-groups 3
+          EXECUTOR_RETRY_STATUS=$?
+          set -e
+          if [ "$EXECUTOR_RETRY_STATUS" -ne 0 ]; then
+            echo "::warning::Executor timeout recovery exited $EXECUTOR_RETRY_STATUS; adapting original and any atomically recovered records"
+          fi
+
           # Run the retained skill-validator overfitting judge over the same
           # skills this leg evaluated, before adapting. It reads GITHUB_TOKEN
           # (already exported above) for its single LLM call per skill. Scope it

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -693,6 +693,29 @@ esac
             "Vally comparison watchdog expired after 45 minutes",
             run_script,
         )
+        self.assertIn(
+            "retry-executor-timeouts.mjs",
+            run_script,
+        )
+        self.assertIn(
+            '--max-groups 3',
+            run_script,
+        )
+        self.assertIn(
+            'EXECUTOR_RETRY_STATUS=$?',
+            run_script,
+        )
+        self.assertIn(
+            'if [ "$EXECUTOR_RETRY_STATUS" -ne 0 ]',
+            run_script,
+        )
+        self.assertLess(
+            run_script.index("retry-executor-timeouts.mjs"),
+            run_script.index(
+                'node "$RUNNER_TEMP/trusted-validator-src/'
+                'eng/vally-adapter/adapt.mjs"'
+            ),
+        )
         summary_script = by_name["Write summary"]["run"]
         self.assertIn('ICON="➖"', summary_script)
         self.assertNotIn('ICON="❌"', summary_script)

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -1,6 +1,11 @@
 # Investigating Evaluation Results
 
 > **⚠️ Skill evaluations now run on the Vally harness.** As of the Vally migration, the LLM eval pipeline (`evaluation.yml`) no longer uses `skill-validator evaluate`; it runs Vally via `eng/vally-adapter/` and uploads `vally-results-*` artifacts. For investigating current eval failures, use the guide at `eng/vally-adapter/InvestigatingResults.md` in the repository root instead. This document describes the legacy `skill-validator evaluate` schema and is retained for historical results and reference. (The `skill-validator check` **linter** is unaffected and still runs via `skill-check.yml`.)
+>
+> The current Vally workflow makes one targeted recovery attempt for executor
+> `session.idle` timeouts before adaptation. See
+> `executor-retry-summary.json` in the result artifact and the current guide for
+> the bounded retry and fail-closed rules.
 
 > **Current Vally schema:** `state` is authoritative:
 > `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -176,10 +176,11 @@ variant once, preserves all successful first-attempt slots, and replaces only
 matching failed `shardKey` slots from the same normalized eval path that
 succeed. Records without a `shardKey` remain invalid. Check
 `executor-retry-summary.json` and the raw record's `executorRetry` field for
-recovered attempts. Persistent timeouts, other executor failures, or more than
-three affected eval/variant groups remain measurement-invalid and keep the
-matrix leg red. The optional whole-plugin arm is report-only telemetry and is
-not retried.
+recovered attempts. The merged record retains the original experiment
+provenance; `executorRetry.retryRunId` identifies the successful retry run.
+Persistent timeouts, other executor failures, or more than three affected
+eval/variant groups remain measurement-invalid and keep the matrix leg red. The
+optional whole-plugin arm is report-only telemetry and is not retried.
 
 If Vally writes a JSON record that cannot satisfy the comparison schema, the
 adapter emits `comparison_report_invalid` for that eval and continues the batch.

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -170,6 +170,16 @@ Work top-down; earlier categories often cause later ones.
 ### 1. Errored or missing trials (`state == "INVALID_INCONCLUSIVE"`)
 The agent crashed, the model was unavailable, evidence was missing, or the comparison judge failed. Check `stateReason`, `errors[]`, `adapter-summary.json`, and the variant's `results.jsonl`/session logs. These are invalid measurements, not skill regressions. If a required variant produced no records, the adapter writes an explicit invalid result with `missing_baseline_records` or `missing_skilled_records`.
 
+The workflow retries only required baseline or isolated-skilled executor records
+whose exact failure is a `session.idle` timeout. It reruns the affected eval and
+variant once, preserves all successful first-attempt slots, and replaces only
+matching failed `shardKey` slots that succeed. Check
+`executor-retry-summary.json` and the raw record's `executorRetry` field for
+recovered attempts. Persistent timeouts, other executor failures, or more than
+three affected eval/variant groups remain measurement-invalid and keep the
+matrix leg red. The optional whole-plugin arm is report-only telemetry and is
+not retried.
+
 If Vally writes a JSON record that cannot satisfy the comparison schema, the
 adapter emits `comparison_report_invalid` for that eval and continues the batch.
 This preserves exact result accounting without treating malformed evidence as a

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -173,7 +173,8 @@ The agent crashed, the model was unavailable, evidence was missing, or the compa
 The workflow retries only required baseline or isolated-skilled executor records
 whose exact failure is a `session.idle` timeout. It reruns the affected eval and
 variant once, preserves all successful first-attempt slots, and replaces only
-matching failed `shardKey` slots that succeed. Check
+matching failed `shardKey` slots from the same normalized eval path that
+succeed. Records without a `shardKey` remain invalid. Check
 `executor-retry-summary.json` and the raw record's `executorRetry` field for
 recovered attempts. Persistent timeouts, other executor failures, or more than
 three affected eval/variant groups remain measurement-invalid and keep the

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -193,7 +193,22 @@ metadata. The adapter keeps the raw report available for diagnosis. It does not
 replace Vally's evidence; it adds repository-specific validity and decision
 fields.
 
-### 5. Retry only failed comparison-judge slots
+### 5. Retry transient executor timeouts once
+
+If a required baseline or isolated-skilled trial fails with
+`Timeout after ... waiting for session.idle`, the workflow reruns only that eval
+and variant once. The recovery step merges only successful records with matching
+stable `shardKey` values. It never replaces successful first-attempt records. A
+persistent timeout or a different executor error stays in the original JSONL
+and remains measurement-invalid. The optional whole-plugin telemetry arm is not
+retried and remains outside the baseline-versus-skilled measurement gate.
+
+The retry is limited to three affected eval/variant groups per matrix leg. More
+groups indicate a systemic failure, so the workflow skips recovery and fails
+closed instead of multiplying load. `executor-retry-summary.json` and each
+recovered record's `executorRetry` field retain the attempt evidence.
+
+### 6. Retry only failed comparison-judge slots
 
 The paired identity is `(stimulusName, trialIndex)`. If a comparison judge
 times out or its organization is disabled, the adapter builds a retry report
@@ -203,7 +218,7 @@ The merged report keeps retry diagnostics even when no slot recovers.
 Retry is bounded to one additional attempt. Remaining judge errors make the
 result invalid. They are not counted as skill losses.
 
-### 6. Convert repeated trials into independent stimulus votes
+### 7. Convert repeated trials into independent stimulus votes
 
 Repeated runs answer "does this task behave consistently?" They do not answer
 "does this work on more kinds of tasks?" The adapter therefore gives each
@@ -230,7 +245,7 @@ flowchart LR
 This prevents a four-task eval with three repetitions from pretending to have
 twelve independent test cases.
 
-### 7. Apply the repository decision rule
+### 8. Apply the repository decision rule
 
 For one model and skill's baseline-versus-isolated comparison:
 

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -198,10 +198,12 @@ fields.
 If a required baseline or isolated-skilled trial fails with
 `Timeout after ... waiting for session.idle`, the workflow reruns only that eval
 and variant once. The recovery step merges only successful records with matching
-stable `shardKey` values. It never replaces successful first-attempt records. A
-persistent timeout or a different executor error stays in the original JSONL
-and remains measurement-invalid. The optional whole-plugin telemetry arm is not
-retried and remains outside the baseline-versus-skilled measurement gate.
+stable `shardKey` values after normalizing each eval path. A record without a
+`shardKey` fails closed instead of using another field as an unproven identity.
+The recovery never replaces successful first-attempt records. A persistent
+timeout or a different executor error stays in the original JSONL and remains
+measurement-invalid. The optional whole-plugin telemetry arm is not retried and
+remains outside the baseline-versus-skilled measurement gate.
 
 The retry is limited to three affected eval/variant groups per matrix leg. More
 groups indicate a systemic failure, so the workflow skips recovery and fails

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -208,7 +208,9 @@ remains outside the baseline-versus-skilled measurement gate.
 The retry is limited to three affected eval/variant groups per matrix leg. More
 groups indicate a systemic failure, so the workflow skips recovery and fails
 closed instead of multiplying load. `executor-retry-summary.json` and each
-recovered record's `executorRetry` field retain the attempt evidence.
+recovered record's `executorRetry` field retain the attempt evidence. Recovered
+records keep the original experiment provenance required by `vally compare`;
+the retry run ID is recorded separately as `executorRetry.retryRunId`.
 
 ### 6. Retry only failed comparison-judge slots
 

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -1669,6 +1669,7 @@ export {
   classifyComparisonError,
   mergeComparisonReports,
   loadExpectedEvalFiles,
+  normalizeEvalFile,
   VERDICT_STATES,
   MIN_CREDIBLE_STIMULI,
   MIN_PRACTICAL_NET_WIN,

--- a/eng/vally-adapter/retry-executor-timeouts.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.mjs
@@ -160,8 +160,10 @@ function mergeRetryRecords(originalRecords, retryRecords, evalFile) {
     recovered.push(key);
     return {
       ...replacement,
+      experiment: record.experiment,
       executorRetry: {
         attempt: 2,
+        retryRunId: replacement.experiment?.runId ?? null,
         recoveredFrom: {
           status: record.status,
           error: record.error,

--- a/eng/vally-adapter/retry-executor-timeouts.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+
+/**
+ * Retry transient Vally executor timeouts without rerunning successful slots.
+ *
+ * Vally can rerun one eval and variant, but it cannot resume a partial
+ * experiment. This tool runs that narrow retry and merges only successful
+ * records whose first attempt timed out waiting for session.idle.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+
+import { splitVallyCommand } from "./adapt.mjs";
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const TIMEOUT_PATTERN = /\bTimeout after \d+ms waiting for session\.idle\b/i;
+const REQUIRED_VARIANTS = new Set(["baseline", "skilled"]);
+
+const { values: opts } = parseArgs({
+  args: isMain ? process.argv.slice(2) : [],
+  options: {
+    "experiment-file": { type: "string" },
+    "experiment-dir": { type: "string" },
+    "retry-output-dir": { type: "string" },
+    summary: { type: "string" },
+    vally: { type: "string", default: "npx @microsoft/vally-cli" },
+    workers: { type: "string", default: "5" },
+    "max-groups": { type: "string", default: "3" },
+    help: { type: "boolean", default: false },
+  },
+  strict: true,
+});
+
+if (
+  isMain &&
+  (opts.help ||
+    !opts["experiment-file"] ||
+    !opts["experiment-dir"] ||
+    !opts["retry-output-dir"] ||
+    !opts.summary)
+) {
+  console.log(`Usage:
+  node retry-executor-timeouts.mjs --experiment-file <file> \
+    --experiment-dir <run-dir> --retry-output-dir <dir> --summary <file> [options]
+
+Retries only trial-result records that timed out waiting for session.idle.
+Each affected eval/variant group is rerun once. Successful first-attempt slots
+are never replaced, and unresolved retries remain errors for the adapter gate.
+
+Options:
+  --vally "<cmd>"      Vally CLI invocation (default: npx @microsoft/vally-cli)
+  --workers <n>        Workers for each targeted retry (default: 5)
+  --max-groups <n>     Maximum eval/variant groups to retry (default: 3)
+  --help               Show this help`);
+  process.exit(opts.help ? 0 : 1);
+}
+
+function parseJsonl(content) {
+  return content
+    .trim()
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line));
+}
+
+function loadJsonl(path) {
+  return parseJsonl(readFileSync(path, "utf8"));
+}
+
+function evalFileOf(record) {
+  return record.experiment?.evalFile ?? record.evalFilePath ?? "";
+}
+
+function slotKey(record) {
+  return record.shardKey || record.itemId || "";
+}
+
+function isRetryableTimeout(record) {
+  return (
+    record?.type === "trial-result" &&
+    record.status === "error" &&
+    TIMEOUT_PATTERN.test(record.error ?? "") &&
+    Boolean(evalFileOf(record)) &&
+    Boolean(slotKey(record))
+  );
+}
+
+function findRetryGroups(runDir) {
+  const groups = [];
+  for (const entry of readdirSync(runDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !REQUIRED_VARIANTS.has(entry.name)) continue;
+    const resultsFile = join(runDir, entry.name, "results.jsonl");
+    if (!existsSync(resultsFile)) continue;
+
+    const records = loadJsonl(resultsFile);
+    const evalFiles = new Set(
+      records.filter(isRetryableTimeout).map((record) => evalFileOf(record)),
+    );
+    for (const evalFile of [...evalFiles].sort()) {
+      groups.push({ variant: entry.name, evalFile, resultsFile });
+    }
+  }
+  return groups.sort(
+    (left, right) =>
+      left.variant.localeCompare(right.variant) ||
+      left.evalFile.localeCompare(right.evalFile),
+  );
+}
+
+function countSlotKeys(records, evalFile) {
+  const counts = new Map();
+  for (const record of records) {
+    if (evalFileOf(record) !== evalFile || !slotKey(record)) continue;
+    counts.set(slotKey(record), (counts.get(slotKey(record)) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function mergeRetryRecords(originalRecords, retryRecords, evalFile) {
+  const originalCounts = countSlotKeys(originalRecords, evalFile);
+  const retryCounts = countSlotKeys(retryRecords, evalFile);
+  const successfulRetries = new Map();
+  for (const record of retryRecords) {
+    const key = slotKey(record);
+    if (
+      record?.type === "trial-result" &&
+      record.status === "success" &&
+      evalFileOf(record) === evalFile &&
+      retryCounts.get(key) === 1
+    ) {
+      successfulRetries.set(key, record);
+    }
+  }
+  const recovered = [];
+  const records = originalRecords.map((record) => {
+    const key = slotKey(record);
+    if (
+      !isRetryableTimeout(record) ||
+      evalFileOf(record) !== evalFile ||
+      originalCounts.get(key) !== 1
+    ) {
+      return record;
+    }
+    const replacement = successfulRetries.get(key);
+    if (!replacement) return record;
+
+    recovered.push(key);
+    return {
+      ...replacement,
+      executorRetry: {
+        attempt: 2,
+        recoveredFrom: {
+          status: record.status,
+          error: record.error,
+          durationMs: record.durationMs,
+        },
+      },
+    };
+  });
+  return { records, recovered };
+}
+
+function newestDirectory(root) {
+  if (!existsSync(root)) return null;
+  const directories = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const path = join(root, entry.name);
+      return { path, mtimeMs: statSync(path).mtimeMs };
+    })
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+  return directories[0]?.path ?? null;
+}
+
+function runRetry(group, index, config) {
+  const attemptRoot = join(
+    config.retryOutputDir,
+    `${index + 1}-${group.variant}-${basename(group.evalFile, ".yaml")}`,
+  );
+  mkdirSync(attemptRoot, { recursive: true });
+
+  const { bin, prefix } = splitVallyCommand(config.vally);
+  const args = [
+    ...prefix,
+    "experiment",
+    "run",
+    config.experimentFile,
+    "--variant",
+    group.variant,
+    "--eval-filter",
+    group.evalFile,
+    "--output-dir",
+    attemptRoot,
+    "--workers",
+    String(config.workers),
+  ];
+
+  let exitCode = 0;
+  try {
+    execFileSync(bin, args, { stdio: "inherit" });
+  } catch (error) {
+    exitCode = Number.isInteger(error?.status) ? error.status : 1;
+    console.warn(
+      `Executor retry for ${group.variant}/${group.evalFile} exited ${exitCode}; ` +
+        "completed retry records will still be inspected.",
+    );
+  }
+
+  const retryRunDir = newestDirectory(attemptRoot);
+  const retryResultsFile = retryRunDir
+    ? join(retryRunDir, group.variant, "results.jsonl")
+    : "";
+  const retryRecords = existsSync(retryResultsFile) ? loadJsonl(retryResultsFile) : [];
+  const originalRecords = loadJsonl(group.resultsFile);
+  const timeoutSlots = originalRecords
+    .filter(
+      (record) =>
+        isRetryableTimeout(record) && evalFileOf(record) === group.evalFile,
+    )
+    .map(slotKey);
+  const { records, recovered } = mergeRetryRecords(
+    originalRecords,
+    retryRecords,
+    group.evalFile,
+  );
+  const mergedFile = `${group.resultsFile}.${process.pid}.tmp`;
+  writeFileSync(mergedFile, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  renameSync(mergedFile, group.resultsFile);
+
+  return {
+    variant: group.variant,
+    evalFile: group.evalFile,
+    attemptedSlots: timeoutSlots,
+    recoveredSlots: recovered,
+    unresolvedSlots: timeoutSlots.filter((key) => !recovered.includes(key)),
+    retryExitCode: exitCode,
+  };
+}
+
+function retryExecutorTimeouts(config) {
+  const groups = findRetryGroups(config.experimentDir);
+  const plannedSlotCount = groups.reduce(
+    (count, group) =>
+      count +
+      loadJsonl(group.resultsFile).filter(
+        (record) =>
+          isRetryableTimeout(record) && evalFileOf(record) === group.evalFile,
+      ).length,
+    0,
+  );
+  const summary = {
+    schemaVersion: 1,
+    maxGroups: config.maxGroups,
+    plannedGroupCount: groups.length,
+    plannedSlotCount,
+    attemptedGroupCount: 0,
+    recoveredSlotCount: 0,
+    unresolvedSlotCount: 0,
+    skippedReason: null,
+    attempts: [],
+  };
+
+  if (groups.length > config.maxGroups) {
+    summary.unresolvedSlotCount = plannedSlotCount;
+    summary.skippedReason =
+      `Found ${groups.length} timeout groups, above the recovery limit of ` +
+      `${config.maxGroups}; treating this as a systemic failure.`;
+    console.warn(summary.skippedReason);
+  } else {
+    for (const [index, group] of groups.entries()) {
+      console.log(
+        `Retrying transient executor timeout for ${group.variant}/${group.evalFile}`,
+      );
+      const attempt = runRetry(group, index, config);
+      summary.attempts.push(attempt);
+      summary.attemptedGroupCount++;
+      summary.recoveredSlotCount += attempt.recoveredSlots.length;
+      summary.unresolvedSlotCount += attempt.unresolvedSlots.length;
+    }
+  }
+
+  mkdirSync(dirname(config.summary), { recursive: true });
+  writeFileSync(config.summary, `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(
+    `Executor timeout recovery: ${summary.recoveredSlotCount} recovered, ` +
+      `${summary.unresolvedSlotCount} unresolved`,
+  );
+  return summary;
+}
+
+if (isMain) {
+  try {
+    const workers = Number(opts.workers);
+    const maxGroups = Number(opts["max-groups"]);
+    if (!Number.isInteger(workers) || workers < 1) {
+      throw new Error("--workers must be a positive integer");
+    }
+    if (!Number.isInteger(maxGroups) || maxGroups < 1) {
+      throw new Error("--max-groups must be a positive integer");
+    }
+    retryExecutorTimeouts({
+      experimentFile: resolve(opts["experiment-file"]),
+      experimentDir: resolve(opts["experiment-dir"]),
+      retryOutputDir: resolve(opts["retry-output-dir"]),
+      summary: resolve(opts.summary),
+      vally: opts.vally,
+      workers,
+      maxGroups,
+    });
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+export {
+  findRetryGroups,
+  isRetryableTimeout,
+  mergeRetryRecords,
+  retryExecutorTimeouts,
+};

--- a/eng/vally-adapter/retry-executor-timeouts.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.mjs
@@ -160,7 +160,8 @@ function mergeRetryRecords(originalRecords, retryRecords, evalFile) {
     recovered.push(key);
     return {
       ...replacement,
-      experiment: record.experiment,
+      experiment: record.experiment ?? replacement.experiment,
+      evalFilePath: record.evalFilePath ?? replacement.evalFilePath,
       executorRetry: {
         attempt: 2,
         retryRunId: replacement.experiment?.runId ?? null,

--- a/eng/vally-adapter/retry-executor-timeouts.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.mjs
@@ -22,7 +22,7 @@ import { execFileSync } from "node:child_process";
 import { parseArgs } from "node:util";
 import { pathToFileURL } from "node:url";
 
-import { splitVallyCommand } from "./adapt.mjs";
+import { normalizeEvalFile, splitVallyCommand } from "./adapt.mjs";
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 const TIMEOUT_PATTERN = /\bTimeout after \d+ms waiting for session\.idle\b/i;
@@ -80,11 +80,11 @@ function loadJsonl(path) {
 }
 
 function evalFileOf(record) {
-  return record.experiment?.evalFile ?? record.evalFilePath ?? "";
+  return normalizeEvalFile(record.experiment?.evalFile ?? record.evalFilePath ?? "");
 }
 
 function slotKey(record) {
-  return record.shardKey || record.itemId || "";
+  return record.shardKey || "";
 }
 
 function isRetryableTimeout(record) {
@@ -129,15 +129,16 @@ function countSlotKeys(records, evalFile) {
 }
 
 function mergeRetryRecords(originalRecords, retryRecords, evalFile) {
-  const originalCounts = countSlotKeys(originalRecords, evalFile);
-  const retryCounts = countSlotKeys(retryRecords, evalFile);
+  const normalizedEvalFile = normalizeEvalFile(evalFile);
+  const originalCounts = countSlotKeys(originalRecords, normalizedEvalFile);
+  const retryCounts = countSlotKeys(retryRecords, normalizedEvalFile);
   const successfulRetries = new Map();
   for (const record of retryRecords) {
     const key = slotKey(record);
     if (
       record?.type === "trial-result" &&
       record.status === "success" &&
-      evalFileOf(record) === evalFile &&
+      evalFileOf(record) === normalizedEvalFile &&
       retryCounts.get(key) === 1
     ) {
       successfulRetries.set(key, record);
@@ -148,7 +149,7 @@ function mergeRetryRecords(originalRecords, retryRecords, evalFile) {
     const key = slotKey(record);
     if (
       !isRetryableTimeout(record) ||
-      evalFileOf(record) !== evalFile ||
+      evalFileOf(record) !== normalizedEvalFile ||
       originalCounts.get(key) !== 1
     ) {
       return record;

--- a/eng/vally-adapter/retry-executor-timeouts.test.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  findRetryGroups,
+  isRetryableTimeout,
+  mergeRetryRecords,
+} from "./retry-executor-timeouts.mjs";
+
+const evalFile = "tests/dotnet-diag/android-tombstone-symbolication/eval.yaml";
+const retryScript = fileURLToPath(
+  new URL("./retry-executor-timeouts.mjs", import.meta.url),
+);
+
+function record({
+  status = "success",
+  error,
+  shardKey = "slot-1",
+  variant = "skilled",
+  stimulus = "Scenario",
+} = {}) {
+  return {
+    type: "trial-result",
+    shardKey,
+    variant,
+    stimulus,
+    status,
+    error,
+    durationMs: 42,
+    experiment: { evalFile },
+  };
+}
+
+function writeJsonl(path, records) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${records.map((item) => JSON.stringify(item)).join("\n")}\n`);
+}
+
+test("classifies only session.idle executor timeouts as retryable", () => {
+  assert.equal(
+    isRetryableTimeout(
+      record({
+        status: "error",
+        error: "Trial failed: Timeout after 300000ms waiting for session.idle",
+      }),
+    ),
+    true,
+  );
+  assert.equal(
+    isRetryableTimeout(record({ status: "error", error: "401 Unauthorized" })),
+    false,
+  );
+  assert.equal(
+    isRetryableTimeout(
+      record({
+        status: "error",
+        error: "Timeout after 300000ms waiting for session.idle",
+        shardKey: "",
+      }),
+    ),
+    false,
+  );
+});
+
+test("discovers one retry group per affected eval and variant", () => {
+  const root = mkdtempSync(join(tmpdir(), "vally-retry-plan-"));
+  try {
+    writeJsonl(join(root, "skilled", "results.jsonl"), [
+      record({ shardKey: "success" }),
+      record({
+        status: "error",
+        error: "Timeout after 180000ms waiting for session.idle",
+        shardKey: "timeout",
+      }),
+      record({
+        status: "error",
+        error: "Model unavailable",
+        shardKey: "permanent",
+      }),
+    ]);
+    writeJsonl(join(root, "baseline", "results.jsonl"), [record({ variant: "baseline" })]);
+    writeJsonl(join(root, "plugin", "results.jsonl"), [
+      record({
+        variant: "plugin",
+        status: "error",
+        error: "Timeout after 180000ms waiting for session.idle",
+        shardKey: "plugin-timeout",
+      }),
+    ]);
+
+    assert.deepEqual(
+      findRetryGroups(root).map(({ variant, evalFile: file }) => ({ variant, evalFile: file })),
+      [{ variant: "skilled", evalFile }],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("replaces only matching timeout slots with successful retry records", () => {
+  const firstSuccess = record({ shardKey: "success", stimulus: "Keep me" });
+  const timeout = record({
+    status: "error",
+    error: "Timeout after 180000ms waiting for session.idle",
+    shardKey: "timeout",
+    stimulus: "Retry me",
+  });
+  const permanent = record({
+    status: "error",
+    error: "Model unavailable",
+    shardKey: "permanent",
+  });
+  const retryRecords = [
+    record({ shardKey: "success", stimulus: "Changed by retry" }),
+    record({ shardKey: "timeout", stimulus: "Retry me" }),
+    record({ shardKey: "unexpected" }),
+  ];
+
+  const { records, recovered } = mergeRetryRecords(
+    [firstSuccess, timeout, permanent],
+    retryRecords,
+    evalFile,
+  );
+
+  assert.deepEqual(recovered, ["timeout"]);
+  assert.strictEqual(records[0], firstSuccess);
+  assert.equal(records[1].status, "success");
+  assert.equal(records[1].executorRetry.attempt, 2);
+  assert.equal(
+    records[1].executorRetry.recoveredFrom.error,
+    "Timeout after 180000ms waiting for session.idle",
+  );
+  assert.strictEqual(records[2], permanent);
+});
+
+test("keeps an original timeout when its retry does not succeed", () => {
+  const timeout = record({
+    status: "error",
+    error: "Timeout after 180000ms waiting for session.idle",
+    shardKey: "timeout",
+  });
+  const retryError = record({
+    status: "error",
+    error: "Timeout after 180000ms waiting for session.idle",
+    shardKey: "timeout",
+  });
+
+  const { records, recovered } = mergeRetryRecords(
+    [timeout],
+    [retryError],
+    evalFile,
+  );
+  assert.deepEqual(recovered, []);
+  assert.strictEqual(records[0], timeout);
+});
+
+test("never replaces a timeout from another eval with the same slot key", () => {
+  const otherEval = "tests/dotnet-diag/apple-crash-symbolication/eval.yaml";
+  const timeoutFor = (file) => ({
+    ...record({
+      status: "error",
+      error: "Timeout after 180000ms waiting for session.idle",
+      shardKey: "shared-slot",
+    }),
+    experiment: { evalFile: file },
+  });
+  const retrySuccess = record({ shardKey: "shared-slot" });
+
+  const originals = [timeoutFor(evalFile), timeoutFor(otherEval)];
+  const { records, recovered } = mergeRetryRecords(
+    originals,
+    [retrySuccess],
+    evalFile,
+  );
+
+  assert.deepEqual(recovered, ["shared-slot"]);
+  assert.equal(records[0].status, "success");
+  assert.strictEqual(records[1], originals[1]);
+  assert.equal(records[1].experiment.evalFile, otherEval);
+});
+
+test("keeps ambiguous duplicate slots unresolved", () => {
+  const timeout = record({
+    status: "error",
+    error: "Timeout after 180000ms waiting for session.idle",
+    shardKey: "duplicate",
+  });
+  const retrySuccess = record({ shardKey: "duplicate" });
+
+  const originalDuplicate = mergeRetryRecords(
+    [timeout, { ...timeout }],
+    [retrySuccess],
+    evalFile,
+  );
+  assert.deepEqual(originalDuplicate.recovered, []);
+  assert.strictEqual(originalDuplicate.records[0], timeout);
+
+  const retryDuplicate = mergeRetryRecords(
+    [timeout],
+    [retrySuccess, { ...retrySuccess }],
+    evalFile,
+  );
+  assert.deepEqual(retryDuplicate.recovered, []);
+  assert.strictEqual(retryDuplicate.records[0], timeout);
+});
+
+test("CLI reruns one affected eval and merges only its recovered slot", () => {
+  const root = mkdtempSync(join(tmpdir(), "vally-retry-cli-"));
+  try {
+    const runDir = join(root, "run");
+    const retryRoot = join(root, "retry");
+    const summaryPath = join(root, "executor-retry-summary.json");
+    const resultsFile = join(runDir, "skilled", "results.jsonl");
+    const firstSuccess = record({ shardKey: "success", stimulus: "Keep me" });
+    const timeout = record({
+      status: "error",
+      error: "Timeout after 180000ms waiting for session.idle",
+      shardKey: "timeout",
+      stimulus: "Retry me",
+    });
+    writeJsonl(resultsFile, [firstSuccess, timeout]);
+
+    const fakeVally = join(root, "fake-vally.mjs");
+    writeFileSync(
+      fakeVally,
+      `import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+const args = process.argv.slice(2);
+if (args[0] !== "experiment" || args[1] !== "run") process.exit(2);
+const value = (name) => args[args.indexOf(name) + 1];
+const variant = value("--variant");
+const output = join(value("--output-dir"), "retry-run", variant, "results.jsonl");
+mkdirSync(join(value("--output-dir"), "retry-run", variant), { recursive: true });
+const evalFile = value("--eval-filter");
+const records = [
+  ${JSON.stringify(record({ shardKey: "success", stimulus: "Changed by retry" }))},
+  ${JSON.stringify(record({ shardKey: "timeout", stimulus: "Retry me" }))}
+].map((record) => ({ ...record, experiment: { evalFile } }));
+writeFileSync(output, records.map(JSON.stringify).join("\\n") + "\\n");
+`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        retryScript,
+        "--experiment-file",
+        join(root, "experiment.yaml"),
+        "--experiment-dir",
+        runDir,
+        "--retry-output-dir",
+        retryRoot,
+        "--summary",
+        summaryPath,
+        "--vally",
+        `"${process.execPath}" "${fakeVally}"`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const merged = readFileSync(resultsFile, "utf8")
+      .trim()
+      .split("\n")
+      .map(JSON.parse);
+    assert.equal(merged[0].stimulus, "Keep me");
+    assert.equal(merged[1].status, "success");
+    assert.equal(merged[1].executorRetry.attempt, 2);
+    const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+    assert.equal(summary.attemptedGroupCount, 1);
+    assert.equal(summary.recoveredSlotCount, 1);
+    assert.equal(summary.unresolvedSlotCount, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/eng/vally-adapter/retry-executor-timeouts.test.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.test.mjs
@@ -216,6 +216,30 @@ test("preserves original experiment provenance when a retry succeeds", () => {
   assert.equal(records[0].executorRetry.retryRunId, "retry-run");
 });
 
+test("falls back to retry provenance for legacy evalFilePath records", () => {
+  const timeout = {
+    ...record({
+      status: "error",
+      error: "Timeout after 180000ms waiting for session.idle",
+      shardKey: "timeout",
+    }),
+    evalFilePath: `./${evalFile}`,
+  };
+  delete timeout.experiment;
+  const retrySuccess = record({ shardKey: "timeout", runId: "retry-run" });
+
+  const { records, recovered } = mergeRetryRecords(
+    [timeout],
+    [retrySuccess],
+    evalFile,
+  );
+
+  assert.deepEqual(recovered, ["timeout"]);
+  assert.equal(records[0].experiment.runId, "retry-run");
+  assert.equal(records[0].evalFilePath, `./${evalFile}`);
+  assert.equal(records[0].executorRetry.retryRunId, "retry-run");
+});
+
 test("keeps an original timeout when its retry does not succeed", () => {
   const timeout = record({
     status: "error",

--- a/eng/vally-adapter/retry-executor-timeouts.test.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.test.mjs
@@ -29,6 +29,7 @@ function record({
   shardKey = "slot-1",
   variant = "skilled",
   stimulus = "Scenario",
+  runId = "original-run",
 } = {}) {
   return {
     type: "trial-result",
@@ -38,7 +39,7 @@ function record({
     status,
     error,
     durationMs: 42,
-    experiment: { evalFile },
+    experiment: { evalFile, runId },
   };
 }
 
@@ -193,6 +194,28 @@ test("replaces only matching timeout slots with successful retry records", () =>
   assert.strictEqual(records[2], permanent);
 });
 
+test("preserves original experiment provenance when a retry succeeds", () => {
+  const timeout = record({
+    status: "error",
+    error: "Timeout after 180000ms waiting for session.idle",
+    shardKey: "timeout",
+    runId: "original-run",
+  });
+  timeout.experiment.name = "original-experiment";
+  const retrySuccess = record({ shardKey: "timeout", runId: "retry-run" });
+  retrySuccess.experiment.name = "retry-experiment";
+
+  const { records, recovered } = mergeRetryRecords(
+    [timeout],
+    [retrySuccess],
+    evalFile,
+  );
+
+  assert.deepEqual(recovered, ["timeout"]);
+  assert.deepEqual(records[0].experiment, timeout.experiment);
+  assert.equal(records[0].executorRetry.retryRunId, "retry-run");
+});
+
 test("keeps an original timeout when its retry does not succeed", () => {
   const timeout = record({
     status: "error",
@@ -318,7 +341,7 @@ const evalFile = value("--eval-filter");
 const records = [
   ${JSON.stringify(record({ shardKey: "success", stimulus: "Changed by retry" }))},
   ${JSON.stringify(record({ shardKey: "timeout", stimulus: "Retry me" }))}
-].map((record) => ({ ...record, experiment: { evalFile } }));
+].map((record) => ({ ...record, experiment: { evalFile, runId: "retry-run" } }));
 writeFileSync(output, records.map(JSON.stringify).join("\\n") + "\\n");
 `,
     );
@@ -348,7 +371,9 @@ writeFileSync(output, records.map(JSON.stringify).join("\\n") + "\\n");
       .map(JSON.parse);
     assert.equal(merged[0].stimulus, "Keep me");
     assert.equal(merged[1].status, "success");
+    assert.equal(merged[1].experiment.runId, "original-run");
     assert.equal(merged[1].executorRetry.attempt, 2);
+    assert.equal(merged[1].executorRetry.retryRunId, "retry-run");
     const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
     assert.equal(summary.attemptedGroupCount, 1);
     assert.equal(summary.recoveredSlotCount, 1);

--- a/eng/vally-adapter/retry-executor-timeouts.test.mjs
+++ b/eng/vally-adapter/retry-executor-timeouts.test.mjs
@@ -71,6 +71,17 @@ test("classifies only session.idle executor timeouts as retryable", () => {
     ),
     false,
   );
+  assert.equal(
+    isRetryableTimeout({
+      ...record({
+        status: "error",
+        error: "Timeout after 300000ms waiting for session.idle",
+        shardKey: "",
+      }),
+      itemId: "unstable-fallback",
+    }),
+    false,
+  );
 });
 
 test("discovers one retry group per affected eval and variant", () => {
@@ -103,6 +114,44 @@ test("discovers one retry group per affected eval and variant", () => {
       findRetryGroups(root).map(({ variant, evalFile: file }) => ({ variant, evalFile: file })),
       [{ variant: "skilled", evalFile }],
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("normalizes eval paths before grouping and merging retry records", () => {
+  const windowsPath = ".\\tests\\dotnet-diag\\android-tombstone-symbolication\\eval.yaml";
+  const timeout = {
+    ...record({
+      status: "error",
+      error: "Timeout after 180000ms waiting for session.idle",
+      shardKey: "timeout",
+    }),
+    experiment: { evalFile: windowsPath },
+  };
+  const retrySuccess = {
+    ...record({ shardKey: "timeout" }),
+    experiment: { evalFile: `./${evalFile}` },
+  };
+  const root = mkdtempSync(join(tmpdir(), "vally-retry-normalize-"));
+
+  try {
+    writeJsonl(join(root, "skilled", "results.jsonl"), [timeout]);
+    assert.deepEqual(
+      findRetryGroups(root).map(({ variant, evalFile: file }) => ({
+        variant,
+        evalFile: file,
+      })),
+      [{ variant: "skilled", evalFile }],
+    );
+
+    const { records, recovered } = mergeRetryRecords(
+      [timeout],
+      [retrySuccess],
+      `./${evalFile}`,
+    );
+    assert.deepEqual(recovered, ["timeout"]);
+    assert.equal(records[0].status, "success");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -159,6 +208,29 @@ test("keeps an original timeout when its retry does not succeed", () => {
   const { records, recovered } = mergeRetryRecords(
     [timeout],
     [retryError],
+    evalFile,
+  );
+  assert.deepEqual(recovered, []);
+  assert.strictEqual(records[0], timeout);
+});
+
+test("does not use itemId when a retry record has no shardKey", () => {
+  const timeout = {
+    ...record({
+      status: "error",
+      error: "Timeout after 180000ms waiting for session.idle",
+      shardKey: "timeout",
+    }),
+    itemId: "shared-item",
+  };
+  const retrySuccess = {
+    ...record({ shardKey: "" }),
+    itemId: "shared-item",
+  };
+
+  const { records, recovered } = mergeRetryRecords(
+    [timeout],
+    [retrySuccess],
     evalFile,
   );
   assert.deepEqual(recovered, []);

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -1,18 +1,12 @@
 ---
 name: test-tagging
 description: >
-  Classifies existing tests in any language with standardized traits (positive,
-  negative, boundary, critical-path, smoke, regression, integration,
-  performance, security) and reports their distribution. MUST USE to
-  categorize/tag/label tests, compare happy vs error paths, audit the test mix,
-  or describe "coverage shape" by test category/type, not executed lines/branches.
-  Read bodies when names mislead. Auto-edit canonical attributes; for frameworks
-  with neither canonical syntax nor a confirmed convention, report only and do
-  not edit. DO NOT USE FOR: quality/smell audits (test-anti-patterns);
-  diagnostic .NET line/branch/Cobertura analysis or project-wide CRAP
-  (coverage-analysis); raw coverage collection (run-tests for .NET, native
-  tooling otherwise); named-target CRAP (crap-score); behavioral gaps
-  (test-gap-analysis); writing tests; or migration.
+  Classifies existing tests by standard traits and reports their distribution.
+  MUST USE to categorize/tag/label tests, compare happy vs error paths, audit
+  the test mix, or describe coverage shape by test type. Read bodies when names
+  mislead. Apply canonical attributes; otherwise report only. DO NOT USE for
+  test-quality audits, executed coverage or CRAP, behavioral gaps, writing
+  tests, or migration.
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary

- reduce the `dotnet-test` rendered skill-menu footprint from 15,063 to 14,598 characters by tightening only the `test-tagging` routing description
- retry transient `session.idle` executor timeouts once for required baseline and isolated-skilled arms
- preserve all successful first-attempt evidence and merge only unique, eval-scoped retry records with matching stable `shardKey` values
- retain the existing fail-closed `measurementInvalidEvalCount === 0` gate for persistent, systemic, non-timeout, missing, duplicate, or ambiguous comparison evidence

## Root causes

PR #1051 expanded several routing descriptions and moved `dotnet-test` from 14,421 rendered characters to 15,063, above the unchanged Copilot runtime limit of 15,000. PR #1059 did not cause that regression.

In full-corpus runs 32989467349 and 32992064149, every expected result file was written, but one required skilled-arm trial timed out waiting for `session.idle`. The paired baseline record then had no treatment match, so the adapter correctly classified the eval as `unmatched_trajectories` and measurement-invalid. Exact-commit retries moved the timeout to a different plugin/model job, which showed a transient executor failure rather than dashboard or corpus accounting failure.

## Stability behavior

Recovery is narrow and bounded:

- only baseline and isolated-skilled `session.idle` timeout records qualify
- each affected eval/variant group is rerun once, with at most three groups per matrix leg
- successful first-attempt records are never replaced
- retry pairing requires a unique `evalFile` and `shardKey` on both attempts
- merged JSONL is replaced atomically
- retry watchdog or command failure falls through to adaptation, where unresolved evidence still fails closed
- the optional whole-plugin telemetry arm remains report-only and is not retried

## Validation

- full `skill-validator check`: 98 skills, 16 agents, 16 plugins passed
- `dotnet-test` validator check passed at 14,598 / 15,000 rendered characters
- 57 Vally adapter and fault-injection tests passed
- 19 evaluation workflow behavior tests passed
- pinned actionlint 1.7.7 passed for `.github/workflows/evaluation-run.yml`
- multi-model review completed with Claude, Gemini, GPT, and Grok reviewers; findings were reconciled and no blockers remain