### PR TITLE
Improve template and JSON skill guidance

### DIFF
--- a/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
@@ -65,9 +65,12 @@ the target template/project is present.
 
 Analyze the source `.csproj` and create a `.template.config/template.json`:
 
-1. Create `.template.config` directory next to the project
-2. Generate `template.json` with `identity` (reverse-DNS), `name`, `shortName`, `sourceName` (project name for replacement), `classifications`, and `tags`
-3. Preserve from source — generic `dotnet new` templates frequently get these wrong, so verify each is carried over from the original `.csproj`:
+1. Copy the source project into a dedicated template-source directory by default, preserving
+   the original project untouched. Modify the original in place only when the user explicitly
+   asks for that layout.
+2. Create `.template.config` inside the template-source directory.
+3. Generate `template.json` with `identity` (reverse-DNS), `name`, `shortName`, `sourceName` (project name for replacement), `classifications`, and `tags`
+4. Preserve from source — generic `dotnet new` templates frequently get these wrong, so verify each is carried over from the original `.csproj`:
    1. **SDK type** — `Microsoft.NET.Sdk`, `Microsoft.NET.Sdk.Web`, `Microsoft.NET.Sdk.Worker`, etc.
    2. **Analyzer/package reference metadata** — `PrivateAssets`, `IncludeAssets`, `ExcludeAssets`
    3. **`OutputType` and other key properties** — `TreatWarningsAsErrors`, `Nullable`, `LangVersion`
@@ -96,7 +99,7 @@ Minimal example:
 | SDK (`Microsoft.NET.Sdk.*`) | ✅ | template content `.csproj` uses same SDK |
 | `TreatWarningsAsErrors` / `Nullable` / `LangVersion` | ✅ | preserved verbatim in template `.csproj` |
 | PackageReference `PrivateAssets` / `IncludeAssets` / `ExcludeAssets` | ✅ | metadata kept on each reference |
-| CPM (`Directory.Packages.props` present) | ✅ | no inline `Version` attributes emitted |
+| CPM (`Directory.Packages.props` present) | ✅ | `ManagePackageVersionsCentrally` remains enabled and no inline `Version` attributes are emitted |
 
 Mark any row you intentionally omitted as ⚠️ with a reason — never leave it implicit.
 
@@ -175,6 +178,11 @@ When packaging is requested, include the complete pack project, not only a direc
   </ItemGroup>
 </Project>
 ```
+
+For a self-contained CPM template, the packaged `Directory.Packages.props` must include
+`<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>` and every versionless
+`PackageReference` must have a matching `PackageVersion`. Keep the props file at the intended
+generated repository root; do not place a duplicate nearer the project where it changes lookup.
 
 ## Validation
 

--- a/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
@@ -46,13 +46,20 @@ This skill helps an agent create and validate custom `dotnet new` templates. It 
 
 Use these structures exactly; do not invent fields from other template features.
 
+**Deliver the requested artifact.** When the user says "show", "write", or "give me the
+content", put the complete JSON/XML in the final response even if you also wrote it to disk.
+Never edit this skill's `SKILL.md` or plugin documentation as a substitute for authoring the
+user's template. Only create or modify template files when the user requested file changes and
+the target template/project is present.
+
 | Need | Correct structure | Never use |
 |------|-------------------|-----------|
 | Conditional XML in a `.csproj` | XML comments such as `<!--#if (database == "SqlServer") -->` and `<!--#endif -->` around the complete element | bare `#if` lines, which make the XML invalid |
 | Restore generated projects | restore action `210D431B-A78B-4D2F-B762-4ED3E3EA9025`; use `primaryOutputs`, or `args.files` containing source-template paths/globs | run-script fields such as `executable` on the restore action |
-| Restrict to the SDK host | a `host` constraint whose `args` is an array containing `{ "hostname": "dotnetcli", "version": "[10.0.100,)" }` | the invalid host ID `dotnet-cli`, or unrelated `pattern` / `value` fields |
+| Restrict to the SDK host | a `host` constraint whose `args` is an array containing `{ "hostname": "dotnetcli" }`; its optional `version` restricts the host/CLI version | using host `version` when the requirement is specifically the active SDK version, the invalid host ID `dotnet-cli`, or unrelated `pattern` / `value` fields |
 | Restrict the active SDK version | an `sdk-version` constraint with a NuGet version/range string in `args` | a machine-specific exact patch unless the template truly requires it |
 | Preserve CPM | keep generated `PackageReference` items versionless and package the owning `Directory.Packages.props` when the template is self-contained | adding inline `Version` attributes |
+| Package templates | a pack project with `<PackageType>Template</PackageType>` and template content packed below `content/` | describing a layout without showing the requested project file |
 
 ### Step 1: Bootstrap from existing project
 
@@ -139,11 +146,34 @@ renames, for example `"files": ["**/*.csproj"]`. Explain that distinction.
 
 ### Step 4: Test the template locally
 
+For a create-from-existing-project request, this step is required rather than optional:
+install the authored template, run a dry-run, instantiate it into a temporary output folder,
+and build the generated project. Report each observed result; inspecting `template.json` alone
+does not prove the reusable template works.
+
 ```bash
 dotnet new install ./path/to/template/root
 dotnet new mylib --name TestProject --dry-run
 dotnet new mylib --name TestProject --output ./test-output
 dotnet build ./test-output/TestProject
+```
+
+When packaging is requested, include the complete pack project, not only a directory tree:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Contoso.ProjectTemplates</PackageId>
+    <PackageType>Template</PackageType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="**\*" />
+    <Content Include="templates\**\*" Pack="true" PackagePath="content\" />
+  </ItemGroup>
+</Project>
 ```
 
 ## Validation

--- a/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
@@ -42,6 +42,18 @@ This skill helps an agent create and validate custom `dotnet new` templates. It 
 
 ## Workflow
 
+### Rules that change the answer
+
+Use these structures exactly; do not invent fields from other template features.
+
+| Need | Correct structure | Never use |
+|------|-------------------|-----------|
+| Conditional XML in a `.csproj` | XML comments such as `<!--#if (database == "SqlServer") -->` and `<!--#endif -->` around the complete element | bare `#if` lines, which make the XML invalid |
+| Restore generated projects | restore action `210D431B-A78B-4D2F-B762-4ED3E3EA9025`; use `primaryOutputs`, or `args.files` containing source-template paths/globs | run-script fields such as `executable` on the restore action |
+| Restrict to the SDK host | a `host` constraint whose `args` is an array containing `{ "hostname": "dotnetcli", "version": "[10.0.100,)" }` | the invalid host ID `dotnet-cli`, or unrelated `pattern` / `value` fields |
+| Restrict the active SDK version | an `sdk-version` constraint with a NuGet version/range string in `args` | a machine-specific exact patch unless the template truly requires it |
+| Preserve CPM | keep generated `PackageReference` items versionless and package the owning `Directory.Packages.props` when the template is self-contained | adding inline `Version` attributes |
+
 ### Step 1: Bootstrap from existing project
 
 Analyze the source `.csproj` and create a `.template.config/template.json`:
@@ -95,10 +107,35 @@ Quick summary of what gets checked:
 Based on validation results and user requirements:
 
 1. **Add parameters** with appropriate types (string, bool, choice), defaults, and descriptions
-2. **Add conditional content** using `#if` preprocessor directives for optional features
+2. **Add conditional content** using the file type's valid syntax. In XML use template
+   directives inside XML comments, not bare preprocessor lines:
+
+   ```xml
+   <!--#if (database == "SqlServer") -->
+   <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+   <!--#endif -->
+   <!--#if (database == "Postgres") -->
+   <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+   <!--#endif -->
+   ```
 3. **Configure post-actions** for solution add, restore, or custom scripts
 4. **Set constraints** to restrict which SDKs or workloads the template supports
 5. **Add classifications** and tags for discoverability
+
+For a restore post-action, prefer `primaryOutputs` when the project path is known:
+
+```json
+"primaryOutputs": [{ "path": "MyProject.csproj" }],
+"postActions": [{
+  "description": "Restore NuGet packages.",
+  "manualInstructions": [{ "text": "Run 'dotnet restore'." }],
+  "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+  "continueOnError": true
+}]
+```
+
+If `args.files` is needed, its paths are matched against the **source template** before
+renames, for example `"files": ["**/*.csproj"]`. Explain that distinction.
 
 ### Step 4: Test the template locally
 
@@ -117,6 +154,8 @@ dotnet build ./test-output/TestProject
 - [ ] Template can be installed, dry-run, and instantiated successfully
 - [ ] Created projects build cleanly with `dotnet build`
 - [ ] Conditional content produces correct output for all parameter combinations
+- [ ] XML template directives are wrapped in XML comments and the generated project parses
+- [ ] Host constraints use `args[].hostname`; restore actions use `primaryOutputs` or `args.files`
 
 ## Common Pitfalls
 
@@ -128,6 +167,7 @@ dotnet build ./test-output/TestProject
 | Not testing all parameter combinations | Use `dotnet new <template> --dry-run` with different parameter values to verify conditional content works correctly. |
 | Hardcoded versions in template | Use `sourceName` replacement for project names and consider parameterizing framework versions. |
 | Not setting classifications | Add appropriate `classifications` (e.g., `["Web", "API"]`) for template discovery. |
+| Reusing fields from a different constraint or post-action | Follow the exact schema: `host.args[].hostname`, and restore `args.files` rather than run-script fields. |
 
 ## More Info
 

--- a/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md
@@ -168,7 +168,7 @@ When packaging is requested, include the complete pack project, not only a direc
   <PropertyGroup>
     <PackageId>Contoso.ProjectTemplates</PackageId>
     <PackageType>Template</PackageType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
@@ -178,6 +178,10 @@ When packaging is requested, include the complete pack project, not only a direc
   </ItemGroup>
 </Project>
 ```
+
+The pack project's target framework applies only to the content-only packaging project; it
+does not retarget projects inside `templates/`. Prefer a broadly available supported framework
+unless the packaging project itself uses newer build features.
 
 For a self-contained CPM template, the packaged `Directory.Packages.props` must include
 `<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>` and every versionless

--- a/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
@@ -117,7 +117,7 @@ inspect with `--help` before filling the comparison table:
 | `worker` vs `console` | **`worker`** for long-lived/queue/background processing | Generic Host: DI, logging, config, graceful shutdown, `IHostedService` lifecycle |
 | `mvc` vs `webapp` | **`webapp`** (Razor Pages) for page-focused apps; `mvc` for controller/view separation at scale | Razor Pages is lighter for CRUD-style pages |
 
-Two constraints override the shorthand above:
+These constraints override the shorthand above:
 
 - Choose **`mvc`** when the user explicitly anticipates a large application or shared
   controller logic, even if its first pages are CRUD-focused.

--- a/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
@@ -81,6 +81,11 @@ Use one row per requested decision dimension and cite the observed option name i
 Do not fill a requested row with general framework knowledge when it is specifically about
 what the template generates or exposes.
 
+When the user asks about **generated dependencies** without allowing project creation,
+inspect the installed template package's source `.csproj` files. `--help` and `--dry-run`
+do not reveal package references. Do not create temporary projects merely to inspect them,
+and do not guess current package IDs or test-platform defaults.
+
 Example shape:
 
 | Aspect | `webapi` | `webapp` |
@@ -120,6 +125,11 @@ Two constraints override the shorthand above:
   are central but useful HTML must arrive on the first response. Explain that the initial
   render is server-produced and that interactive components use the Blazor form/component
   model rather than Razor Pages `PageModel`.
+- For **offline support**, choose `blazorwasm` and explain the PWA/service-worker requirement,
+  cached-after-first-load behavior, and lack of a required live server for execution.
+- For a **durable queue processor**, choose `worker` and tie the decision to Generic Host
+  lifecycle, dependency injection, configuration, logging, graceful shutdown, and a real
+  durable queue rather than an in-memory loop.
 
 ## Validation
 

--- a/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
@@ -44,6 +44,11 @@ grounded in the currently installed templates. Run each `--help` command sequent
 capture the same requested dimensions for each template, and label an unavailable option
 as `Not exposed` rather than guessing or borrowing a flag from another template.
 
+**Decision contract:** optimize the comparison for the user's stated decision, not table
+size. Cover every requested dimension, omit unrelated option rows, give a scenario-specific
+reason, and include one safe `--dry-run` command for the recommended starting point when it
+would make the recommendation actionable.
+
 ### Step 1: Inspect each template
 
 Run `dotnet new <template> --help` for each template being compared to collect its
@@ -106,6 +111,15 @@ inspect with `--help` before filling the comparison table:
 | `blazor` vs `blazorwasm` | **`blazorwasm`** when offline / no server is required; `blazor` (Web App) for flexible server + client interactivity | Standalone WASM runs fully client-side, works offline |
 | `worker` vs `console` | **`worker`** for long-lived/queue/background processing | Generic Host: DI, logging, config, graceful shutdown, `IHostedService` lifecycle |
 | `mvc` vs `webapp` | **`webapp`** (Razor Pages) for page-focused apps; `mvc` for controller/view separation at scale | Razor Pages is lighter for CRUD-style pages |
+
+Two constraints override the shorthand above:
+
+- Choose **`mvc`** when the user explicitly anticipates a large application or shared
+  controller logic, even if its first pages are CRUD-focused.
+- Choose **`blazor` with Server interactivity** over `webapp` when rich interactive forms
+  are central but useful HTML must arrive on the first response. Explain that the initial
+  render is server-produced and that interactive components use the Blazor form/component
+  model rather than Razor Pages `PageModel`.
 
 ## Validation
 

--- a/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md
@@ -39,6 +39,11 @@ a comparison table.
 
 ## Workflow
 
+**Evidence contract:** a side-by-side table is useful only when every option claim is
+grounded in the currently installed templates. Run each `--help` command sequentially,
+capture the same requested dimensions for each template, and label an unavailable option
+as `Not exposed` rather than guessing or borrowing a flag from another template.
+
 ### Step 1: Inspect each template
 
 Run `dotnet new <template> --help` for each template being compared to collect its
@@ -49,8 +54,8 @@ dotnet new webapi --help
 dotnet new webapp --help
 ```
 
-If a template is not installed, find and install it first (`dotnet new search <keyword>`,
-then `dotnet new install <package>`).
+If a template is not installed, search for its provider and report the missing prerequisite.
+Install it only when the user asked you to modify the environment or approved the install.
 
 > **Run `--help` calls sequentially.** The template engine uses a global mutex, so running
 > several `dotnet new <template> --help` commands concurrently can fail with a transient
@@ -66,6 +71,10 @@ Produce a side-by-side table covering:
 - **Feature support** — auth, AOT, Docker, controllers, interactivity
 - **Available frameworks** — e.g., net8.0, net9.0, net10.0
 - **Classifications** — categories the template advertises (Web, API, Blazor, etc.)
+
+Use one row per requested decision dimension and cite the observed option name in the cell.
+Do not fill a requested row with general framework knowledge when it is specifically about
+what the template generates or exposes.
 
 Example shape:
 
@@ -88,7 +97,8 @@ Then link to `template-instantiation` to create it. A comparison that ends witho
 
 ### Decision shortcuts for common pairs
 
-Use these as the opinionated default when the user hasn't given a countervailing constraint. Still inspect with `--help` to confirm parameters, but lead with the verdict:
+Use these only for the recommendation, not as evidence of current parameter support. Still
+inspect with `--help` before filling the comparison table:
 
 | Pair | Default pick | Because |
 |------|-------------|---------|
@@ -103,6 +113,8 @@ Use these as the opinionated default when the user hasn't given a countervailing
 - [ ] The comparison covers parameters, feature support, frameworks, and classifications
 - [ ] Differences relevant to the user's scenario are called out explicitly
 - [ ] A recommendation (or clear trade-off) is provided
+- [ ] Unsupported or absent options are labeled instead of guessed
+- [ ] The final recommendation is a single decisive `Recommendation:` line
 
 ## Common Pitfalls
 

--- a/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
@@ -44,6 +44,11 @@ This skill helps an agent find, inspect, and select the right `dotnet new` templ
 > result under load, leaving the user nothing. Always close with the written recommendation, and
 > never end a turn on a "let me confirm from the CLI…" teaser.
 
+> **Inspection requests require inspection.** If the user asks for installed choices,
+> exact parameters/defaults, compatibility constraints, or the exact dry-run file list,
+> run the corresponding `dotnet new` command. Do not replace observed data with remembered
+> flags. Report a flag only when the current template's `--help` output contains it.
+
 ## Inputs
 
 | Input | Required | Description |
@@ -148,6 +153,11 @@ Use `dotnet new <template> --help` to get full parameter details for a specific 
 dotnet new webapi --help
 ```
 
+Copy the observed option names, choices, defaults, and compatibility notes into the answer.
+For example, Windows Service support is not universally a worker-template flag. If the
+installed `worker --help` does not expose one, say so and distinguish template creation from
+post-creation hosting configuration; never invent `--windows` or `--use-windows-service`.
+
 ### Step 4: Preview output
 
 Use `dotnet new <template> --dry-run` to show what files and directories a template would create without writing anything to disk:
@@ -157,6 +167,10 @@ dotnet new webapi --name MyApi --auth Individual --dry-run
 ```
 
 If the dry-run fails (transient "mutex"/"persistence" error), retry once; if it still fails, give a **representative** structure (template *family* and typical file kinds) and note it isn't CLI-confirmed. Do not invent specific values, choices, or file paths. When the dry-run **succeeds**, present the actual file list from its output faithfully — don't summarize, regroup, or invent files — and add a one-line purpose for the key entry points (e.g. `Program.cs`, `App.razor`).
+
+If the user says not to create files, every copy-pasteable creation command must include
+`--dry-run`. A plain `dotnet new ...` command contradicts that request even when you did not
+execute it yourself.
 
 ### Step 5: Present findings
 
@@ -179,6 +193,8 @@ An answer without a concrete, copy-pasteable command is what makes this skill ti
 - [ ] At least one template match was found for the user's intent
 - [ ] Template parameters are explained with types and defaults
 - [ ] User understands what the template produces before proceeding to creation
+- [ ] Exact-option claims came from this template's observed `--help` output
+- [ ] Advice-only commands that must not create files include `--dry-run`
 
 ## Common Pitfalls
 
@@ -189,6 +205,7 @@ An answer without a concrete, copy-pasteable command is what makes this skill ti
 | Not checking template constraints | Some templates require specific SDKs or workloads. Use `dotnet new <template> --help` to surface constraints before recommending. |
 | Recommending a template without previewing output | Always use `dotnet new <template> --dry-run` to confirm the template produces what the user expects. |
 | A `dotnet new` call fails with a "mutex"/"persistence" error and you return nothing | These are transient (often from concurrent invocations). Run `dotnet new` calls sequentially, retry once, then fall back to the Step 1 intent mapping and still give the user a concrete answer. |
+| Guessing a Windows Service or AOT flag from another SDK/template | Quote only options observed in `dotnet new <template> --help`; otherwise explain the post-creation path. |
 
 ## More Info
 

--- a/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
@@ -166,7 +166,7 @@ Use `dotnet new <template> --dry-run` to show what files and directories a templ
 dotnet new webapi --name MyApi --auth Individual --dry-run
 ```
 
-If the dry-run fails (transient "mutex"/"persistence" error), retry once; if it still fails, give a **representative** structure (template *family* and typical file kinds) and note it isn't CLI-confirmed. Do not invent specific values, choices, or file paths. When the dry-run **succeeds**, present the actual file list from its output faithfully — don't summarize, regroup, or invent files — and add a one-line purpose for the key entry points (e.g. `Program.cs`, `App.razor`).
+If the dry-run fails (transient "mutex"/"persistence" error), retry once; if it still fails, give a **representative** structure (template *family* and typical file kinds) and note it isn't CLI-confirmed. Do not invent specific values, choices, or file paths. When the dry-run **succeeds**, preserve every actual path from its output. For a long list, render those paths as a directory tree rather than a flat wall of full paths; do not omit or invent entries. Follow the tree with a one-line purpose for each key entry point (for example `Program.cs`, `App.razor`, and the project file). A file list without those explanations is incomplete.
 
 If the user says not to create files, every copy-pasteable creation command must include
 `--dry-run`. A plain `dotnet new ...` command contradicts that request even when you did not

--- a/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md
@@ -35,14 +35,12 @@ This skill helps an agent find, inspect, and select the right `dotnet new` templ
 - User wants smart cross-parameter defaults during creation — route to `template-smart-defaults` skill
 - User is troubleshooting build issues — route to `dotnet-msbuild` plugin
 
-> **Answer first, confirm second — required, in this order.** The Step 1 intent → template
-> and keyword → parameter mappings are a complete answer on their own. **Your first action is
-> to write** a concrete template + parameter recommendation (with a ready-to-run `dotnet new`
-> command) from the mapping, **before you run any `dotnet new` command**. Only then use the CLI
-> to *confirm* exact names/choices and update the answer. **Never make a `dotnet new` call your
-> final action** — the engine's global mutex can make it fail with an empty "persistence"/"mutex"
-> result under load, leaving the user nothing. Always close with the written recommendation, and
-> never end a turn on a "let me confirm from the CLI…" teaser.
+> **Recommendation requests: answer first, confirm second. Inspection requests: inspect
+> first.** For a general "which template?" question, start from the Step 1 mappings so a
+> transient CLI failure cannot leave the user without an answer. When the user explicitly
+> asks what is installed, requests exact options/defaults, or asks for dry-run output, run
+> the relevant `dotnet new` command before writing the final answer. Never end a turn on a
+> `dotnet new` call or a "let me confirm..." teaser.
 
 > **Inspection requests require inspection.** If the user asks for installed choices,
 > exact parameters/defaults, compatibility constraints, or the exact dry-run file list,
@@ -59,8 +57,8 @@ This skill helps an agent find, inspect, and select the right `dotnet new` templ
 
 ## Workflow
 
-> **Do Step 1 and write the recommendation to the user before running Step 2–4 commands.**
-> Steps 2–4 only *confirm* the answer; a `dotnet new` failure must never leave the turn empty.
+> For recommendations, use Step 1 before Steps 2–4. For explicit inspection requests,
+> execute the requested inspection first and use Step 1 only as a fallback.
 
 ### Step 1: Resolve intent to template candidates
 
@@ -167,6 +165,10 @@ dotnet new webapi --name MyApi --auth Individual --dry-run
 ```
 
 If the dry-run fails (transient "mutex"/"persistence" error), retry once; if it still fails, give a **representative** structure (template *family* and typical file kinds) and note it isn't CLI-confirmed. Do not invent specific values, choices, or file paths. When the dry-run **succeeds**, preserve every actual path from its output. For a long list, render those paths as a directory tree rather than a flat wall of full paths; do not omit or invent entries. Follow the tree with a one-line purpose for each key entry point (for example `Program.cs`, `App.razor`, and the project file). A file list without those explanations is incomplete.
+
+If command execution is unavailable, do not stop at "run this yourself." Give the
+representative tree and key-file explanations from the known template family, clearly labeled
+as unconfirmed, so the user still receives a useful preview.
 
 If the user says not to create files, every copy-pasteable creation command must include
 `--dry-run`. A plain `dotnet new ...` command contradicts that request even when you did not

--- a/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
@@ -22,12 +22,17 @@ This skill creates .NET projects from templates using `dotnet new` CLI commands,
 
 > **Match the workspace, then stop.** The highest-value move is aligning the new project with the repo it lands in: detect **CPM** (`Directory.Packages.props`) and the **target framework** used by neighbouring `.csproj` files, and mirror both. **Treat the discovered target framework as an explicit choice** — pass it as `--framework` so `template-smart-defaults` won't override it; deviate only when it's incompatible with a requested feature (then flag the conflict). Do this in as few steps as possible — a `--dry-run`, the create, and one `dotnet build` to confirm is usually enough. Extra exploratory turns add cost without improving the result.
 
+> **Perform the requested creation.** Do not return only a plan or statement of intent.
+> Run state-dependent commands sequentially: inspect, dry-run, create, then build. Never
+> launch create and build in parallel; a build-before-create race produces a false failure.
+
 | Situation | Required action |
 |-----------|-----------------|
 | Simple standalone project | inspect only the requested template, create at the exact path, then build |
 | Existing neighboring projects | read their TFMs first and pass the matching supported `--framework` explicitly |
 | `Directory.Packages.props` found | create with `--no-restore` when supported, normalize generated package references, then restore/build once |
 | Multi-project solution | create each project at its final path, add references, add all projects to the solution, then build the solution once |
+| User explicitly requests `.sln` | inspect `dotnet new sln --help`; pass `--format sln` when supported, otherwise use the older SDK's default `.sln` output |
 
 Do not predict the generated target framework. If the user did not request one and the
 workspace does not supply one, let the template choose, then read the generated project and
@@ -145,8 +150,11 @@ dotnet new uninstall Microsoft.DotNet.Web.ProjectTemplates.10.0
 ### Step 7: Post-creation verification
 
 1. Verify the project builds: `dotnet build`
-2. If added to a solution, verify `dotnet build` at the solution level
-3. If CPM was adapted, verify `Directory.Packages.props` has the new entries
+2. For a runnable template such as `console`, run the generated app when the request is
+   simple and no external service is required; report the observed output rather than only
+   build success.
+3. If added to a solution, verify `dotnet build` at the solution level
+4. If CPM was adapted, verify `Directory.Packages.props` has the new entries
 
 ## Validation
 

--- a/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
@@ -34,10 +34,10 @@ This skill creates .NET projects from templates using `dotnet new` CLI commands,
 | Multi-project solution | create each project at its final path, add references, add all projects to the solution, then build the solution once |
 | User explicitly requests `.sln` | inspect `dotnet new sln --help`; pass `--format sln` when supported, otherwise use the older SDK's default `.sln` output |
 
-Do not predict the generated target framework. If the user did not request one and the
-workspace does not supply one, let the template choose, then read the generated project and
-report the actual TFM. Never announce an intermediate framework guess that contradicts the
-generated `.csproj`.
+Do not predict the generated target framework. If the user and workspace do not supply one,
+inspect `dotnet new <template> --help`, choose a supported value (normally its documented
+default), pass it explicitly, then confirm the generated `.csproj`. Never announce an
+intermediate framework guess that was not grounded in the template's current choices.
 
 ## When to Use
 

--- a/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
@@ -22,6 +22,13 @@ This skill creates .NET projects from templates using `dotnet new` CLI commands,
 
 > **Match the workspace, then stop.** The highest-value move is aligning the new project with the repo it lands in: detect **CPM** (`Directory.Packages.props`) and the **target framework** used by neighbouring `.csproj` files, and mirror both. **Treat the discovered target framework as an explicit choice** — pass it as `--framework` so `template-smart-defaults` won't override it; deviate only when it's incompatible with a requested feature (then flag the conflict). Do this in as few steps as possible — a `--dry-run`, the create, and one `dotnet build` to confirm is usually enough. Extra exploratory turns add cost without improving the result.
 
+| Situation | Required action |
+|-----------|-----------------|
+| Simple standalone project | inspect only the requested template, create at the exact path, then build |
+| Existing neighboring projects | read their TFMs first and pass the matching supported `--framework` explicitly |
+| `Directory.Packages.props` found | create with `--no-restore` when supported, normalize generated package references, then restore/build once |
+| Multi-project solution | create each project at its final path, add references, add all projects to the solution, then build the solution once |
+
 ## When to Use
 
 - User asks to create a new .NET project, app, or service
@@ -79,6 +86,12 @@ Use `dotnet new` with the template name and all parameters:
 dotnet new webapi --name MyApi --output ./src/MyApi --framework net10.0 --auth Individual
 ```
 
+Before running it, emit one compact decision line:
+
+`Creating <template> at <path>; framework=<value> (<user|workspace|template>); CPM=<on|off>.`
+
+This makes workspace adaptations explicit without adding a long report.
+
 #### Common parameter combinations
 
 | Template | Parameters | Example |
@@ -93,14 +106,16 @@ Note: Use `dotnet new <template> --help` to see all available parameters for any
 
 After creation, adapt the project to Central Package Management and refresh stale versions:
 
-1. **Detect CPM** — walk up the directory tree from the new project looking for a `Directory.Packages.props`.
-2. **Strip inline versions** — if found, for each `<PackageReference Include="X" Version="Y" />` the template generated, remove the `Version` attribute from the `.csproj` (leaving `<PackageReference Include="X" />`).
-3. **Centralize the version** — add or merge a `<PackageVersion Include="X" Version="Y" />` entry in `Directory.Packages.props`.
-4. **Optionally refresh stale template-default versions** — templates often hardcode old versions. Keep the template's versions by default (safest for reproducibility and controlled upgrades). Only refresh when the user asks, and when you do:
+1. **Detect CPM before creation** — walk up from the destination looking for `Directory.Packages.props`.
+2. **Avoid a doomed automatic restore** — when CPM is active and the template exposes
+   `--no-restore`, pass it during creation so package centralization happens first.
+3. **Strip inline versions** — for each generated `<PackageReference Include="X" Version="Y" />`, remove the `Version` attribute (leaving `<PackageReference Include="X" />`).
+4. **Centralize the version** — add or merge a `<PackageVersion Include="X" Version="Y" />` entry in `Directory.Packages.props`; preserve unrelated existing entries.
+5. **Optionally refresh stale template-default versions** — templates often hardcode old versions. Keep the template's versions by default (safest for reproducibility and controlled upgrades). Only refresh when the user asks, and when you do:
    - Prefer a tooling-driven flow: run `dotnet list package --outdated` and confirm the proposed bumps with the user before changing anything.
    - Constrain upgrades to the same **major** (or major/minor) version unless the user explicitly opts into larger upgrades, since cross-major bumps can introduce breaking changes.
    - When checking the latest **stable** version of a package conceptually, the NuGet V3 flat-container `index.json` endpoint for that package ID lists published versions; never select a prerelease unless requested.
-5. **Build** — run `dotnet build` to confirm the centralized/refreshed versions resolve.
+6. **Build** — run `dotnet build` once to restore and confirm the centralized/refreshed versions resolve.
 
 ### Step 5: Multi-project composition (optional)
 
@@ -141,6 +156,7 @@ dotnet new uninstall Microsoft.DotNet.Web.ProjectTemplates.10.0
 | Pitfall | Solution |
 |---------|----------|
 | Not checking for CPM before creating a project | If `Directory.Packages.props` exists, `dotnet new` creates projects with inline versions that conflict. After creation, move versions to `Directory.Packages.props` and remove them from `.csproj`. |
+| Letting template restore fail before adapting CPM | Detect CPM first and use the template's `--no-restore` option when available; centralize versions before the first restore/build. |
 | Creating projects without specifying the framework | Always specify `--framework` when the template supports multiple TFMs to avoid defaulting to an older version. |
 | Not adding the project to the solution | After creation, run `dotnet sln add` to include the project in the solution. |
 | Not verifying the project builds | Always run `dotnet build` after creation to catch missing dependencies or parameter issues early. |

--- a/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md
@@ -29,6 +29,11 @@ This skill creates .NET projects from templates using `dotnet new` CLI commands,
 | `Directory.Packages.props` found | create with `--no-restore` when supported, normalize generated package references, then restore/build once |
 | Multi-project solution | create each project at its final path, add references, add all projects to the solution, then build the solution once |
 
+Do not predict the generated target framework. If the user did not request one and the
+workspace does not supply one, let the template choose, then read the generated project and
+report the actual TFM. Never announce an intermediate framework guess that contradicts the
+generated `.csproj`.
+
 ## When to Use
 
 - User asks to create a new .NET project, app, or service

--- a/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
@@ -93,7 +93,7 @@ you are not actually passing. Boolean switches such as `--no-https` are passed w
 - [ ] The exact single `dotnet new` command line was emitted, listing only flags actually passed
 - [ ] No parameter the user set explicitly was overridden
 - [ ] Only unset parameters were filled
-- [ ] Parameter names/choices were confirmed against `dotnet new <template> --help` at creation (for advice-only requests, flagged as to-confirm rather than run eagerly)
+- [ ] Exact parameter names/choices were confirmed against `dotnet new <template> --help`, including for advice-only exact commands
 - [ ] A no-file advice command includes `--dry-run`
 - [ ] Boolean switches are emitted without a trailing `true`
 

--- a/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
@@ -89,6 +89,9 @@ you are not actually passing. Boolean switches such as `--no-https` are passed w
 | User set a value explicitly | Leave it unchanged | Smart defaults only fill gaps; explicit user intent always wins. |
 | Advice-only command must not create files | Add `--dry-run` | The command itself must honor the no-write constraint, not only the agent's behavior. |
 
+When controllers are explicitly requested, the command must contain the controller option
+shown by `--help`; explaining controllers without passing the option is incomplete.
+
 ## Validation
 
 - [ ] A "Defaults applied" log was produced with a Source (user/rule) and rationale per row

--- a/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
@@ -51,8 +51,10 @@ they only fill gaps and never override a value the user set explicitly.
 4. **Emit the two required outputs** (see below) — this is what makes the skill decisive rather than inert.
 
 For advice-only prompts that say "don't create files", make the displayed command safe to run
-by appending `--dry-run`. If the user omitted a project name, choose a short descriptive sample
-name and mark it `Source = rule`; do not leave an otherwise copy-pasteable command incomplete.
+by appending `--dry-run`. If a scenario needs a named example and the user omitted the name,
+choose a short descriptive sample name and mark it `Source = rule`. Do not add a name when the
+user asked for a command containing only explicitly requested choices or when the template can
+demonstrate those choices safely without one.
 
 ### Required output
 
@@ -64,7 +66,7 @@ Always produce **both**, in this order:
 |-----------|-------|--------|-----|
 | `--framework` | `net10.0` | rule | Native AOT (from `--aot`) needs the latest AOT-capable TFM |
 | `--auth` | `Individual` | user | Explicitly requested — left unchanged |
-| `--name` | `AotWorker` | rule | Added a descriptive sample name so the dry-run command is complete |
+| `--name` | `AotWorker` | rule | Added a descriptive sample name for this named example |
 
 Use `Source = user` for explicit values (never overridden) and `Source = rule` for gap-fills.
 

--- a/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
@@ -44,8 +44,15 @@ they only fill gaps and never override a value the user set explicitly.
 
 1. Gather the parameters the user has explicitly set.
 2. Apply each rule below **only where the corresponding parameter is unset** — never override a value the user set explicitly.
-3. Confirm the chosen parameter names and choices against `dotnet new <template> --help` **at creation time**. For an advice-only request (the user isn't creating yet — e.g. "tell me the parameters/command"), answer from the rules below and note you'd confirm the exact names at creation; don't spend a `--help` call just to advise on well-known parameters.
+3. Confirm the chosen parameter names and choices against `dotnet new <template> --help`
+   whenever the user asks for an exact command. This inspection does not create files and is
+   worthwhile even for advice-only requests. Skip it only for a conceptual explanation that
+   does not claim exact option names.
 4. **Emit the two required outputs** (see below) — this is what makes the skill decisive rather than inert.
+
+For advice-only prompts that say "don't create files", make the displayed command safe to run
+by appending `--dry-run`. If the user omitted a project name, choose a short descriptive sample
+name and mark it `Source = rule`; do not leave an otherwise copy-pasteable command incomplete.
 
 ### Required output
 
@@ -57,10 +64,16 @@ Always produce **both**, in this order:
 |-----------|-------|--------|-----|
 | `--framework` | `net10.0` | rule | Native AOT (from `--aot`) needs the latest AOT-capable TFM |
 | `--auth` | `Individual` | user | Explicitly requested — left unchanged |
+| `--name` | `AotWorker` | rule | Added a descriptive sample name so the dry-run command is complete |
 
 Use `Source = user` for explicit values (never overridden) and `Source = rule` for gap-fills.
 
 **B. The exact single `dotnet new` command line** you would run — include **only** the flags you are actually passing. Do not list flags you decided *not* to pass (e.g. don't mention `--no-https` when you are keeping HTTPS; don't mention a minimal-API flag when using controllers). Silence on an omitted flag is the correct, decisive signal.
+
+Always emit a flag the user explicitly requested when the observed template help exposes it,
+even when its value matches the template default; this keeps intent visible and reproducible
+(for example, `--auth None` or `--use-minimal-apis`). Omit only **inferred** defaults that
+you are not actually passing. Boolean switches such as `--no-https` are passed without `true`.
 
 > **AOT at create time vs publish time.** `--aot` is a `dotnet new` flag only on the templates that expose it — always confirm with `dotnet new <template> --help` rather than assuming a given template does or doesn't offer it. There is no `--publish-aot` template flag — publish-time native AOT is enabled with the MSBuild property `PublishAot=true` (via `dotnet publish` or in the `.csproj`), not through `dotnet new`. Apply the framework rule only when the template actually offers `--aot`.
 
@@ -72,6 +85,7 @@ Use `Source = user` for explicit values (never overridden) and `Source = rule` f
 | `--auth` is anything other than `None` | Do NOT pass `--no-https` | Authentication flows (cookies, tokens, redirects) require HTTPS; disabling it breaks auth. |
 | `--use-controllers` is set | Do NOT also pass a minimal-API flag | Controllers and minimal APIs are mutually exclusive program models; passing both is contradictory. |
 | User set a value explicitly | Leave it unchanged | Smart defaults only fill gaps; explicit user intent always wins. |
+| Advice-only command must not create files | Add `--dry-run` | The command itself must honor the no-write constraint, not only the agent's behavior. |
 
 ## Validation
 
@@ -80,6 +94,8 @@ Use `Source = user` for explicit values (never overridden) and `Source = rule` f
 - [ ] No parameter the user set explicitly was overridden
 - [ ] Only unset parameters were filled
 - [ ] Parameter names/choices were confirmed against `dotnet new <template> --help` at creation (for advice-only requests, flagged as to-confirm rather than run eagerly)
+- [ ] A no-file advice command includes `--dry-run`
+- [ ] Boolean switches are emitted without a trailing `true`
 
 ## Common Pitfalls
 
@@ -89,6 +105,7 @@ Use `Source = user` for explicit values (never overridden) and `Source = rule` f
 | Overriding an explicit user value | Apply a rule only when the target parameter is unset. |
 | Assuming a flag name | The exact flag differs per template — always verify with `--help` (e.g. `--aot` is present only where `--help` lists it; controllers use `--use-controllers`). |
 | Picking a framework the template doesn't support | Use the latest framework that appears in the template's `--framework` choices, not an arbitrary newest version. |
+| Showing a plain creation command after "don't create files" | Append `--dry-run` so the displayed command is safe to execute. |
 
 ## More Info
 

--- a/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md
@@ -74,8 +74,8 @@ Use `Source = user` for explicit values (never overridden) and `Source = rule` f
 
 Always emit a flag the user explicitly requested when the observed template help exposes it,
 even when its value matches the template default; this keeps intent visible and reproducible
-(for example, `--auth None` or `--use-minimal-apis`). Omit only **inferred** defaults that
-you are not actually passing. Boolean switches such as `--no-https` are passed without `true`.
+(for example, `--auth None`). Omit only **inferred** defaults that you are not actually
+passing. Boolean switches such as `--no-https` are passed without `true`.
 
 > **AOT at create time vs publish time.** `--aot` is a `dotnet new` flag only on the templates that expose it — always confirm with `dotnet new <template> --help` rather than assuming a given template does or doesn't offer it. There is no `--publish-aot` template flag — publish-time native AOT is enabled with the MSBuild property `PublishAot=true` (via `dotnet publish` or in the `.csproj`), not through `dotnet new`. Apply the framework rule only when the template actually offers `--aot`.
 

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -46,6 +46,10 @@ When reviewing a template.json, check ALL of the following categories systematic
 > correction, and stop. Do not invent required-field, symbol, post-action, or discoverability
 > findings from a document that did not parse. Re-parse after the correction before making any
 > semantic claim.
+>
+> The malformed-JSON final response has exactly two parts: the one-line parse verdict and a
+> corrected snippet showing the exact edit. Do not append semantic recommendations, optional
+> metadata, or a full replacement manifest.
 
 ### 1. Required Fields
 
@@ -99,6 +103,11 @@ For each symbol in the `symbols` object:
 - For `type: "generated"`:
   - ERROR if missing `generator` field
   - Valid generators: `casing`, `coalesce`, `constant`, `port`, `guid`, `now`, `random`, `regex`, `regexMatch`, `switch`, `join`
+
+Custom parameter help is template-specific: it appears under
+`dotnet new <shortName> --help`, not the global `dotnet new --help`. Correct that premise
+when necessary, then explain which invalid symbol definitions prevent the parameters from
+appearing reliably.
 
 **Parameter prefix collisions**: WARNING if any parameter name is a prefix of another parameter name (e.g., `Auth` and `AuthMode`) — this creates ambiguous parsing in expression contexts.
 

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -41,6 +41,12 @@ This skill helps validate custom `dotnet new` templates for correctness before p
 
 When reviewing a template.json, check ALL of the following categories systematically. Report every finding as an error, warning, or suggestion.
 
+> **Parse gate — stop on syntax errors.** Parse JSON before applying any semantic rule. If
+> parsing fails, report the parser's line and column, show only the smallest concrete syntax
+> correction, and stop. Do not invent required-field, symbol, post-action, or discoverability
+> findings from a document that did not parse. Re-parse after the correction before making any
+> semantic claim.
+
 ### 1. Required Fields
 
 | Field | Severity | Rule |
@@ -113,6 +119,12 @@ For each post-action:
 For each constraint:
 - ERROR if missing `type` field
 - WARNING if missing `args` — most constraint types require arguments
+- For `type: "host"`, missing `args` is an ERROR. `args` is a required array; each entry needs `hostname`. Supported
+  built-in identifiers include `dotnetcli`, `vs`, `vs-mac`, `ide`, and
+  `dotnetcli-preview`. An optional `version` uses NuGet version/range syntax such as
+  `[10.0.100,)`. The engine matches argument keys case-insensitively, so the documented
+  `hostName` spelling is also valid. Reject unrelated fields such as `pattern` and `value`.
+- For `type: "sdk-version"`, `args` is a version string or array using the same syntax.
 
 ### 8. Tags Validation
 
@@ -132,7 +144,9 @@ The file can be at:
 
 Read the JSON. If it's malformed, report the JSON parse error with line number.
 
-Run all 8 validation categories above. Collect errors, warnings, and suggestions separately.
+Only after parsing succeeds, run all 8 validation categories above. Collect errors, warnings,
+and suggestions separately. Verify schema-sensitive claims against the installed SDK or the
+current template-engine schema; do not infer a runtime failure from a field name alone.
 
 ### Step 3: Report results
 
@@ -155,6 +169,12 @@ Then one table, ordered errors → warnings → suggestions:
 
 Close with the total: "N error(s), M warning(s), K suggestion(s)."
 
+For malformed JSON the output is intentionally smaller:
+
+`❌ Not ready — JSON parse error at line N, column M: <message>. Fix: <exact edit>.`
+
+Do not append a findings table or semantic totals until the corrected file parses.
+
 ## Common Pitfalls
 
 | Pitfall | Impact |
@@ -166,6 +186,8 @@ Close with the total: "N error(s), M warning(s), K suggestion(s)."
 | Computed symbol without `value` | Template engine throws at instantiation time |
 | Parameter prefix collision (`Auth` vs `AuthMode`) | Ambiguous expression evaluation |
 | Source condition without parentheses | Condition may not evaluate correctly |
+| Continuing semantic validation after JSON parsing failed | Findings are speculative. Report the exact parse fix and stop. |
+| Host constraint uses scalar `args`, the invalid `dotnet-cli` host ID, or unrelated fields | Use `args: [{ "hostname": "dotnetcli", "version": "[10.0.100,)" }]`; `hostName` is also accepted case-insensitively. |
 
 ## More Info
 

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -109,6 +109,20 @@ Custom parameter help is template-specific: it appears under
 when necessary, then explain which invalid symbol definitions prevent the parameters from
 appearing reliably.
 
+A valid choice parameter uses a non-empty choices object, for example:
+
+```json
+"Color": {
+  "type": "parameter",
+  "datatype": "choice",
+  "defaultValue": "Blue",
+  "choices": {
+    "Blue": { "displayName": "Blue" },
+    "Green": { "displayName": "Green" }
+  }
+}
+```
+
 **Parameter prefix collisions**: WARNING if any parameter name is a prefix of another parameter name (e.g., `Auth` and `AuthMode`) — this creates ambiguous parsing in expression contexts.
 
 ### 5. Sources Validation
@@ -152,6 +166,8 @@ The file can be at:
 ### Step 2: Parse and validate
 
 Read the JSON. If it's malformed, report the JSON parse error with line and column.
+If an absolute-path read fails, retry the user-supplied relative path from the working
+directory before concluding the file is unavailable.
 
 Only after parsing succeeds, run all 8 validation categories above. Collect errors, warnings,
 and suggestions separately. Verify schema-sensitive claims against the installed SDK or the

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -188,7 +188,7 @@ Then one table, ordered errors → warnings → suggestions:
 |----------|------------------------------------|-------|-----|
 | ERROR | `shortName` | `"list"` conflicts with a `dotnet new` subcommand | Rename to a distinctive value, e.g. `"my-list"` |
 | ERROR | `symbols.maxRetries.defaultValue` | `"abc"` is not a valid `int` | Set a numeric default, e.g. `"3"` |
-| ERROR | `12:5` | JSON parse error: unexpected `,` | Remove the trailing comma |
+| WARNING | `sourceName` | Missing replacement token | Set it to the source project name |
 
 **Every ERROR and WARNING MUST include a concrete fix** — the corrected value, JSON snippet, or a specific edit instruction (e.g. "remove the trailing comma"), not just a restatement of the problem. A finding without an actionable fix is incomplete. This is the single biggest thing that separates a useful validation from a generic lint.
 

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -178,9 +178,13 @@ Then one table, ordered errors → warnings → suggestions:
 
 Close with the total: "N error(s), M warning(s), K suggestion(s)."
 
-For malformed JSON the output is intentionally smaller:
+For malformed JSON the output is intentionally smaller and has exactly two parts:
 
-`❌ Not ready — JSON parse error at line N, column M: <message>. Fix: <exact edit>.`
+`❌ Not ready — JSON parse error at line N, column M: <message>.`
+
+```json
+<smallest corrected fragment showing the exact edit>
+```
 
 Do not append a findings table or semantic totals until the corrected file parses.
 

--- a/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
+++ b/plugins/dotnet-template-engine/skills/template-validation/SKILL.md
@@ -142,7 +142,7 @@ The file can be at:
 
 ### Step 2: Parse and validate
 
-Read the JSON. If it's malformed, report the JSON parse error with line number.
+Read the JSON. If it's malformed, report the JSON parse error with line and column.
 
 Only after parsing succeeds, run all 8 validation categories above. Collect errors, warnings,
 and suggestions separately. Verify schema-sensitive claims against the installed SDK or the

--- a/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
+++ b/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
@@ -35,25 +35,29 @@ These APIs only exist in the .NET 11 base class library. Before writing code:
 1. Run `dotnet --list-sdks` and confirm an SDK that can target `net11.0` is present — an
    `11.x` SDK, or a later SDK with the `net11.0` targeting pack.
 2. If the user explicitly asks you to run the sample and no suitable SDK is installed,
-   use the official `dotnet-install` script to install the current .NET 11 preview into a
-   temporary or project-local directory. Do not require administrator access, change the
-   machine-wide `PATH`, or replace an installed SDK.
+   use the official `dotnet-install` script to install the current .NET 11 SDK into a
+   temporary or project-local directory. Prefer the GA channel build. Use a preview only
+   when GA is not yet available or the user explicitly requested a preview. Do not require
+   administrator access, change the machine-wide `PATH`, or replace an installed SDK.
 3. Run the sample with that local `dotnet` executable. If download or execution is blocked,
    still provide the complete `net11.0` program and report that it was **not run**. Never
    substitute `net10.0`, a custom naming policy, or a different API and present that as
    validation of the .NET 11 feature.
 
-Use the channel, not a guessed preview version:
+Use the channel, not a guessed version. Try the GA channel first:
 
 ```powershell
-./dotnet-install.ps1 -Channel 11.0 -Quality preview -InstallDir ./.dotnet
+./dotnet-install.ps1 -Channel 11.0 -InstallDir ./.dotnet
 ./.dotnet/dotnet run --project ./Sample
 ```
 
 ```bash
-./dotnet-install.sh --channel 11.0 --quality preview --install-dir ./.dotnet
+./dotnet-install.sh --channel 11.0 --install-dir ./.dotnet
 ./.dotnet/dotnet run --project ./Sample
 ```
+
+Before .NET 11 GA, retry the install with `-Quality preview` (PowerShell) or
+`--quality preview` (shell).
 
 ## Decision table — symptom → do this → never do this
 

--- a/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
+++ b/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
@@ -47,13 +47,23 @@ These APIs only exist in the .NET 11 base class library. Before writing code:
 Use the channel, not a guessed version. Try the GA channel first:
 
 ```powershell
-./dotnet-install.ps1 -Channel 11.0 -InstallDir ./.dotnet
-./.dotnet/dotnet run --project ./Sample
+$installScript = Join-Path $env:TEMP "dotnet-install-$([guid]::NewGuid()).ps1"
+try {
+    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile $installScript
+    & $installScript -Channel 11.0 -InstallDir .\.dotnet
+    & .\.dotnet\dotnet.exe run --project <PATH_TO_NET11_PROJECT>
+}
+finally {
+    Remove-Item -LiteralPath $installScript -Force -ErrorAction SilentlyContinue
+}
 ```
 
 ```bash
-./dotnet-install.sh --channel 11.0 --install-dir ./.dotnet
-./.dotnet/dotnet run --project ./Sample
+install_script="$(mktemp "${TMPDIR:-/tmp}/dotnet-install.XXXXXX")"
+trap 'rm -f "$install_script"' EXIT
+curl -fsSL https://dot.net/v1/dotnet-install.sh -o "$install_script"
+bash "$install_script" --channel 11.0 --install-dir ./.dotnet
+./.dotnet/dotnet run --project <PATH_TO_NET11_PROJECT>
 ```
 
 Before .NET 11 GA, retry the install with `-Quality preview` (PowerShell) or

--- a/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
+++ b/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
@@ -7,7 +7,7 @@ description: >
   `JsonSerializerOptions.TryGetTypeInfo<T>(out JsonTypeInfo<T>? info)`
   metadata accessors.
   USE FOR: serializing or deserializing JSON in a net11.0-or-later project when you need
-  PascalCase JSON property names without writing a custom naming policy, a strongly-typed
+  PascalCase JSON property or dictionary-key names without writing a custom naming policy, a strongly-typed
   `JsonTypeInfo<T>` instead of the non-generic `JsonTypeInfo`, or a no-throw way to probe
   whether a type's serialization metadata is resolved.
   DO NOT USE FOR: projects targeting net10.0 or earlier (none of these APIs exist there),
@@ -29,15 +29,32 @@ show the output.
 | `JsonSerializerOptions.GetTypeInfo<T>()` | calling non-generic `GetTypeInfo(typeof(T))` and casting to `JsonTypeInfo<T>` |
 | `JsonSerializerOptions.TryGetTypeInfo<T>(out JsonTypeInfo<T>? info)` | wrapping `GetTypeInfo` in `try`/`catch` to probe availability |
 
-## Step 0 — Confirm you can target .NET 11
+## Step 0 — Make the requested `net11.0` validation possible
 
 These APIs only exist in the .NET 11 base class library. Before writing code:
 
 1. Run `dotnet --list-sdks` and confirm an SDK that can target `net11.0` is present — an
-   `11.x` SDK, or any later SDK (`12.x`+) that has the `net11.0` targeting pack installed.
-2. If no such SDK is available, **stop**: tell the user these APIs require targeting
-   `net11.0` (on the .NET 11 SDK or later) and cannot compile on `net10.0` or earlier. Do
-   not fall back to a custom implementation and pretend it is the new API.
+   `11.x` SDK, or a later SDK with the `net11.0` targeting pack.
+2. If the user explicitly asks you to run the sample and no suitable SDK is installed,
+   use the official `dotnet-install` script to install the current .NET 11 preview into a
+   temporary or project-local directory. Do not require administrator access, change the
+   machine-wide `PATH`, or replace an installed SDK.
+3. Run the sample with that local `dotnet` executable. If download or execution is blocked,
+   still provide the complete `net11.0` program and report that it was **not run**. Never
+   substitute `net10.0`, a custom naming policy, or a different API and present that as
+   validation of the .NET 11 feature.
+
+Use the channel, not a guessed preview version:
+
+```powershell
+./dotnet-install.ps1 -Channel 11.0 -Quality preview -InstallDir ./.dotnet
+./.dotnet/dotnet run --project ./Sample
+```
+
+```bash
+./dotnet-install.sh --channel 11.0 --quality preview --install-dir ./.dotnet
+./.dotnet/dotnet run --project ./Sample
+```
 
 ## Decision table — symptom → do this → never do this
 
@@ -47,6 +64,7 @@ Match the user's request to a row, apply the **Do this** cell verbatim, and conf
 | User asks for… | Do this (on `net11.0`) | Never do this | Verify |
 | --- | --- | --- | --- |
 | PascalCase JSON property names | `options.PropertyNamingPolicy = JsonNamingPolicy.PascalCase;` | define `class …: JsonNamingPolicy`; add per-member `[JsonPropertyName]`; string-case the names yourself | output JSON keys are PascalCase — e.g. `"Name"`, `"Age"` |
+| PascalCase dictionary keys | `options.DictionaryKeyPolicy = JsonNamingPolicy.PascalCase;` | set only `PropertyNamingPolicy`; pre-transform the dictionary; define a custom policy | dictionary keys such as `pendingOrders` become `"PendingOrders"` |
 | Strongly-typed metadata `JsonTypeInfo<T>` | set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`, then `JsonTypeInfo<T> ti = options.GetTypeInfo<T>();` | `(JsonTypeInfo<T>)options.GetTypeInfo(typeof(T))` | variable is typed `JsonTypeInfo<T>`, no cast |
 | Probe whether metadata is resolved | `if (options.TryGetTypeInfo<T>(out var ti)) { … } else { … }` | `try { options.GetTypeInfo<T>(); } catch (…) { … }` | no `try`/`catch`; both branches handled |
 
@@ -76,6 +94,25 @@ var options = new JsonSerializerOptions
 string json = JsonSerializer.Serialize(new { name = "Jane", age = 30 }, options);
 Console.WriteLine(json);
 // {"Name":"Jane","Age":30}
+```
+
+### Dictionary keys are a separate setting
+
+`PropertyNamingPolicy` does not transform `Dictionary<string, TValue>` keys. For that
+request, set `DictionaryKeyPolicy`:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    DictionaryKeyPolicy = JsonNamingPolicy.PascalCase
+};
+var values = new Dictionary<string, int>
+{
+    ["pendingOrders"] = 2,
+    ["activeUsers"] = 5
+};
+Console.WriteLine(JsonSerializer.Serialize(values, options));
+// {"PendingOrders":2,"ActiveUsers":5}
 ```
 
 ## Rule 2 — Strongly-typed `JsonTypeInfo<T>`
@@ -162,6 +199,10 @@ The task is not done until the program runs on `net11.0` and prints its JSON. Pr
 console **project** — reflection-based serialization works there out of the box. A
 file-based app also works but has one important caveat (below).
 
+When the installed SDK cannot target `net11.0` and execution was requested, install an
+SDK locally with the official script and invoke it by full path. The install script is
+non-administrative and does not persistently alter `PATH`.
+
 ### Option A — console project (recommended)
 
 Create a project whose `.csproj` contains `<TargetFramework>net11.0</TargetFramework>`,
@@ -238,6 +279,7 @@ Before reporting success, confirm every applicable box:
       `#:property TargetFramework=net11.0` directive).
 - [ ] PascalCase requests use `JsonNamingPolicy.PascalCase` — no custom `JsonNamingPolicy`
       subclass and no per-member `[JsonPropertyName]` attributes just to change casing.
+- [ ] Dictionary-key requests set `DictionaryKeyPolicy`, not only `PropertyNamingPolicy`.
 - [ ] Typed-metadata requests use the generic `GetTypeInfo<T>()` — no cast of a
       non-generic `JsonTypeInfo` — and the options set a `TypeInfoResolver` (e.g.
       `DefaultJsonTypeInfoResolver`) so the call doesn't throw `NoMetadataForType`.

--- a/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
+++ b/plugins/dotnet11/skills/system-text-json-net11/SKILL.md
@@ -6,13 +6,12 @@ description: >
   `JsonSerializerOptions.GetTypeInfo<T>()` and
   `JsonSerializerOptions.TryGetTypeInfo<T>(out JsonTypeInfo<T>? info)`
   metadata accessors.
-  USE FOR: serializing or deserializing JSON in a net11.0-or-later project when you need
+  USE ONLY when the user is targeting net11.0 or later and needs
   PascalCase JSON property or dictionary-key names without writing a custom naming policy, a strongly-typed
   `JsonTypeInfo<T>` instead of the non-generic `JsonTypeInfo`, or a no-throw way to probe
   whether a type's serialization metadata is resolved.
-  DO NOT USE FOR: projects targeting net10.0 or earlier (none of these APIs exist there),
-  JSON libraries other than System.Text.Json (e.g. Newtonsoft.Json), or camelCase /
-  snake_case / kebab-case naming — those policies shipped in earlier releases.
+  DO NOT USE when the target is earlier than net11.0, the requested behavior uses an
+  established pre-net11 naming policy, or the user explicitly selected another JSON library.
 license: MIT
 ---
 

--- a/tests/dotnet-template-engine/template-authoring/eval.yaml
+++ b/tests/dotnet-template-engine/template-authoring/eval.yaml
@@ -66,6 +66,10 @@ stimuli:
       Create the packaging project content needed to ship both in a NuGet package
       named `Contoso.ProjectTemplates`, and give me the pack, local install, and
       verification commands.
+    environment:
+      files:
+        - src: ./fixtures/package-project-templates/templates
+          dest: templates
     graders:
       - type: exit-success
       - type: output-matches

--- a/tests/dotnet-template-engine/template-authoring/eval.yaml
+++ b/tests/dotnet-template-engine/template-authoring/eval.yaml
@@ -68,8 +68,18 @@ stimuli:
       verification commands.
     environment:
       files:
-        - src: ./fixtures/package-project-templates/templates
-          dest: templates
+        - src: ./fixtures/package-project-templates/templates/Worker/.template.config/template.json
+          dest: templates/Worker/.template.config/template.json
+        - src: ./fixtures/package-project-templates/templates/Worker/Program.cs
+          dest: templates/Worker/Program.cs
+        - src: ./fixtures/package-project-templates/templates/Worker/Worker.csproj
+          dest: templates/Worker/Worker.csproj
+        - src: ./fixtures/package-project-templates/templates/WebApi/.template.config/template.json
+          dest: templates/WebApi/.template.config/template.json
+        - src: ./fixtures/package-project-templates/templates/WebApi/Program.cs
+          dest: templates/WebApi/Program.cs
+        - src: ./fixtures/package-project-templates/templates/WebApi/WebApi.csproj
+          dest: templates/WebApi/WebApi.csproj
     graders:
       - type: exit-success
       - type: output-matches

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/.template.config/template.json
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/.template.config/template.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "identity": "Contoso.Templates.WebApi",
+  "name": "Contoso Web API",
+  "shortName": "contoso-webapi",
+  "sourceName": "WebApi",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  }
+}

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/Program.cs
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/Program.cs
@@ -1,0 +1,4 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/", () => "Web API");
+app.Run();

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/WebApi.csproj
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/WebApi/WebApi.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/.template.config/template.json
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/.template.config/template.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "identity": "Contoso.Templates.Worker",
+  "name": "Contoso Worker",
+  "shortName": "contoso-worker",
+  "sourceName": "Worker",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  }
+}

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/Program.cs
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Worker");

--- a/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/Worker.csproj
+++ b/tests/dotnet-template-engine/template-authoring/fixtures/package-project-templates/templates/Worker/Worker.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -16,10 +16,7 @@ stimuli:
           pattern: (?i)net(8|9|10|11)\.0
       - type: output-matches
         config:
-          pattern: (?i)dotnet new \w
-      - type: output-matches
-        config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -45,10 +42,7 @@ stimuli:
           pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
       - type: output-matches
         config:
-          pattern: (?i)dotnet new \w
-      - type: output-matches
-        config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -74,10 +68,7 @@ stimuli:
           pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal
       - type: output-matches
         config:
-          pattern: (?i)dotnet new \w
-      - type: output-matches
-        config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -143,7 +134,7 @@ stimuli:
           pattern: (?i)\b(workspace|repository)\b
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The command keeps net9.0 because the repository framework counts as an explicit choice
@@ -176,7 +167,7 @@ stimuli:
           pattern: (?i)\|.*(minimal|framework).*(user|explicit).*\|
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The command preserves the explicit minimal-API and net9.0 choices
@@ -206,7 +197,7 @@ stimuli:
           pattern: (?i)\|.*user.*\|
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The answer preserves the explicit None authentication and disabled HTTPS choices

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -42,7 +42,7 @@ stimuli:
           pattern: (?i)SingleOrg
       - type: output-not-matches
         config:
-          pattern: (?i)dotnet new[^\n]*--no-https
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
       - type: output-matches
         config:
           pattern: (?i)dotnet new \w
@@ -71,7 +71,7 @@ stimuli:
           pattern: (?i)(use-controllers|controllers)
       - type: output-not-matches
         config:
-          pattern: (?i)dotnet new[^\n]*--[a-z-]*minimal
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal
       - type: output-matches
         config:
           pattern: (?i)dotnet new \w
@@ -100,7 +100,7 @@ stimuli:
           substring: net8.0
       - type: output-not-matches
         config:
-          pattern: (?i)dotnet new[^\n]*(?:--framework|-f)[ =]+net(9|10|11)\.0
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*(?:--framework|-f)[ =]+net(9|10|11)\.0
       - type: output-matches
         config:
           pattern: (?i)dotnet new \w
@@ -170,7 +170,7 @@ stimuli:
           pattern: (?i)(?:--framework|-f)[ =]+net9\.0
       - type: output-not-matches
         config:
-          pattern: (?i)dotnet new[^\n]*--use-controllers
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--use-controllers\b
       - type: output-matches
         config:
           pattern: (?i)\|.*(minimal|framework).*(user|explicit).*\|

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -134,7 +134,7 @@ stimuli:
           pattern: (?i)(?:--framework|-f)[ =]+net9\.0
       - type: output-not-matches
         config:
-          pattern: (?i)(?:--framework|-f)[ =]+net(10|11)\.0
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*(?:--framework|-f)[ =]+net(10|11)\.0|`dotnet\s+new[^`\r\n#]*(?:--framework|-f)[ =]+net(10|11)\.0[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?i)\|.*\b(user|rule)\b.*\|

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -42,7 +42,7 @@ stimuli:
           pattern: (?i)SingleOrg
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b|`dotnet\s+new[^`\r\n#]*--no-https\b[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
@@ -71,7 +71,7 @@ stimuli:
           pattern: (?i)(use-controllers|controllers)
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal|`dotnet\s+new[^`\r\n#]*--[a-z-]*minimal[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
@@ -100,7 +100,7 @@ stimuli:
           substring: net8.0
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*(?:--framework|-f)[ =]+net(9|10|11)\.0
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*(?:--framework|-f)[ =]+net(9|10|11)\.0|`dotnet\s+new[^`\r\n#]*(?:--framework|-f)[ =]+net(9|10|11)\.0[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?i)dotnet new \w
@@ -173,7 +173,7 @@ stimuli:
           pattern: (?i)(?:--framework|-f)[ =]+net9\.0
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--use-controllers\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--use-controllers\b|`dotnet\s+new[^`\r\n#]*--use-controllers\b[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?i)\|.*(minimal|framework).*(user|explicit).*\|
@@ -203,10 +203,10 @@ stimuli:
       - type: exit-success
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+webapi(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--auth[ =]+None
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+webapi(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--auth[ =]+None|`dotnet\s+new\s+webapi[^`\r\n#]*--auth[ =]+None[^`\r\n#]*`)
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+webapi(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+webapi(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b|`dotnet\s+new\s+webapi[^`\r\n#]*--no-https\b[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: (?i)\|.*user.*\|

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -19,6 +19,9 @@ stimuli:
           pattern: (?i)dotnet new \w
       - type: output-matches
         config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+      - type: output-matches
+        config:
           pattern: \|.*\|
       - type: prompt
     rubric:
@@ -26,6 +29,7 @@ stimuli:
       - Because AOT was requested, the agent also selected a target framework
       - The agent chose a current, AOT-capable framework rather than an arbitrary one
       - The agent explained why native AOT requires a suitable target framework
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill
@@ -44,6 +48,9 @@ stimuli:
           pattern: (?i)dotnet new \w
       - type: output-matches
         config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+      - type: output-matches
+        config:
           pattern: \|.*\|
       - type: prompt
     rubric:
@@ -51,6 +58,7 @@ stimuli:
       - Because auth is not None, the agent did NOT add a --no-https flag
       - The agent explained that authentication flows require HTTPS
       - The agent made clear which parameter values it chose and why
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill
@@ -69,6 +77,9 @@ stimuli:
           pattern: (?i)dotnet new \w
       - type: output-matches
         config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+      - type: output-matches
+        config:
           pattern: \|.*\|
       - type: prompt
     rubric:
@@ -76,6 +87,7 @@ stimuli:
       - The agent passed the controllers flag
       - The agent did NOT also pass a minimal-API flag (the two are mutually exclusive)
       - The agent explained the reasoning
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill
@@ -129,11 +141,15 @@ stimuli:
       - type: output-matches
         config:
           pattern: (?i)\b(workspace|repository)\b
+      - type: output-matches
+        config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The command keeps net9.0 because the repository framework counts as an explicit choice
       - Native AOT is enabled without replacing the compatible workspace framework with a newer default
       - The parameter summary distinguishes workspace-provided values from values chosen to fill gaps
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill
@@ -158,11 +174,15 @@ stimuli:
       - type: output-matches
         config:
           pattern: (?i)\|.*(minimal|framework).*(user|explicit).*\|
+      - type: output-matches
+        config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The command preserves the explicit minimal-API and net9.0 choices
       - The agent does not add the mutually exclusive controllers flag
       - The parameter summary separates preserved values from any genuine gap-fill
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill
@@ -184,11 +204,15 @@ stimuli:
       - type: output-matches
         config:
           pattern: (?i)\|.*user.*\|
+      - type: output-matches
+        config:
+          pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
       - type: prompt
     rubric:
       - The answer preserves the explicit None authentication and disabled HTTPS choices
       - Both choices are identified as user-supplied rather than assumptions made by the response
-      - The exact command contains the requested auth and no-https flags without unrelated options
+      - Apart from the dry-run safety option, the exact command contains only the requested auth and no-https flags
+      - The displayed command is safe to run without creating files
     constraints:
       expect_tools:
         - skill

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -16,7 +16,10 @@ stimuli:
           pattern: (?i)net(8|9|10|11)\.0
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -42,7 +45,10 @@ stimuli:
           pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -68,7 +74,10 @@ stimuli:
           pattern: (?im)^\s*dotnet\s+new(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: output-matches
         config:
           pattern: \|.*\|
@@ -134,7 +143,10 @@ stimuli:
           pattern: (?i)\b(workspace|repository)\b
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: prompt
     rubric:
       - The command keeps net9.0 because the repository framework counts as an explicit choice
@@ -167,7 +179,10 @@ stimuli:
           pattern: (?i)\|.*(minimal|framework).*(user|explicit).*\|
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: prompt
     rubric:
       - The command preserves the explicit minimal-API and net9.0 choices
@@ -197,7 +212,10 @@ stimuli:
           pattern: (?i)\|.*user.*\|
       - type: output-matches
         config:
-          pattern: (?im)^\s*dotnet\s+new\s+\S+(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--dry-run\b
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s--dry-run\b|`dotnet\s+new\s+\S+[^`\r\n#]*\s--dry-run\b[^`\r\n#]*`)
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+\S+(?!(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*\s(?:--dry-run|--help)\b)(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*|`dotnet\s+new\s+\S+(?![^`\r\n#]*\s(?:--dry-run|--help)\b)[^`\r\n#]*`)
       - type: prompt
     rubric:
       - The answer preserves the explicit None authentication and disabled HTTPS choices

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -197,10 +197,10 @@ stimuli:
       - type: exit-success
       - type: output-matches
         config:
-          pattern: (?i)dotnet new webapi[^\n]*--auth[ =]+None
+          pattern: (?im)^\s*dotnet\s+new\s+webapi(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--auth[ =]+None
       - type: output-matches
         config:
-          pattern: (?i)dotnet new webapi[^\n]*--no-https
+          pattern: (?im)^\s*dotnet\s+new\s+webapi(?:[^\r\n]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b
       - type: output-matches
         config:
           pattern: (?i)\|.*user.*\|

--- a/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
+++ b/tests/dotnet-template-engine/template-smart-defaults/eval.yaml
@@ -39,7 +39,7 @@ stimuli:
       - type: exit-success
       - type: output-matches
         config:
-          pattern: (?i)SingleOrg
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+webapi(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--auth[ =]+SingleOrg|`dotnet\s+new\s+webapi[^`\r\n#]*--auth[ =]+SingleOrg[^`\r\n#]*`)
       - type: output-not-matches
         config:
           pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--no-https\b|`dotnet\s+new[^`\r\n#]*--no-https\b[^`\r\n#]*`)
@@ -68,7 +68,7 @@ stimuli:
       - type: exit-success
       - type: output-matches
         config:
-          pattern: (?i)(use-controllers|controllers)
+          pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new\s+webapi(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--use-controllers\b|`dotnet\s+new\s+webapi[^`\r\n#]*--use-controllers\b[^`\r\n#]*`)
       - type: output-not-matches
         config:
           pattern: (?im)(?:(?:^|[;&|])\s*dotnet\s+new(?:[^\r\n`;&|#]|\\\r?\n|`\r?\n|\^\r?\n)*--[a-z-]*minimal|`dotnet\s+new[^`\r\n#]*--[a-z-]*minimal[^`\r\n#]*`)


### PR DESCRIPTION
## Summary

Latest cross-model evaluation evidence showed repeatable skill-induced failures rather than general response-quality gaps: the .NET 11 JSON skill stopped when the SDK was absent, and template skills guessed option or schema shapes, emitted unsafe creation commands for advice-only requests, or continued semantic validation after malformed JSON.

This change replaces those failure modes with explicit decision rules. It adds self-contained local .NET 11 acquisition and the correct dictionary-key policy, grounds template option claims in observed `dotnet new --help` output, documents valid host constraints and restore post-actions, makes CPM-aware creation restore-safe, requires `--dry-run` for no-write advice, and stops validation at parse errors.

The follow-up six-model run also exposed two evaluator contradictions. Template-packaging prompts now receive real buildable Worker and Web API fixtures instead of nonexistent directories, and smart-default no-write scenarios explicitly grade `--dry-run` as the required safety behavior. Additional guidance addresses model-family failures around `.sln` format selection, sequential project creation, installed-template inspection, generated dependencies, and template-specific help.

## Evaluation evidence

The first default-profile run improved 2 of 14 model/skill results. A six-model run on the first revision improved 8 of 42. After the evidence-driven redesign, two full-profile runs over the materially identical core skill payload improved 15 of 42 and 11 of 42 respectively.

The remaining outcomes are not a stable content signal: many are one-loss `6W/0T/1L` or four-discordant `4W/3T/0L` records that miss the exact sign-test gate at `p=0.063`, while template instantiation frequently ties a saturated baseline despite producing the correct files and successful builds. The 15-to-11 swing on equivalent content demonstrates judge variance. Adding post-hoc stimuli solely to force every model over the threshold would violate this repository's eval-quality guidance, so this PR fixes the repeatable defects and records the residual statistical limitation rather than gaming the gate.

## Related issue

N/A

## Validation

- `dotnet run --no-build --project eng\skill-validator\src\SkillValidator.csproj -- check --plugin .\plugins\dotnet11`
- `dotnet run --no-build --project eng\skill-validator\src\SkillValidator.csproj -- check --plugin .\plugins\dotnet-template-engine`
- `python eng\eval-quality\check_eval_quality.py`
- `npx --yes markdownlint-cli2` on all changed skill files
- Built both new project-template fixtures on `net8.0`
- Exercised command graders against single-line, continued, chained, inline-code, comment, option-value, and additional unsafe-command cases
- Compiled and ran a `net11.0` probe covering `JsonNamingPolicy.PascalCase`, `DictionaryKeyPolicy`, `GetTypeInfo<T>()`, and `TryGetTypeInfo<T>()`

All local checks passed.

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content.
- [x] I updated all marketplace manifests when plugin metadata changed.
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.