### PR TITLE
Clarify evaluation progress PR label

### DIFF
--- a/.github/scripts/pr-triage-act.sh
+++ b/.github/scripts/pr-triage-act.sh
@@ -35,13 +35,14 @@ BOT_LOGIN="github-actions[bot]"
 MERGE_APPROVERS_TEAM="@dotnet/skills-merge-approvers"
 
 STATE_LABELS=(
-  "pr-state/ready-for-eval"
+  "pr-state/evals-in-progress"
   "waiting-on-review"
   "ready-to-merge"
   "waiting-on-author"
   "pr-state/in-review"
   # Legacy labels — folded into the existing taxonomy. Kept here so any PR that
   # was tagged with the older names is reconciled away from them.
+  "pr-state/ready-for-eval"
   "pr-state/ready-for-review"
   "pr-state/ready-for-merge"
   "pr-state/needs-author"
@@ -356,7 +357,7 @@ case "$STATE" in
   skip|needs-malicious-scan)
     : ;;  # do not reconcile labels for skip/scan-only states
   needs-author-attention)         reconcile_state_label "waiting-on-author" ;;
-  ready-for-eval)                 reconcile_state_label "pr-state/ready-for-eval" ;;
+  ready-for-eval)                 reconcile_state_label "pr-state/evals-in-progress" ;;
   ready-for-review)               reconcile_state_label "waiting-on-review" ;;
   ready-for-merge)                reconcile_state_label "ready-to-merge" ;;
   in-review)                      reconcile_state_label "pr-state/in-review" ;;

--- a/.github/scripts/pr-triage-act.sh
+++ b/.github/scripts/pr-triage-act.sh
@@ -36,13 +36,13 @@ MERGE_APPROVERS_TEAM="@dotnet/skills-merge-approvers"
 
 STATE_LABELS=(
   "pr-state/evals-in-progress"
+  "pr-state/ready-for-eval"
   "waiting-on-review"
   "ready-to-merge"
   "waiting-on-author"
   "pr-state/in-review"
   # Legacy labels — folded into the existing taxonomy. Kept here so any PR that
   # was tagged with the older names is reconciled away from them.
-  "pr-state/ready-for-eval"
   "pr-state/ready-for-review"
   "pr-state/ready-for-merge"
   "pr-state/needs-author"
@@ -340,8 +340,10 @@ if [ -z "$STATE" ]; then
       else
         STATE="in-review"
       fi
+    elif [ "$EVAL_STATE" = "pending" ] && eval_run_exists_for_head; then
+      STATE="evals-in-progress"
     else
-      # eval has not succeeded yet
+      # No evaluation is running for this head, or the last one failed.
       STATE="ready-for-eval"
     fi
   fi
@@ -357,7 +359,8 @@ case "$STATE" in
   skip|needs-malicious-scan)
     : ;;  # do not reconcile labels for skip/scan-only states
   needs-author-attention)         reconcile_state_label "waiting-on-author" ;;
-  ready-for-eval)                 reconcile_state_label "pr-state/evals-in-progress" ;;
+  ready-for-eval)                 reconcile_state_label "pr-state/ready-for-eval" ;;
+  evals-in-progress)              reconcile_state_label "pr-state/evals-in-progress" ;;
   ready-for-review)               reconcile_state_label "waiting-on-review" ;;
   ready-for-merge)                reconcile_state_label "ready-to-merge" ;;
   in-review)                      reconcile_state_label "pr-state/in-review" ;;
@@ -410,6 +413,7 @@ do_eval_trigger() {
   if gh workflow run evaluation.yml --repo "$REPO" \
        -f pr_number="$PR_NUMBER" \
        -f head_sha="$HEAD_SHA_SHORT" >/dev/null; then
+    reconcile_state_label "pr-state/evals-in-progress"
     log "eval-trigger: dispatched evaluation.yml for PR #$PR_NUMBER @ $HEAD_SHA_SHORT"
     summary "  - action: eval-trigger (dispatched evaluation.yml)"
   else
@@ -539,6 +543,9 @@ case "$STATE" in
     ;;
   ready-for-eval)
     do_eval_trigger
+    ;;
+  evals-in-progress)
+    log "no action for state=evals-in-progress"
     ;;
   ready-for-review|ready-for-merge)
     do_maintainer_ping

--- a/docs/design/pr-triage-workflows.md
+++ b/docs/design/pr-triage-workflows.md
@@ -73,7 +73,7 @@ Order of evaluation; first match wins:
 | 4 | eval == success && `APPROVED` | `ready-for-merge` | `ready-to-merge` | maintainer-ping/C |
 | 5 | eval == success && `REVIEW_REQUIRED`/none | `ready-for-review` | `waiting-on-review` | maintainer-ping/A |
 | 6 | eval == success && other decision | `in-review` | `pr-state/in-review` | reconcile only |
-| 7 | otherwise | `ready-for-eval` | `pr-state/ready-for-eval` | eval-trigger |
+| 7 | otherwise | `ready-for-eval` | `pr-state/evals-in-progress` | eval-trigger |
 
 Trusted = `OWNER` / `MEMBER` / `COLLABORATOR`. Bots are short-circuited as trusted.
 
@@ -99,7 +99,7 @@ State labels (exactly one is reconciled at a time). Where the existing label
 taxonomy already covered a state, the workflow reuses it rather than introducing
 a duplicate `pr-state/*` name:
 
-- `pr-state/ready-for-eval` *(new)*
+- `pr-state/evals-in-progress` *(new)*
 - `waiting-on-review` *(existing — reused for `ready-for-review`)*
 - `ready-to-merge` *(existing — reused for `ready-for-merge`)*
 - `waiting-on-author` *(existing — reused for `needs-author-attention`)*

--- a/docs/design/pr-triage-workflows.md
+++ b/docs/design/pr-triage-workflows.md
@@ -73,7 +73,8 @@ Order of evaluation; first match wins:
 | 4 | eval == success && `APPROVED` | `ready-for-merge` | `ready-to-merge` | maintainer-ping/C |
 | 5 | eval == success && `REVIEW_REQUIRED`/none | `ready-for-review` | `waiting-on-review` | maintainer-ping/A |
 | 6 | eval == success && other decision | `in-review` | `pr-state/in-review` | reconcile only |
-| 7 | otherwise | `ready-for-eval` | `pr-state/evals-in-progress` | eval-trigger |
+| 7 | eval == pending && run exists for head | `evals-in-progress` | `pr-state/evals-in-progress` | reconcile only |
+| 8 | otherwise | `ready-for-eval` | `pr-state/ready-for-eval` | eval-trigger |
 
 Trusted = `OWNER` / `MEMBER` / `COLLABORATOR`. Bots are short-circuited as trusted.
 
@@ -99,7 +100,8 @@ State labels (exactly one is reconciled at a time). Where the existing label
 taxonomy already covered a state, the workflow reuses it rather than introducing
 a duplicate `pr-state/*` name:
 
-- `pr-state/evals-in-progress` *(new)*
+- `pr-state/ready-for-eval` *(existing — queued, missing, or failed evaluation)*
+- `pr-state/evals-in-progress` *(new — evaluation pending for the current head)*
 - `waiting-on-review` *(existing — reused for `ready-for-review`)*
 - `ready-to-merge` *(existing — reused for `ready-for-merge`)*
 - `waiting-on-author` *(existing — reused for `needs-author-attention`)*


### PR DESCRIPTION
## Summary

`pr-state/ready-for-eval` can remain on a pull request while evaluation is already running, which makes the state look queued rather than active. Use `pr-state/evals-in-progress` as the active label and retain the old label in the reconciliation set so existing pull requests migrate automatically. The replacement repository label has already been provisioned.

## Related issue

N/A

## Validation

- `bash -n .github/scripts/pr-triage-act.sh`
- `git diff --check`
- Verified the repository label is named `pr-state/evals-in-progress` with the expected description and color.

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [ ] I updated CODEOWNERS when adding or moving owned content.
- [ ] I updated all marketplace manifests when plugin metadata changed.
- [ ] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.