### PR TITLE
Allow manual main dispatches to publish dashboard eval data

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -2094,9 +2094,14 @@ jobs:
         (
           github.event_name == 'workflow_dispatch' &&
           inputs.pr_number == '' &&
-          github.repository == 'dotnet/skills' &&
           github.ref == 'refs/heads/main' &&
-          (!inputs.publish_eval_data || needs.publish-eval-data.result == 'success')
+          (
+            !inputs.publish_eval_data ||
+            (
+              github.repository == 'dotnet/skills' &&
+              needs.publish-eval-data.result == 'success'
+            )
+          )
         )
       )
     concurrency:

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -49,8 +49,8 @@ name: evaluation
 run-name: "${{ inputs.pr_number != '' && format('Evaluate PR #{0} @ {1}', inputs.pr_number, inputs.head_sha) || (github.event.schedule == '0 7 * * 1,3,5' && 'schedule: default') || (github.event.schedule == '0 7 * * 2,6' && 'schedule: mid') || (github.event.schedule == '0 7 * * 4' && 'schedule: opus48') || (github.event.schedule == '0 7 * * 0' && 'schedule: newer') || '' }}"
 
 on:
-  # Manual trigger for one-off deploys (e.g., AGENTVIZ SPA update) and
-  # targeted re-runs of a single plugin without committing to main.
+  # Manual trigger for one-off deploys (e.g., AGENTVIZ SPA update),
+  # targeted re-runs of a single plugin, and explicit dashboard-data publishes.
   # The pr_number/head_sha inputs are also the PR-triage worker's entry point:
   # the worker dispatches this workflow directly (workflow_dispatch is exempt
   # from GitHub's GITHUB_TOKEN recursion guard) instead of relying on the
@@ -80,6 +80,11 @@ on:
           - opus48
           - full
           - newer
+      publish_eval_data:
+        description: "Publish generated evaluation data to the shared dashboard. Only allowed for manual runs on main without a PR number."
+        type: boolean
+        required: false
+        default: false
 
   # Same-repo PRs: post initial status
   pull_request:
@@ -1735,7 +1740,8 @@ jobs:
 
   # ==========================================================================
   # PUBLISH EVAL DATA
-  # Scheduled runs only: generate benchmark data → dashboard-eval-data
+  # Scheduled runs and explicit main-only manual publishes:
+  # generate benchmark data → dashboard-eval-data.
   # ==========================================================================
   publish-eval-data:
     needs: [gate, discover, evaluate]
@@ -1744,7 +1750,17 @@ jobs:
       !cancelled() &&
       needs.discover.result == 'success' &&
       needs.discover.outputs.has_plugins == 'true' &&
-      github.event_name == 'schedule'
+      (
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.publish_eval_data &&
+          inputs.pr_number == '' &&
+          github.repository == 'dotnet/skills' &&
+          github.ref == 'refs/heads/main' &&
+          needs.evaluate.result == 'success'
+        )
+      )
     concurrency:
       group: publish-eval-data
       cancel-in-progress: false
@@ -2065,7 +2081,8 @@ jobs:
   # ==========================================================================
   # DEPLOY DASHBOARD
   # Scheduled runs + manual dispatch on main: assemble data from both
-  # branches + UI → gh-pages. No data generation — pure copy and deploy.
+  # branches + UI → gh-pages. An explicit manual eval-data publish must
+  # succeed before deployment; unflagged manual UI deploys remain unchanged.
   # ==========================================================================
   deploy-dashboard:
     needs: [discover, publish-token-data, publish-eval-data, publish-session-data]
@@ -2074,7 +2091,13 @@ jobs:
       !cancelled() &&
       (
         (needs.discover.result == 'success' && needs.discover.outputs.has_plugins == 'true' && github.event_name == 'schedule') ||
-        (github.event_name == 'workflow_dispatch' && inputs.pr_number == '' && github.ref == 'refs/heads/main')
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.pr_number == '' &&
+          github.repository == 'dotnet/skills' &&
+          github.ref == 'refs/heads/main' &&
+          (!inputs.publish_eval_data || needs.publish-eval-data.result == 'success')
+        )
       )
     concurrency:
       group: deploy-dashboard

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -466,6 +466,38 @@ esac
             steps["Run adapter fault-injection and report tests"]["run"],
         )
 
+    def test_manual_eval_data_publish_is_explicit_and_main_only(self) -> None:
+        workflow = yaml.safe_load(CALLER_WORKFLOW.read_text(encoding="utf-8"))
+        triggers = workflow.get("on", workflow.get(True))
+        publish_input = triggers["workflow_dispatch"]["inputs"]["publish_eval_data"]
+
+        self.assertEqual(publish_input["type"], "boolean")
+        self.assertFalse(publish_input["default"])
+
+        publish_job = workflow["jobs"]["publish-eval-data"]
+        self.assertIn("evaluate", publish_job["needs"])
+        publish_condition = publish_job["if"]
+        self.assertIn("github.event_name == 'schedule'", publish_condition)
+        self.assertIn(
+            "github.event_name == 'workflow_dispatch'",
+            publish_condition,
+        )
+        self.assertIn("inputs.publish_eval_data", publish_condition)
+        self.assertIn("inputs.pr_number == ''", publish_condition)
+        self.assertIn("github.repository == 'dotnet/skills'", publish_condition)
+        self.assertIn("github.ref == 'refs/heads/main'", publish_condition)
+        self.assertIn("needs.evaluate.result == 'success'", publish_condition)
+
+        deploy_condition = workflow["jobs"]["deploy-dashboard"]["if"]
+        self.assertIn("inputs.pr_number == ''", deploy_condition)
+        self.assertIn("github.repository == 'dotnet/skills'", deploy_condition)
+        self.assertIn("github.ref == 'refs/heads/main'", deploy_condition)
+        self.assertIn(
+            "!inputs.publish_eval_data || "
+            "needs.publish-eval-data.result == 'success'",
+            deploy_condition,
+        )
+
     def test_pr_report_binds_identity_and_reruns_to_exact_commit(self) -> None:
         workflow = yaml.safe_load(CALLER_WORKFLOW.read_text(encoding="utf-8"))
         comment_job = workflow["jobs"]["comment-on-pr"]

--- a/eng/evaluation/test_token_failover.py
+++ b/eng/evaluation/test_token_failover.py
@@ -488,14 +488,28 @@ esac
         self.assertIn("github.ref == 'refs/heads/main'", publish_condition)
         self.assertIn("needs.evaluate.result == 'success'", publish_condition)
 
-        deploy_condition = workflow["jobs"]["deploy-dashboard"]["if"]
+        deploy_job = workflow["jobs"]["deploy-dashboard"]
+        self.assertIn("publish-eval-data", deploy_job["needs"])
+        deploy_condition = deploy_job["if"]
         self.assertIn("inputs.pr_number == ''", deploy_condition)
         self.assertIn("github.repository == 'dotnet/skills'", deploy_condition)
         self.assertIn("github.ref == 'refs/heads/main'", deploy_condition)
+        normalized_deploy_condition = " ".join(deploy_condition.split())
+        self.assertEqual(
+            deploy_condition.count("github.repository == 'dotnet/skills'"),
+            1,
+        )
         self.assertIn(
-            "!inputs.publish_eval_data || "
-            "needs.publish-eval-data.result == 'success'",
-            deploy_condition,
+            "github.event_name == 'workflow_dispatch' && "
+            "inputs.pr_number == '' && github.ref == 'refs/heads/main' && "
+            "( !inputs.publish_eval_data",
+            normalized_deploy_condition,
+        )
+        self.assertIn(
+            "( !inputs.publish_eval_data || "
+            "( github.repository == 'dotnet/skills' && "
+            "needs.publish-eval-data.result == 'success' ) )",
+            normalized_deploy_condition,
         )
 
     def test_pr_report_binds_identity_and_reruns_to_exact_commit(self) -> None:


### PR DESCRIPTION
## Problem

PR #1059 merged the Skill Value dashboard after the latest scheduled evaluation run had already started. The deployed GitHub Pages UI and evaluation data therefore remain stale, and `data/skill-value.json` is absent.

A manual `workflow_dispatch` on `main` can currently deploy the dashboard UI, but `publish-eval-data` is restricted to scheduled events. This prevents a safe manual run from generating, publishing, and then deploying fresh evaluation data.

## Change

- Add a `publish_eval_data` boolean dispatch input with a safe default of `false`.
- Allow evaluation-data publication only for an explicit manual dispatch in `dotnet/skills` on `refs/heads/main` with no `pr_number` and a successful evaluation.
- Make a flagged manual dashboard deployment wait for successful publication to `dashboard-eval-data` before copying that data to `gh-pages`.
- Keep scheduled publication and normal unflagged manual UI deployments unchanged.
- Keep PR-routed dispatches and forks unable to publish shared dashboard data.
- Add a workflow contract test for the input and all publication guards.

## After merge

Run the full default profile and publish its dashboard data with:

```shell
gh workflow run evaluation.yml --repo dotnet/skills --ref main -f matrix_profile=default -f publish_eval_data=true
```

The input can use another existing matrix profile when needed.

## Validation

- `python -m unittest eng.evaluation.test_token_failover`
- `actionlint` v1.7.7 on `.github/workflows/evaluation.yml` with shell and Python checks disabled
- `git diff --check`