### PR TITLE
Harden CRAP score calculation reliability

### DIFF
--- a/plugins/dotnet-test/skills/crap-score/SKILL.md
+++ b/plugins/dotnet-test/skills/crap-score/SKILL.md
@@ -28,8 +28,8 @@ Where:
 | CRAP Score | Risk Level | Interpretation |
 |------------|------------|----------------|
 | < 5        | Low        | Simple and well-tested |
-| 5-15       | Moderate   | Acceptable for most code |
-| 15-30      | High       | Needs more tests or simplification |
+| 5 to < 15  | Moderate   | Acceptable for most code |
+| 15 to 30   | High       | Needs more tests or simplification |
 | > 30       | Critical   | Refactor and add coverage urgently |
 
 A method with 100% coverage has CRAP = complexity (the minimum). A method with 0% coverage has CRAP = complexity^2 + complexity.
@@ -101,9 +101,26 @@ or summarize that existing data with ReportGenerator:
 
 If every path fails, **report that coverage could not be collected, show the commands you tried and their errors, and stop.** Report complexity on its own if useful, but never publish a CRAP number derived from an assumed coverage percentage.
 
+Before using a report, verify that it parses, contains at least one class and
+method, and contains the requested target. An empty report or a report that
+omits the target is failed collection or filtering, not 0% coverage. Regenerate
+coverage when possible; otherwise stop without publishing a CRAP score.
+
+If the user supplies an existing report, state that it was not regenerated.
+Do not describe its data as current unless its provenance is established by
+running the repository's coverage command in this analysis.
+
 ### Step 2: Compute cyclomatic complexity
 
-Analyze the target source files to determine cyclomatic complexity per method. Count the following decision points (each adds 1 to the base complexity of 1):
+Prefer a machine-produced per-method complexity from a repository-provided code
+metrics report or from the Cobertura method's `complexity` attribute when that
+report maps to the current source. Microsoft.CodeAnalysis.Metrics can generate
+method-level `CyclomaticComplexity` data through `msbuild /t:Metrics`, but do
+not add the package or modify the project without user approval.
+
+If no machine-produced metric exists, analyze the current target source and
+label the result as a manual complexity count. Count the following decision
+points (each adds 1 to the base complexity of 1):
 
 | Construct | Example |
 |-----------|---------|
@@ -124,7 +141,10 @@ Analyze the target source files to determine cyclomatic complexity per method. C
 
 Base complexity is 1 for every method. Each decision point adds 1.
 
-When analyzing, read the source file and count these constructs per method. Report the breakdown.
+When counting manually, read the source file, report the construct-by-construct
+breakdown, and do not use a source comment as evidence. If the report's
+complexity attribute disagrees with the current-source count, report the
+conflict and do not present either resulting CRAP score as authoritative.
 
 ### Step 3: Extract per-method coverage from Cobertura XML
 
@@ -134,11 +154,20 @@ $$\text{cov}(m) = \frac{\text{lines with hits} > 0}{\text{total lines}}$$
 
 Method names in Cobertura may differ from source (async methods, lambdas). Match by line ranges when names don't align.
 
+When both `line-rate` and `<lines>` exist, recompute the hit ratio and compare
+them. Allow only normal report rounding (one percentage point); if they differ
+more, the report contradicts itself. Regenerate it or report the conflict and
+stop without calculating CRAP. Never silently choose whichever value produces
+the expected score.
+
 ### Step 4: Calculate CRAP scores
 
 For each method in scope, apply the formula:
 
 $$\text{CRAP}(m) = \text{comp}(m)^2 \times (1 - \text{cov}(m))^3 + \text{comp}(m)$$
+
+Use a calculator or script for the arithmetic and show the substituted
+complexity and coverage. Do not calculate the formula mentally.
 
 ### Step 5: Present results
 
@@ -147,7 +176,7 @@ Present a sorted table (highest CRAP first):
 ```text
 | Method                          | Complexity | Coverage | CRAP Score | Risk     |
 |---------------------------------|------------|----------|------------|----------|
-| OrderService.ProcessOrder       | 12         | 45%      | 28.4       | High     |
+| OrderService.ProcessOrder       | 10         | 45%      | 26.6       | High     |
 | OrderService.ValidateItems      | 8          | 90%      | 8.1        | Moderate |
 | OrderService.CalculateTotal     | 3          | 100%     | 3.0        | Low      |
 ```
@@ -171,21 +200,26 @@ $$\text{cov}_{\text{needed}} = 1 - \left(\frac{15 - \text{comp}}{\text{comp}^2}\
 
 This formula only applies when comp < 15. When comp >= 15, the minimum possible CRAP score (at 100% coverage) is comp itself, which already meets or exceeds the threshold. In that case, **coverage alone cannot bring the CRAP score below the threshold** -- the method must be refactored to reduce its cyclomatic complexity first.
 
-Report this as: "To bring `ProcessOrder` (complexity 12) below CRAP 15, increase coverage from 45% to at least 72%." For methods where complexity alone exceeds the threshold, report: "`ComplexMethod` (complexity 18) cannot reach CRAP < 15 through testing alone -- reduce complexity by extracting sub-methods."
+Report this as: "To bring `ProcessOrder` (complexity 10) below CRAP 15, increase coverage from 45% to more than 63.2% (at least 64% when reporting whole percentages)." For methods where complexity alone exceeds the threshold, report: "`ComplexMethod` (complexity 18) cannot reach CRAP < 15 through testing alone -- reduce complexity by extracting sub-methods."
 
 ## Validation
 
 - Verify that coverage data was collected successfully (Cobertura XML exists and contains data)
+- Confirm the target method is present; absence is not evidence of 0% coverage
 - Confirm every coverage figure came from that XML — no estimated, assumed, or source-comment-derived values
+- Cross-check method `line-rate` against its line-hit ratio when both exist
 - Cross-check that method names in coverage data match the source code
-- Confirm CRAP scores by spot-checking the formula on one method manually
+- Confirm CRAP scores with calculator or script output
 - Ensure a 100%-covered method's CRAP equals its complexity exactly
 
 ## Common Pitfalls
 
 - **Estimating coverage when collection fails**: never do it — the resulting CRAP scores are wrong in the direction that matters. Work through the fallbacks in Step 1, then report the blocker instead.
+- **Treating an empty report or missing method as 0% coverage**: this is failed collection, filtering, or method mapping; do not manufacture a score.
+- **Trusting contradictory Cobertura fields**: compare `line-rate` with the line-hit ratio and stop if they disagree beyond rounding.
 - **Trusting a stale complexity comment in the source**: compute cyclomatic complexity from the current code; a `// complexity: 7` comment left by a previous author is not evidence.
+- **Mental CRAP arithmetic**: use a calculator or script and show the substituted inputs.
 - **Giving up on a shared-assembly or test-host collector error**: `dotnet-coverage collect` runs out of process and usually succeeds where the in-proc collector fails.
-- **Stale coverage data**: Always regenerate coverage before computing CRAP scores. Old coverage files will produce misleading results.
+- **Stale coverage data**: regenerate when the user asks for current results or the source/binaries changed; otherwise disclose that a supplied report was not regenerated.
 - **Method name mismatches**: Cobertura XML may use mangled/compiler-generated names for async methods, lambdas, or local functions. Match by line ranges when names don't align.
 - **Generated code**: Exclude auto-generated files (e.g., `*.Designer.cs`, `*.g.cs`) from analysis unless explicitly requested.

--- a/tests/dotnet-test/crap-score/eval.yaml
+++ b/tests/dotnet-test/crap-score/eval.yaml
@@ -61,6 +61,31 @@ stimuli:
       - Used the report's 50% line coverage rather than treating ProcessAsync as absent or 0% covered
       - Calculated a CRAP score of 6 and classified it as moderate risk
 
+  - name: Do not turn an empty coverage report into zero coverage
+    prompt: |
+      Calculate the CRAP score for AsyncProcessor.ProcessAsync in
+      AsyncProcessor.cs using TestResults/coverage.cobertura.xml. The coverage
+      command said it completed, but the report looks suspicious.
+    environment:
+      files:
+        - src: fixtures/async-line-mapping/AsyncProcessor.cs
+          dest: AsyncProcessor.cs
+      commands:
+        - mkdir -p TestResults && printf '%s\n' '<?xml version="1.0" encoding="utf-8"?>' '<coverage line-rate="0" branch-rate="0" lines-covered="0" lines-valid="0"><packages /></coverage>' > TestResults/coverage.cobertura.xml
+    graders:
+      - type: output-matches
+        config:
+          pattern: (?i)(empty|no (?:class|method|coverage data)|does not contain|collection|regenerate|re-run)
+      - type: output-not-matches
+        config:
+          pattern: '(?i)CRAP(?: score)?\s*(?:is|=|:)\s*\d'
+      - type: prompt
+    rubric:
+      - Inspected the report contents instead of treating the mere existence of the XML file as successful collection
+      - Recognized that a report with no classes or methods provides no coverage for ProcessAsync
+      - Did not convert the missing method into 0% coverage or publish a numeric CRAP score
+      - Recommended regenerating coverage or diagnosing the collection/filtering issue
+
   - name: Calculate CRAP score for a single method with partial coverage
     prompt: Calculate the CRAP score for the ProcessOrder method in OrderService.cs. I already have coverage data in
       TestResults/coverage.cobertura.xml.
@@ -153,12 +178,12 @@ stimuli:
     rubric:
       - 'Counted the decision points in the current body of ApplySurcharges rather than reusing the stale
         "Complexity: 4" comment above it'
-      - Reported a complexity in the low-to-mid teens, counting the && and || operators, the ?? and the two ternaries
-        as decision points — not 4
+      - Reported complexity 14, counting the && and || operators, both ?? operators, and both ternaries as decision
+        points — not 4 or 13
       - Used the coverage recorded for ApplySurcharges in the Cobertura XML (roughly half the lines covered), whether
         read from line-rate or recomputed from the line hits — both agree
-      - Reported a CRAP score around 30 and classified it as high risk
-      - Stated the coverage level required to bring the method under a CRAP threshold of 15
+      - Reported a CRAP score around 34 and classified it as critical risk
+      - Stated that coverage must exceed roughly 82.8% to bring the method under a CRAP threshold of 15
 
   - name: Recognize when complexity alone blocks the CRAP threshold
     prompt: >

--- a/tests/dotnet-test/crap-score/fixtures/refactor-required/coverage.cobertura.xml
+++ b/tests/dotnet-test/crap-score/fixtures/refactor-required/coverage.cobertura.xml
@@ -7,18 +7,18 @@
   both paths must agree, otherwise the two arms of the eval disagree on the input
   and the comparison measures nothing. Verified by check_cobertura.py.
 
-    ApplySurcharges   8/15 = 0.53   complexity 13 -> CRAP 30.5  (needs 77.2% for <15)
+    ApplySurcharges   8/15 = 0.53   complexity 14 -> CRAP 34.3  (needs >82.8% for <15)
     ClassifyAccount   6/19 = 0.32   complexity 17 -> CRAP 107.9 (unreachable: 17 > 15)
     RoundToCurrency   3/3  = 1.00   complexity  3 -> CRAP 3.0   (floor == complexity)
     class total      17/37 = 0.46
 -->
 <coverage line-rate="0.46" branch-rate="0.36" version="1.0" timestamp="1700000000">
   <packages>
-    <package name="Billing" line-rate="0.46" branch-rate="0.36" complexity="33">
+    <package name="Billing" line-rate="0.46" branch-rate="0.36" complexity="34">
       <classes>
-        <class name="Billing.InvoiceEngine" filename="InvoiceEngine.cs" line-rate="0.46" branch-rate="0.36" complexity="33">
+        <class name="Billing.InvoiceEngine" filename="InvoiceEngine.cs" line-rate="0.46" branch-rate="0.36" complexity="34">
           <methods>
-            <method name="ApplySurcharges" signature="(Billing.Invoice,System.String,System.String)" line-rate="0.53" branch-rate="0.40" complexity="13">
+            <method name="ApplySurcharges" signature="(Billing.Invoice,System.String,System.String)" line-rate="0.53" branch-rate="0.40" complexity="14">
               <lines>
                 <line number="19" hits="9"/>
                 <line number="20" hits="1"/>


### PR DESCRIPTION
## Summary

User feedback indicated that CRAP scores could appear authoritative even when coverage collection failed or score inputs were inferred incorrectly. This change makes the skill reject empty, missing-target, and contradictory coverage reports; disclose whether supplied coverage was regenerated; prefer machine-produced complexity; and require calculator-backed score arithmetic.

It also corrects the `ApplySurcharges` fixture from complexity 13 / CRAP 30.5 to complexity 14 / CRAP 34.3 (critical), fixes the worked `ProcessOrder` score, and adds an eval that verifies an empty Cobertura report cannot become invented 0% coverage.

## Related issue

N/A

## Validation

- `python eng/eval-quality/check_eval_quality.py` - passed with no errors
- `dotnet artifacts/bin/SkillValidator/debug/skill-validator.dll check --plugin ./plugins/dotnet-test` - all checks passed
- Recomputed fixture line-hit ratios and CRAP formula outputs - `ApplySurcharges` 34.3, `ClassifyAccount` 107.9, `RoundToCurrency` 3.0

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content.
- [x] I updated all marketplace manifests when plugin metadata changed.
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.