### PR TITLE
Fix MSTest version and retry guidance

### DIFF
--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -88,6 +88,7 @@ the project format unless the user explicitly asks for a migration.
 |---|---:|---|
 | `Assert.ThrowsExactly*`, unified `Assert.Contains` / `HasCount` / `IsEmpty` / `IsNotEmpty` | 3.8 | `Assert.ThrowsException*`, `CollectionAssert`, `StringAssert` |
 | `Assert.IsGreaterThan`, `IsLessThan`, `IsInRange`, `StartsWith`, `EndsWith`, `MatchesRegex` | 3.10 | `Assert.IsTrue` with a clear message, or `StringAssert` |
+| Generic `Assert.IsInstanceOfType<T>(value, out var typed)` | 3.4-3.11 only | Non-generic assertion then post-assert cast on 3.0-3.3; v4 returns the typed value directly |
 | ValueTuple `DynamicData` | 3.7 | `IEnumerable<object[]>` |
 | Constructor injection of `TestContext` | 3.6 | Instance `TestContext` property |
 | `[Retry]`, `[OSCondition]` | 3.8 | No built-in retry/OS condition; fix flakiness or retain the existing condition mechanism |
@@ -265,12 +266,23 @@ On earlier versions use `StringAssert.Contains`, `StringAssert.StartsWith`,
 
 #### Type assertions
 
+MSTest 3.x is not one API level. Pick the form supported by the installed
+minor version:
+
 ```csharp
-// MSTest 3.x -- out parameter
+// MSTest 3.0-3.3
+Assert.IsInstanceOfType(result, typeof(MyHandler));
+var typed = (MyHandler)result; // Safe because the assertion stops a mismatch.
+```
+
+```csharp
+// MSTest 3.4-3.11 -- out parameter
 Assert.IsInstanceOfType<MyHandler>(result, out var typed);
 typed.Handle();
+```
 
-// MSTest 4.x -- returns directly
+```csharp
+// MSTest 4.x -- returns the proven value directly
 var typed = Assert.IsInstanceOfType<MyHandler>(result);
 ```
 
@@ -397,11 +409,20 @@ public async Task FetchData_ReturnsWithinTimeout()
 #### Retry flaky tests (MSTest 3.8+)
 
 Use only for genuinely flaky external dependencies (network, file system), not to paper over race conditions or shared state issues.
+For an external service, use bounded attempts plus a nonzero delay/backoff so
+the retry policy does not immediately hammer the same dependency:
 
 ```csharp
 [TestMethod]
-[Retry(3)]
-public void ExternalService_EventuallyResponds() { }
+[Retry(
+    3,
+    MillisecondsDelayBetweenRetries = 1_000,
+    BackoffType = DelayBackoffType.Exponential)]
+public async Task ExternalService_EventuallyResponds()
+{
+    var response = await WeatherClient.GetAsync();
+    Assert.IsNotNull(response);
+}
 ```
 
 #### Conditional execution
@@ -417,6 +438,11 @@ public void WindowsRegistry_ReadsValue() { }
 [CICondition(ConditionMode.Exclude)]
 public void LocalOnly_InteractiveTest() { }
 ```
+
+Attributes replace environment branches in test bodies; they do not replace
+the operation being tested. When correcting supplied code, retain the real
+registry/GPU/service operation and concrete resource cleanup rather than
+returning empty methods or comment-only placeholders.
 
 #### Parallelization
 

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -245,7 +245,7 @@ stimuli:
       If this factory returns the wrong handler, this test currently throws
       InvalidCastException before MSTest can explain the mismatch. Rewrite it so
       the failure reports the expected and actual runtime types. Our repositories
-      include both MSTest 3.x and 4.x, so call out the syntax difference:
+      include MSTest 3.0, 3.8, and 4.x, so call out the syntax differences:
 
       ```csharp
       [TestMethod]
@@ -266,9 +266,13 @@ stimuli:
       - type: prompt
     rubric:
       - A wrong factory result fails as an assertion that reports expected and actual runtime types
-      - The value proven to be an EmailHandler is then used for the Type behavior check without another unsafe cast
-      - The answer does not present MSTest v4-only syntax as valid for MSTest v3
-      - The explanation makes the syntax difference between installed major versions actionable
+      - The value proven to be an EmailHandler is then used for the Type behavior check; a cast after a successful
+        non-generic assertion is safe, while a cast before the assertion is not
+      - >-
+        The answer accounts for the API split within MSTest 3.x: 3.0-3.3 need the non-generic assertion, 3.4+
+        can capture the typed value through an out parameter, and v4 returns it directly
+      - The explanation makes the installed-version decision actionable instead of treating every 3.x release as
+        one API level
     constraints:
       reject_tools:
         - bash
@@ -427,9 +431,12 @@ stimuli:
     rubric:
       - The registry test is discoverable everywhere but executes only on Windows
       - The GPU test is excluded in CI without embedding an environment branch in its body
-      - The external-service test has a small, bounded retry policy rather than an unbounded loop
-      - Temporary files are removed through lifecycle cleanup that still runs after test failure
+      - The external-service test has a small, bounded retry policy with a nonzero delay/backoff rather than an
+        unbounded or immediate tight retry loop
+      - Temporary files are concretely removed through lifecycle cleanup that still runs after test failure
       - The response does not use retry to conceal deterministic race conditions or shared-state defects
+      - The examples retain representative tested operations and cleanup behavior instead of replacing the bodies
+        with comments or empty placeholders merely to demonstrate attributes
     constraints:
       reject_tools:
         - bash


### PR DESCRIPTION
## Summary

- Corrects `Assert.IsInstanceOfType` guidance across MSTest 3.0-3.3, 3.4-3.11, and 4.x.
- Uses a bounded delayed backoff for flaky external-service retries and preserves real test/cleanup behavior instead of placeholder bodies.
- Rewrites the two losing rubrics around observable correctness and installed-version decisions; no stimuli were added after observing the result.

## Evidence and decision

PR #1054's valid Luna run ([32852289045](https://github.com/dotnet/skills/actions/runs/32852289045)) measured 7W/5T/2L. The two losses were concrete:

- **Runtime type mismatch:** the skilled answer treated all MSTest 3.x releases as supporting the generic `out` overload. Microsoft Learn's API monikers place that overload in 3.4-3.11; v4 returns the typed value directly, while 3.0-3.3 need the non-generic assertion followed by a safe post-assert cast.
- **Environment retry/cleanup:** the skilled answer emitted comment-only test bodies and immediate `[Retry(3)]`; the baseline retained representative operations and used the documented nonzero exponential backoff.

`migrate-static-to-wrapper` was also investigated from PR #1057's valid Luna run ([32983373666](https://github.com/dotnet/skills/actions/runs/32983373666)): 4W/5T/0L. All five tied transcripts reached functionally equivalent correct code, and the existing rubrics already assert behavior, scope, tests, and truthful validation. No skill or eval change is justified there; adding breadth now would only chase the observed p-value.

## Validation

- `python eng/eval-quality/check_eval_quality.py`
- `skill-validator check --plugin ./plugins/dotnet-test`
- YAML parse and `git diff --check`