### PR TITLE
Document efficient repository cloning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,27 @@ This repository contains shared building blocks for coding agents:
 
 Because these artifacts can affect many users and workflows, we prioritize correctness, clarity, and long term maintainability over speed.
 
+## Cloning efficiently
+
+This repository has generated dashboard branches with substantial history. For a
+contributor clone that retains the `main` branch history, use:
+
+```bash
+git clone --filter=blob:none --single-branch https://github.com/dotnet/skills.git
+```
+
+`--single-branch` excludes the disconnected generated branches, while
+`--filter=blob:none` downloads file contents on demand.
+
+For CI or read-only use that needs only the latest `main` snapshot, use:
+
+```bash
+git clone --depth=1 --single-branch https://github.com/dotnet/skills.git
+```
+
+The shallow option omits older `main` history, so it is not recommended when that
+history is needed for development.
+
 ## Code ownership
 
 Every plugin, skill, and agent must have designated owners in the `.github/CODEOWNERS` file. When you add a new skill or agent, add a matching CODEOWNERS entry. Ownership must be either:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ git clone --filter=blob:none --single-branch https://github.com/dotnet/skills.gi
 For CI or read-only use that needs only the latest `main` snapshot, use:
 
 ```bash
-git clone --depth=1 --single-branch https://github.com/dotnet/skills.git
+git clone --branch main --depth=1 --single-branch https://github.com/dotnet/skills.git
 ```
 
 The shallow option omits older `main` history, so it is not recommended when that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,12 @@ This repository has generated dashboard branches with substantial history. For a
 contributor clone that retains the `main` branch history, use:
 
 ```bash
-git clone --filter=blob:none --single-branch https://github.com/dotnet/skills.git
+git clone --branch main --filter=blob:none --single-branch https://github.com/dotnet/skills.git
 ```
 
 `--single-branch` excludes the disconnected generated branches, while
-`--filter=blob:none` downloads file contents on demand.
+`--filter=blob:none` avoids downloading historical file contents until needed;
+files required for the initial checkout are still downloaded.
 
 For CI or read-only use that needs only the latest `main` snapshot, use:
 


### PR DESCRIPTION
## Summary

- recommend a blobless, single-branch clone for contributors who need `main` history
- document a shallow, single-branch option for CI and read-only use
- explain the history tradeoff of the shallow option

This helps users avoid downloading disconnected generated dashboard branch history without changing repository behavior or expanding the focused Actions change in #1089.

## Validation

- `npx --yes markdownlint-cli2 CONTRIBUTING.md`