### PR TITLE
Clarify injected dependency scan exclusions

### DIFF
--- a/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
+++ b/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
@@ -61,6 +61,12 @@ Always exclude `obj/`, `bin/`, and any user-specified exclusion patterns.
 
 Scan each file for calls matching these categories:
 
+Treat pattern matches as candidates, not findings. Before counting an instance call, trace how its
+receiver enters the class. A collaborator supplied through a constructor, parameter, property, or
+DI is already a test seam. In particular, an injected `HttpClient` is testable with a controlled
+`HttpMessageHandler`; do not count its calls or recommend replacing it merely because the injected
+type is concrete.
+
 | Category | Patterns to search for | Recommended replacement |
 |----------|----------------------|------------------------|
 | **Time** | `DateTime.Now`, `DateTime.UtcNow`, `DateTime.Today`, `DateTimeOffset.Now`, `DateTimeOffset.UtcNow`, `Task.Delay(`, `new CancellationTokenSource(TimeSpan` | `TimeProvider` (.NET 8+) |
@@ -68,7 +74,7 @@ Scan each file for calls matching these categories:
 | **Randomness / identity** | `new Random(`, `Random.Shared`, `Guid.NewGuid(` | `TimeProvider`-style seam: inject `Random` / an `IGuidProvider` |
 | **Culture / serialization** | `CultureInfo.CurrentCulture`, `CultureInfo.CurrentUICulture`, `JsonSerializer.Serialize(`, `JsonSerializer.Deserialize(` | Pass culture/options explicitly, or inject a serializer abstraction |
 | **Environment** | `Environment.GetEnvironmentVariable(`, `Environment.SetEnvironmentVariable(`, `Environment.MachineName`, `Environment.UserName`, `Environment.CurrentDirectory`, `Environment.Exit(` | Custom `IEnvironmentProvider` |
-| **Network** | `new HttpClient(`, `HttpClient.GetAsync(`, `HttpClient.PostAsync(`, `HttpClient.SendAsync(` | `IHttpClientFactory` (built-in) |
+| **Network** | `new HttpClient(` and `GetAsync` / `PostAsync` / `SendAsync` on clients created or acquired inside the code under test; exclude calls on injected clients | Inject `HttpClient` (commonly supplied by `IHttpClientFactory`) |
 | **Console** | `Console.WriteLine(`, `Console.ReadLine(`, `Console.Write(`, `Console.ReadKey(` | `IConsole` wrapper or `ILogger` |
 | **Process** | `Process.Start(`, `Process.GetCurrentProcess(`, `Process.GetProcessesByName(` | Custom `IProcessRunner` |
 
@@ -80,6 +86,7 @@ Count each call site across the entire scan scope — including the instance-mem
 
 - **One authoritative total.** Every call site you found belongs in the category summary and the grand total. Never park real findings in an "additional observations" section that the totals exclude.
 - **Classify by what the member touches, not by whether it is `static`.** Instance members that reach the same untestable resource still count and belong in the matching category (`new FileInfo(path).LastWriteTimeUtc` → File System; `httpClient.GetAsync(...)` → Network). Say "hidden dependency", not "static", when the member is an instance call.
+- **Check receiver provenance before counting instance calls.** Count a resource access only when the code under test acquires or constructs the dependency itself. Exclude constructor-, parameter-, property-, and DI-injected collaborators from the "needs wrapping" total, including concrete `HttpClient` instances.
 - **Exclude deterministic pure helpers from the "needs wrapping" total.** `Path.Combine`, `Path.GetExtension`, `Path.GetFileName`, and `Math.*`/`string.*` statics take no ambient input and are trivially testable. List them, if at all, in a separate "no action needed" note — never as testability blockers.
 - **Cover every category before reporting** — time, file system, environment, network, console, process, randomness (`new Random()`, `Guid.NewGuid()`), culture (`CultureInfo.CurrentCulture`), and serialization/statics such as `JsonSerializer`. Omitting a category that is present is an under-count.
 - **Give `file:line` for every occurrence** so the user can jump straight to it.
@@ -149,6 +156,7 @@ Mention `generate-testability-wrappers` or `migrate-static-to-wrapper` only when
 - [ ] Category totals, top patterns, and per-file counts reconcile to the same grand total
 - [ ] Every occurrence carries a `file:line` location
 - [ ] No findings are held outside the totals in an "additional" section
+- [ ] Calls on injected collaborators are excluded from the "needs wrapping" total
 - [ ] Deterministic pure helpers (`Path.Combine`, `Math.*`) are not counted as testability blockers
 - [ ] Each detected pattern has a recommended replacement listed
 - [ ] `obj/` and `bin/` directories were excluded
@@ -159,7 +167,7 @@ Mention `generate-testability-wrappers` or `migrate-static-to-wrapper` only when
 | Pitfall | Solution |
 |---------|----------|
 | Scanning `obj/` or generated code | Always exclude `obj/`, `bin/`, and `*.Designer.cs` |
-| Counting wrapped calls as statics | Check if the call is behind an interface or injected service before counting |
+| Counting calls on injected collaborators | Trace the receiver: an injected `HttpClient`, `TimeProvider`, interface, or other caller-supplied dependency already has a seam and needs no replacement |
 | Missing statics inside lambdas/LINQ | Search covers all code within `.cs` files, including lambdas |
 | Recommending `TimeProvider` on < .NET 8 | Check `TargetFramework` in `.csproj` — if < net8.0, recommend `NodaTime.IClock` or custom `ISystemClock` |
 | Ignoring test projects | Only scan production code — exclude `*.Tests.csproj` projects from the scan |

--- a/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
+++ b/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
@@ -63,9 +63,9 @@ Scan each file for calls matching these categories:
 
 Treat pattern matches as candidates, not findings. Before counting an instance call, trace how its
 receiver enters the class. A collaborator supplied through a constructor, parameter, property, or
-DI is already a test seam. In particular, an injected `HttpClient` is testable with a controlled
-`HttpMessageHandler`; do not count its calls or recommend replacing it merely because the injected
-type is concrete.
+dependency injection (DI) is already a test seam. In particular, an injected `HttpClient` is
+testable with a controlled `HttpMessageHandler`; do not count its calls or recommend replacing it
+merely because the injected type is concrete.
 
 | Category | Patterns to search for | Recommended replacement |
 |----------|----------------------|------------------------|
@@ -74,7 +74,7 @@ type is concrete.
 | **Randomness / identity** | `new Random(`, `Random.Shared`, `Guid.NewGuid(` | `TimeProvider`-style seam: inject `Random` / an `IGuidProvider` |
 | **Culture / serialization** | `CultureInfo.CurrentCulture`, `CultureInfo.CurrentUICulture`, `JsonSerializer.Serialize(`, `JsonSerializer.Deserialize(` | Pass culture/options explicitly, or inject a serializer abstraction |
 | **Environment** | `Environment.GetEnvironmentVariable(`, `Environment.SetEnvironmentVariable(`, `Environment.MachineName`, `Environment.UserName`, `Environment.CurrentDirectory`, `Environment.Exit(` | Custom `IEnvironmentProvider` |
-| **Network** | `new HttpClient(` and `GetAsync` / `PostAsync` / `SendAsync` on clients created or acquired inside the code under test; exclude calls on injected clients | Inject `HttpClient` (commonly supplied by `IHttpClientFactory`) |
+| **Network** | `new HttpClient(`, `.GetAsync(`, `.PostAsync(`, `.SendAsync(` (exclude calls whose receiver is injected or produced by an injected factory) | Inject `HttpClient` (commonly supplied by `IHttpClientFactory`) |
 | **Console** | `Console.WriteLine(`, `Console.ReadLine(`, `Console.Write(`, `Console.ReadKey(` | `IConsole` wrapper or `ILogger` |
 | **Process** | `Process.Start(`, `Process.GetCurrentProcess(`, `Process.GetProcessesByName(` | Custom `IProcessRunner` |
 
@@ -85,7 +85,7 @@ Count each call site across the entire scan scope — including the instance-mem
 **Counting rules — inaccurate totals are the main way this report loses to an ad-hoc scan:**
 
 - **One authoritative total.** Every call site you found belongs in the category summary and the grand total. Never park real findings in an "additional observations" section that the totals exclude.
-- **Classify by what the member touches, not by whether it is `static`.** Instance members that reach the same untestable resource still count and belong in the matching category (`new FileInfo(path).LastWriteTimeUtc` → File System; `httpClient.GetAsync(...)` → Network). Say "hidden dependency", not "static", when the member is an instance call.
+- **Classify by what the member touches, not by whether it is `static`.** Instance members that reach the same untestable resource still count and belong in the matching category (`new FileInfo(path).LastWriteTimeUtc` → File System; `new HttpClient().GetAsync(...)` → Network). Say "hidden dependency", not "static", when the member is an instance call.
 - **Check receiver provenance before counting instance calls.** Count a resource access only when the code under test acquires or constructs the dependency itself. Exclude constructor-, parameter-, property-, and DI-injected collaborators from the "needs wrapping" total, including concrete `HttpClient` instances.
 - **Exclude deterministic pure helpers from the "needs wrapping" total.** `Path.Combine`, `Path.GetExtension`, `Path.GetFileName`, and `Math.*`/`string.*` statics take no ambient input and are trivially testable. List them, if at all, in a separate "no action needed" note — never as testability blockers.
 - **Cover every category before reporting** — time, file system, environment, network, console, process, randomness (`new Random()`, `Guid.NewGuid()`), culture (`CultureInfo.CurrentCulture`), and serialization/statics such as `JsonSerializer`. Omitting a category that is present is an under-count.

--- a/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
+++ b/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md
@@ -74,7 +74,7 @@ merely because the injected type is concrete.
 | **Randomness / identity** | `new Random(`, `Random.Shared`, `Guid.NewGuid(` | `TimeProvider`-style seam: inject `Random` / an `IGuidProvider` |
 | **Culture / serialization** | `CultureInfo.CurrentCulture`, `CultureInfo.CurrentUICulture`, `JsonSerializer.Serialize(`, `JsonSerializer.Deserialize(` | Pass culture/options explicitly, or inject a serializer abstraction |
 | **Environment** | `Environment.GetEnvironmentVariable(`, `Environment.SetEnvironmentVariable(`, `Environment.MachineName`, `Environment.UserName`, `Environment.CurrentDirectory`, `Environment.Exit(` | Custom `IEnvironmentProvider` |
-| **Network** | `new HttpClient(`, `.GetAsync(`, `.PostAsync(`, `.SendAsync(` (exclude calls whose receiver is injected or produced by an injected factory) | Inject `HttpClient` (commonly supplied by `IHttpClientFactory`) |
+| **Network** | `new HttpClient(`, `.GetAsync(`, `.PostAsync(`, `.SendAsync(` (confirm the receiver is an `HttpClient`; exclude calls whose receiver is injected or produced by an injected factory) | Inject `HttpClient` (commonly supplied by `IHttpClientFactory`) |
 | **Console** | `Console.WriteLine(`, `Console.ReadLine(`, `Console.Write(`, `Console.ReadKey(` | `IConsole` wrapper or `ILogger` |
 | **Process** | `Process.Start(`, `Process.GetCurrentProcess(`, `Process.GetProcessesByName(` | Custom `IProcessRunner` |
 


### PR DESCRIPTION
## Summary

- classify identical-payload reruns before changing either target skill
- keep `test-smell-detection` unchanged because its losses were not reproducible
- add one narrow `detect-static-dependencies` stop condition for calls on injected collaborators

## Evidence

The compared payloads are byte-identical:

- `detect-static-dependencies`: PR evaluation commit `aa3aff61ed8d9730f999a16884c0d54d94b89b7f`, scheduled commit `98a6816daa0d5ddc15cacae974e023ada1829aac`, and current main `d3921f7418de361ad95f842f9178f2c71ef9bbac` all have skill tree `8e3a2d37a1c5affa31361f56c3b4a083d7ce2115` and eval tree `ee6e2e1aa3e1f0cffdbf7938a3dfafce4be5196c`.
- `test-smell-detection`: PR evaluation commit `7e672c19bf9e46bbb94ef64f98e08cab4402fa26`, scheduled commit `98a6816daa0d5ddc15cacae974e023ada1829aac`, and current main all have skill tree `db83bc3e5f8a01991dbd2b990aa4ce37bb9ff26a` and eval tree `6dcc98e47f0b3e743c9524dcbf14223876d75847`.

| Skill / executor | PR evaluation | Scheduled rerun |
|---|---:|---:|
| detect / Sonnet 4.6 | 5W/1T/2L, p=.227 | 7W/0T/1L, p=.035 |
| detect / Luna | 4W/2T/2L, p=.344 | 5W/3T/0L, p=.031 |
| smell / Sonnet 4.6 | 8W/1T/1L, p=.020 | 9W/1T/0L, p=.002 |
| smell / Luna | 8W/1T/1L, p=.020 | 4W/3T/3L, p=.500 |

Across the 36 per-stimulus votes, 12 changed direction (33%). Three of four model/skill gate outcomes flipped. All eight measurements were conclusive, activated in every isolated and plugin scenario, had no timeouts, and had no unresolved or recovered comparison errors. The executor/judge pair was also unchanged between each PR result and its scheduled rerun.

One defect did recur on the same payload: both Sonnet runs lost `Avoid false positives when ambient resources are already abstracted`. In both skilled transcripts, the response counted constructor-injected `HttpClient` as one remaining seam and recommended replacing it. The judges consistently said this manufactured a seam for an already injected collaborator; the scheduled rationale also called the `new HttpClient` characterization misleading.

The skill now makes receiver provenance an explicit classification step: pattern matches are candidates, calls on caller/DI-supplied collaborators are excluded, and injected `HttpClient` is recognized as testable with a controlled `HttpMessageHandler`.

Official evidence:

- PR #1055 evaluation: https://github.com/dotnet/skills/actions/runs/32856237180
- PR #1056 evaluation: https://github.com/dotnet/skills/actions/runs/32854823932
- scheduled identical-payload rerun: https://github.com/dotnet/skills/actions/runs/32941933669

## Official reruns on this change

- Default profile: https://github.com/dotnet/skills/actions/runs/33061392605
  - Sonnet 4.6: 6W/1T/1L, p=.063
  - Luna: 4W/3T/1L, p=.188
- Full profile: https://github.com/dotnet/skills/actions/runs/33062567395
  - Pass: Sonnet 4.6 (7W/0T/1L), Haiku 4.5 (7W/1T/0L), MAI Flash (5W/3T/0L)
  - Not proven: Luna (5W/1T/2L), Codex 5.3 (5W/2T/1L), Opus 4.8 (4W/0T/4L)
- Newer profile: https://github.com/dotnet/skills/actions/runs/33064303076
  - Pass: Sonnet 5 (7W/0T/1L), GPT-5.6 Sol (5W/3T/0L)
  - Not proven: Opus 5 (5W/1T/2L)

All 11 post-change model measurements were conclusive and had zero timeouts, comparison errors, or
recovered error slots. The nine full/newer skilled transcripts for the target abstracted-services
stimulus all stopped manufacturing the `HttpClient` seam and reported no new seam required. Its
cross-family vote was 5W/2T/2L; the two losses were about line-location precision and response
concision, not the fixed classification error. Overfit scores remained low or moderate (.13-.49).

The overall gate remains variable: the two default executors changed again between the default and
full-profile runs on this same PR commit. Six of nine full/newer executors also had isolated or
plugin activation gaps outside the target scenario, primarily on the deliberate non-C# decline
case. This reinforces the decision not to broaden the content change around unrelated votes.

## Validation

- `dotnet artifacts\bin\SkillValidator\debug\skill-validator.dll check --plugin .\plugins\dotnet-test`
- `python eng\eval-quality\check_eval_quality.py`
