### PR TITLE
Use shallow fetches for generated dashboard branches

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -1497,7 +1497,7 @@ jobs:
 
       - name: Fetch existing token data from dashboard-token-data
         run: |
-          git fetch origin dashboard-token-data:dashboard-token-data 2>/dev/null || true
+          git fetch --depth=1 origin dashboard-token-data:dashboard-token-data 2>/dev/null || true
           mkdir -p /tmp/token-data/data
           git checkout dashboard-token-data -- data/token-usage.json 2>/dev/null && \
             cp data/token-usage.json /tmp/token-data/data/ && \
@@ -1591,7 +1591,7 @@ jobs:
           REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
 
           if git ls-remote --exit-code --heads "$REPO_URL" dashboard-token-data > /dev/null 2>&1; then
-            git clone --branch dashboard-token-data --single-branch "$REPO_URL" token-deploy
+            git clone --depth=1 --branch dashboard-token-data --single-branch "$REPO_URL" token-deploy
           else
             mkdir token-deploy && cd token-deploy && git init && git checkout -b dashboard-token-data
             git remote add origin "$REPO_URL"
@@ -1793,7 +1793,7 @@ jobs:
 
       - name: Fetch existing eval data from dashboard-eval-data
         run: |
-          git fetch origin dashboard-eval-data:dashboard-eval-data 2>/dev/null || true
+          git fetch --depth=1 origin dashboard-eval-data:dashboard-eval-data 2>/dev/null || true
           mkdir -p /tmp/eval-data/data
           git checkout dashboard-eval-data -- data/ 2>/dev/null && \
             cp -r data/* /tmp/eval-data/data/ && \
@@ -2051,7 +2051,7 @@ jobs:
           REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
 
           if git ls-remote --exit-code --heads "$REPO_URL" dashboard-eval-data > /dev/null 2>&1; then
-            git clone --branch dashboard-eval-data --single-branch "$REPO_URL" eval-deploy
+            git clone --depth=1 --branch dashboard-eval-data --single-branch "$REPO_URL" eval-deploy
           else
             mkdir eval-deploy && cd eval-deploy && git init && git checkout -b dashboard-eval-data
             git remote add origin "$REPO_URL"
@@ -2121,14 +2121,14 @@ jobs:
       - name: Fetch eval data from dashboard-eval-data branch
         run: |
           mkdir -p /tmp/gh-pages/data
-          git fetch origin dashboard-eval-data:dashboard-eval-data 2>/dev/null || true
+          git fetch --depth=1 origin dashboard-eval-data:dashboard-eval-data 2>/dev/null || true
           git checkout dashboard-eval-data -- data/ 2>/dev/null && \
             cp -r data/* /tmp/gh-pages/data/ && \
             git checkout HEAD -- . || true
 
       - name: Fetch token data from dashboard-token-data branch
         run: |
-          git fetch origin dashboard-token-data:dashboard-token-data 2>/dev/null || true
+          git fetch --depth=1 origin dashboard-token-data:dashboard-token-data 2>/dev/null || true
           git show dashboard-token-data:data/token-usage.json > /tmp/gh-pages/data/token-usage.json 2>/dev/null || \
             echo '{"entries":[]}' > /tmp/gh-pages/data/token-usage.json
 
@@ -2195,7 +2195,7 @@ jobs:
           REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
 
           if git ls-remote --exit-code --heads "$REPO_URL" gh-pages > /dev/null 2>&1; then
-            git clone --branch gh-pages --single-branch "$REPO_URL" deploy
+            git clone --depth=1 --branch gh-pages --single-branch "$REPO_URL" deploy
           else
             mkdir deploy && cd deploy && git init && git checkout -b gh-pages
             git remote add origin "$REPO_URL"


### PR DESCRIPTION
## Problem

The dashboard publishing workflow fetches and clones generated branches that contain append-only snapshots. Its consumers only need the current files at each branch tip, but several operations currently allow Git to bring in the branches' full reachable ancestry. On ephemeral Actions runners, that creates avoidable network transfer and object retention.

This is not the same as the repository's compact server-side size. GitHub repository metadata reports roughly **139,194 KiB (~136 MiB)** because the server-side pack is well delta-compressed. Our local analysis with `git-sizer`, however, found about **10.2 GiB of total uncompressed blob content** across reachable history.

## Evidence

Measurements from a fresh bare clone show how much historical snapshot content is reachable from each generated branch versus how compactly GitHub can represent it in an optimized pack:

| Generated branch | Raw historical blob content | Blob count | Optimized on-disk representation |
| --- | ---: | ---: | ---: |
| `gh-pages` | ~4,187.8 MiB | 3,026 | ~94.4 MiB |
| `dashboard-eval-data` | ~1,970.6 MiB | 1,966 | ~47.4 MiB |
| `dashboard-token-data` | ~7,582.0 MiB | 624 | ~67.3 MiB |

These branch totals **overlap** because branches can reach shared objects. They should not be added together and presented as the repository's unique size.

One concrete source of growth is `data/token-usage.json`: the analysis found 258 historical `gh-pages` versions, with individual historical blobs reaching roughly 20–40 MiB. That history is useful context for understanding object volume, but the workflow reads only the current file.

## Why this happens

The generated branches are append-only snapshots. Fetching a disconnected generated branch without `--depth=1` can download and retain ancestry that the job never reads. Depending on fetch order, automatic maintenance/repacking, retained refs or reflogs, and duplicate or poorly packed local packs, an ephemeral runner can therefore end up with much more data than GitHub's optimized server-side pack suggests.

This explains reports of workflow `.git` directories exceeding 2 GiB without implying that every clone will have that size. The exact local footprint is sequence- and maintenance-dependent.

## What changed

This PR adds `--depth=1` at all seven relevant sites in `.github/workflows/evaluation.yml`:

- four fetches: `dashboard-token-data` and `dashboard-eval-data` in their data-generation jobs, plus both branches again in `deploy-dashboard`
- three clones: `dashboard-token-data`, `dashboard-eval-data`, and `gh-pages` before publishing updates

No unrelated fetches or clones are changed.

## Safety and behavior

The change preserves the existing workflow behavior:

- data consumers use `checkout`, `show`, or `copy` only against files in the fetched tip snapshot; they do not inspect generated-branch history
- publishers shallow-clone the current tip, update the snapshot, and create a normal child commit, so the push remains a fast-forward update
- existing error handling and branch-creation paths are unchanged

## Limitations

This is deliberately a safe first step. It does **not** rewrite or compact existing remote history, alter retention behavior, force-push, or permanently stop generated-branch history growth. It reduces runner transfer and local object retention now.

A maintainer-approved generated-branch compaction or migration to Pages artifacts could address remote history growth separately, but neither is part of this PR.

## Validation

- `actionlint` v1.7.7 passed for `.github/workflows/evaluation.yml` with ShellCheck and pyflakes integration disabled, matching the repository's targeted workflow validation.