### PR TITLE
Improve non-passing dotnet-test scenarios

### DIFF
--- a/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
+++ b/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md
@@ -187,6 +187,12 @@ in-scope production file. Re-open each changed file and compare the result to
 the pre-edit inventory. A summary count is not evidence if one method was
 silently missed.
 
+Also verify the exclusive side of the scope: search or compare every file the
+user explicitly said to leave alone and require its original static calls and
+content to remain. For a single-file migration, report both numbers even when
+they are small: `N/N` in-scope calls replaced and `M` named out-of-scope calls
+preserved.
+
 #### Adding using directives
 
 | Abstraction | Using directive |
@@ -216,6 +222,13 @@ value assertion and one fallback or error-path assertion where the original
 static API exposed both outcomes. Merely making the old tests compile is not
 complete migration evidence.
 
+When the request explicitly converts affected unit tests away from real file or
+environment access, prove those tests no longer touch the process-global
+dependency: search them for temp-file, real-disk, or environment-mutation APIs
+after editing. Preserve intentional integration tests outside that requested
+scope. Report the deterministic fake's configured and fallback/error cases
+rather than only saying that a fake was added.
+
 ### Step 6: Build verification
 
 After all changes in the current scope, build the affected production project
@@ -242,7 +255,9 @@ that blocker rather than claiming the migration is fully validated.
 
 ### Step 7: Report changes
 
-Summarize what was done:
+Summarize what was done. Even for one production file and one test file, include
+the exact in-scope replacement count, the named out-of-scope files or calls
+verified unchanged, and the targeted build/test result:
 
 ```
 ## Migration Summary

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: scaffold-dotnet-test-project
 description: >-
-  MUST USE for any request to set up, create, reuse, add, register, include, or
-  repair a .NET test project; edit .sln, .slnx, .slnf, solution-filter, or CI test
-  discovery wiring; restore a missing ProjectReference; or fix tests that pass
-  directly while solution/CI discovers zero tests. Handles xUnit/NUnit/MSTest and central
+  MUST USE when an existing .NET test project was excluded from a .slnf/CI
+  solution filter, disappeared from .sln/.slnx discovery, or lost its production
+  ProjectReference; also for requests to set up, create, reuse, add, register,
+  include, or repair a test project. Handles "tests pass directly but CI
+  discovers zero", exact solution wiring, xUnit/NUnit/MSTest, and central
   packages. DO NOT USE to only author tests in an already-wired project
   (code-testing-agent), run tests, migrate, or correct MSTest syntax/configuration
   without changing project or CI files (writing-mstest-tests).
@@ -104,14 +105,16 @@ the repository's `dotnet test` command.
 ### 3. Repair only the missing edge when the project exists
 
 - Missing production reference: use `dotnet add <test-project> reference
-  <production-project>`, inspect the resulting project, and leave package and
-  test source files unchanged.
+  <production-project>`, inspect the resulting project, and leave every other
+  project element plus all test source files unchanged. Compare the project
+  before and after so the added `ProjectReference` is the only semantic change.
 - Missing `.sln` or `.slnx` registration: run `dotnet sln <entry-point> add
   <test-project>`, then immediately run `dotnet sln <entry-point> list` against
   that exact path. If the project is absent, the repair has not happened; do not
   validate a sibling solution or report success.
 - Missing `.slnf` registration: add the existing project to its underlying
-  solution if necessary, then include that same project path in the filter.
+  solution if necessary, then include that same project path in the filter. If
+  the underlying solution already contains it, edit only the filter.
 - Multiple solution artifacts: modify only the one named by the user or invoked
   by CI. Do not substitute an easier format.
 - No solution artifact: preserve the existing project-oriented workflow. Do not
@@ -144,6 +147,10 @@ Inspect the repository's command before adding switches. Do not prepend a
 speculative `--no-restore` attempt or hide alternatives in `command-a ||
 command-b`; run the configured entry-point command whose clean exit is the
 evidence.
+
+For every wiring repair, invoke the exact validation command directly and
+preserve its exit status. Reading generated files, a grader script, or a later
+build is not a substitute for observing that command complete successfully.
 
 Before reporting completion, inspect the final changed-file set. Remove only
 `bin`/`obj` or equivalent build artifacts created by this task when they were

--- a/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
+++ b/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md
@@ -103,6 +103,7 @@ sound. In particular:
 | **Over-mocking** | More mock setup lines than actual test logic. Verifying exact call sequences on mocks rather than outcomes. Mocking types the test owns. Per language: Moq/NSubstitute/FakeItEasy (.NET), `unittest.mock` / `pytest-mock` (Python), Jest auto-mocks / Sinon (JS/TS), Mockito/PowerMock (Java), gomock/testify mock (Go), RSpec mocks/mocha (Ruby), `mockall` (Rust), MockK (Kotlin), `Mock` cmdlet (Pester), gmock (C++). For a deep mock audit in .NET, use `exp-mock-usage-analysis`. |
 | **Implementation coupling** | Testing private methods via reflection (`MethodInfo.Invoke`, `getattr` in Python, `(thing as any)` in TS, `Field.setAccessible(true)` in Java, `Object#send` in Ruby, internal `pub(crate)` access in Rust). Asserting on internal state instead of observable behavior. Verifying exact method call counts on collaborators instead of business outcomes. |
 | **Broad exception assertions** | `Assert.ThrowsException<Exception>(...)` (.NET) / `pytest.raises(Exception)` / `expect(fn).toThrow(Error)` without a message matcher / `assertThrows(Exception.class, ...)` (Java) / `assert.Error(t, err)` without checking the kind / `expect { ... }.to raise_error` without class (RSpec) / `#[should_panic]` without `expected = "..."` / `Should -Throw` without `-ExpectedMessage` / `EXPECT_ANY_THROW` instead of `EXPECT_THROW(stmt, SpecificType)`. |
+| **Weak transformation oracle** | A normalization, casing, trimming, mapping, or conversion test supplies an input already in the expected form, so a no-op implementation passes even though the assertion may catch other defects. Use an input that must change and assert an independently derived expected value. A producer/consumer round trip is useful but does not replace an independent format assertion when both sides could share the same defect. |
 
 #### Medium -- Maintainability and clarity issues
 
@@ -128,14 +129,15 @@ sound. In particular:
 
 Before reporting, re-check each finding against these severity rules:
 
-- **Critical/High**: Only for issues that cause tests to give false confidence or be unreliable. A test that always passes regardless of correctness is Critical. Flaky shared state is High. Missing-await on async assertions is Critical (silent pass).
+- **Critical/High**: Only for issues that cause tests to give false confidence or be unreliable. A test that always passes regardless of correctness is Critical. Shared mutable state is High when it is a latent isolation risk, but **Critical when the user reports actual order-dependent failures or the code proves one test requires another to run first**. Missing-await on async assertions is Critical (silent pass).
 - **Medium**: Only for issues that actively harm maintainability -- 5+ nearly-identical tests, truly meaningless names like `Test1` / `test` / `it1`.
 - **Low**: Cosmetic naming mismatches, minor style preferences, assertion messages that could be better. When in doubt, rate Low.
 - **Use the caller's severity vocabulary consistently.** If the caller asks for
-  Critical / Warning / Info, map reliability risks to Warning and
-  maintenance/cosmetic concerns to Info rather than silently collapsing every
-  item into Critical. Severity describes the demonstrated failure mode, not how
-  much prose a finding receives.
+  Critical / Warning / Info, map latent reliability risks to Warning and
+  maintenance/cosmetic concerns to Info. Keep a demonstrated false-confidence
+  or current order-dependency root cause Critical; do not downgrade it merely to
+  make every requested tier non-empty. Severity describes the demonstrated
+  failure mode, not how much prose a finding receives.
 - **Separate a systemic finding from its instances.** Coverage touching across a
   facade is one Critical systemic finding whose evidence lists every affected
   test. All assertion-free instances, including the last facade method, retain
@@ -182,7 +184,12 @@ IMPORTANT: If the tests are well-written, say so clearly up front. Do not inflat
    before assigning a finding. If the assertion compares a transformed output
    with non-trivial input, clone state, snapshot, mock verification, or a
    framework-native assertion context, explain why it can fail before calling it
-   tautological or assertion-free.
+   tautological or assertion-free. Conversely, when a transformation test uses
+   an already-normalized input, call out that the input cannot distinguish the
+   real transformation from a no-op and provide a changing input plus exact
+   expected output. For paired producer/consumer APIs, retain the round-trip test
+   and add one independent representation oracle rather than replacing valid
+   metamorphic evidence.
 3. **Make every Critical/High fix complete and specific.** Give the replacement assertion with the *exact expected value* (the computed discount, the exact CSV line, the full expected object), not a `// assert something here` placeholder.
 4. **Name obvious adjacent gaps without widening into mutation analysis** —
    when production code is supplied, note directly related untested throws,

--- a/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
+++ b/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
@@ -59,6 +59,13 @@ commands for an advisory review; continue statically and label all candidates
 **unverified**. Do not infer a project-configuration cause from missing output;
 name a cause only when the command reports it.
 
+Missing runner output limits only claims of empirical mutation survival. It does
+not make source-proven facts tentative: a public outcome with no reaching test
+is still **No coverage**, and an exact expected value derived from the
+unmodified implementation is still actionable. State the baseline limitation
+once, then give the static source/assertion conclusion directly instead of
+hedging every row.
+
 For an advisory review such as "would tests catch this?", stop execution after
 that baseline. Source-to-assertion mapping is sufficient evidence for **No
 coverage** and **Candidate survivor (unverified)**. Trace or run the unmodified
@@ -185,6 +192,11 @@ A handful of validation gaps does not make an otherwise broad suite **Mixed**
 unless validation is the named risk or the gaps threaten security, data, or
 other contract-critical behavior.
 
+For an otherwise well-tested suite, lead with **Strong** and name the protected
+boundaries and dual assertions before listing minor gaps. Do not open with
+`Mixed`, "only core paths", or a risk-heavy dashboard when the inventory shows
+that most meaningful changes are already killed.
+
 Stop when existing assertions kill the remaining candidates or no credible
 public survivor remains. Do not mutate every operator merely to fill a report or
 calculate a score.
@@ -244,6 +256,11 @@ score unless the user requested an exhaustive audit.
    increase do not replace the supplied oracle. Once every requested survivor
    maps to a focused test and the canonical verifier passes, stop; extra tests
    are not an advantage.
+8. When the request requires existing source or test files to remain unchanged,
+   compare each protected file byte-for-byte with its pre-edit snapshot and
+   report that evidence. Before adding a test, prove its witness differs from
+   every existing case on the relevant branch, boundary, or rounded result so a
+   nominally new test does not duplicate existing coverage.
 
 ## Output contract
 
@@ -252,7 +269,9 @@ Scale the response to the request.
 For focused or small analysis, return:
 
 1. A one-line verdict: **Strong**, **Mixed**, or **Weak**, with the reason.
-2. One compact row per actionable **Survived**, **Candidate survivor
+2. For a **Strong** suite, one short strengths sentence naming the concrete
+   protected boundaries, guards, or paired observations that justify the verdict.
+3. One compact row per actionable **Survived**, **Candidate survivor
    (unverified)**, or **No coverage** outcome. Before adding a row, apply the
    outcome allowlist when the request names a risk, then apply the
    observable-candidate rules; omit any candidate that fails either filter.
@@ -265,8 +284,9 @@ For focused or small analysis, return:
    Every gap needs a distinguishing witness and a concrete smallest test. An
    error-path gap must name an invalid input and the expected error/result.
 
-3. One short strengths sentence naming important killed behavior.
-4. When the request names exclusions, one short scope sentence naming the
+4. For a **Mixed** or **Weak** suite, one short strengths sentence naming
+   important killed behavior.
+5. When the request names exclusions, one short scope sentence naming the
    generated, trivial, or unrelated code intentionally skipped.
 
 Do not repeat the table in prose or report discarded mutants, tool chronology,

--- a/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
+++ b/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md
@@ -192,10 +192,9 @@ A handful of validation gaps does not make an otherwise broad suite **Mixed**
 unless validation is the named risk or the gaps threaten security, data, or
 other contract-critical behavior.
 
-For an otherwise well-tested suite, lead with **Strong** and name the protected
-boundaries and dual assertions before listing minor gaps. Do not open with
-`Mixed`, "only core paths", or a risk-heavy dashboard when the inventory shows
-that most meaningful changes are already killed.
+When the inventory meets the **Strong** criteria above, lead with **Strong** and
+name the protected boundaries and dual assertions before listing minor gaps. Do
+not open with `Mixed`, "only core paths", or a risk-heavy dashboard.
 
 Stop when existing assertions kill the remaining candidates or no credible
 public survivor remains. Do not mutate every operator merely to fill a report or

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -268,7 +268,7 @@ completed edit.
 
 | Framework | Minimum verification |
 |---|---|
-| .NET | Use the repository's configured runner: normally `dotnet test <test-project>`, or `dotnet run --project <test-project>` for self-hosted Microsoft.Testing.Platform projects. Use `dotnet build` when the user explicitly requests build-only verification. |
+| .NET | Run `dotnet build <test-project>`, then confirm discovery with `dotnet test <test-project> --list-tests --no-build`. Do not execute the suite unless the user asks; route execution to `run-tests`. |
 | pytest | collect the edited suite with the repository's configured pytest command |
 | JUnit/TestNG | compile tests through the repository's Maven/Gradle test task |
 | Other auto-edit frameworks | Use the repository's narrowest compile or test-discovery command |

--- a/plugins/dotnet-test/skills/test-tagging/SKILL.md
+++ b/plugins/dotnet-test/skills/test-tagging/SKILL.md
@@ -259,6 +259,26 @@ Include observations such as:
 case still counts as `positive`; a rejected boundary still counts as `negative`.
 Derive the positive/negative distribution after applying this rule.
 
+### Step 6: Verify edits before reporting
+
+For every `auto-edit` framework, run the narrowest command that compiles the
+edited attributes and confirms test discovery. This is required even when the
+user asks only to add tags: syntactically plausible attributes are not a
+completed edit.
+
+| Framework | Minimum verification |
+|---|---|
+| .NET | Use the repository's configured runner: normally `dotnet test <test-project>`, or `dotnet run --project <test-project>` for self-hosted Microsoft.Testing.Platform projects. Use `dotnet build` when the user explicitly requests build-only verification. |
+| pytest | collect the edited suite with the repository's configured pytest command |
+| JUnit/TestNG | compile tests through the repository's Maven/Gradle test task |
+| Other auto-edit frameworks | Use the repository's narrowest compile or test-discovery command |
+
+If an edit or patch application was uncertain, re-open the complete edited file
+before verification and reconcile every inventory row with the actual
+attribute next to that test. Do not report success from a partial diff or from
+the intended patch. If verification fails, report the exact command and error;
+never publish a successful distribution handoff for uncompiled edits.
+
 ## Validation
 
 - [ ] Every test method has at least one trait classification (`positive` or `negative` at minimum) — in the report for `report-only` frameworks, or as an attribute for `auto-edit` frameworks


### PR DESCRIPTION
## Summary

The latest dotnet-test evaluation on PR #1106 left five model/skill results not proven improved. Their scenario evidence showed concrete decision gaps rather than harness, fixture, or activation-contract failures.

This change targets those gaps without adding post-hoc evaluation breadth:

- prioritizes scaffold routing for missing project references and CI solution-filter omissions;
- distinguishes demonstrated order-dependent failures from latent flakiness and adds independent oracles for transformation tests;
- keeps static test-gap reports decisive when runner output is unavailable while preserving truthful mutation labels;
- requires exact scope evidence for static-to-wrapper migrations;
- requires configured test discovery or compilation after automatic trait edits.

## Related issue

N/A

## Validation

- `python eng\eval-quality\check_eval_quality.py` - passed with existing repository warnings only
- released `skill-validator` `check --plugin .\plugins\dotnet-test` - passed
- `markdownlint-cli2` on all five modified skill files - passed
- `git diff --check` - passed

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [ ] I updated CODEOWNERS when adding or moving owned content.
- [ ] I updated all marketplace manifests when plugin metadata changed.
- [ ] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.