### PR TITLE
Harden evaluation result schema handling

### DIFF
--- a/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
@@ -70,7 +70,14 @@ public static class ConsolidateCommand
 
         var output = Reporter.GenerateMarkdownSummary(allVerdicts, model, judgeModel);
         await File.WriteAllTextAsync(outputPath, output);
+        if (inputFailed)
+        {
+            Console.Error.WriteLine(
+                $"Wrote a partial diagnostic summary to {outputPath}; one or more input files failed.");
+            return 1;
+        }
+
         Console.WriteLine($"Consolidated {files.Length} result file(s) into {outputPath}");
-        return inputFailed ? 1 : 0;
+        return 0;
     }
 }

--- a/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
@@ -44,22 +44,21 @@ public static class ConsolidateCommand
             try
             {
                 var content = await File.ReadAllTextAsync(file);
-                var data = System.Text.Json.JsonSerializer.Deserialize(content,
-                    SkillValidatorJsonContext.Default.ConsolidateData);
-                if (data is not null)
+                var data = System.Text.Json.JsonSerializer.Deserialize(
+                    content,
+                    SkillValidatorJsonContext.Default.ConsolidateData)
+                    ?? throw new InvalidDataException("Results JSON root must be an object.");
+                LegacySkillValidatorResultsSchema.EnsureSupported(data.SchemaOwner, data.SchemaVersion);
+                foreach (var verdict in data.Verdicts ?? [])
                 {
-                    LegacySkillValidatorResultsSchema.EnsureSupported(data.SchemaOwner, data.SchemaVersion);
-                    foreach (var verdict in data.Verdicts ?? [])
-                    {
-                        LegacySkillValidatorResultsSchema.EnsureSupported(
-                            verdict.SchemaOwner,
-                            verdict.SchemaVersion);
-                    }
+                    LegacySkillValidatorResultsSchema.EnsureSupported(
+                        verdict.SchemaOwner,
+                        verdict.SchemaVersion);
                 }
-                if (data?.Verdicts is not null)
+                if (data.Verdicts is not null)
                     allVerdicts.AddRange(data.Verdicts);
-                if (data?.Model is not null && model is null) model = data.Model;
-                if (data?.JudgeModel is not null && judgeModel is null) judgeModel = data.JudgeModel;
+                if (data.Model is not null && model is null) model = data.Model;
+                if (data.JudgeModel is not null && judgeModel is null) judgeModel = data.JudgeModel;
             }
             catch (Exception error)
             {

--- a/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
@@ -25,7 +25,7 @@ public static class ConsolidateCommand
         return command;
     }
 
-    private static async Task<int> Consolidate(string[] files, string outputPath)
+    internal static async Task<int> Consolidate(string[] files, string outputPath)
     {
         if (files.Length == 0)
         {
@@ -37,6 +37,7 @@ public static class ConsolidateCommand
         var allVerdicts = new List<SkillVerdict>();
         string? model = null;
         string? judgeModel = null;
+        bool inputFailed = false;
 
         foreach (var file in files)
         {
@@ -45,6 +46,16 @@ public static class ConsolidateCommand
                 var content = await File.ReadAllTextAsync(file);
                 var data = System.Text.Json.JsonSerializer.Deserialize(content,
                     SkillValidatorJsonContext.Default.ConsolidateData);
+                if (data is not null)
+                {
+                    LegacySkillValidatorResultsSchema.EnsureSupported(data.SchemaOwner, data.SchemaVersion);
+                    foreach (var verdict in data.Verdicts ?? [])
+                    {
+                        LegacySkillValidatorResultsSchema.EnsureSupported(
+                            verdict.SchemaOwner,
+                            verdict.SchemaVersion);
+                    }
+                }
                 if (data?.Verdicts is not null)
                     allVerdicts.AddRange(data.Verdicts);
                 if (data?.Model is not null && model is null) model = data.Model;
@@ -52,6 +63,7 @@ public static class ConsolidateCommand
             }
             catch (Exception error)
             {
+                inputFailed = true;
                 Console.Error.WriteLine($"Failed to parse {file}: {error}");
             }
         }
@@ -59,6 +71,6 @@ public static class ConsolidateCommand
         var output = Reporter.GenerateMarkdownSummary(allVerdicts, model, judgeModel);
         await File.WriteAllTextAsync(outputPath, output);
         Console.WriteLine($"Consolidated {files.Length} result file(s) into {outputPath}");
-        return 0;
+        return inputFailed ? 1 : 0;
     }
 }

--- a/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
+++ b/eng/skill-validator/src/Evaluate/ConsolidateCommand.cs
@@ -64,7 +64,7 @@ public static class ConsolidateCommand
             catch (Exception error)
             {
                 inputFailed = true;
-                Console.Error.WriteLine($"Failed to parse {file}: {error}");
+                Console.Error.WriteLine($"Failed to read or validate {file}: {error.Message}");
             }
         }
 

--- a/eng/skill-validator/src/Evaluate/Models.cs
+++ b/eng/skill-validator/src/Evaluate/Models.cs
@@ -340,6 +340,27 @@ public sealed class ScenarioComparison
 
 public sealed class SkillVerdict
 {
+    private string? _schemaOwner;
+    private int? _schemaVersion;
+
+    /// <summary>
+    /// Identifies this as the retired skill-validator evaluate verdict format,
+    /// not the independently versioned Vally adapter verdict format.
+    /// </summary>
+    public string SchemaOwner
+    {
+        get => _schemaOwner ?? LegacySkillValidatorResultsSchema.Owner;
+        init => _schemaOwner = value;
+    }
+
+    public int SchemaVersion
+    {
+        // Source-generated deserialization supplies 0 when old verdict JSON omits this property.
+        get => _schemaVersion is null or 0
+            ? LegacySkillValidatorResultsSchema.CurrentVersion
+            : _schemaVersion.Value;
+        init => _schemaVersion = value;
+    }
     public required string SkillName { get; init; }
     public required string SkillPath { get; init; }
     public required bool Passed { get; set; }
@@ -489,8 +510,34 @@ public static class DefaultWeights
 
 // --- JSON transport types ---
 
+internal static class LegacySkillValidatorResultsSchema
+{
+    internal const string Owner = "skill-validator";
+    internal const int CurrentVersion = 1;
+
+    internal static void EnsureSupported(string? owner, int? version)
+    {
+        // Historical skill-validator results were unversioned. Continue to read
+        // them as the predecessor of the explicit version 1 format.
+        if (owner is null && version is null)
+            return;
+
+        if (!string.Equals(owner, Owner, StringComparison.Ordinal) ||
+            version != CurrentVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported results schema owner/version '{owner ?? "(missing)"}'/" +
+                $"'{version?.ToString() ?? "(missing)"}'. This command only reads " +
+                $"legacy {Owner} results version {CurrentVersion}; Vally adapter results " +
+                "use a separate schema.");
+        }
+    }
+}
+
 internal sealed class ConsolidateData
 {
+    public string? SchemaOwner { get; set; }
+    public int? SchemaVersion { get; set; }
     public string? Model { get; set; }
     public string? JudgeModel { get; set; }
     public List<SkillVerdict>? Verdicts { get; set; }
@@ -498,6 +545,8 @@ internal sealed class ConsolidateData
 
 internal sealed class ResultsOutput
 {
+    public string SchemaOwner { get; init; } = LegacySkillValidatorResultsSchema.Owner;
+    public int SchemaVersion { get; init; } = LegacySkillValidatorResultsSchema.CurrentVersion;
     public required string Model { get; init; }
     public required string JudgeModel { get; init; }
     public required string Timestamp { get; init; }

--- a/eng/skill-validator/src/Evaluate/Models.cs
+++ b/eng/skill-validator/src/Evaluate/Models.cs
@@ -353,12 +353,9 @@ public sealed class SkillVerdict
         init => _schemaOwner = value;
     }
 
-    public int SchemaVersion
+    public int? SchemaVersion
     {
-        // Source-generated deserialization supplies 0 when old verdict JSON omits this property.
-        get => _schemaVersion is null or 0
-            ? LegacySkillValidatorResultsSchema.CurrentVersion
-            : _schemaVersion.Value;
+        get => _schemaVersion ?? LegacySkillValidatorResultsSchema.CurrentVersion;
         init => _schemaVersion = value;
     }
     public required string SkillName { get; init; }

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -8,9 +8,9 @@
 > the bounded retry and fail-closed rules.
 
 > **Vally schema:** Vally adapter results use an independently owned and
-> versioned schema. Vally `schemaVersion: 4` records add separate
-> activation-contract and preference-eligibility evidence. `state` is
-> authoritative:
+> versioned schema. Current `main` emits schema version 3; the version 4 shape
+> reviewed in dotnet/skills#1079 adds separate activation-contract and
+> preference-eligibility evidence. `state` is authoritative:
 > `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or
 > `INVALID_INCONCLUSIVE`. Use `stateReason` and `errors[]` for machine-readable
 > causes. `preferenceRegressed` is report-only LLM preference evidence and is

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -7,7 +7,10 @@
 > `executor-retry-summary.json` in the result artifact and the current guide for
 > the bounded retry and fail-closed rules.
 
-> **Current Vally schema:** `state` is authoritative:
+> **Vally schema:** Vally adapter results use an independently owned and
+> versioned schema. Vally `schemaVersion: 4` records add separate
+> activation-contract and preference-eligibility evidence. `state` is
+> authoritative:
 > `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or
 > `INVALID_INCONCLUSIVE`. Use `stateReason` and `errors[]` for machine-readable
 > causes. `preferenceRegressed` is report-only LLM preference evidence and is
@@ -16,7 +19,10 @@
 > `practicalSignificance` adds the 20% net-win floor. Objective completion is a
 > separately defined tri-state over explicitly selected deterministic graders;
 > aggregate Vally pass booleans remain report-only. These fields do not exist
-> in the legacy schema documented below.
+> in the legacy schema documented below. Do not pass Vally results to
+> `skill-validator consolidate`; it accepts only the legacy skill-validator
+> schema. Malformed or unsupported inputs make consolidation return a nonzero
+> exit code, even when it can still write a partial diagnostic summary.
 
 This guide is intended primarily for AI agents investigating skill evaluation failures, though humans will find it useful too. It documents the `results.json` schema, common failure patterns, and recommended fixes.
 
@@ -65,6 +71,8 @@ Each file contains a top-level object with:
 
 | Field | Description |
 |-------|-------------|
+| `schemaOwner` | `skill-validator`. This distinguishes the retired evaluator output from Vally adapter results |
+| `schemaVersion` | Legacy skill-validator results schema version. The first explicit version is `1`; older unversioned files remain readable |
 | `model` | Model used for agent runs |
 | `judgeModel` | Model used for judging |
 | `timestamp` | When the results were written (UTC) |
@@ -76,6 +84,7 @@ Each verdict contains:
 
 | Field | Description |
 |-------|-------------|
+| `schemaOwner` / `schemaVersion` | The same legacy schema identity, repeated so standalone `verdict.json` files are self-describing |
 | `skillName` | Name of the skill being evaluated |
 | `passed` | Overall pass/fail |
 | `scenarios[]` | Array of per-scenario comparisons |

--- a/eng/skill-validator/src/docs/InvestigatingResults.md
+++ b/eng/skill-validator/src/docs/InvestigatingResults.md
@@ -8,9 +8,8 @@
 > the bounded retry and fail-closed rules.
 
 > **Vally schema:** Vally adapter results use an independently owned and
-> versioned schema. Current `main` emits schema version 3; the version 4 shape
-> reviewed in dotnet/skills#1079 adds separate activation-contract and
-> preference-eligibility evidence. `state` is authoritative:
+> versioned schema. Consult the current Vally investigation guide for its
+> schema version and fields. `state` is authoritative:
 > `VALID_PASS`, `VALID_REGRESSION`, `VALID_NO_CHANGE`, or
 > `INVALID_INCONCLUSIVE`. Use `stateReason` and `errors[]` for machine-readable
 > causes. `preferenceRegressed` is report-only LLM preference evidence and is

--- a/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using SkillValidator.Evaluate;
+
+namespace SkillValidator.Tests;
+
+public class ResultsSchemaTests
+{
+    private const string UnversionedResultsJson = """
+        {
+          "model": "executor",
+          "judgeModel": "judge",
+          "timestamp": "2026-08-27T00:00:00Z",
+          "verdicts": [
+            {
+              "skillName": "example",
+              "skillPath": "plugins/example/skills/example",
+              "passed": false,
+              "scenarios": [],
+              "overallImprovementScore": 0,
+              "reason": "legacy"
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void SerializedResultsIdentifyTheLegacySkillValidatorSchema()
+    {
+        var verdict = CreateVerdict();
+        var output = new ResultsOutput
+        {
+            Model = "executor",
+            JudgeModel = "judge",
+            Timestamp = "2026-08-27T00:00:00.0000000Z",
+            Verdicts = [verdict],
+        };
+
+        var json = JsonSerializer.Serialize(output, SkillValidatorJsonContext.Default.ResultsOutput);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal(LegacySkillValidatorResultsSchema.Owner, root.GetProperty("schemaOwner").GetString());
+        Assert.Equal(LegacySkillValidatorResultsSchema.CurrentVersion, root.GetProperty("schemaVersion").GetInt32());
+        var serializedVerdict = root.GetProperty("verdicts")[0];
+        Assert.Equal(LegacySkillValidatorResultsSchema.Owner, serializedVerdict.GetProperty("schemaOwner").GetString());
+        Assert.Equal(
+            LegacySkillValidatorResultsSchema.CurrentVersion,
+            serializedVerdict.GetProperty("schemaVersion").GetInt32());
+    }
+
+    [Fact]
+    public void UnversionedLegacyResultsRemainSupported()
+    {
+        var data = JsonSerializer.Deserialize(
+            UnversionedResultsJson,
+            SkillValidatorJsonContext.Default.ConsolidateData);
+
+        Assert.NotNull(data);
+        LegacySkillValidatorResultsSchema.EnsureSupported(data.SchemaOwner, data.SchemaVersion);
+        var verdict = Assert.Single(data.Verdicts!);
+        Assert.Equal(LegacySkillValidatorResultsSchema.Owner, verdict.SchemaOwner);
+        Assert.Equal(LegacySkillValidatorResultsSchema.CurrentVersion, verdict.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task ConsolidationAcceptsUnversionedLegacyResults()
+    {
+        var paths = CreateTempPaths();
+        try
+        {
+            await File.WriteAllTextAsync(paths.Input, UnversionedResultsJson, TestContext.Current.CancellationToken);
+
+            var exitCode = await ConsolidateCommand.Consolidate([paths.Input], paths.Output);
+
+            Assert.Equal(0, exitCode);
+            var markdown = await File.ReadAllTextAsync(paths.Output, TestContext.Current.CancellationToken);
+            Assert.Contains("Skill Validation Results", markdown);
+        }
+        finally
+        {
+            DeleteTempPaths(paths);
+        }
+    }
+
+    [Fact]
+    public void VallyAdapterSchemaIsRejectedByLegacyConsolidation()
+    {
+        var error = Assert.Throws<InvalidDataException>(
+            () => LegacySkillValidatorResultsSchema.EnsureSupported(null, 4));
+
+        Assert.Contains("Vally adapter results use a separate schema", error.Message);
+    }
+
+    [Fact]
+    public async Task ConsolidationFailsForVallyAdapterResults()
+    {
+        var paths = CreateTempPaths();
+        try
+        {
+            await File.WriteAllTextAsync(
+                paths.Input,
+                """{"schemaVersion":4,"verdicts":[]}""",
+                TestContext.Current.CancellationToken);
+
+            var exitCode = await ConsolidateCommand.Consolidate([paths.Input], paths.Output);
+
+            Assert.Equal(1, exitCode);
+        }
+        finally
+        {
+            DeleteTempPaths(paths);
+        }
+    }
+
+    private static SkillVerdict CreateVerdict() => new()
+    {
+        SkillName = "example",
+        SkillPath = "plugins/example/skills/example",
+        Passed = false,
+        Scenarios = [],
+        OverallImprovementScore = 0,
+        Reason = "test",
+    };
+
+    private static (string Directory, string Input, string Output) CreateTempPaths()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"skill-validator-schema-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return (directory, Path.Combine(directory, "results.json"), Path.Combine(directory, "summary.md"));
+    }
+
+    private static void DeleteTempPaths((string Directory, string Input, string Output) paths)
+    {
+        if (File.Exists(paths.Input))
+            File.Delete(paths.Input);
+        if (File.Exists(paths.Output))
+            File.Delete(paths.Output);
+        Directory.Delete(paths.Directory);
+    }
+}

--- a/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
@@ -158,10 +158,7 @@ public class ResultsSchemaTests
 
     private static void DeleteTempPaths((string Directory, string Input, string Output) paths)
     {
-        if (File.Exists(paths.Input))
-            File.Delete(paths.Input);
-        if (File.Exists(paths.Output))
-            File.Delete(paths.Output);
-        Directory.Delete(paths.Directory);
+        if (Directory.Exists(paths.Directory))
+            Directory.Delete(paths.Directory, recursive: true);
     }
 }

--- a/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
@@ -139,6 +139,27 @@ public class ResultsSchemaTests
         }
     }
 
+    [Fact]
+    public async Task ConsolidationFailsForNullJsonRoot()
+    {
+        var paths = CreateTempPaths();
+        try
+        {
+            await File.WriteAllTextAsync(
+                paths.Input,
+                "null",
+                TestContext.Current.CancellationToken);
+
+            var exitCode = await ConsolidateCommand.Consolidate([paths.Input], paths.Output);
+
+            Assert.Equal(1, exitCode);
+        }
+        finally
+        {
+            DeleteTempPaths(paths);
+        }
+    }
+
     private static SkillVerdict CreateVerdict() => new()
     {
         SkillName = "example",

--- a/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
@@ -82,11 +82,13 @@ public class ResultsSchemaTests
         }
     }
 
-    [Fact]
-    public void VallyAdapterSchemaIsRejectedByLegacyConsolidation()
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void VallyAdapterSchemasAreRejectedByLegacyConsolidation(int schemaVersion)
     {
         var error = Assert.Throws<InvalidDataException>(
-            () => LegacySkillValidatorResultsSchema.EnsureSupported(null, 4));
+            () => LegacySkillValidatorResultsSchema.EnsureSupported(null, schemaVersion));
 
         Assert.Contains("Vally adapter results use a separate schema", error.Message);
     }
@@ -124,7 +126,7 @@ public class ResultsSchemaTests
         {
             await File.WriteAllTextAsync(
                 paths.Input,
-                """{"schemaVersion":4,"verdicts":[]}""",
+                """{"schemaVersion":3,"verdicts":[]}""",
                 TestContext.Current.CancellationToken);
 
             var exitCode = await ConsolidateCommand.Consolidate([paths.Input], paths.Output);

--- a/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
+++ b/eng/skill-validator/tests/Evaluate/ResultsSchemaTests.cs
@@ -92,6 +92,31 @@ public class ResultsSchemaTests
     }
 
     [Fact]
+    public void ExplicitSchemaVersionZeroIsRejected()
+    {
+        var json = """
+            {
+              "schemaOwner": "skill-validator",
+              "schemaVersion": 0,
+              "skillName": "example",
+              "skillPath": "plugins/example/skills/example",
+              "passed": false,
+              "scenarios": [],
+              "overallImprovementScore": 0,
+              "reason": "invalid version"
+            }
+            """;
+        var verdict = JsonSerializer.Deserialize(json, SkillValidatorJsonContext.Default.SkillVerdict);
+
+        Assert.NotNull(verdict);
+        var error = Assert.Throws<InvalidDataException>(
+            () => LegacySkillValidatorResultsSchema.EnsureSupported(
+                verdict.SchemaOwner,
+                verdict.SchemaVersion));
+        Assert.Contains("'0'", error.Message);
+    }
+
+    [Fact]
     public async Task ConsolidationFailsForVallyAdapterResults()
     {
         var paths = CreateTempPaths();

--- a/eng/vally-adapter/InvestigatingResults.md
+++ b/eng/vally-adapter/InvestigatingResults.md
@@ -157,11 +157,14 @@ Each scenario merges the compare preference for that stimulus with the absolute 
 `unexpectedEvals`, `invalidEvals`, and `measurementInvalidEvals`.
 `measurementInvalidEvals` is the fail-closed subset: missing baseline or skilled
 records, unresolved judge or pairing failures, malformed reports, and other
-adapter failures. It excludes only the explicit `underpowered` eval-design
-state. The workflow requires this list to be empty and also checks that the
-number of primary result files equals the exact pre-run manifest count. A
-missing or invalid measurement cannot disappear while unrelated results make
-the job look complete.
+adapter failures. This includes an eval spec that the adapter cannot read:
+without that file it cannot enforce `expect_activation: false`, so it writes an
+`eval_spec_unreadable` invalid verdict instead of assuming that every stimulus
+should activate. The subset excludes only the explicit `underpowered`
+eval-design state. The workflow requires this list to be empty and also checks
+that the number of primary result files equals the exact pre-run manifest
+count. A missing or invalid measurement cannot disappear while unrelated
+results make the job look complete.
 
 ## Reaching the raw Vally output
 

--- a/eng/vally-adapter/README.md
+++ b/eng/vally-adapter/README.md
@@ -163,8 +163,10 @@ collector to distinguish:
 
 The run fails closed unless expected, observed, and written identities match
 exactly and no measurement-invalid result remains. Missing execution arms,
-unresolved judge or pairing errors, malformed reports, and unknown invalid
-states fail the matrix leg after diagnostic artifacts are written. The explicit
+unreadable eval specs, unresolved judge or pairing errors, malformed reports,
+and unknown invalid states fail the matrix leg after diagnostic artifacts are
+written. An unreadable spec is invalid because the adapter cannot safely infer
+whether `expect_activation: false` dormancy contracts apply. The explicit
 `underpowered` eval-design state remains visible as instrument debt but does not
 become an infrastructure failure. This proof applies inside each matrix leg.
 Discovery omits entries with no eval specs. The PR collector separately requires

--- a/eng/vally-adapter/adapt.mjs
+++ b/eng/vally-adapter/adapt.mjs
@@ -239,17 +239,19 @@ function evalIdentity(evalFile) {
 // skill is *expected to stay dormant* isn't flagged on the dashboard as a
 // missing activation. This is a deliberately small, block-scalar-aware YAML
 // scan rather than a full parser so the adapter keeps its zero-dependency
-// contract (no `yaml` module is guaranteed on CI runners). If the file can't be
-// read, the set is empty and every scenario defaults to expect-activation —
-// matching the historical behavior.
+// contract (no `yaml` module is guaranteed on CI runners). Reading the spec is
+// required because silently defaulting to expect-activation can remove an
+// explicit dormancy contract from the pass gate.
 function readNonActivationStimuli(evalFile, repoRoot) {
   const path = resolve(repoRoot ?? ".", evalFile);
-  if (!existsSync(path)) return new Set();
   let text;
   try {
     text = readFileSync(path, "utf-8");
-  } catch {
-    return new Set();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const readError = new Error(`cannot read eval spec ${evalFile} at ${path}: ${detail}`);
+    readError.code = "eval_spec_unreadable";
+    throw readError;
   }
   const lines = text.split(/\r?\n/);
   const indentOf = (l) => l.length - l.trimStart().length;
@@ -1497,6 +1499,31 @@ function main() {
         continue;
       }
 
+      let nonActivationStimuli;
+      try {
+        nonActivationStimuli = readNonActivationStimuli(evalFile, opts["repo-root"]);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const message = `${plugin}/${skill}: ${detail}`;
+        warn(message);
+        const verdict = invalidVerdict(
+          identity,
+          { code: "eval_spec_unreadable", phase: "adapter", kind: "permanent" },
+          message,
+          {
+            baselineRecords: baseline.length,
+            skilledRecords: skilled.length,
+            pluginRecords: pluginRecs.length,
+          },
+        );
+        const outputPath = writeVerdictResults(outputRoot, evalFile, identity, verdict, expectedEval);
+        console.log(`\n${verdictSummaryLine(verdict)}\n  → ${outputPath}`);
+        recordInvalidEval(evalFile, verdict);
+        written++;
+        incomplete++;
+        continue;
+      }
+
       const baselineSlice = join(workDir, `${plugin}__${skill}__baseline.jsonl`);
       const skilledSlice = join(workDir, `${plugin}__${skill}__skilled.jsonl`);
       const compareOut = join(workDir, `${plugin}__${skill}__compare.jsonl`);
@@ -1561,7 +1588,7 @@ function main() {
           report,
           identity,
           roles,
-          readNonActivationStimuli(evalFile, opts["repo-root"]),
+          nonActivationStimuli,
         );
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);

--- a/eng/vally-adapter/adapt.test.mjs
+++ b/eng/vally-adapter/adapt.test.mjs
@@ -162,27 +162,26 @@ function runAdapter(
   trialCount = 5,
   expectedEvalFiles = [evalFile],
   experimentFactory = createExperiment,
+  repoRoot,
 ) {
   const runDir = experimentFactory(root);
   const outputRoot = join(root, "output");
   const expectedEvalsPath = join(root, "expected-evals.txt");
   writeFileSync(expectedEvalsPath, `${expectedEvalFiles.join("\n")}\n`);
   const fakeVally = createFakeVally(root, mode, trialCount);
-  const result = spawnSync(
-    process.execPath,
-    [
-      adapterPath,
-      "--experiment-dir",
-      runDir,
-      "--output-root",
-      outputRoot,
-      "--vally",
-      fakeVally.command,
-      "--expected-evals",
-      expectedEvalsPath,
-    ],
-    { encoding: "utf8" },
-  );
+  const args = [
+    adapterPath,
+    "--experiment-dir",
+    runDir,
+    "--output-root",
+    outputRoot,
+    "--vally",
+    fakeVally.command,
+    "--expected-evals",
+    expectedEvalsPath,
+  ];
+  if (repoRoot) args.push("--repo-root", repoRoot);
+  const result = spawnSync(process.execPath, args, { encoding: "utf8" });
   const verdictPath = join(
     outputRoot,
     "dotnet-diag",
@@ -309,6 +308,31 @@ test("a malformed comparison report becomes one explicit invalid result", () => 
     const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
     assert.equal(summary.writtenResultCount, 1);
     assert.deepEqual(summary.invalidEvals, [evalFile]);
+    assert.deepEqual(summary.measurementInvalidEvals, [evalFile]);
+  });
+});
+
+test("an unreadable eval spec becomes one measurement-invalid result", () => {
+  withTempDir((root) => {
+    const { result, compareCount, verdict, outputRoot } = runAdapter(
+      root,
+      "clean",
+      5,
+      [evalFile],
+      createExperiment,
+      root,
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(compareCount, undefined);
+    assert.equal(verdict.state, VERDICT_STATES.INVALID_INCONCLUSIVE);
+    assert.equal(verdict.stateReason.code, "eval_spec_unreadable");
+    assert.equal(verdict.errors[0].phase, "adapter");
+    assert.match(verdict.errors[0].message, /cannot read eval spec/);
+
+    const summary = JSON.parse(readFileSync(join(outputRoot, "adapter-summary.json"), "utf8"));
+    assert.equal(summary.invalidEvalCount, 1);
+    assert.equal(summary.measurementInvalidEvalCount, 1);
     assert.deepEqual(summary.measurementInvalidEvals, [evalFile]);
   });
 });


### PR DESCRIPTION
## Origin and rationale

This follow-up originated during review of #1079. That PR made `expect_activation: false` an explicit, pass-blocking dormancy contract. The review found that `readNonActivationStimuli` returned an empty set when an eval spec was missing or unreadable, which silently removed the dormancy contract and let evaluation continue with incomplete input.

The same review also found a separate compatibility risk in the retired C# `skill-validator evaluate` pipeline: its result and verdict JSON had no explicit schema owner or version, while the current Vally adapter owns an independently evolving schema. Legacy consolidation could therefore accept incompatible Vally results instead of rejecting them at the schema boundary.

Both issues still exist on current `main`. This PR stays separate from #1079 and hardens the shared evaluation infrastructure without depending on that PR's implementation commits.

## Summary

- fail closed when the Vally adapter cannot read an eval spec, with an explicit `eval_spec_unreadable` measurement-invalid verdict before any comparison call
- give retired `skill-validator evaluate` results an explicit `skill-validator` schema owner and version 1 while preserving unversioned historical files
- reject Vally adapter result schemas in legacy consolidation and return a nonzero exit code for malformed or unsupported inputs
- document the separate Vally and legacy schema ownership boundaries

## Validation

- `node --test eng\vally-adapter\*.test.mjs` (62 passed)
- `dotnet build eng\skill-validator\tests\SkillValidator.Tests.csproj --no-restore` using installed .NET 10 SDK (0 warnings, 0 errors)
- full `SkillValidator.Tests.dll` suite (passed)
- final diff check passed

`eng/eval-quality/check_eval_quality.py` was not required because no eval files changed.

## Compatibility

Unversioned historical skill-validator result files remain readable. Vally adapter results, including schema v4 activation-contract and preference-eligibility records, are intentionally not deserialized as the retired C# schema.