### PR TITLE
Keep test agent state out of commits

### DIFF
--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -26,7 +26,9 @@ Run the appropriate build command and report success or failure with error detai
 
 If not provided, check in order:
 
-1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
+1. The exact command or relevant Commands excerpt supplied by the caller; if
+   the caller instead supplies a document, it must provide its absolute
+   `<TESTAGENT_DIR>/research.md` or `<TESTAGENT_DIR>/plan.md` path
 2. Project files:
    - SDK-style `*.csproj` / `*.sln` → `dotnet build`
    - Classic non-SDK `*.csproj` / `*.sln` → repository-documented MSBuild command

--- a/plugins/dotnet-test/agents/code-testing-builder.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-builder.agent.md
@@ -26,7 +26,7 @@ Run the appropriate build command and report success or failure with error detai
 
 If not provided, check in order:
 
-1. `.testagent/research.md` or `.testagent/plan.md` for Commands section
+1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
 2. Project files:
    - SDK-style `*.csproj` / `*.sln` → `dotnet build`
    - Classic non-SDK `*.csproj` / `*.sln` → repository-documented MSBuild command

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -35,7 +35,22 @@ You coordinate test generation using the Research-Plan-Implement (RPI) pipeline.
 
 Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](../skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
 
-Before writing code, read the language-specific base extension. Reuse it for the whole run; sub-agents must not independently reload the same reference unless they need a section that was not captured in `.testagent/research.md`.
+Before writing code, read the language-specific base extension. Reuse it for the whole run; sub-agents must not independently reload the same reference unless they need a section that was not captured in the research document.
+
+For Single pass and Iterative strategies, resolve one absolute `TESTAGENT_DIR`
+before invoking any sub-agent:
+
+1. Prefer a host-provided session artifact or scratch directory when one is
+   available.
+2. Otherwise, in a Git worktree use the absolute form of
+   `git rev-parse --git-path testagent`. This stores state in worktree-specific
+   Git metadata, which cannot be staged or committed.
+3. Outside Git, create a unique directory under the operating system's
+   temporary directory.
+
+Create the resolved directory and pass its absolute path explicitly in every
+sub-agent prompt. Never create `.testagent/` in the workspace or add a
+`.gitignore` entry for agent state.
 
 Create a **requirement checklist** from the request before choosing a strategy.
 Preserve each explicit behavior, layer, collaborator seam, boundary case,
@@ -43,7 +58,7 @@ integration, coverage threshold, and required artifact as a separate item. For
 example, "mock the repository in service tests", "exercise SQLite in memory",
 and "cover pagination boundaries" are three independently verifiable
 requirements. Direct strategy keeps this checklist in context; delegated
-strategies record it in `.testagent/research.md`.
+strategies record it in `<TESTAGENT_DIR>/research.md`.
 
 ### Step 2: Choose Execution Strategy
 
@@ -53,7 +68,7 @@ Based on the request scope, pick exactly one strategy and follow it:
 | ---------- | ------------- | ------------ |
 | **Direct** | A small, self-contained request (e.g., tests for a single function or class) that you can complete without sub-agents | Follow the codebase conventions on test file structure, naming, style, and testing approaches. Reuse existing test projects and test files when possible — if the code under test already has tests, add new tests to the same file or test project. Only create a new test file when no canonical file is named or discoverable for the symbol under test. Write the tests immediately. **Run them right away** — if any test fails, read the production code, fix the assertion, and re-run before writing more tests. Skip Steps 3-5 (research, plan, implement sub-agents). Then proceed to Steps 6-9 for validation and reporting — **Direct skips only the sub-agents, never the Step 7 pre-completion gate** (which still runs per its own threshold in Step 7 — i.e. for any non-trivial addition: ≥5 tests, or any request that enumerates behaviors/scenarios to verify). |
 | **Single pass** | A moderate scope (couple projects or modules) that a single Research → Plan → Implement cycle can cover | Execute Steps 3-8 once, then proceed to Step 9. |
-| **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's `.testagent/` documents (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
+| **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's documents in `TESTAGENT_DIR` (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
 
 **Default to Direct** unless the user asks for a project/package-wide suite or
 the scope explicitly spans multiple files or modules. Most test generation
@@ -87,25 +102,25 @@ Delegate to the `code-testing-researcher` subagent with this task:
 ```text
 runSubagent({
   agent: "code-testing-researcher",
-  prompt: "Research [REQUESTED SCOPE] at [PATH] for test generation. Produce a bounded target inventory, existing test conventions, source-to-test pairs, dependencies only for those targets, and exact build/test/discovery commands. Do not inventory unrelated source files."
+  prompt: "Research [REQUESTED SCOPE] at [PATH] for test generation. Write the research document to [ABSOLUTE TESTAGENT_DIR]/research.md. Produce a bounded target inventory, existing test conventions, source-to-test pairs, dependencies only for those targets, and exact build/test/discovery commands. Do not inventory unrelated source files."
 })
 ```
 
-Output: `.testagent/research.md`
+Output: `<TESTAGENT_DIR>/research.md`
 
 ### Step 4: Planning Phase
 
 Delegate to the `code-testing-planner` subagent with this task:
 
-> Create a test implementation plan based on .testagent/research.md. Create phased approach with specific files and test cases.
+> Create a test implementation plan based on [ABSOLUTE TESTAGENT_DIR]/research.md. Write it to [ABSOLUTE TESTAGENT_DIR]/plan.md. Create a phased approach with specific files and test cases.
 
-Output: `.testagent/plan.md`
+Output: `<TESTAGENT_DIR>/plan.md`
 
 ### Step 5: Implementation Phase
 
 Execute each phase by delegating to the `code-testing-implementer` subagent — once per phase, sequentially. For each phase, delegate with this task:
 
-> Implement Phase N from .testagent/plan.md: [phase description]. Ensure tests compile and pass.
+> Implement Phase N from [ABSOLUTE TESTAGENT_DIR]/plan.md: [phase description]. Use [ABSOLUTE TESTAGENT_DIR]/research.md for commands and conventions. Ensure tests compile and pass.
 
 ### Step 6: Final Build Validation
 
@@ -152,7 +167,7 @@ Additional self-review heuristics (still required, even when running the skills)
 
 ### Step 8: Coverage Gap Iteration
 
-After the previous phases complete, use the target inventory already recorded in `.testagent/research.md` and the files reported by implementers. Do not rescan or reread the workspace.
+After the previous phases complete, use the target inventory already recorded in `<TESTAGENT_DIR>/research.md` and the files reported by implementers. Do not rescan or reread the workspace.
 
 1. Compare the requirement checklist and bounded target inventory with the implemented tests.
 2. Inspect the generated test bodies for evidence of every checklist item. A covered line does not prove that a requested collaborator was mocked, a concrete result was asserted, or a boundary/property combination was exercised.
@@ -161,10 +176,10 @@ After the previous phases complete, use the target inventory already recorded in
 5. Stop only when every feasible checklist item is covered and the stated target is met; do not recursively expand into unrelated files.
 6. If this step added or modified tests, re-run the full Step 7 pre-completion gate (`test-gap-analysis` + `assertion-quality` + prompt-scenario coverage) on those tests before reporting completion.
 
-For Single pass and Iterative strategies, write `.testagent/status.md` after
+For Single pass and Iterative strategies, write `<TESTAGENT_DIR>/status.md` after
 the final review and validation. Record the completed checklist, commands and
 results, quality findings, fixes, and any explicit blockers. Direct strategy
-keeps this evidence in the final response and must not create `.testagent/`.
+keeps this evidence in the final response and must not create pipeline state.
 
 ### Step 9: Report Results
 
@@ -208,11 +223,12 @@ Use a language example from `code-testing-extensions` only when no existing test
 
 ## State Management
 
-All state is stored in `.testagent/` folder:
+All delegated pipeline state is stored outside the working tree in the resolved
+`TESTAGENT_DIR`:
 
-- `.testagent/research.md` — Research findings
-- `.testagent/plan.md` — Implementation plan
-- `.testagent/status.md` — Final quality review, fixes, and validation status
+- `<TESTAGENT_DIR>/research.md` — Research findings
+- `<TESTAGENT_DIR>/plan.md` — Implementation plan
+- `<TESTAGENT_DIR>/status.md` — Final quality review, fixes, and validation status
 
 ## Rules
 
@@ -224,9 +240,9 @@ All state is stored in `.testagent/` folder:
 6. **Scoped builds during phases, full build at the end** — build specific test projects during implementation for speed; run a full-workspace non-incremental build after all phases to catch cross-project errors
 7. **No environment-dependent tests** — mock all external dependencies; never call external URLs, bind ports, or depend on timing
 8. **Fix assertions, don't skip tests** — when tests fail, read production code and fix the expected value; never `[Ignore]` or `[Skip]`
-9. **Retain `.testagent/` through completion** — keep the research, plan, and final status available as auditable pipeline evidence. Do not delete them automatically; if the repository should not commit agent state, advise the user to add `.testagent/` to `.gitignore` after reporting the result.
+9. **Keep agent state out of commits** — retain research, plan, and final status in `TESTAGENT_DIR` through completion, but never create `.testagent/` in the workspace, stage agent state, or modify `.gitignore` for it. Before reporting, inspect the working-tree changes and confirm they contain only requested deliverables and required manifest edits.
 10. **Read language extensions first** — always call the `code-testing-extensions` skill and read the relevant extension file before writing any code; it contains critical project registration and build validation steps
 11. **Always validate** — final build, final test, coverage-gap review, and reporting are mandatory for ALL strategies including Direct; never skip final validation. The pre-completion self-review gate from Step 7 (`test-gap-analysis` + `assertion-quality` skills, plus the prompt-scenario coverage check) is mandatory for every non-trivial test addition and may be skipped only for trivially small tasks (fewer than 5 generated tests *and* no behaviors specified in the prompt), per Step 7
 12. **Preserve existing tests** — never delete or overwrite existing test files; create new files or append to existing ones
 13. **Never mutate version control** — your only outputs are additive test files plus minimal build-manifest edits to register a new test project. Any command that reverts, restores, resets, stashes, or cleans the tree, or deletes tracked files, is out of scope — even when the workspace looks broken or incomplete.
-14. **Bound context and reuse findings** — scope every search to the user's requested files/modules, read only the source and existing tests needed for the next implementation phase, and reuse `.testagent/research.md` instead of repeating workspace discovery.
+14. **Bound context and reuse findings** — scope every search to the user's requested files/modules, read only the source and existing tests needed for the next implementation phase, and reuse `<TESTAGENT_DIR>/research.md` instead of repeating workspace discovery.

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -37,7 +37,8 @@ Understand what the user wants: scope (project, files, classes), priority areas,
 
 Before writing code, read the language-specific base extension. Reuse it for the whole run; sub-agents must not independently reload the same reference unless they need a section that was not captured in the research document.
 
-For Single pass and Iterative strategies, resolve one absolute `TESTAGENT_DIR`
+For Single pass and Iterative strategies, resolve one absolute
+`<TESTAGENT_DIR>`
 before invoking any sub-agent:
 
 1. Prefer a host-provided session artifact or scratch directory when one is
@@ -49,8 +50,9 @@ before invoking any sub-agent:
    temporary directory.
 
 Create the resolved directory and pass its absolute path explicitly in every
-sub-agent prompt. Never create `.testagent/` in the workspace or add a
-`.gitignore` entry for agent state.
+sub-agent prompt. Never create `<TESTAGENT_DIR>` or any intermediate state file
+in version-controlled workspace content, and never modify `.gitignore` to hide
+them.
 
 Create a **requirement checklist** from the request before choosing a strategy.
 Preserve each explicit behavior, layer, collaborator seam, boundary case,
@@ -68,7 +70,7 @@ Based on the request scope, pick exactly one strategy and follow it:
 | ---------- | ------------- | ------------ |
 | **Direct** | A small, self-contained request (e.g., tests for a single function or class) that you can complete without sub-agents | Follow the codebase conventions on test file structure, naming, style, and testing approaches. Reuse existing test projects and test files when possible — if the code under test already has tests, add new tests to the same file or test project. Only create a new test file when no canonical file is named or discoverable for the symbol under test. Write the tests immediately. **Run them right away** — if any test fails, read the production code, fix the assertion, and re-run before writing more tests. Skip Steps 3-5 (research, plan, implement sub-agents). Then proceed to Steps 6-9 for validation and reporting — **Direct skips only the sub-agents, never the Step 7 pre-completion gate** (which still runs per its own threshold in Step 7 — i.e. for any non-trivial addition: ≥5 tests, or any request that enumerates behaviors/scenarios to verify). |
 | **Single pass** | A moderate scope (couple projects or modules) that a single Research → Plan → Implement cycle can cover | Execute Steps 3-8 once, then proceed to Step 9. |
-| **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's documents in `TESTAGENT_DIR` (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
+| **Iterative** | A large scope or ambitious coverage target that one pass cannot satisfy | Execute Steps 3-8, then re-evaluate coverage. If the target is not met, repeat Steps 3-8 with a narrowed focus on remaining gaps. Use unique names for each iteration's documents in `<TESTAGENT_DIR>` (e.g., `research-2.md`, `plan-2.md`) so earlier results are not overwritten. Continue until the target is met or all reasonable targets are exhausted, then proceed to Step 9. |
 
 **Default to Direct** unless the user asks for a project/package-wide suite or
 the scope explicitly spans multiple files or modules. Most test generation
@@ -102,7 +104,7 @@ Delegate to the `code-testing-researcher` subagent with this task:
 ```text
 runSubagent({
   agent: "code-testing-researcher",
-  prompt: "Research [REQUESTED SCOPE] at [PATH] for test generation. Write the research document to [ABSOLUTE TESTAGENT_DIR]/research.md. Produce a bounded target inventory, existing test conventions, source-to-test pairs, dependencies only for those targets, and exact build/test/discovery commands. Do not inventory unrelated source files."
+  prompt: "Research [REQUESTED SCOPE] at [PATH] for test generation. Write the research document to <TESTAGENT_DIR>/research.md. Produce a bounded target inventory, existing test conventions, source-to-test pairs, dependencies only for those targets, and exact build/test/discovery commands. Do not inventory unrelated source files."
 })
 ```
 
@@ -112,7 +114,7 @@ Output: `<TESTAGENT_DIR>/research.md`
 
 Delegate to the `code-testing-planner` subagent with this task:
 
-> Create a test implementation plan based on [ABSOLUTE TESTAGENT_DIR]/research.md. Write it to [ABSOLUTE TESTAGENT_DIR]/plan.md. Create a phased approach with specific files and test cases.
+> Create a test implementation plan based on `<TESTAGENT_DIR>/research.md`. Write it to `<TESTAGENT_DIR>/plan.md`. Create a phased approach with specific files and test cases.
 
 Output: `<TESTAGENT_DIR>/plan.md`
 
@@ -120,7 +122,7 @@ Output: `<TESTAGENT_DIR>/plan.md`
 
 Execute each phase by delegating to the `code-testing-implementer` subagent — once per phase, sequentially. For each phase, delegate with this task:
 
-> Implement Phase N from [ABSOLUTE TESTAGENT_DIR]/plan.md: [phase description]. Use [ABSOLUTE TESTAGENT_DIR]/research.md for commands and conventions. Ensure tests compile and pass.
+> Implement Phase N from `<TESTAGENT_DIR>/plan.md`: [phase description]. Use `<TESTAGENT_DIR>/research.md` for commands and conventions. Ensure tests compile and pass.
 
 ### Step 6: Final Build Validation
 
@@ -188,7 +190,8 @@ After the previous phases complete, use the target inventory already recorded in
 For Single pass and Iterative strategies, write `<TESTAGENT_DIR>/status.md` after
 the final review and validation. Record the completed checklist, commands and
 results, quality findings, fixes, and any explicit blockers. Direct strategy
-keeps this evidence in the final response and must not create pipeline state.
+keeps this evidence in the final response and must not create intermediate
+state files.
 
 ### Step 9: Report Results
 
@@ -232,8 +235,8 @@ Use a language example from `code-testing-extensions` only when no existing test
 
 ## State Management
 
-All delegated pipeline state is stored in the resolved, non-stageable
-`TESTAGENT_DIR`:
+All delegated intermediate state files are stored in the resolved,
+non-stageable `<TESTAGENT_DIR>`:
 
 - `<TESTAGENT_DIR>/research.md` — Research findings
 - `<TESTAGENT_DIR>/plan.md` — Implementation plan
@@ -249,7 +252,7 @@ All delegated pipeline state is stored in the resolved, non-stageable
 6. **Scoped builds during phases, full build at the end** — build specific test projects during implementation for speed; run a full-workspace non-incremental build after all phases to catch cross-project errors
 7. **No environment-dependent tests** — mock all external dependencies; never call external URLs, bind ports, or depend on timing
 8. **Fix assertions, don't skip tests** — when tests fail, read production code and fix the expected value; never `[Ignore]` or `[Skip]`
-9. **Keep agent state out of commits** — retain research, plan, and final status in `TESTAGENT_DIR` through completion, but never create `.testagent/` in the workspace, stage agent state, or modify `.gitignore` for it. Before reporting, inspect the working-tree changes and confirm they contain only requested deliverables and required manifest edits.
+9. **Keep intermediate state files out of commits** — retain research, plan, and final status in `<TESTAGENT_DIR>` through completion, but never place `<TESTAGENT_DIR>` or its files in version-controlled workspace content, stage them, or modify `.gitignore` to hide them. Before reporting, inspect the working-tree changes and confirm they contain only requested deliverables and required manifest edits.
 10. **Read language extensions first** — always call the `code-testing-extensions` skill and read the relevant extension file before writing any code; it contains critical project registration and build validation steps
 11. **Always validate** — final build, final test, coverage-gap review, and reporting are mandatory for ALL strategies including Direct; never skip final validation. The pre-completion self-review gate from Step 7 (`test-gap-analysis` + `assertion-quality` skills, plus the prompt-scenario coverage check) is mandatory for every non-trivial test addition and may be skipped only for trivially small tasks (fewer than 5 generated tests *and* no behaviors specified in the prompt), per Step 7
 12. **Preserve existing tests** — never delete or overwrite existing test files; create new files or append to existing ones

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -232,7 +232,7 @@ Use a language example from `code-testing-extensions` only when no existing test
 
 ## State Management
 
-All delegated pipeline state is stored outside the working tree in the resolved
+All delegated pipeline state is stored in the resolved, non-stageable
 `TESTAGENT_DIR`:
 
 - `<TESTAGENT_DIR>/research.md` — Research findings

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -42,9 +42,9 @@ before invoking any sub-agent:
 
 1. Prefer a host-provided session artifact or scratch directory when one is
    available.
-2. Otherwise, in a Git worktree use the absolute form of
-   `git rev-parse --git-path testagent`. This stores state in worktree-specific
-   Git metadata, which cannot be staged or committed.
+2. Otherwise, in a Git worktree run
+   `git rev-parse --path-format=absolute --git-path testagent`. This returns a
+   path in worktree-specific Git metadata, which cannot be staged or committed.
 3. Outside Git, create a unique directory under the operating system's
    temporary directory.
 

--- a/plugins/dotnet-test/agents/code-testing-generator.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-generator.agent.md
@@ -172,9 +172,18 @@ After the previous phases complete, use the target inventory already recorded in
 1. Compare the requirement checklist and bounded target inventory with the implemented tests.
 2. Inspect the generated test bodies for evidence of every checklist item. A covered line does not prove that a requested collaborator was mocked, a concrete result was asserted, or a boundary/property combination was exercised.
 3. If the user requested a measurable coverage target, collect coverage once and prioritize only gaps inside the requested scope.
-4. Add tests for any unaddressed checklist item before adding optional cases merely to raise test count.
-5. Stop only when every feasible checklist item is covered and the stated target is met; do not recursively expand into unrelated files.
-6. If this step added or modified tests, re-run the full Step 7 pre-completion gate (`test-gap-analysis` + `assertion-quality` + prompt-scenario coverage) on those tests before reporting completion.
+4. Add tests for any unaddressed checklist item first.
+5. For Single pass and Iterative strategies, treat that checklist as the floor.
+   Sweep each bounded target API for still-unproved observable equivalence
+   partitions and invariants: identity/empty/singleton/interior inputs, exact
+   and immediately adjacent boundaries, invalid partitions, and ordering,
+   monotonicity, rollover, capacity, truncation, or state properties implied by
+   the implementation. Add one mutation-relevant case per distinct partition;
+   consolidate sibling inputs in parameterized or table-driven tests.
+6. Stop only when every feasible checklist item and distinct behavioral
+   partition is covered and the stated target is met. Do not recursively expand
+   into unrelated files or add equivalent cases merely to raise test count.
+7. If this step added or modified tests, re-run the full Step 7 pre-completion gate (`test-gap-analysis` + `assertion-quality` + prompt-scenario coverage) on those tests before reporting completion.
 
 For Single pass and Iterative strategies, write `<TESTAGENT_DIR>/status.md` after
 the final review and validation. Record the completed checklist, commands and

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -30,8 +30,10 @@ Given a phase from the plan, write all the test files for that phase and ensure 
 
 ### 1. Read the Plan and Research
 
-- Read only the current phase from `.testagent/plan.md`
-- Read the command, convention, and target entries needed for that phase from `.testagent/research.md`
+- Read only the current phase from the caller-provided absolute
+  `<TESTAGENT_DIR>/plan.md` path
+- Read the command, convention, and target entries needed for that phase from
+  `<TESTAGENT_DIR>/research.md`
 - Identify which phase you're implementing
 
 ### 2. Read Source Files and Validate References
@@ -69,7 +71,10 @@ For each test file in your phase:
 These rules apply to every language and override any pattern an existing test file may suggest. They keep generated changes additive so reviewers, CI gates, and test-quality benchmarks treat your output as a clean test addition rather than a refactor:
 
 - **Existing test files are append-only.** When growing an existing test file, insert new test methods/cases at the end of the relevant class/describe-block/module. Do not reformat, reorder, rename, or remove any existing line — even whitespace-only churn counts as a destructive edit.
-- **Do not modify non-test source files.** If a class, method, or symbol is hard to test (sealed, internal, no seam, tightly coupled), record the gap in `.testagent/plan.md` as a follow-up. Do not edit production code to make it testable as part of test generation — that is the scope of the `testability-migration` agent, not this one.
+- **Do not modify non-test source files.** If a class, method, or symbol is hard to test (sealed, internal, no seam, tightly coupled), record the gap in `<TESTAGENT_DIR>/plan.md` as a follow-up. Do not edit production code to make it testable as part of test generation — that is the scope of the `testability-migration` agent, not this one.
+- **Keep pipeline state outside the working tree.** Use only the absolute
+  `TESTAGENT_DIR` supplied by the caller for research, plan, or status updates.
+  Never create `.testagent/` in the workspace or stage pipeline state.
 - **Never revert or clean the working tree.** Do not run `git checkout`, `git restore`, `git reset`, `git clean`, `git stash`, `git rm`, or delete tracked files. Generate tests against the workspace exactly as delivered, even if the source looks synthetic, deleted, gutted, or incomplete — that state is intentional, not corruption.
 - **Prefer new test files over edits to existing ones** when both options are equally valid (e.g., a new feature, a separate concern, or any case where the existing file isn't strictly required). A new file is always purely additive.
 - **One exception**: build-system manifests (`.csproj`/`.sln`/`packages.config`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited when registering a new test file/project or adding a missing test dependency. Keep these edits minimal and limited to the registration/dependency change. Never convert `packages.config` to `PackageReference`, convert a classic project to SDK style, or upgrade the test stack unless the user explicitly requested that migration.
@@ -80,13 +85,16 @@ Coverage alone gives false confidence — every test must *pin down behavior* so
 
 ### 5. Verify with Build
 
-Call the `code-testing-builder` sub-agent to compile. Build only the specific test project, not the full solution.
+Call the `code-testing-builder` sub-agent to compile, passing the exact build
+command and absolute `TESTAGENT_DIR`. Build only the specific test project, not
+the full solution.
 
 If build fails: call `code-testing-fixer`, rebuild, retry up to 3 times.
 
 ### 6. Verify with Tests
 
-Call the `code-testing-tester` sub-agent to run tests.
+Call the `code-testing-tester` sub-agent to run tests, passing the exact test
+command and absolute `TESTAGENT_DIR`.
 
 If tests fail:
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -76,9 +76,9 @@ These rules apply to every language and override any pattern an existing test fi
 
 - **Existing test files are append-only.** When growing an existing test file, insert new test methods/cases at the end of the relevant class/describe-block/module. Do not reformat, reorder, rename, or remove any existing line — even whitespace-only churn counts as a destructive edit.
 - **Do not modify non-test source files.** If a class, method, or symbol is hard to test (sealed, internal, no seam, tightly coupled), record the gap in `<TESTAGENT_DIR>/plan.md` as a follow-up. Do not edit production code to make it testable as part of test generation — that is the scope of the `testability-migration` agent, not this one.
-- **Keep pipeline state outside the working tree.** Use only the absolute
-  `TESTAGENT_DIR` supplied by the caller for research, plan, or status updates.
-  Never create `.testagent/` in the workspace or stage pipeline state.
+- **Keep pipeline state non-stageable.** Use only the absolute `TESTAGENT_DIR`
+  supplied by the caller for research, plan, or status updates. Never create
+  `.testagent/` in the workspace or stage pipeline state.
 - **Never revert or clean the working tree.** Do not run `git checkout`, `git restore`, `git reset`, `git clean`, `git stash`, `git rm`, or delete tracked files. Generate tests against the workspace exactly as delivered, even if the source looks synthetic, deleted, gutted, or incomplete — that state is intentional, not corruption.
 - **Prefer new test files over edits to existing ones** when both options are equally valid (e.g., a new feature, a separate concern, or any case where the existing file isn't strictly required). A new file is always purely additive.
 - **One exception**: build-system manifests (`.csproj`/`.sln`/`packages.config`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited when registering a new test file/project or adding a missing test dependency. Keep these edits minimal and limited to the registration/dependency change. Never convert `packages.config` to `PackageReference`, convert a classic project to SDK style, or upgrade the test stack unless the user explicitly requested that migration.

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -76,9 +76,10 @@ These rules apply to every language and override any pattern an existing test fi
 
 - **Existing test files are append-only.** When growing an existing test file, insert new test methods/cases at the end of the relevant class/describe-block/module. Do not reformat, reorder, rename, or remove any existing line — even whitespace-only churn counts as a destructive edit.
 - **Do not modify non-test source files.** If a class, method, or symbol is hard to test (sealed, internal, no seam, tightly coupled), record the gap in `<TESTAGENT_DIR>/plan.md` as a follow-up. Do not edit production code to make it testable as part of test generation — that is the scope of the `testability-migration` agent, not this one.
-- **Keep pipeline state non-stageable.** Use only the absolute `TESTAGENT_DIR`
-  supplied by the caller for research, plan, or status updates. Never create
-  `.testagent/` in the workspace or stage pipeline state.
+- **Keep intermediate state files non-stageable.** Use only the absolute
+  `<TESTAGENT_DIR>` supplied by the caller for research, plan, or status
+  updates. Never place `<TESTAGENT_DIR>` or its files in version-controlled
+  workspace content or stage them.
 - **Never revert or clean the working tree.** Do not run `git checkout`, `git restore`, `git reset`, `git clean`, `git stash`, `git rm`, or delete tracked files. Generate tests against the workspace exactly as delivered, even if the source looks synthetic, deleted, gutted, or incomplete — that state is intentional, not corruption.
 - **Prefer new test files over edits to existing ones** when both options are equally valid (e.g., a new feature, a separate concern, or any case where the existing file isn't strictly required). A new file is always purely additive.
 - **One exception**: build-system manifests (`.csproj`/`.sln`/`packages.config`/`pom.xml`/`build.gradle`/`Cargo.toml`/`package.json`/etc.) may be edited when registering a new test file/project or adding a missing test dependency. Keep these edits minimal and limited to the registration/dependency change. Never convert `packages.config` to `PackageReference`, convert a classic project to SDK style, or upgrade the test stack unless the user explicitly requested that migration.
@@ -90,15 +91,15 @@ Coverage alone gives false confidence — every test must *pin down behavior* so
 ### 5. Verify with Build
 
 Call the `code-testing-builder` sub-agent to compile, passing the exact build
-command and absolute `TESTAGENT_DIR`. Build only the specific test project, not
-the full solution.
+command and absolute `<TESTAGENT_DIR>`. Build only the specific test project,
+not the full solution.
 
 If build fails: call `code-testing-fixer`, rebuild, retry up to 3 times.
 
 ### 6. Verify with Tests
 
 Call the `code-testing-tester` sub-agent to run tests, passing the exact test
-command and absolute `TESTAGENT_DIR`.
+command and absolute `<TESTAGENT_DIR>`.
 
 If tests fail:
 
@@ -128,7 +129,7 @@ If your language extension has no "Harness Discovery Check" section, use the can
 ### 8. Format Code (Optional)
 
 If a lint command is available, call the `code-testing-linter` sub-agent,
-passing the exact lint command and absolute `TESTAGENT_DIR`.
+passing the exact lint command and absolute `<TESTAGENT_DIR>`.
 
 ### 9. Report Results
 

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -64,6 +64,10 @@ For each test file in your phase:
 - Create the test file with appropriate structure
 - Follow the project's testing patterns
 - Include tests for: happy path, edge cases (empty, null, boundary), error conditions
+- Treat the plan's explicit requirements as a floor. For broad/comprehensive
+  scope, add one mutation-relevant case for every distinct observable
+  equivalence partition or invariant in the target implementation that the plan
+  missed; parameterize sibling inputs instead of duplicating test structure.
 - Mock all external dependencies — never call external URLs, bind ports, or depend on timing
 
 #### Edit boundaries (cross-language invariants)

--- a/plugins/dotnet-test/agents/code-testing-implementer.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-implementer.agent.md
@@ -123,7 +123,8 @@ If your language extension has no "Harness Discovery Check" section, use the can
 
 ### 8. Format Code (Optional)
 
-If a lint command is available, call the `code-testing-linter` sub-agent.
+If a lint command is available, call the `code-testing-linter` sub-agent,
+passing the exact lint command and absolute `TESTAGENT_DIR`.
 
 ### 9. Report Results
 

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -24,7 +24,7 @@ Run the appropriate lint/format command to fix code style issues.
 
 If not provided, check in order:
 
-1. `.testagent/research.md` or `.testagent/plan.md` for Commands section
+1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
 2. Project files:
    - `*.csproj` / `*.sln` → `dotnet format`
    - `package.json` → `npm run lint:fix` or `npm run format`

--- a/plugins/dotnet-test/agents/code-testing-linter.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-linter.agent.md
@@ -24,7 +24,9 @@ Run the appropriate lint/format command to fix code style issues.
 
 If not provided, check in order:
 
-1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
+1. The exact command or relevant Commands excerpt supplied by the caller; if
+   the caller instead supplies a document, it must provide its absolute
+   `<TESTAGENT_DIR>/research.md` or `<TESTAGENT_DIR>/plan.md` path
 2. Project files:
    - `*.csproj` / `*.sln` → `dotnet format`
    - `package.json` → `npm run lint:fix` or `npm run format`

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -70,6 +70,11 @@ For each file in each phase, specify:
 - Test class/module name
 - Methods/functions to test
 - Key test scenarios (happy path, edge cases, errors)
+- For broad/comprehensive scope, one mutation-relevant case for each observable
+  equivalence partition or invariant discovered in the source, including useful
+  identity/empty/singleton/interior cases, exact and adjacent boundaries, and
+  ordering, rollover, capacity, truncation, or state properties not named by
+  the prompt. Group sibling inputs in parameterized or table-driven tests.
 
 **Important**: When adding new tests, they MUST go into the existing test project that already tests the target code. Do not create a separate test project unnecessarily. If no existing test project covers the target, create a new one.
 

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -147,5 +147,5 @@ Only consult a language example when research found no existing tests and the ba
 ## Output
 
 Write the plan document to the absolute `<TESTAGENT_DIR>/plan.md` path provided
-by the caller. `TESTAGENT_DIR` must be outside the working tree; never create
-`.testagent/` in the workspace.
+by the caller. `TESTAGENT_DIR` must be non-stageable host scratch storage, Git
+metadata, or OS temp; never create `.testagent/` in the workspace.

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -147,5 +147,6 @@ Only consult a language example when research found no existing tests and the ba
 ## Output
 
 Write the plan document to the absolute `<TESTAGENT_DIR>/plan.md` path provided
-by the caller. `TESTAGENT_DIR` must be non-stageable host scratch storage, Git
-metadata, or OS temp; never create `.testagent/` in the workspace.
+by the caller. `<TESTAGENT_DIR>` must be non-stageable host scratch storage,
+Git metadata, or OS temp. Never place it or its files in version-controlled
+workspace content.

--- a/plugins/dotnet-test/agents/code-testing-planner.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-planner.agent.md
@@ -3,7 +3,7 @@ description: >-
   Creates structured test implementation plans from research findings.
 
   Use when: organizing tests into phases, prioritizing test generation,
-  creating .testagent/plan.md from research.
+  creating the pipeline plan document from research.
 name: code-testing-planner
 user-invocable: false
 tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
@@ -22,7 +22,9 @@ Read the research document and create a phased implementation plan that will gui
 
 ### 1. Read the Research
 
-Read the target inventory, command section, dependency summary, and testing conventions from `.testagent/research.md`. Do not reread repository files during planning.
+Read the target inventory, command section, dependency summary, and testing
+conventions from the absolute `<TESTAGENT_DIR>/research.md` path provided by the
+caller. Do not reread repository files during planning.
 
 - Project structure and language
 - Files that need tests
@@ -73,7 +75,7 @@ For each file in each phase, specify:
 
 ### 5. Generate Plan Document
 
-Create `.testagent/plan.md` with this structure:
+Create `<TESTAGENT_DIR>/plan.md` with this structure:
 
 ```markdown
 # Test Implementation Plan
@@ -139,4 +141,6 @@ Only consult a language example when research found no existing tests and the ba
 
 ## Output
 
-Write the plan document to `.testagent/plan.md` in the workspace root.
+Write the plan document to the absolute `<TESTAGENT_DIR>/plan.md` path provided
+by the caller. `TESTAGENT_DIR` must be outside the working tree; never create
+`.testagent/` in the workspace.

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -190,7 +190,7 @@ For each test project found, list:
 ## Output
 
 Write the research document to the absolute `<TESTAGENT_DIR>/research.md` path
-provided by the caller. `TESTAGENT_DIR` must be outside the working tree; never
-create `.testagent/` in the workspace.
+provided by the caller. `TESTAGENT_DIR` must be non-stageable host scratch
+storage, Git metadata, or OS temp; never create `.testagent/` in the workspace.
 
 Only consult a language example when no representative tests exist and the base extension does not establish the needed convention.

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -190,7 +190,8 @@ For each test project found, list:
 ## Output
 
 Write the research document to the absolute `<TESTAGENT_DIR>/research.md` path
-provided by the caller. `TESTAGENT_DIR` must be non-stageable host scratch
-storage, Git metadata, or OS temp; never create `.testagent/` in the workspace.
+provided by the caller. `<TESTAGENT_DIR>` must be non-stageable host scratch
+storage, Git metadata, or OS temp. Never place `<TESTAGENT_DIR>` or its files in
+version-controlled workspace content.
 
 Only consult a language example when no representative tests exist and the base extension does not establish the needed convention.

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -3,7 +3,7 @@ description: >-
   Analyzes codebases to understand structure, testing patterns, and testability.
 
   Use when: researching project structure, identifying source files to test,
-  discovering test frameworks and build commands, producing .testagent/research.md.
+  discovering test frameworks and build commands, producing the pipeline research document.
 name: code-testing-researcher
 user-invocable: false
 tools: ["skill", "read", "search", "edit", "execute", "Skill", "Read", "Glob", "Grep", "Edit", "Write", "Bash", "read_file", "replace", "write_file", "glob", "grep_search", "run_shell_command"]
@@ -96,7 +96,7 @@ Search for commands in:
 - `README.md` instructions
 - Project files
 
-Identify **two** test commands and record both in `.testagent/research.md`:
+Identify **two** test commands and record both in the caller-provided research document:
 
 1. **Scoped test command** — what the implementer should run during fix cycles (e.g., `dotnet test <test.csproj>` for SDK-style .NET, the repository's MSBuild + VSTest/MSTest command for classic .NET, `bundle exec rspec spec/foo_spec.rb`, `Invoke-Pester -Path ./Tests/Foo.Tests.ps1`). Optimized for speed and locality.
 2. **Harness-equivalent discovery command** — what a generic CI/benchmark verifier would run from the repo root with no args (e.g., `dotnet test <solution> --list-tests` for SDK-style .NET, the checked-in runner/discovery command for classic .NET, `bundle exec rspec --dry-run`, `Invoke-Pester` with default config, `pytest --collect-only -q`). This is the command the implementer's "Verify Harness Discovery" step uses to confirm new tests are visible to outside tooling. Call the `code-testing-extensions` skill and consult the "Harness Discovery Check" section of the relevant language extension.
@@ -121,7 +121,7 @@ Before manually pairing source ↔ test files in C#, Python, TypeScript/JavaScri
 
 ### 8. Generate Research Document
 
-Create `.testagent/research.md` with this structure:
+Create `<TESTAGENT_DIR>/research.md` with this structure:
 
 ```markdown
 # Test Generation Research
@@ -189,6 +189,8 @@ For each test project found, list:
 
 ## Output
 
-Write the research document to `.testagent/research.md` in the workspace root.
+Write the research document to the absolute `<TESTAGENT_DIR>/research.md` path
+provided by the caller. `TESTAGENT_DIR` must be outside the working tree; never
+create `.testagent/` in the workspace.
 
 Only consult a language example when no representative tests exist and the base extension does not establish the needed convention.

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -26,7 +26,9 @@ Run the appropriate test command and report pass/fail with details.
 
 If not provided, check in order:
 
-1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
+1. The exact command or relevant Commands excerpt supplied by the caller; if
+   the caller instead supplies a document, it must provide its absolute
+   `<TESTAGENT_DIR>/research.md` or `<TESTAGENT_DIR>/plan.md` path
 2. Project files:
    - SDK-style `*.csproj` with Test SDK → `dotnet test`
    - Classic non-SDK `*.csproj` / `packages.config` → repository-documented VSTest, MSTest, or custom runner command

--- a/plugins/dotnet-test/agents/code-testing-tester.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-tester.agent.md
@@ -26,7 +26,7 @@ Run the appropriate test command and report pass/fail with details.
 
 If not provided, check in order:
 
-1. `.testagent/research.md` or `.testagent/plan.md` for Commands section
+1. The caller-provided research or plan document in `TESTAGENT_DIR`, when available
 2. Project files:
    - SDK-style `*.csproj` with Test SDK → `dotnet test`
    - Classic non-SDK `*.csproj` / `packages.config` → repository-documented VSTest, MSTest, or custom runner command

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -23,9 +23,9 @@ Classify scope **before editing**:
 
 - **Broad** (a project/package-wide suite, or multiple production
   files/modules): create `research.md` and `plan.md` in a resolved
-  `TESTAGENT_DIR` outside the working tree before implementation, then
-  `status.md` there after the final test-quality review. If these files are
-  absent, the broad workflow is incomplete.
+  non-stageable `TESTAGENT_DIR` before implementation, then `status.md` there
+  after the final test-quality review. If these files are absent, the broad
+  workflow is incomplete.
 - **Focused** (the user explicitly limits work to one function/class/file or one
   missing method): do not create pipeline artifacts or fan out to multiple
   agents. A sparse project-wide request remains broad even when only one source
@@ -166,8 +166,9 @@ For broad scope, resolve one absolute `TESTAGENT_DIR` before creating state:
 3. Outside Git, create a unique directory under the operating system's
    temporary directory.
 
-Pass the absolute directory to every pipeline agent. Never use a path under the
-working tree for this state.
+Pass the absolute directory to every pipeline agent. The path may be inside the
+repository's `.git` metadata directory, but it must not be version-controlled
+workspace content, appear in `git status`, or be stageable.
 
 ### Step 4: Execute with bounded context
 
@@ -244,8 +245,9 @@ among the changes intended for commit.
 
 ## State Management
 
-Broad-scope runs store pipeline state outside the working tree in
-`TESTAGENT_DIR`. A focused request does not create these files:
+Broad-scope runs store pipeline state in a non-stageable `TESTAGENT_DIR` backed
+by host scratch storage, Git metadata, or OS temp. A focused request does not
+create these files:
 
 | File                     | Purpose                      |
 | ------------------------ | ---------------------------- |

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -149,9 +149,9 @@ completion contract.
 For broad scope, resolve one absolute `TESTAGENT_DIR` before creating state:
 
 1. Prefer a host-provided session artifact or scratch directory.
-2. Otherwise, in a Git worktree use the absolute form of
-   `git rev-parse --git-path testagent`; this is worktree-specific Git metadata
-   and cannot be staged.
+2. Otherwise, in a Git worktree run
+   `git rev-parse --path-format=absolute --git-path testagent`; this returns a
+   path in worktree-specific Git metadata that cannot be staged.
 3. Outside Git, create a unique directory under the operating system's
    temporary directory.
 

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -22,20 +22,24 @@ An AI-powered skill that generates comprehensive, workable unit tests for any pr
 Classify scope **before editing**:
 
 - **Broad** (a project/package-wide suite, or multiple production
-  files/modules): create
-  `.testagent/research.md` and `.testagent/plan.md` before implementation, then
-  `.testagent/status.md` after the final test-quality review. If these files are
+  files/modules): create `research.md` and `plan.md` in a resolved
+  `TESTAGENT_DIR` outside the working tree before implementation, then
+  `status.md` there after the final test-quality review. If these files are
   absent, the broad workflow is incomplete.
 - **Focused** (the user explicitly limits work to one function/class/file or one
-  missing method): do not create `.testagent/` artifacts or fan out to multiple
+  missing method): do not create pipeline artifacts or fan out to multiple
   agents. A sparse project-wide request remains broad even when only one source
   module is present.
 
 For either scope, run the narrowest relevant test command to a clean exit and
 finish with a compact `Requirement | Evidence` table. Each requested behavior
 must cite an exact test name; validation rows cite the successful command.
-For focused work, "no `.testagent/` artifacts" changes only the process, not the
+For focused work, "no pipeline artifacts" changes only the process, not the
 final evidence contract.
+
+Pipeline state is internal working data, never a deliverable. Do not create
+`.testagent/` in the repository, stage state files, commit them, or modify the
+project's `.gitignore` to hide them.
 
 Treat completeness as a requirement matrix, not a test-count target. Give every
 independently requested state, boundary, error path, or interaction its own
@@ -109,8 +113,8 @@ request costs turns and tool calls without improving the tests.
 
 | Scope | What it looks like | How to run it |
 | --- | --- | --- |
-| **Focused** | One function, class, or file; "tests for X only"; extending an existing suite with the missing cases | Skip the `.testagent/` artifacts and the sub-agent fan-out. Keep the requirement checklist in your head (or in the final table), read only the target and one neighbouring test for conventions, write the tests, run the narrowest test command, review your own assertions inline. |
-| **Broad** | A project, package, or module set; "comprehensive suite"; a coverage threshold to clear across several files | Run the full Research → Plan → Implement pipeline in Step 3, with the `.testagent/` artifacts and the completion contract below. |
+| **Focused** | One function, class, or file; "tests for X only"; extending an existing suite with the missing cases | Skip pipeline artifacts and the sub-agent fan-out. Keep the requirement checklist in your head (or in the final table), read only the target and one neighbouring test for conventions, write the tests, run the narrowest test command, review your own assertions inline. |
+| **Broad** | A project, package, or module set; "comprehensive suite"; a coverage threshold to clear across several files | Run the full Research → Plan → Implement pipeline in Step 3, with internal state under `TESTAGENT_DIR` and the completion contract below. |
 
 When in doubt, start focused and escalate only if the request turns out to span
 several files. Escalating costs one extra pass; running the broad pipeline on a
@@ -138,15 +142,28 @@ Generate unit tests for [path or description of what to test], following the [un
 The Test Generator will manage the entire pipeline automatically.
 
 If `code-testing-generator` is unavailable, do not skip the workflow. Execute the
-same Research → Plan → Implement sequence inline, create the `.testagent/`
-artifacts described below, and apply the same completion contract.
+same Research → Plan → Implement sequence inline, resolve `TESTAGENT_DIR` as
+described below, create the internal artifacts there, and apply the same
+completion contract.
+
+For broad scope, resolve one absolute `TESTAGENT_DIR` before creating state:
+
+1. Prefer a host-provided session artifact or scratch directory.
+2. Otherwise, in a Git worktree use the absolute form of
+   `git rev-parse --git-path testagent`; this is worktree-specific Git metadata
+   and cannot be staged.
+3. Outside Git, create a unique directory under the operating system's
+   temporary directory.
+
+Pass the absolute directory to every pipeline agent. Never use a path under the
+working tree for this state.
 
 ### Step 4: Execute with bounded context
 
 For multi-file requests:
 
 1. Turn every explicit user requirement into a checklist before implementation. Include requested layers, collaborators to mock, boundary cases, integrations, coverage thresholds, and report artifacts. Copy multi-condition requirements verbatim — they must each map to one test that exercises the whole combination.
-2. Research only the requested module or project and write the checklist plus a compact target inventory to `.testagent/research.md`.
+2. Research only the requested module or project and write the checklist plus a compact target inventory to `<TESTAGENT_DIR>/research.md`.
 3. Reuse manifests, symbol references, and deterministic pairing tools instead of reading every source and test file.
 4. For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, or Ruby, run `find-untested-sources` once and consume its pairing and suggested-path output; do not repeat that discovery manually.
 5. Plan each target file once, then implement phases sequentially. Map every checklist item to at least one concrete test or explain why it is blocked.
@@ -162,13 +179,13 @@ For multi-file requests:
 
 Every scope must satisfy points 3–5 below. Points 1 and 2 are the **broad-scope**
 artifacts: on a focused request the same reasoning happens inline and no
-`.testagent/` files are written.
+pipeline state files are written.
 
 Do not report completion until all of these are true:
 
-1. *(broad scope)* `.testagent/research.md` records the bounded target
+1. *(broad scope)* `<TESTAGENT_DIR>/research.md` records the bounded target
    inventory, existing test conventions, and the acceptance checklist.
-2. *(broad scope)* `.testagent/plan.md` maps each checklist item to a planned
+2. *(broad scope)* `<TESTAGENT_DIR>/plan.md` maps each checklist item to a planned
    test or an explicit blocker.
 3. Generated tests compile and pass with the narrowest relevant test command.
 4. Every explicit user requirement is backed by a concrete test and assertion.
@@ -184,7 +201,7 @@ Do not report completion until all of these are true:
    nonredundant evidence, not by raw test volume.
 5. Review the generated tests for behavior gaps and weak assertions. On a broad
    scope, invoke `test-gap-analysis` and `assertion-quality` when available and
-   record the findings and fixes in `.testagent/status.md`. On a focused scope,
+   record the findings and fixes in `<TESTAGENT_DIR>/status.md`. On a focused scope,
    do the equivalent review inline — re-read each generated assertion against
    the source — without spawning extra passes.
 
@@ -207,16 +224,20 @@ thresholds were requested, the per-module coverage table from a run that exited
 0. If the last coverage run exited non-zero, fix it and re-run before reporting;
 never infer threshold clearance from a failed or partial run.
 
+Before reporting, inspect the final working-tree changes and confirm that
+`.testagent/`, research/plan/status files, and other pipeline-only state are not
+among the changes intended for commit.
+
 ## State Management
 
-Broad-scope runs store pipeline state in the `.testagent/` folder. A focused
-request does not create these files:
+Broad-scope runs store pipeline state outside the working tree in
+`TESTAGENT_DIR`. A focused request does not create these files:
 
 | File                     | Purpose                      |
 | ------------------------ | ---------------------------- |
-| `.testagent/research.md` | Codebase analysis results    |
-| `.testagent/plan.md`     | Phased implementation plan   |
-| `.testagent/status.md`   | Final quality review and fixes |
+| `<TESTAGENT_DIR>/research.md` | Codebase analysis results    |
+| `<TESTAGENT_DIR>/plan.md`     | Phased implementation plan   |
+| `<TESTAGENT_DIR>/status.md`   | Final quality review and fixes |
 
 ## Agent Reference
 
@@ -246,7 +267,10 @@ execution as blocked rather than substituting `dotnet test`.
 
 ### Tests don't compile
 
-The `code-testing-fixer` agent will attempt to resolve compilation errors. Check `.testagent/plan.md` for the expected test structure. Call the `code-testing-extensions` skill and read the language-specific extension file for error code references (e.g., `dotnet.md` for .NET).
+The `code-testing-fixer` agent will attempt to resolve compilation errors. Check
+`<TESTAGENT_DIR>/plan.md` for the expected test structure. Call the
+`code-testing-extensions` skill and read the language-specific extension file
+for error code references (e.g., `dotnet.md` for .NET).
 
 ### Tests fail
 

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -23,23 +23,24 @@ Classify scope **before editing**:
 
 - **Broad** (a project/package-wide suite, or multiple production
   files/modules): create `research.md` and `plan.md` in a resolved
-  non-stageable `TESTAGENT_DIR` before implementation, then `status.md` there
+  non-stageable `<TESTAGENT_DIR>` before implementation, then `status.md` there
   after the final test-quality review. If these files are absent, the broad
   workflow is incomplete.
 - **Focused** (the user explicitly limits work to one function/class/file or one
-  missing method): do not create pipeline artifacts or fan out to multiple
+  missing method): do not create intermediate state files or fan out to multiple
   agents. A sparse project-wide request remains broad even when only one source
   module is present.
 
 For either scope, run the narrowest relevant test command to a clean exit and
 finish with a compact `Requirement | Evidence` table. Each requested behavior
 must cite an exact test name; validation rows cite the successful command.
-For focused work, "no pipeline artifacts" changes only the process, not the
+For focused work, "no intermediate state files" changes only the process, not the
 final evidence contract.
 
-Pipeline state is internal working data, never a deliverable. Do not create
-`.testagent/` in the repository, stage state files, commit them, or modify the
-project's `.gitignore` to hide them.
+Intermediate state files are internal working data, never deliverables. Keep
+`<TESTAGENT_DIR>` non-stageable, never place it or its files in
+version-controlled workspace content, and never modify `.gitignore` to hide
+them.
 
 Treat completeness as a requirement matrix, not a test-count target. Give every
 independently requested state, boundary, error path, or interaction its own
@@ -129,8 +130,8 @@ request costs turns and tool calls without improving the tests.
 
 | Scope | What it looks like | How to run it |
 | --- | --- | --- |
-| **Focused** | One function, class, or file; "tests for X only"; extending an existing suite with the missing cases | Skip pipeline artifacts and the sub-agent fan-out. Keep the requirement checklist in your head (or in the final table), read only the target and one neighbouring test for conventions, write the tests, run the narrowest test command, review your own assertions inline. |
-| **Broad** | A project, package, or module set; "comprehensive suite"; a coverage threshold to clear across several files | Run the full Research → Plan → Implement pipeline in Step 3, with internal state under `TESTAGENT_DIR` and the completion contract below. |
+| **Focused** | One function, class, or file; "tests for X only"; extending an existing suite with the missing cases | Skip intermediate state files and the sub-agent fan-out. Keep the requirement checklist in your head (or in the final table), read only the target and one neighbouring test for conventions, write the tests, run the narrowest test command, review your own assertions inline. |
+| **Broad** | A project, package, or module set; "comprehensive suite"; a coverage threshold to clear across several files | Run the full Research → Plan → Implement pipeline in Step 3, with intermediate state files under `<TESTAGENT_DIR>` and the completion contract below. |
 
 When in doubt, start focused and escalate only if the request turns out to span
 several files. Escalating costs one extra pass; running the broad pipeline on a
@@ -158,11 +159,12 @@ Generate unit tests for [path or description of what to test], following the [un
 The Test Generator will manage the entire pipeline automatically.
 
 If `code-testing-generator` is unavailable, do not skip the workflow. Execute the
-same Research → Plan → Implement sequence inline, resolve `TESTAGENT_DIR` as
-described below, create the internal artifacts there, and apply the same
+same Research → Plan → Implement sequence inline, resolve `<TESTAGENT_DIR>` as
+described below, create the intermediate state files there, and apply the same
 completion contract.
 
-For broad scope, resolve one absolute `TESTAGENT_DIR` before creating state:
+For broad scope, resolve one absolute `<TESTAGENT_DIR>` before creating
+intermediate state files:
 
 1. Prefer a host-provided session artifact or scratch directory.
 2. Otherwise, in a Git worktree run
@@ -196,7 +198,7 @@ For multi-file requests:
 
 Every scope must satisfy points 3–5 below. Points 1 and 2 are the **broad-scope**
 artifacts: on a focused request the same reasoning happens inline and no
-pipeline state files are written.
+intermediate state files are written.
 
 Do not report completion until all of these are true:
 
@@ -248,14 +250,14 @@ thresholds were requested, the per-module coverage table from a run that exited
 never infer threshold clearance from a failed or partial run.
 
 Before reporting, inspect the final working-tree changes and confirm that
-`.testagent/`, research/plan/status files, and other pipeline-only state are not
-among the changes intended for commit.
+`research.md`, `plan.md`, `status.md`, and any other intermediate state files are
+not among the changes intended for commit.
 
 ## State Management
 
-Broad-scope runs store pipeline state in a non-stageable `TESTAGENT_DIR` backed
-by host scratch storage, Git metadata, or OS temp. A focused request does not
-create these files:
+Broad-scope runs store intermediate state files in a non-stageable
+`<TESTAGENT_DIR>` backed by host scratch storage, Git metadata, or OS temp. A
+focused request does not create these files:
 
 | File                     | Purpose                      |
 | ------------------------ | ---------------------------- |

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -47,6 +47,17 @@ concrete assertion. Combine cases only when one execution genuinely proves the
 whole requested combination; do not let a parameterized happy-path case stand in
 for an empty state, invalid discriminator, or before/at/after boundary.
 
+For a **broad or comprehensive** request, the explicit matrix is the floor, not
+the ceiling. After satisfying it, inspect each target API for observable
+equivalence partitions and invariants that the prompt did not name: identity,
+empty, singleton and representative interior inputs; exact boundaries plus an
+immediately adjacent value; invalid partitions; and ordering, monotonicity,
+rollover, capacity, truncation, or state invariants implied by the implementation.
+Add one mutation-relevant case per distinct partition not already proved, using
+parameterized or table-driven cases for siblings. Stop when remaining inputs
+exercise the same branch and invariant, not merely when the explicit checklist
+is complete; never add cases only to raise the count.
+
 ## When to Use This Skill
 
 Use this skill when you need to:
@@ -199,6 +210,9 @@ Do not report completion until all of these are true:
    A passing suite with fewer tests is not automatically weaker: judge
    completeness by whether every independently requested behavior has direct,
    nonredundant evidence, not by raw test volume.
+   For broad/comprehensive scope, also verify that every observable equivalence
+   partition and invariant discovered in the bounded target APIs has one
+   mutation-relevant case, even when the prompt did not name it.
 5. Review the generated tests for behavior gaps and weak assertions. On a broad
    scope, invoke `test-gap-analysis` and `assertion-quality` when available and
    record the findings and fixes in `<TESTAGENT_DIR>/status.md`. On a focused scope,

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/cpp-examples.md
@@ -72,7 +72,7 @@ void InvoiceService::mark_as_paid(int id) {
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet-examples.md
@@ -56,7 +56,7 @@ public class InvoiceService(IInvoiceRepository repository)
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research
@@ -112,7 +112,7 @@ What `code-testing-researcher` produces in `.testagent/research.md`:
 
 ## Sample Plan Output
 
-What `code-testing-planner` produces in `.testagent/plan.md`:
+What `code-testing-planner` produces in `<TESTAGENT_DIR>/plan.md`:
 
 ```markdown
 # Test Implementation Plan

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
@@ -101,7 +101,7 @@ not part of the test assembly and must never be reported as generated coverage.
 
 A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` run from the repo root, and to any CI/benchmark harness until it is added to the solution. Run `dotnet sln add` *immediately* after creating the project as part of Step 3 ("Register Test Project with Build System") — do not defer it to a later step.
 
-1. Use the exact solution or solution-filter target identified in the research or plan document under `TESTAGENT_DIR` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
+1. Use the exact solution or solution-filter target identified in the research or plan document under `<TESTAGENT_DIR>` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
 2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
 3. If the target is a `.slnf` (solution filter), also ensure the new project is included in the filter; adding only to the underlying `.sln` may not be enough for test discovery.
 4. Skip this if the project is already included in the solution or solution filter used for testing.

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
@@ -101,7 +101,7 @@ not part of the test assembly and must never be reported as generated coverage.
 
 A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` run from the repo root, and to any CI/benchmark harness until it is added to the solution. Run `dotnet sln add` *immediately* after creating the project as part of Step 3 ("Register Test Project with Build System") — do not defer it to a later step.
 
-1. Use the exact solution or solution-filter target identified in `.testagent/research.md` or `.testagent/plan.md` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
+1. Use the exact solution or solution-filter target identified in the research or plan document under `TESTAGENT_DIR` — do not search for or substitute a different `.sln`, `.slnx`, or `.slnf` target.
 2. If that target is a `.sln` or `.slnx`, run `dotnet sln <solution> add <test-project.csproj>`.
 3. If the target is a `.slnf` (solution filter), also ensure the new project is included in the filter; adding only to the underlying `.sln` may not be enough for test discovery.
 4. Skip this if the project is already included in the solution or solution filter used for testing.
@@ -112,7 +112,7 @@ A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` r
 Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the test count went up by at least the number of tests you generated. The harness (CI, msbench, coverage tools) does not know which `.csproj` you targeted — it runs the solution-level command, so a test that passes via `dotnet test MyProject.Tests.csproj` is still worthless if `dotnet test <solution> --list-tests` doesn't enumerate it.
 
 ```bash
-# From repo root, against the solution identified in .testagent/research.md
+# From repo root, against the solution identified in TESTAGENT_DIR/research.md
 dotnet test <solution> --list-tests --no-build 2>&1 | grep -c '^    [A-Za-z]'
 ```
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/dotnet.md
@@ -112,7 +112,7 @@ A new `.csproj` is **invisible** to `dotnet test <solution>`, to `dotnet test` r
 Before reporting success, run the **harness-equivalent** discovery command from the repo root and confirm the test count went up by at least the number of tests you generated. The harness (CI, msbench, coverage tools) does not know which `.csproj` you targeted — it runs the solution-level command, so a test that passes via `dotnet test MyProject.Tests.csproj` is still worthless if `dotnet test <solution> --list-tests` doesn't enumerate it.
 
 ```bash
-# From repo root, against the solution identified in TESTAGENT_DIR/research.md
+# From repo root, against the solution identified in <TESTAGENT_DIR>/research.md
 dotnet test <solution> --list-tests --no-build 2>&1 | grep -c '^    [A-Za-z]'
 ```
 

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/go-examples.md
@@ -80,7 +80,7 @@ func (s *InvoiceService) MarkAsPaid(ctx context.Context, id int) error {
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/java-examples.md
@@ -75,7 +75,7 @@ public class InvoiceService {
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/kotlin-examples.md
@@ -57,7 +57,7 @@ class InvoiceService(
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/powershell-examples.md
@@ -72,7 +72,7 @@ Export-ModuleMember -Function Get-InvoiceTotal, Get-InvoiceById, Set-InvoicePaid
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/python-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/python-examples.md
@@ -67,7 +67,7 @@ def _utcnow():
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research
@@ -121,7 +121,7 @@ What `code-testing-researcher` produces in `.testagent/research.md`:
 
 ## Sample Plan Output
 
-What `code-testing-planner` produces in `.testagent/plan.md`:
+What `code-testing-planner` produces in `<TESTAGENT_DIR>/plan.md`:
 
 ```markdown
 # Test Implementation Plan

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/ruby-examples.md
@@ -60,7 +60,7 @@ end
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/rust-examples.md
@@ -75,7 +75,7 @@ where
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research

--- a/plugins/dotnet-test/skills/code-testing-extensions/extensions/typescript-examples.md
+++ b/plugins/dotnet-test/skills/code-testing-extensions/extensions/typescript-examples.md
@@ -71,7 +71,7 @@ function roundTo2(n: number): number {
 
 ## Sample Research Output
 
-What `code-testing-researcher` produces in `.testagent/research.md`:
+What `code-testing-researcher` produces in `<TESTAGENT_DIR>/research.md`:
 
 ```markdown
 # Test Generation Research
@@ -126,7 +126,7 @@ What `code-testing-researcher` produces in `.testagent/research.md`:
 
 ## Sample Plan Output
 
-What `code-testing-planner` produces in `.testagent/plan.md`:
+What `code-testing-planner` produces in `<TESTAGENT_DIR>/plan.md`:
 
 ```markdown
 # Test Implementation Plan

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -51,7 +51,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -149,7 +149,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -196,7 +196,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -248,7 +248,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -297,7 +297,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -336,7 +336,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -379,7 +379,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -422,7 +422,8 @@ stimuli:
             --include='*.cs'
             && ! grep -Rq 'OrderPricing' fixtures/sdk-xunit-orders/tests
             --include='*.cs'
-            && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+            && test ! -e .testagent
+            && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -462,7 +463,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "test ! -e .testagent && test ! -L .testagent"
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -51,7 +51,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -149,7 +149,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -196,7 +196,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -248,7 +248,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -297,7 +297,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -336,7 +336,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -379,7 +379,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -422,7 +422,7 @@ stimuli:
             --include='*.cs'
             && ! grep -Rq 'OrderPricing' fixtures/sdk-xunit-orders/tests
             --include='*.cs'
-            && test -z \"$(find . -type d -name .testagent -print -quit)\""
+            && test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -462,7 +462,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -53,7 +53,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -63,7 +63,7 @@ stimuli:
       - Asserted concrete averages, peaks, percentiles, and slugs rather than existence-only results
       - Kept the work project-wide but bounded to the three supplied modules
       - Mapped each requested behavior to named test evidence
-      - Kept broad-scope research, planning, and review state outside the working tree so only requested deliverables remain commit candidates
+      - Kept broad-scope intermediate state files non-stageable so only requested deliverables remain commit candidates
 
   - name: Generate project-wide tests for a classic MSTest library
     prompt: |
@@ -152,7 +152,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -162,7 +162,7 @@ stimuli:
       - Used Assert.ThrowsException<T> for exception paths, avoiding both Assert.Throws<T> and Assert.ThrowsExactly<T>, which are unavailable in MSTest 3.5.2
       - Covered every named DiscountService and TieredDiscountPolicy boundary with concrete expected values
       - Mapped each requested behavior and build-registration requirement to evidence
-      - Kept broad-scope pipeline state outside the working tree without modernizing the classic project
+      - Kept broad-scope intermediate state files non-stageable without modernizing the classic project
 
   - name: Generate a project-wide Go suite across collaborating packages
     prompt: |
@@ -201,7 +201,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -212,7 +212,7 @@ stimuli:
       - Covered each collaborator error and verified short-circuit behavior when discount calculation fails
       - Covered shipping equality and overflow boundaries
       - Mapped every requested behavior to named test evidence
-      - Kept broad-scope research, planning, and review state outside the working tree
+      - Kept broad-scope intermediate state files non-stageable
 
   # The fixture is intentionally committed with a larger project and then
   # stripped down in setup. The agent must test the remaining source without
@@ -254,7 +254,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -269,7 +269,7 @@ stimuli:
         command, rather than being covered by a broad list of tested areas
       - Once every requested behavior is covered, evaluates suite quality by meaningful, nonredundant cases rather than
         rewarding a higher raw test count
-      - Kept internal research, planning, and review state outside the working tree
+      - Kept internal intermediate state files non-stageable
 
   - name: Generate a layered Vitest suite for an async shopping cart
     prompt: |
@@ -305,7 +305,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -314,7 +314,7 @@ stimuli:
       - Covered sum and chain discount behavior plus discounted-subtotal tax and shipping composition
       - Proved snapshot isolation, refreshed prices, partial-stock denial, collaborator failures, and InventoryError fields
       - Cleared the configured line, statement, function, and branch coverage thresholds
-      - Mapped each requested behavior to exact test evidence after the broad-scope research, plan, and quality review while keeping pipeline state outside the working tree
+      - Mapped each requested behavior to exact test evidence after the broad-scope research, plan, and quality review while keeping intermediate state files non-stageable
 
   - name: Expand a healthy existing pytest suite to every ledger boundary
     prompt: |
@@ -346,7 +346,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -354,7 +354,7 @@ stimuli:
       - Preserved the existing tests and added passing tests for every requested ledger boundary
       - Used exact Decimal values around the overdraft limit rather than float approximations
       - Covered empty and multi-entry running balances plus invalid entry kinds
-      - Treated the project-wide existing-suite extension as broad scope, completed its research, plan, and final review, and kept that state outside the working tree
+      - Treated the project-wide existing-suite extension as broad scope, completed its research, plan, and final review, and kept intermediate state files non-stageable
       - Mapped each requested behavior and the successful pytest command to concrete evidence
       - Once empty, multi-entry, exact/inside/outside limit, positive-balance, negative-limit, and unknown-kind states all
         have direct assertions, evaluates completeness by those independent state transitions rather than raw test count
@@ -390,7 +390,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -399,7 +399,7 @@ stimuli:
       - Covered every validation and exact decimal pricing boundary
       - Distinguished reservation start and expiry boundary semantics with concrete instants
       - Followed the SDK-style project conventions and kept the work bounded to this library
-      - Completed the broad research, plan, quality review, and requirement-to-test evidence mapping while keeping pipeline state outside the working tree
+      - Completed the broad research, plan, quality review, and requirement-to-test evidence mapping while keeping intermediate state files non-stageable
 
   - name: Add focused xUnit tests for one reservation class
     prompt: |
@@ -414,6 +414,7 @@ stimuli:
           dest: fixtures/sdk-xunit-orders
       commands:
         - find fixtures/sdk-xunit-orders/tests -type f -name '*.cs' -delete && cp fixtures/sdk-xunit-orders/src/ReservationWindow.cs .eval-reservation-window.cs
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -433,8 +434,9 @@ stimuli:
             --include='*.cs'
             && ! grep -Rq 'OrderPricing' fixtures/sdk-xunit-orders/tests
             --include='*.cs'
-            && test ! -e .testagent
-            && test ! -L .testagent"
+            && test -z \"\$(git ls-files --cached --others --exclude-standard
+            -- ':(glob)**/research.md' ':(glob)**/plan.md'
+            ':(glob)**/status.md')\""
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -461,6 +463,8 @@ stimuli:
       files:
         - src: fixtures/python-single-function
           dest: fixtures/python-single-function
+      commands:
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -474,7 +478,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "test ! -e .testagent && test ! -L .testagent"
+          command: test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -485,5 +489,5 @@ stimuli:
       - Generated passing pytest tests for slugify under fixtures/python-single-function/tests/
       - Covered separator collapsing/trimming, both truncation paths, non-positive max_length, and empty output
       - Asserted concrete expected slugs rather than only checking that a string came back
-      - Kept work proportional to one function with no .testagent artifacts, multi-phase ceremony, or unrelated tests
+      - Kept work proportional to one function with no intermediate state files, multi-phase ceremony, or unrelated tests
       - Produced the Requirement | Evidence table with each behavior traced to a named test

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -49,12 +49,11 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Generated passing tests under the configured tests directory for all three modules
@@ -62,7 +61,7 @@ stimuli:
       - Asserted concrete averages, peaks, percentiles, and slugs rather than existence-only results
       - Kept the work project-wide but bounded to the three supplied modules
       - Mapped each requested behavior to named test evidence
-      - Created the broad-scope research, plan, and status artifacts with the target inventory, acceptance mapping, and final quality review
+      - Kept broad-scope research, planning, and review state outside the working tree so only requested deliverables remain commit candidates
 
   - name: Generate project-wide tests for a classic MSTest library
     prompt: |
@@ -148,12 +147,11 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Added both requested test files and registered each exactly once in the classic project
@@ -161,7 +159,7 @@ stimuli:
       - Used Assert.ThrowsException<T> for exception paths, avoiding both Assert.Throws<T> and Assert.ThrowsExactly<T>, which are unavailable in MSTest 3.5.2
       - Covered every named DiscountService and TieredDiscountPolicy boundary with concrete expected values
       - Mapped each requested behavior and build-registration requirement to evidence
-      - Created the broad-scope research, plan, and status artifacts without modernizing the classic project
+      - Kept broad-scope pipeline state outside the working tree without modernizing the classic project
 
   - name: Generate a project-wide Go suite across collaborating packages
     prompt: |
@@ -196,12 +194,11 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Generated passing tests in all three packages
@@ -210,7 +207,7 @@ stimuli:
       - Covered each collaborator error and verified short-circuit behavior when discount calculation fails
       - Covered shipping equality and overflow boundaries
       - Mapped every requested behavior to named test evidence
-      - Created the broad-scope research, plan, and status artifacts with the package inventory, test mapping, and final quality review
+      - Kept broad-scope research, planning, and review state outside the working tree
 
   # The fixture is intentionally committed with a larger project and then
   # stripped down in setup. The agent must test the remaining source without
@@ -249,12 +246,11 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Generated passing pytest tests for the synthstr module under fixtures/python-workspace-integrity/tests/,
@@ -267,6 +263,7 @@ stimuli:
         command, rather than being covered by a broad list of tested areas
       - Once every requested behavior is covered, evaluates suite quality by meaningful, nonredundant cases rather than
         rewarding a higher raw test count
+      - Kept internal research, planning, and review state outside the working tree
 
   - name: Generate a layered Vitest suite for an async shopping cart
     prompt: |
@@ -298,19 +295,18 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Generated passing Vitest tests for every production module without real I/O
       - Covered sum and chain discount behavior plus discounted-subtotal tax and shipping composition
       - Proved snapshot isolation, refreshed prices, partial-stock denial, collaborator failures, and InventoryError fields
       - Cleared the configured line, statement, function, and branch coverage thresholds
-      - Mapped each requested behavior to exact test evidence after the broad-scope research, plan, and quality review
+      - Mapped each requested behavior to exact test evidence after the broad-scope research, plan, and quality review while keeping pipeline state outside the working tree
 
   - name: Expand a healthy existing pytest suite to every ledger boundary
     prompt: |
@@ -338,18 +334,17 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Preserved the existing tests and added passing tests for every requested ledger boundary
       - Used exact Decimal values around the overdraft limit rather than float approximations
       - Covered empty and multi-entry running balances plus invalid entry kinds
-      - Treated the project-wide existing-suite extension as broad scope and completed its research, plan, and final review
+      - Treated the project-wide existing-suite extension as broad scope, completed its research, plan, and final review, and kept that state outside the working tree
       - Mapped each requested behavior and the successful pytest command to concrete evidence
       - Once empty, multi-entry, exact/inside/outside limit, positive-balance, negative-limit, and unknown-kind states all
         have direct assertions, evaluates completeness by those independent state transitions rather than raw test count
@@ -382,19 +377,18 @@ stimuli:
       - type: output-matches
         config:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
-      - type: file-exists
+      - type: run-command
         config:
-          path: .testagent/research.md
-      - type: file-exists
-        config:
-          path: .testagent/plan.md
+          command: sh -c "test -z \"$(find . -type d -name .testagent -print -quit)\""
+          expected_exit_code: 0
+          timeout: 1m
       - type: prompt
     rubric:
       - Generated passing xUnit v3 tests for both production types without modifying production code
       - Covered every validation and exact decimal pricing boundary
       - Distinguished reservation start and expiry boundary semantics with concrete instants
       - Followed the SDK-style project conventions and kept the work bounded to this library
-      - Completed the broad research, plan, quality review, and requirement-to-test evidence mapping
+      - Completed the broad research, plan, quality review, and requirement-to-test evidence mapping while keeping pipeline state outside the working tree
 
   - name: Add focused xUnit tests for one reservation class
     prompt: |

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -35,6 +35,8 @@ stimuli:
       files:
         - src: fixtures/python-multimodule
           dest: fixtures/python-multimodule
+      commands:
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -84,6 +86,7 @@ stimuli:
           dest: fixtures/classic-mstest
       commands:
         - rm -f fixtures/classic-mstest/tests/DiscountServiceBoundaryTests.cs fixtures/classic-mstest/tests/TieredDiscountPolicyTests.cs && cp fixtures/classic-mstest/tests/Discounts.Tests.csproj.pristine fixtures/classic-mstest/tests/Discounts.Tests.csproj && rm fixtures/classic-mstest/tests/Discounts.Tests.csproj.pristine && mkdir -p .eval-baseline && cp fixtures/classic-mstest/tests/DiscountServiceTests.cs .eval-baseline/DiscountServiceTests.cs && cp fixtures/classic-mstest/tests/packages.config .eval-baseline/packages.config
+        - git init -q
     graders:
       - type: file-exists
         config:
@@ -180,6 +183,8 @@ stimuli:
       files:
         - src: fixtures/go-multipackage
           dest: fixtures/go-multipackage
+      commands:
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -227,6 +232,7 @@ stimuli:
           dest: fixtures/python-workspace-integrity
       commands:
         - cd fixtures/python-workspace-integrity && git init -q && git config maintenance.auto false && git config gc.auto 0 && git -c user.email=eval@example.com -c user.name=eval add -A && git -c user.email=eval@example.com -c user.name=eval commit -qm baseline && rm -rf core io tests_real
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -281,6 +287,8 @@ stimuli:
       files:
         - src: fixtures/typescript-vitest-cart
           dest: fixtures/typescript-vitest-cart
+      commands:
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -320,6 +328,8 @@ stimuli:
       files:
         - src: fixtures/failing-suite
           dest: fixtures/failing-suite
+      commands:
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -363,6 +373,7 @@ stimuli:
           dest: fixtures/sdk-xunit-orders
       commands:
         - find fixtures/sdk-xunit-orders/tests -type f -name '*.cs' -delete
+        - git init -q
     graders:
       - type: run-command
         config:

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -51,7 +51,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -149,7 +149,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -196,7 +196,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -248,7 +248,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -297,7 +297,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -336,7 +336,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -379,7 +379,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
+          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -51,7 +51,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -149,7 +149,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -196,7 +196,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -248,7 +248,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -297,7 +297,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -336,7 +336,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -379,7 +379,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "state_dir=\"$(git rev-parse --path-format=absolute --git-path testagent)\" && test -f \"$state_dir/research.md\" && test -f \"$state_dir/plan.md\" && test -f \"$state_dir/status.md\" && test ! -e .testagent && test ! -L .testagent"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test ! -e .testagent && test ! -L .testagent
           expected_exit_code: 0
           timeout: 1m
       - type: prompt

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -51,7 +51,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -149,7 +149,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -196,7 +196,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -248,7 +248,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -297,7 +297,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -336,7 +336,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -379,7 +379,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -422,7 +422,7 @@ stimuli:
             --include='*.cs'
             && ! grep -Rq 'OrderPricing' fixtures/sdk-xunit-orders/tests
             --include='*.cs'
-            && test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+            && test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -462,7 +462,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -type d -name .testagent -print -quit)\""
+          command: sh -c "test -z \"$(find . -type d -name .git -prune -o -name .testagent -print -quit)\""
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -53,7 +53,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -152,7 +152,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -201,7 +201,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -253,7 +253,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -287,7 +287,7 @@ stimuli:
         - src: fixtures/typescript-vitest-cart
           dest: fixtures/typescript-vitest-cart
       commands:
-        - git init -q && printf 'node_modules/\n' >> .git/info/exclude
+        - git init -q
     graders:
       - type: run-command
         config:
@@ -304,7 +304,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -345,7 +345,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -389,7 +389,7 @@ stimuli:
           pattern: \|\s*Requirement\s*\|\s*Evidence\s*\|
       - type: run-command
         config:
-          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test -f "$state_dir/research.md" && test -f "$state_dir/plan.md" && test -f "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: prompt
@@ -432,10 +432,12 @@ stimuli:
             && grep -Rq 'ReservationWindow' fixtures/sdk-xunit-orders/tests
             --include='*.cs'
             && ! grep -Rq 'OrderPricing' fixtures/sdk-xunit-orders/tests
-            --include='*.cs'
-            && test -z \"\$(git ls-files --cached --others --exclude-standard
-            -- ':(glob)**/research.md' ':(glob)**/plan.md'
-            ':(glob)**/status.md')\""
+            --include='*.cs'"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test ! -e "$state_dir/research.md" && test ! -L "$state_dir/research.md" && test ! -e "$state_dir/plan.md" && test ! -L "$state_dir/plan.md" && test ! -e "$state_dir/status.md" && test ! -L "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches
@@ -477,7 +479,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: test -z "$(git ls-files --cached --others --exclude-standard -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md')"
+          command: state_dir="$(git rev-parse --path-format=absolute --git-path testagent)" && test ! -e "$state_dir/research.md" && test ! -L "$state_dir/research.md" && test ! -e "$state_dir/plan.md" && test ! -L "$state_dir/plan.md" && test ! -e "$state_dir/status.md" && test ! -L "$state_dir/status.md" && test -z "$(git ls-files --cached --others -- ':(glob)**/research.md' ':(glob)**/plan.md' ':(glob)**/status.md' ':(exclude,glob)**/node_modules/**')"
           expected_exit_code: 0
           timeout: 1m
       - type: output-matches

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -287,7 +287,7 @@ stimuli:
         - src: fixtures/typescript-vitest-cart
           dest: fixtures/typescript-vitest-cart
       commands:
-        - git init -q
+        - git init -q && printf 'node_modules/\n' >> .git/info/exclude
     graders:
       - type: run-command
         config:

--- a/tests/dotnet-test/code-testing-agent/eval.yaml
+++ b/tests/dotnet-test/code-testing-agent/eval.yaml
@@ -231,8 +231,7 @@ stimuli:
         - src: fixtures/python-workspace-integrity
           dest: fixtures/python-workspace-integrity
       commands:
-        - cd fixtures/python-workspace-integrity && git init -q && git config maintenance.auto false && git config gc.auto 0 && git -c user.email=eval@example.com -c user.name=eval add -A && git -c user.email=eval@example.com -c user.name=eval commit -qm baseline && rm -rf core io tests_real
-        - git init -q
+        - git init -q && git config maintenance.auto false && git config gc.auto 0 && git -c user.email=eval@example.com -c user.name=eval add fixtures/python-workspace-integrity && git -c user.email=eval@example.com -c user.name=eval commit -qm baseline && rm -rf fixtures/python-workspace-integrity/core fixtures/python-workspace-integrity/io fixtures/python-workspace-integrity/tests_real
     graders:
       - type: run-command
         config:


### PR DESCRIPTION
## Summary

Broad test-generation runs currently create and retain `.testagent/` inside the repository, which allows fully autonomous workflows to commit internal research, planning, and status files alongside generated tests.

This change introduces a shared `<TESTAGENT_DIR>` contract across the test-generation skill and its sub-agents. Intermediate state files now prefer host-provided scratch storage, fall back to worktree-specific Git metadata, and use OS temporary storage. The invariant is that these files are non-stageable: they must not be version-controlled workspace content or appear in `git status`. The eval suite detects stageable `research.md`, `plan.md`, or `status.md` files regardless of parent directory.

A conclusive Claude Sonnet 4.6 evaluation exposed a separate completeness over-correction in broad suites. The pytest judge found that the baseline had "materially broader reported behavioral and edge-case coverage (56 tests versus 43)," and the xUnit judge preferred its "meaningful decimal-pricing and reservation coverage beyond the minimum." The requirement matrix had become an implicit ceiling. Broad workflows now treat named requirements as the floor, then add one mutation-relevant case for every distinct equivalence partition or invariant, while still rejecting raw test-count padding.

## Related issue

N/A

## Validation

- `dotnet run --project eng\skill-validator\src\SkillValidator.csproj -p:CopilotSkipCliDownload=true --no-restore -- check --plugin .\plugins\dotnet-test` - passed
- `python eng\eval-quality\check_eval_quality.py` - passed with existing repository warnings
- `git diff --check` - passed
- Intermediate-state grader probe - broad runs require external state; focused runs reject both Git-metadata and stageable state files, including ignored files, while `node_modules` is excluded by pathspec
- Workspace-integrity setup probe - one eval-root Git repository tracks the fixture deletions, retains the synthetic target, and leaves no nested repository
- Run `33734244414` - merge-head evaluation passed with Claude Sonnet 4.6 at 7W/1T/1L (p=0.035) and GPT-5.6 Luna at 9W/0T/0L (p=0.002); fresh evaluation requested for `4b73d614b`

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content. N/A: no owned content was added or moved.
- [x] I updated all marketplace manifests when plugin metadata changed. N/A: plugin metadata was unchanged.
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content. N/A: no external domains were added.