### PR TITLE
Improve dotnet-test results for GPT-5.6 Sol

### DIFF
--- a/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
@@ -47,6 +47,9 @@ pairing beats the polyglot engine's identifier overlap.
    manual globbing, filename matching, or visual inspection.
    For polyglot analysis, pass `--include-tested` when the answer must distinguish
    paired sources from unpaired sources.
+   "Static pairing only" prohibits compiling the target repository and running
+   its tests; it does not prohibit launching this skill's parse-only analyzer.
+   State that distinction briefly when the caller also says "do not build."
 3. Base the result on the analyzer's JSON. Preserve its paired/unpaired
    classification and suggested relative path; do not guess a different path.
 4. When the caller named a subdirectory, prefix analyzer-relative paths with
@@ -274,8 +277,9 @@ file has an obvious matching or missing test.
 - `*.suggested_test_path` — drop-in target for the new test file; the Roslyn
   engine honors the test project that already `<ProjectReference>`s the source's
   project, so `dotnet sln add` is not needed. The polyglot engine may suggest a
-  co-located test when no test root is discoverable; that is a valid fallback,
-  but prefer an established repository test directory when one exists.
+  co-located test when no test root is discoverable. When a source sibling is
+  already paired, its test directory is the established convention and must be
+  reused for the missing sibling rather than falling back to source co-location.
 - `source_to_tests` (Roslyn) / `--include-tested` `tested_sources` (polyglot) —
   verify a newly written test file lands in the list for the intended source.
 - `orphan_tests` (polyglot) — tests that don't reference any same-language

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
@@ -580,29 +580,48 @@ def build_pairings(
 # --- Output ----------------------------------------------------------------
 
 
-def _suggest_test_path(source: FileInfo) -> str:
+def _test_filename(source: FileInfo) -> str:
     rel = source.rel
     lang = source.lang
     stem = rel.stem
-    parent = rel.parent
 
     if lang == "python":
-        return str(parent / f"test_{stem}.py")
+        return f"test_{stem}.py"
     if lang == "go":
-        return str(parent / f"{stem}_test.go")
+        return f"{stem}_test.go"
     if lang in ("typescript", "tsx"):
-        return str(parent / f"{stem}.test.{rel.suffix.lstrip('.')}")
+        return f"{stem}.test.{rel.suffix.lstrip('.')}"
     if lang == "javascript":
-        return str(parent / f"{stem}.test.js")
+        return f"{stem}.test.js"
     if lang == "java":
-        return str(parent / f"{stem}Test.java")
+        return f"{stem}Test.java"
     if lang == "rust":
-        return str(parent / f"{stem}_test.rs")
+        return f"{stem}_test.rs"
     if lang == "csharp":
-        return str(parent / f"{stem}Tests.cs")
+        return f"{stem}Tests.cs"
     if lang == "ruby":
-        return str(parent / f"{stem}_spec.rb")
+        return f"{stem}_spec.rb"
     return ""
+
+
+def _suggest_test_path(
+    source: FileInfo,
+    source_to_tests: dict[FileInfo, set[FileInfo]],
+) -> str:
+    filename = _test_filename(source)
+    if not filename:
+        return ""
+
+    language_family = {"typescript", "tsx"} if source.lang in {"typescript", "tsx"} else {source.lang}
+    sibling_test_dirs = sorted({
+        test.rel.parent
+        for paired_source, covering_tests in source_to_tests.items()
+        if paired_source.lang in language_family and paired_source.rel.parent == source.rel.parent
+        for test in covering_tests
+    }, key=lambda path: path.as_posix())
+
+    parent = sibling_test_dirs[0] if sibling_test_dirs else source.rel.parent
+    return (parent / filename).as_posix()
 
 
 def build_output(
@@ -626,7 +645,7 @@ def build_output(
             entry["covering_tests"] = [c.rel.as_posix() for c in covering]
             tested.append(entry)
         else:
-            entry["suggested_test_path"] = _suggest_test_path(s)
+            entry["suggested_test_path"] = _suggest_test_path(s, source_to_tests)
             untested.append(entry)
 
     return {

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
@@ -606,21 +606,14 @@ def _test_filename(source: FileInfo) -> str:
 
 def _suggest_test_path(
     source: FileInfo,
-    source_to_tests: dict[FileInfo, set[FileInfo]],
+    sibling_test_dirs: dict[tuple[str, PurePosixPath], PurePosixPath],
 ) -> str:
     filename = _test_filename(source)
     if not filename:
         return ""
 
-    language_family = {"typescript", "tsx"} if source.lang in {"typescript", "tsx"} else {source.lang}
-    sibling_test_dirs = sorted({
-        test.rel.parent
-        for paired_source, covering_tests in source_to_tests.items()
-        if paired_source.lang in language_family and paired_source.rel.parent == source.rel.parent
-        for test in covering_tests
-    }, key=lambda path: path.as_posix())
-
-    parent = sibling_test_dirs[0] if sibling_test_dirs else source.rel.parent
+    language_family = "typescript" if source.lang in {"typescript", "tsx"} else source.lang
+    parent = sibling_test_dirs.get((language_family, source.rel.parent), source.rel.parent)
     return (parent / filename).as_posix()
 
 
@@ -633,6 +626,16 @@ def build_output(
 ) -> dict:
     untested: list[dict] = []
     tested: list[dict] = []
+    sibling_test_dirs: dict[tuple[str, PurePosixPath], PurePosixPath] = {}
+    for paired_source, covering_tests in source_to_tests.items():
+        language_family = "typescript" if paired_source.lang in {"typescript", "tsx"} else paired_source.lang
+        key = (language_family, paired_source.rel.parent)
+        for test in covering_tests:
+            candidate = test.rel.parent
+            current = sibling_test_dirs.get(key)
+            if current is None or candidate.as_posix() < current.as_posix():
+                sibling_test_dirs[key] = candidate
+
     for s in sources:
         covering = sorted(source_to_tests.get(s, set()), key=lambda t: t.rel.as_posix())
         entry = {
@@ -645,7 +648,7 @@ def build_output(
             entry["covering_tests"] = [c.rel.as_posix() for c in covering]
             tested.append(entry)
         else:
-            entry["suggested_test_path"] = _suggest_test_path(s, source_to_tests)
+            entry["suggested_test_path"] = _suggest_test_path(s, sibling_test_dirs)
             untested.append(entry)
 
     return {

--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -198,6 +198,11 @@ Preserve every observable branch that depended on the original static result. Fo
 example, migrating `Environment.GetEnvironmentVariable(name) ?? "production"`
 requires tests for both a configured value and `null`/missing input selecting the
 fallback. A fake-only happy path is not enough to prove a mechanical migration.
+When tests already exist, preserve their framework and assertion style, but make
+the replacement dependency observable: include at least one configured/fake
+value assertion and one fallback or error-path assertion where the original
+static API exposed both outcomes. Merely making the old tests compile is not
+complete migration evidence.
 
 ### Step 6: Build verification
 

--- a/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
+++ b/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
@@ -49,6 +49,10 @@ edits and automatically reruns tests.
 - For a named test, identify the framework and return one runnable command with
   that framework's filter syntax. Never substitute MSTest/NUnit `--filter` for
   xUnit v3 `--filter-method` or TUnit `--treenode-filter`.
+- A directly launched MTP host is itself the persistent watcher: `dotnet run`
+  stays alive and the HotReload extension reacts to edits. Do not replace it
+  with `dotnet watch run` for the normal MTP path; reserve `dotnet watch` for the
+  explicit restart fallback below.
 
 ## Workflow
 
@@ -176,6 +180,11 @@ dotnet watch --project <project-path> run -- <existing-MTP-arguments>
 `dotnet watch` restarts the process when a rude edit cannot be applied. Without
 the auto-restart variable, accept the restart prompt or press `Ctrl+R`. Preserve
 any existing test filter after `--`.
+`DOTNET_WATCH_RESTART_ON_RUDE_EDIT` is a documented .NET SDK switch, not an MTP
+extension setting. When correctness may be questioned, cite the `dotnet watch`
+documentation and say that it makes the watcher restart instead of prompting.
+Never omit the original filter or replace the requested watch-managed fallback
+with a one-shot `dotnet run`.
 
 ### Step 6: Finalize
 

--- a/plugins/dotnet-test/skills/platform-detection/SKILL.md
+++ b/plugins/dotnet-test/skills/platform-detection/SKILL.md
@@ -197,6 +197,11 @@ the runner-selection signal; never say that this property alone enables the
 bridge. For a request asking which single signal decides, stop there. Omit
 bridge or host-shape prerequisites when the configuration is complete, and add
 them only when needed to explain why the selected runner cannot execute.
+Likewise, when an enabled runner is overridden or unreachable, state both axes
+causally: the runner property makes the project MTP-capable, but the final
+`UseVSTest`/bridge/output setting determines which platform actually executes.
+Name the runner selector before using a package reference only to identify the
+framework.
 
 Use causal evidence, not a bag of signals. For example:
 

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -123,6 +123,10 @@ later `dotnet test` filter examples for a classic runner.
 Use the installed adapter-compatible VSTest/MSTest toolchain. If it is not
 available, state the missing prerequisite and the documented command; do not
 claim tests ran.
+Classic `packages.config` fallback commands are Windows toolchain commands.
+Explicitly say they require a Windows Developer Command Prompt (or the
+repository's equivalent configured environment) when the current host cannot
+provide `nuget`, full MSBuild, and `vstest.console.exe`.
 
 For SDK-style projects, distinguish:
 
@@ -242,6 +246,9 @@ dotnet test Tests.csproj -- --report-trx
 
 # Native MTP TRX and hang detection
 dotnet test --project Tests.csproj --report-trx --hangdump --hangdump-timeout 5min
+
+# Native MTP diagnostics
+dotnet test --project Tests.csproj --diagnostic --diagnostic-output-directory artifacts/diagnostics
 ```
 
 5. **Execute only when requested.**

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -130,7 +130,7 @@ Run the narrowest commands that prove the chosen route:
 
 | Route | Required evidence |
 |---|---|
-| Newly created project | `dotnet test <test-project>`, exact entry-point test/build command, and registration listing |
+| Newly created project | `dotnet test <test-project>`, the exact entry-point command CI uses, and registration listing. If the entry point is a `.slnf`/`.slnx` containing tests, run `dotnet test` on that artifact rather than proving only that it builds. |
 | Missing reference | Targeted project test plus the exact solution/root test command requested |
 | Missing `.sln`/`.slnx` registration | Listing and `dotnet test` for that exact artifact; never use another solution as a fallback |
 | Missing `.slnf` entry | Inspect the filter entry and run the exact CI filter build command; do not prepend a deliberately failing alternate command |

--- a/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
+++ b/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
@@ -164,9 +164,18 @@ IMPORTANT: If the tests are well-written, say so clearly up front. Do not inflat
    actual transformation, DTO fields, and promised identity/clone semantics.
    Never invent fields or require lossless round-tripping when production is
    intentionally lossy.
+   For every suspicious equality, write down the independently known oracle
+   before assigning a finding. If the assertion compares a transformed output
+   with non-trivial input, clone state, snapshot, mock verification, or a
+   framework-native assertion context, explain why it can fail before calling it
+   tautological or assertion-free.
 3. **Make every Critical/High fix complete and specific.** Give the replacement assertion with the *exact expected value* (the computed discount, the exact CSV line, the full expected object), not a `// assert something here` placeholder.
 4. **Name the adjacent gaps the tests should also cover** — untested error paths, boundary values, and round-trip/culture-sensitivity risks in the same class. These are part of "what's wrong with my tests", and omitting them is the most common way this review loses to an unassisted one.
 5. **Keep the report internally consistent.** Summary counts must equal the enumerated findings. Publish a settled conclusion: do all reconsidering before you write, and never leave "wait, that's wrong" / "this should fail but doesn't" reasoning in the output.
+6. **Make non-findings decisive.** For a clean or mostly clean small suite, name
+   the suspicious constructs you cleared and the framework rule that makes each
+   valid. Do not bury a clean verdict under a generic checklist or speculative
+   improvements.
 
 Present findings in this structure:
 

--- a/plugins/dotnet-test/skills/test-smell-detection/SKILL.md
+++ b/plugins/dotnet-test/skills/test-smell-detection/SKILL.md
@@ -88,6 +88,11 @@ Apply these before assigning a finding:
   Exception Handling.
 - Integration markers legitimize declared external resources and multi-step
   flows, but not fixed sleeps or assertion-free execution.
+- For integration tests, trace helper factories and repository return types
+  before judging branch coverage. If a test branches on a subtype or state that
+  the real helper can never produce, report the unreachable assertion path and
+  explain the resulting false confidence. Do not stop at assigning the generic
+  Conditional Test Logic label.
 - A local temporary file still meets the formal Mystery Guest definition.
   Hermetic creation and cleanup reduce its severity; they do not change its
   taxonomy.

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -128,6 +128,14 @@ For each test method without traits, analyze:
 
 When in doubt between `positive` and `negative`, read the assertion: if it asserts success -> `positive`; if it asserts failure -> `negative`.
 
+For a requested distribution or coverage-shape audit, use available production
+code to map each test to the exact outcome it exercises before summarizing.
+Call out duplicated boundary coverage and whether the test inventory represents
+both sides of named thresholds and the observable collaborator outcomes on
+business-critical paths. Keep these as concise distribution observations, not
+new trait values. Do not perform mutation reasoning, prescribe new tests, or
+expand into the behavioral-gap audit owned by `test-gap-analysis`.
+
 ### Step 4: Apply trait attributes (or report only)
 
 **If the loaded language extension declares `auto-edit` for the framework**, add the appropriate attribute to each test method. Place trait attributes adjacent to the existing test attribute. Examples:

--- a/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
+++ b/plugins/dotnet-test/skills/testability-obstacle/SKILL.md
@@ -234,6 +234,14 @@ default; do not create an interface, implementation, friend-assembly setting,
 and extra project wiring unless repository conventions or multiple operations
 justify them.
 
+Preserve the public API surface as well as existing signatures. Do not add a
+public dependency-injecting constructor solely for tests. When a class currently
+has only its implicit public parameterless constructor and the exact test
+assembly is known, keep that constructor behavior and make the test-only
+constructor internal; an `InternalsVisibleTo` entry is justified in this narrow
+case because it prevents the seam from becoming public API. Prefer an existing
+repository friend-assembly convention when one is present.
+
 Do not add `InternalsVisibleTo` merely to reach a constructor-injected delegate
 or other seam that the test project can already supply. Friend-assembly access
 is justified only when the chosen minimum seam must remain internal and the
@@ -272,6 +280,7 @@ tests pass.
 - [ ] An existing seam was reused when available.
 - [ ] The new abstraction exposes only members required by the target behavior.
 - [ ] Production defaults still delegate to the original dependency.
+- [ ] The seam did not enlarge the public API when an internal test seam was sufficient.
 - [ ] Time conversions preserve local/UTC and `DateTime.Kind` semantics.
 - [ ] Static ambient overrides are async-safe, scoped, nested, and reversible.
 - [ ] New tests use fixed/in-memory dependencies and no real I/O or wall clock.

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -68,6 +68,9 @@ conventions of the project's installed test stack.
   distinguish `ThrowsExactly<T>` (exact type) from `Throws<T>` (type or derived
   type), and capture the returned exception when properties such as `ParamName`
   are part of the behavior.
+- **Supplied code requests**: Return complete representative method bodies, not
+  comment-only placeholders. Preserve the real operation and show symmetric
+  setup/cleanup when lifecycle or environment policy is part of the request.
 
 ## Workflow
 
@@ -196,6 +199,11 @@ intent clear, but uncompilable "modern" assertions are worse than compatible
 On MSTest 3.8+, prefer `Assert` class methods over `StringAssert` or
 `CollectionAssert` where both exist. Older versions should keep the compatible
 specialized classes.
+When several independent collection properties were requested, keep each
+semantic check explicit even if another assertion happens to imply it. For
+example, retain `IsNotEmpty` when the requested diagnostics distinguish
+empty/non-empty, then use `HasCount` and `ContainsSingle` for their separate
+cardinality guarantees.
 
 #### Equality, null, and reference checks
 
@@ -462,6 +470,9 @@ Attributes replace environment branches in test bodies; they do not replace
 the operation being tested. When correcting supplied code, retain the real
 registry/GPU/service operation and concrete resource cleanup rather than
 returning empty methods or comment-only placeholders.
+Show cleanup state initialized safely and released symmetrically (including a
+null guard when setup can fail). A policy-only sketch that omits the operation,
+assertion, or cleanup body is incomplete.
 
 #### Parallelization
 
@@ -528,3 +539,7 @@ corrected existing suite from running (for example, a missing namespace import
 in the supplied production file), make only that minimum fix and rerun. Do not
 upgrade packages or broaden the modernization. Report the actual test count and
 the fixes made; never present unrun or output-free tests as passing.
+In the final handoff, map every requested modernization to the exact corrected
+construct and cite the passing test command. Do not rely on a generic "modernized"
+summary when expected/actual order, exact type checks, data discovery, or class
+shape were explicit requirements.

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -147,7 +147,8 @@ stimuli:
     prompt: >
       Which classes under Billing still need unit tests, and is any test file
       not exercising production code at all? Sources are under src/, tests under
-      tests/. Static pairing only — do not build or run the tests.
+      tests/. Run the shipped parse-only analyzer, but do not compile the
+      Billing production project or run its tests.
     environment:
       files:
         - src: fixtures/generated-and-orphan
@@ -175,7 +176,7 @@ stimuli:
         naming them as generated and skipped is fine, listing them as sources needing tests is not
       - Flagged SmokeEnvironmentTests.cs as an orphan test that references no production type, rather than
         pairing it to a source file
-      - Did not run dotnet build, dotnet restore or dotnet test — this is static pairing analysis
+      - Did not build, restore, or test the Billing production project; launching the shipped parse-only analyzer is expected
       - Labelled the result as static source-to-test pairing rather than line or branch coverage
 
   - name: Pair sources to tests across a src/tests directory split

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -488,12 +488,12 @@ stimuli:
         - create
   - name: Collect coverage with VSTest
     prompt: |
-      Give me the exact command to run an SDK-style VSTest project and collect
-      code coverage. Do not run anything.
+      Give me the exact command to run the SDK-style VSTest project at
+      `Tests.csproj` and collect code coverage. Do not run anything.
     graders:
       - type: output-matches
         config:
-          pattern: '(?im)^\s*(?:[$>]\s*)?dotnet\s+test(?![^\r\n]*\s--(?:\s|$))[^\r\n]*--collect(?:\s+|:)["'']Code Coverage["''](?:\s|$)'
+          pattern: '(?im)^\s*(?:[$>]\s*)?dotnet\s+test(?=[^\r\n]*Tests\.csproj)(?![^\r\n]*\s--(?:\s|$))[^\r\n]*--collect(?:\s+|:)["'']Code Coverage["''](?:\s|$)'
       - type: output-not-matches
         config:
           pattern: (?im)^\s*(?:[$>]\s*)?dotnet\s+test[^\r\n]*--coverage(?:\s|$)

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -493,7 +493,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: '(?im)^\s*(?:[$>]\s*)?dotnet\s+test(?=[^\r\n]*Tests\.csproj)(?![^\r\n]*\s--(?:\s|$))[^\r\n]*--collect(?:\s+|:)["'']Code Coverage["''](?:\s|$)'
+          pattern: '(?im)^\s*(?:[$>]\s*)?dotnet\s+test(?=[^\r\n]*(?<![A-Za-z0-9_.-])Tests\.csproj(?![A-Za-z0-9_.-]))(?![^\r\n]*\s--(?:\s|$))[^\r\n]*--collect(?:\s+|:)["'']Code Coverage["''](?:\s|$)'
       - type: output-not-matches
         config:
           pattern: (?im)^\s*(?:[$>]\s*)?dotnet\s+test[^\r\n]*--coverage(?:\s|$)

--- a/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
+++ b/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
@@ -93,14 +93,14 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "dotnet build fixtures/multi-project/Commerce.slnf && dotnet test $(find fixtures/multi-project/tests -name '*.csproj' -print -quit)"
+          command: sh -c "dotnet test fixtures/multi-project/Commerce.slnf"
           expected_exit_code: 0
           timeout: 10m
       - type: prompt
     rubric:
       - Added one pricing test project to both Commerce.sln and Commerce.slnf
       - Preserved central package management and added real PriceCalculator tests
-      - Verified the solution filter builds and the test project passes
+      - Verified the exact CI solution filter discovers and passes the new test
 
   - name: Reuse an existing suitable test project
     prompt: |


### PR DESCRIPTION
## Summary

The retained GPT-5.6 Sol evaluation activated every targeted skill, but 10 `dotnet-test` skills were not proven improved because of concrete quality losses, high tie rates, and several misleading eval comparisons. This change turns the losing judge evidence into focused model decisions instead of broadly expanding skill prose.

Key changes:
- sharpen the exact decisions Sol missed across test execution, MTP hot reload, platform detection, MSTest authoring, testability, tagging, and test-review skills;
- fix polyglot source pairing so an untested source reuses the established sibling test directory, including shared TypeScript/TSX conventions;
- align three evals with the behavior they intend to reward: parse-only analyzer execution, solution-filter test discovery, and an explicit VSTest project path.

Representative losing evidence addressed here:

> Both correctly identified tax.ts as untested and pricing.ts as paired. A's suggested test location follows the repo's actual convention (tests/cart/), which is more accurate and useful, while B placed it in src/ inconsistent with the existing tests folder.

> Response B places the MTP options as dotnet CLI arguments before any '--', which would not be recognized and would fail.

> B exposed a public writer-injecting constructor, enlarging the public surface.

The hot-reload remediation retains `DOTNET_WATCH_RESTART_ON_RUDE_EDIT`: source inspection in `dotnet/sdk` confirmed it is a supported `dotnet watch` switch, so the skill now explains and attributes that behavior instead of accepting the judge's incorrect "fabricated" characterization.

## Related issue

N/A

## Validation

- `python eng/eval-quality/check_eval_quality.py` - passed all 98 eval specs with no errors.
- `dotnet run -p:CopilotSkipCliDownload=true --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-test` - passed for 22 skills and 10 agents.
- Analyzer assertions passed for TypeScript, TSX, Python, and C# sibling test-directory conventions.
- `git diff --check` - passed.

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] CODEOWNERS is unchanged because no owned content was added or moved.
- [x] Marketplace manifests are unchanged because plugin metadata did not change.
- [x] `eng/known-domains.txt` is unchanged because no new external domain was added.