### PR TITLE
Surface the Skill Value dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,6 +367,9 @@ Per-skill verdicts are written to `./eval-results/<plugin>/<skill>/results.json`
 
 Tests do **not** run automatically on pull requests. When a PR changes skills, the `pr-status` job posts a pending commit status and a maintainer must trigger the evaluation, binding it to a specific reviewed commit — either by submitting a PR review ("Files changed" → "Review changes") whose body contains `/evaluate` (recommended, no SHA to copy), or by commenting `/evaluate <sha>`. A bare `/evaluate` comment only posts guidance. Results are posted as a PR comment and uploaded as build artifacts.
 
+The [Skill Value dashboard](https://dotnet.github.io/skills/) provides historical
+results for each skill by executor and judge model.
+
 For the architecture, metrics, verdict policy, and real repair examples, see the
 [Skill evaluation infrastructure overview](eng/vally-adapter/README.md). If a
 scenario fails or regresses, see

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 This repository contains the .NET team's curated set of core skills and custom agents for coding agents. For information about the Agent Skills standard, see [agentskills.io](https://agentskills.io).
 
-[**📊 Dashboard**](https://dotnet.github.io/skills/) - Accuracy and efficiency scoring trends for contained plugins (https://dotnet.github.io/skills/)
+> [!TIP]
+> **Compare skill value:** [Open the Skill Value dashboard](https://dotnet.github.io/skills/)
+> See token use, elapsed time, activation, and not-passed rates by plugin, skill,
+> executor model, and judge model.
 
 ## What's Included
 


### PR DESCRIPTION
## Summary

- replace the duplicate README dashboard link with a focused TIP callout
- link CI evaluation guidance to historical per-skill results

## Validation

- `npx --no-install markdownlint-cli2 README.md CONTRIBUTING.md`
- `git diff --check`