### PR TITLE
Fix nested testability override restoration

### DIFF
--- a/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
+++ b/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
@@ -107,20 +107,73 @@ Use built-in fake-time-aware overloads instead of inventing an `IDelay` wrapper:
 Test delayed behavior by starting the operation, proving it is incomplete,
 advancing `FakeTimeProvider`, then awaiting it. Never wait for wall-clock time.
 
-For a nested ambient override, disposing the inner scope must restore the outer
-value, not clear the slot. Capture the previous value per scope:
+For a nested ambient override, each scope owns the value that was active when it
+started. Dispose scopes in LIFO order with `using` (which emits `try/finally`) or
+an explicit `finally`; disposing the inner scope restores the outer value, never
+an unconditional `null`. For an environment-backed static API, use this shape:
 
 ```csharp
-public static IDisposable OverrideClock(Func<DateTimeOffset> clock)
+public static class FeatureFlags
 {
-    var previous = s_clock.Value;
-    s_clock.Value = clock;
-    return new Scope(() => s_clock.Value = previous);
+    private static readonly AsyncLocal<Func<string, string?>?> s_environment = new();
+
+    public static bool IsEnabled(string name)
+    {
+        var reader = s_environment.Value;
+        var value = reader is null
+            ? Environment.GetEnvironmentVariable(name)
+            : reader(name);
+
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static IDisposable OverrideEnvironment(Func<string, string?> reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var previous = s_environment.Value;
+        s_environment.Value = reader;
+        return new RestoreScope(() => s_environment.Value = previous);
+    }
+
+    private sealed class RestoreScope : IDisposable
+    {
+        private Action? _restore;
+
+        public RestoreScope(Action restore)
+        {
+            _restore = restore;
+        }
+
+        public void Dispose() =>
+            Interlocked.Exchange(ref _restore, null)?.Invoke();
+    }
 }
 ```
 
-Add tests for both nesting and parallel async flows; parallel-only tests do not
-catch the common "dispose sets null" bug.
+The exception test must observe the outer value after the exception has escaped
+the inner `using` scope but before the outer scope is disposed:
+
+```csharp
+using var outer = FeatureFlags.OverrideEnvironment(_ => "true");
+Assert.True(FeatureFlags.IsEnabled("Preview"));
+
+Assert.Throws<InvalidOperationException>(() =>
+{
+    using var inner = FeatureFlags.OverrideEnvironment(_ => "false");
+    Assert.False(FeatureFlags.IsEnabled("Preview"));
+    throw new InvalidOperationException("test");
+});
+
+Assert.True(FeatureFlags.IsEnabled("Preview"));
+```
+
+Also overlap two async flows that each establish a fresh override and assert
+that each flow sees only its own value. Parallel-only tests do not catch the
+common "dispose sets null" bug. Do not mutate process environment variables in
+these tests; the scoped reader is the deterministic input. Choose an outer value
+different from the production fallback so clearing the slot cannot accidentally
+pass the restoration assertion.
 
 ### Step 3: Preserve behavior and API shape
 

--- a/tests/dotnet-test/testability-obstacle/eval.yaml
+++ b/tests/dotnet-test/testability-obstacle/eval.yaml
@@ -79,8 +79,13 @@ stimuli:
     prompt: |
       FeatureFlags.IsEnabled is a public static API that reads environment
       variables directly. Add a deterministic scoped seam without changing its
-      signature. Tests must prove nested overrides restore correctly even when
-      code inside the inner scope throws, and parallel async flows stay isolated.
+      signature. Each scope must own and restore the value active before it, with
+      nested scopes unwinding in LIFO order through disposal. Tests must let an
+      inner override throw, run its using/finally cleanup, and assert that the
+      outer override is active before the outer scope is disposed. Make the outer
+      value differ from the production fallback so clearing the override cannot
+      accidentally pass. The tests must also overlap parallel async flows and
+      prove isolation without setting process environment variables.
     environment:
       files:
         - src: fixtures/static-feature-flags
@@ -93,20 +98,38 @@ stimuli:
           timeout: 10m
       - type: run-command
         config:
-          command: sh -c "grep -q 'static class FeatureFlags' fixtures/static-feature-flags/src/FeatureFlags.cs && grep -q 'AsyncLocal' fixtures/static-feature-flags/src/FeatureFlags.cs"
+          command: >-
+            sh -c "grep -q 'static class FeatureFlags'
+            fixtures/static-feature-flags/src/FeatureFlags.cs
+            && grep -q 'AsyncLocal'
+            fixtures/static-feature-flags/src/FeatureFlags.cs
+            && grep -q 'IDisposable'
+            fixtures/static-feature-flags/src/FeatureFlags.cs
+            && grep -q 'Dispose'
+            fixtures/static-feature-flags/src/FeatureFlags.cs"
           expected_exit_code: 0
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "grep -REqi 'throw|exception' fixtures/static-feature-flags/tests --include='*.cs' && grep -REqi 'nested|outer.*inner|inner.*outer|restore' fixtures/static-feature-flags/tests --include='*.cs'"
+          command: >-
+            sh -c "grep -REqi 'throw|exception'
+            fixtures/static-feature-flags/tests --include='*.cs'
+            && grep -REqi 'using[[:space:]]*(var[[:space:]]|[(])|finally'
+            fixtures/static-feature-flags/tests --include='*.cs'
+            && grep -REqi 'nested|outer.*inner|inner.*outer|restore'
+            fixtures/static-feature-flags/tests --include='*.cs'
+            && grep -REqi 'parallel|Task[.]Run|WhenAll'
+            fixtures/static-feature-flags/tests --include='*.cs'
+            && ! grep -Rq 'Environment.SetEnvironmentVariable'
+            fixtures/static-feature-flags/tests --include='*.cs'"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
     rubric:
       - Preserved the static API and real environment lookup as the production default
-      - Used an async-flowing scoped override that restores the previous provider
-      - Added a test proving restoration after an exception inside a nested inner scope
-      - Added a passing parallel isolation test without mutating process environment variables
+      - Used an async-flowing scoped override whose disposal restores the provider captured by that scope
+      - Proved an exception unwinds the inner scope before asserting a distinct outer value, so clearing the slot cannot pass
+      - Added a passing overlapping-flow isolation test without mutating process environment variables
 
   - name: Scope deterministic identity generation without breaking callers
     prompt: |


### PR DESCRIPTION
## Summary

- teaches `testability-obstacle` an explicit exception-safe `AsyncLocal<T>` scope that captures and restores the previous provider in LIFO order;
- makes the restoration test discriminating by choosing an outer value different from the production fallback, so an incorrect `Dispose()` that clears the slot cannot pass;
- strengthens only the existing environment-restoration stimulus with disposal, parallel-overlap, and no-process-environment-mutation checks;
- leaves routing unchanged because the only plugin-arm miss was the identity-generation stimulus, while the description already names `Guid`, identity generation, static API preservation, and nested/parallel overrides.

## Evidence and root cause

Authoritative evidence is PR #1057, workflow run [32983373666](https://github.com/dotnet/skills/actions/runs/32983373666), evaluated commit `1cc012d18effd5c5cd3fed3c85135fecb4daccc2`.

- Sonnet: 3W/4T/1L over 8 stimuli (`d=4`, `p=.312`, net `+25%`); repeated evidence 6W/6T/4L.
- Luna: 6W/2T/0L (`d=6`, `p=.016`, net `+75%`).
- Isolated activation: 8/8; plugin activity: 7/8.
- The repeatable Sonnet loss was **Restore environment overrides after exceptions and nesting**: 0W/0T/2L.

The first losing judge wrote:

> Both solutions appear to satisfy every requested behavior. A has a modest quality edge through a compositional immutable override stack and a clean warning-free final verification, while B is also substantively correct and well-tested.

The second wrote:

> Both solutions meet the central requirements and pass their stated tests. A supplies a robust immutable stacked implementation and broader directly relevant async/nesting coverage. B is a compact valid design, but its explanation of AsyncLocal child-flow behavior is imprecise and its final claim that tests are clean conflicts with the remaining warning shown in its timeline.

Both skilled trials used an outer `false`, inner `true`, and an absent environment fallback of `false`. Their post-exception `Assert.False` therefore still passed if `Dispose()` incorrectly cleared the slot instead of restoring the outer provider. The preferred baseline used outer `true`, inner `false`, so clearing the slot was observable. This change encodes that discriminator directly rather than adding another stimulus or repeated-run padding.

## Validation

- `python eng/eval-quality/check_eval_quality.py`
- `dotnet artifacts\bin\SkillValidator\debug\skill-validator.dll check --plugin .\plugins\dotnet-test`
- `dotnet exec artifacts\bin\SkillValidator.Tests\debug\SkillValidator.Tests.dll -class SkillValidator.Tests.AnalyzeSkillTests -class SkillValidator.Tests.EvalSchemaTests -maxThreads 2 -reporter quiet -noLogo`
- `dotnet build tests\dotnet-test\testability-obstacle\fixtures\static-feature-flags\tests\StaticFeatureFlags.Tests.csproj --no-restore --nologo --verbosity minimal -nr:false`
- compiled runtime probe covering nested exception restoration and parallel async-flow isolation