### PR TITLE
Pilot repository-specific overlays for dotnet-test skills

### DIFF
--- a/eng/known-domains.txt
+++ b/eng/known-domains.txt
@@ -64,8 +64,7 @@ github.com/username
 testsmells.org
 
 # Community
-github.com/JeremyKuhne/agent-skills
-github.com/JeremyKuhne/touki
+github.com/JeremyKuhne
 github.com/Youssef1313/Combinatorial.MSTest
 ollama.com
 stackoverflow.com

--- a/eng/known-domains.txt
+++ b/eng/known-domains.txt
@@ -64,6 +64,8 @@ github.com/username
 testsmells.org
 
 # Community
+github.com/JeremyKuhne/agent-skills
+github.com/JeremyKuhne/touki
 github.com/Youssef1313/Combinatorial.MSTest
 ollama.com
 stackoverflow.com

--- a/plugins/dotnet-test/OVERLAYS.md
+++ b/plugins/dotnet-test/OVERLAYS.md
@@ -43,7 +43,7 @@ mode: extend
 `mode: extend` is the only mode in the pilot. The skill applies an overlay only
 when `core` identifies that exact skill and `binding-revision` matches the
 revision in the skill's own metadata. A missing or mismatched field is reported
-and the overlay is not applied.
+and the overlay is not applied; the skill continues with its portable guidance.
 
 An overlay may provide paths, names, commands, framework choices, and local
 policies. It may narrow portable defaults, but it cannot expand tool

--- a/plugins/dotnet-test/OVERLAYS.md
+++ b/plugins/dotnet-test/OVERLAYS.md
@@ -1,0 +1,68 @@
+# Repository overlays
+
+The `dotnet-test` plugin is piloting repository-specific overlays based on the
+portable-core strategy proposed by
+[@JeremyKuhne](https://github.com/JeremyKuhne). His
+[`agent-skills`](https://github.com/JeremyKuhne/agent-skills) repository and the
+[`touki` Roslyn analyzer overlay](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/roslyn-analyzers/overlay.md)
+demonstrate the original convention.
+
+An overlay lets a user-installed or vendored portable skill apply local
+conventions without copying those conventions into the shared skill.
+
+## Pilot skills and paths
+
+| Skill | Repository overlay |
+|---|---|
+| `writing-mstest-tests` | `.agents/skill-overlays/dotnet-test/writing-mstest-tests.md` |
+| `scaffold-dotnet-test-project` | `.agents/skill-overlays/dotnet-test/scaffold-dotnet-test-project.md` |
+| `run-tests` | `.agents/skill-overlays/dotnet-test/run-tests.md` |
+
+Each path is relative to the repository root being worked on, not the plugin
+installation directory. The files are optional. Skills continue with their
+portable behavior when no overlay exists.
+
+## Overlay format
+
+Use YAML frontmatter to identify the portable core and its overlay binding
+contract:
+
+```markdown
+---
+core: dotnet-test/run-tests
+binding-revision: "1"
+mode: extend
+---
+
+# Repository test execution
+
+- Run unit tests with `pwsh ./eng/test.ps1 -Suite Unit`.
+- Do not replace the repository entry point with a direct `dotnet test`.
+```
+
+`mode: extend` is the only mode in the pilot. The skill applies an overlay only
+when `core` identifies that exact skill and `binding-revision` matches the
+revision in the skill's own metadata. A missing or mismatched field is reported
+and the overlay is not applied.
+
+An overlay may provide paths, names, commands, framework choices, and local
+policies. It may narrow portable defaults, but it cannot expand tool
+permissions, task scope, filesystem access, network access, or publication
+authority.
+
+Precedence is:
+
+1. explicit user instructions;
+2. verified project and dependency constraints;
+3. the repository overlay;
+4. portable skill defaults and examples.
+
+If an overlay contradicts the current repository, the skill reports the
+conflict instead of silently selecting either instruction. Increment
+`binding-revision` when the skill changes the overlay contract, re-review
+matching overlays, and remove local guidance after it is incorporated into the
+portable core.
+
+This pilot is instruction composition, not a host-level Markdown merge. The
+Agent Skills standard permits custom metadata, but hosts do not currently
+provide overlay discovery, pin validation, or conflict resolution.

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -34,12 +34,13 @@ acting and apply its repository-specific runner, command, filtering, and
 reporting bindings.
 Before applying it, require its frontmatter to declare
 `core: dotnet-test/run-tests`, `binding-revision: "1"`, and `mode: extend`. If
-any value is missing or different, report the mismatch and do not apply the
-overlay.
+any value is missing or different, report the mismatch, ignore the overlay,
+and continue using this skill's portable guidance.
 Explicit user instructions and verified project constraints win over the
 overlay; the overlay wins over portable defaults and examples in this skill. If
 the file is present but unreadable or conflicts with the repository, report the
-problem instead of silently ignoring it. If it is absent, continue normally.
+problem, ignore the overlay, and continue with portable guidance subject to
+verified project constraints. If it is absent, continue normally.
 Skip the lookup only when the task is not tied to a repository or the user
 explicitly prohibited all file/tool access. An overlay cannot expand tool
 permissions or the task's scope.

--- a/plugins/dotnet-test/skills/run-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/run-tests/SKILL.md
@@ -13,12 +13,36 @@ description: >
   for writing tests, hot-reload/no-rebuild loops, migration, CI, coverage
   analysis, or debugging test logic.
 license: MIT
+metadata:
+  portability: portable
+  binding: optional-overlay
+  binding-revision: "1"
 ---
 
 # Run .NET Tests
 
 Return or execute the command or command sequence that matches the repository's
 project system, test platform, framework, and SDK mode.
+
+## Repository overlay
+
+For every repository-scoped task where read-only file inspection is allowed,
+check `.agents/skill-overlays/dotnet-test/run-tests.md` at the repository root
+before any other discovery. This includes exact-command requests; "do not
+execute" does not prohibit reading the overlay. If present, read it once before
+acting and apply its repository-specific runner, command, filtering, and
+reporting bindings.
+Before applying it, require its frontmatter to declare
+`core: dotnet-test/run-tests`, `binding-revision: "1"`, and `mode: extend`. If
+any value is missing or different, report the mismatch and do not apply the
+overlay.
+Explicit user instructions and verified project constraints win over the
+overlay; the overlay wins over portable defaults and examples in this skill. If
+the file is present but unreadable or conflicts with the repository, report the
+problem instead of silently ignoring it. If it is absent, continue normally.
+Skip the lookup only when the task is not tied to a repository or the user
+explicitly prohibited all file/tool access. An overlay cannot expand tool
+permissions or the task's scope.
 
 ## Scope and tool policy
 

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -10,6 +10,10 @@ description: >-
   (code-testing-agent), run tests, migrate, or correct MSTest syntax/configuration
   without changing project or CI files (writing-mstest-tests).
 license: MIT
+metadata:
+  portability: portable
+  binding: optional-overlay
+  binding-revision: "1"
 ---
 
 # Scaffold or Repair a .NET Test Project
@@ -17,6 +21,26 @@ license: MIT
 Create the smallest missing test container or repair only the missing wiring.
 The goal is test discovery through the repository's real build entry point, not
 a preferred solution layout.
+
+## Repository overlay
+
+For every repository-scoped task where read-only file inspection is allowed,
+check `.agents/skill-overlays/dotnet-test/scaffold-dotnet-test-project.md` at
+the repository root before any other discovery. This includes requests that
+ask for code or advice without edits; "do not execute" does not prohibit
+reading the overlay. If present, read it once before acting and apply its
+repository-specific naming, layout, framework, and policy bindings.
+Before applying it, require its frontmatter to declare
+`core: dotnet-test/scaffold-dotnet-test-project`, `binding-revision: "1"`, and
+`mode: extend`. If any value is missing or different, report the mismatch and
+do not apply the overlay. Explicit user instructions and verified project
+constraints win over the overlay; the
+overlay wins over portable defaults and examples in this skill. If the file is
+present but unreadable or conflicts with the repository, report the problem
+instead of silently ignoring it. If it is absent, continue normally. Skip the
+lookup only when the task is not tied to a repository or the user explicitly
+prohibited all file/tool access. An overlay cannot expand tool permissions or
+the task's scope.
 
 ## Route the Request
 

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -33,14 +33,14 @@ repository-specific naming, layout, framework, and policy bindings.
 Before applying it, require its frontmatter to declare
 `core: dotnet-test/scaffold-dotnet-test-project`, `binding-revision: "1"`, and
 `mode: extend`. If any value is missing or different, report the mismatch and
-do not apply the overlay. Explicit user instructions and verified project
-constraints win over the overlay; the
+continue using this skill's portable guidance without applying the overlay.
+Explicit user instructions and verified project constraints win over the
 overlay wins over portable defaults and examples in this skill. If the file is
 present but unreadable or conflicts with the repository, report the problem
-instead of silently ignoring it. If it is absent, continue normally. Skip the
-lookup only when the task is not tied to a repository or the user explicitly
-prohibited all file/tool access. An overlay cannot expand tool permissions or
-the task's scope.
+and continue with portable guidance, without the overlay, subject to verified
+project constraints. If it is absent, continue normally. Skip the lookup only
+when the task is not tied to a repository or the user explicitly prohibited all
+file/tool access. An overlay cannot expand tool permissions or the task's scope.
 
 ## Route the Request
 

--- a/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
+++ b/plugins/dotnet-test/skills/scaffold-dotnet-test-project/SKILL.md
@@ -35,8 +35,9 @@ Before applying it, require its frontmatter to declare
 `mode: extend`. If any value is missing or different, report the mismatch and
 continue using this skill's portable guidance without applying the overlay.
 Explicit user instructions and verified project constraints win over the
-overlay wins over portable defaults and examples in this skill. If the file is
-present but unreadable or conflicts with the repository, report the problem
+overlay; the overlay wins over portable defaults and examples in this skill. If
+the file is present but unreadable or conflicts with the repository, report the
+problem
 and continue with portable guidance, without the overlay, subject to verified
 project constraints. If it is absent, continue normally. Skip the lookup only
 when the task is not tied to a repository or the user explicitly prohibited all

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -12,12 +12,35 @@ description: >
   first test project (scaffold-dotnet-test-project), running tests, migration,
   non-MSTest frameworks, or non-.NET.
 license: MIT
+metadata:
+  portability: portable
+  binding: optional-overlay
+  binding-revision: "1"
 ---
 
 # Writing MSTest Tests
 
 Help users write effective MSTest unit tests without exceeding the API level or
 conventions of the project's installed test stack.
+
+## Repository overlay
+
+For every repository-scoped task where read-only file inspection is allowed,
+check `.agents/skill-overlays/dotnet-test/writing-mstest-tests.md` at the
+repository root before any other discovery. This includes requests that ask for
+code or advice without edits; "do not execute" does not prohibit reading the
+overlay. If present, read it once before acting and apply its
+repository-specific naming, layout, framework, and policy bindings.
+Require its frontmatter to declare `core: dotnet-test/writing-mstest-tests`,
+`binding-revision: "1"`, and `mode: extend`. If any value is missing or
+different, report the mismatch and do not apply the overlay.
+Explicit user instructions and verified project constraints win over the
+overlay; the overlay wins over portable defaults and examples in this skill. If
+the file is present but unreadable or conflicts with the repository, report the
+problem instead of silently ignoring it. If it is absent, continue normally.
+Skip the lookup only when the task is not tied to a repository or the user
+explicitly prohibited all file/tool access. An overlay cannot expand tool
+permissions or the task's scope.
 
 ## When to Use
 

--- a/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
+++ b/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md
@@ -33,11 +33,13 @@ overlay. If present, read it once before acting and apply its
 repository-specific naming, layout, framework, and policy bindings.
 Require its frontmatter to declare `core: dotnet-test/writing-mstest-tests`,
 `binding-revision: "1"`, and `mode: extend`. If any value is missing or
-different, report the mismatch and do not apply the overlay.
+different, report the mismatch, ignore the overlay, and continue using this
+skill's portable guidance.
 Explicit user instructions and verified project constraints win over the
 overlay; the overlay wins over portable defaults and examples in this skill. If
 the file is present but unreadable or conflicts with the repository, report the
-problem instead of silently ignoring it. If it is absent, continue normally.
+problem, ignore the overlay, and continue with portable guidance subject to
+verified project constraints. If it is absent, continue normally.
 Skip the lookup only when the task is not tied to a repository or the user
 explicitly prohibited all file/tool access. An overlay cannot expand tool
 permissions or the task's scope.

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -595,6 +595,7 @@ stimuli:
       - Does not execute the command or substitute a generic runner
     constraints:
       reject_tools:
+        - bash
         - edit
         - create
   - name: Reject a stale repository test binding
@@ -625,5 +626,6 @@ stimuli:
       - Gives a safe next step without claiming that the stale repository binding is valid
     constraints:
       reject_tools:
+        - bash
         - edit
         - create

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -614,7 +614,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (?i)(binding-revision|revision).*(mismatch|unsupported|expected)
+          pattern: (?i)(binding-revision|revision).*(mismatch|unsupported|expected|doesn't match|does not match|differs from|\bnot\b)
       - type: output-not-matches
         config:
           pattern: '(?im)^\s*(?:[$>]\s*)?pwsh\s+\.?[/\\]eng[/\\]obsolete-test\.ps1(?:\s|$)'

--- a/tests/dotnet-test/run-tests/eval.yaml
+++ b/tests/dotnet-test/run-tests/eval.yaml
@@ -565,3 +565,65 @@ stimuli:
     constraints:
       expect_tools:
         - bash
+  - name: Use the repository unit-test entry point
+    tags:
+      feature: repository-overlay
+    prompt: |
+      What command should I use to run only the unit tests without restoring
+      packages? Give me one exact command and do not execute it.
+    environment:
+      files:
+        - src: fixtures/vstest-mstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: fixtures/vstest-mstest/OrderServiceTests.cs
+          dest: OrderServiceTests.cs
+        - src: fixtures/repository-overlay/test.ps1
+          dest: eng/test.ps1
+        - src: fixtures/repository-overlay/overlay.md
+          dest: .agents/skill-overlays/dotnet-test/run-tests.md
+    graders:
+      - type: output-matches
+        config:
+          pattern: '(?i)pwsh\s+\.?[/\\]eng[/\\]test\.ps1\s+-Suite\s+Unit\s+-NoRestore'
+      - type: output-not-matches
+        config:
+          pattern: (?im)^\s*(?:[$>]\s*)?dotnet\s+test
+      - type: prompt
+    rubric:
+      - Gives one runnable command that uses the repository's supported test entry point
+      - Selects only the unit suite and disables package restore
+      - Does not execute the command or substitute a generic runner
+    constraints:
+      reject_tools:
+        - edit
+        - create
+  - name: Reject a stale repository test binding
+    tags:
+      feature: repository-overlay
+    prompt: |
+      What command should I use to run only the unit tests in this repository?
+      Give me one exact command and do not execute it.
+    environment:
+      files:
+        - src: fixtures/vstest-mstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: fixtures/vstest-mstest/OrderServiceTests.cs
+          dest: OrderServiceTests.cs
+        - src: fixtures/repository-overlay/stale-overlay.md
+          dest: .agents/skill-overlays/dotnet-test/run-tests.md
+    graders:
+      - type: output-matches
+        config:
+          pattern: (?i)(binding-revision|revision).*(mismatch|unsupported|expected)
+      - type: output-not-matches
+        config:
+          pattern: '(?im)^\s*(?:[$>]\s*)?pwsh\s+\.?[/\\]eng[/\\]obsolete-test\.ps1(?:\s|$)'
+      - type: prompt
+    rubric:
+      - Identifies that the repository overlay targets an unsupported binding revision
+      - Does not apply or recommend the stale overlay's obsolete command
+      - Gives a safe next step without claiming that the stale repository binding is valid
+    constraints:
+      reject_tools:
+        - edit
+        - create

--- a/tests/dotnet-test/run-tests/fixtures/repository-overlay/overlay.md
+++ b/tests/dotnet-test/run-tests/fixtures/repository-overlay/overlay.md
@@ -1,0 +1,12 @@
+---
+core: dotnet-test/run-tests
+binding-revision: "1"
+mode: extend
+---
+
+# Repository test execution
+
+- Run the unit suite without restoring with
+  `pwsh ./eng/test.ps1 -Suite Unit -NoRestore`.
+- The script is the supported entry point; do not substitute a direct
+  `dotnet test` command.

--- a/tests/dotnet-test/run-tests/fixtures/repository-overlay/stale-overlay.md
+++ b/tests/dotnet-test/run-tests/fixtures/repository-overlay/stale-overlay.md
@@ -1,0 +1,9 @@
+---
+core: dotnet-test/run-tests
+binding-revision: "999"
+mode: extend
+---
+
+# Obsolete repository test execution
+
+- Run unit tests with `pwsh ./eng/obsolete-test.ps1 -Unit`.

--- a/tests/dotnet-test/run-tests/fixtures/repository-overlay/test.ps1
+++ b/tests/dotnet-test/run-tests/fixtures/repository-overlay/test.ps1
@@ -1,0 +1,13 @@
+param(
+    [ValidateSet("Unit")]
+    [string] $Suite,
+    [switch] $NoRestore
+)
+
+$arguments = @("test", "TestProject.csproj", "--filter", "TestCategory=Unit")
+if ($NoRestore) {
+    $arguments += "--no-restore"
+}
+
+dotnet @arguments
+exit $LASTEXITCODE

--- a/tests/dotnet-test/run-tests/fixtures/repository-overlay/test.ps1
+++ b/tests/dotnet-test/run-tests/fixtures/repository-overlay/test.ps1
@@ -1,10 +1,10 @@
 param(
     [ValidateSet("Unit")]
-    [string] $Suite,
+    [string] $Suite = "Unit",
     [switch] $NoRestore
 )
 
-$arguments = @("test", "TestProject.csproj", "--filter", "TestCategory=Unit")
+$arguments = @("test", "TestProject.csproj", "--filter", "TestCategory=$Suite")
 if ($NoRestore) {
     $arguments += "--no-restore"
 }

--- a/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
+++ b/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
@@ -272,3 +272,35 @@ stimuli:
       - Preserved central package management and added only the required production reference
       - Registered the project in the existing Catalog.slnx using valid SDK solution XML
       - Verified the exact solution-level dotnet test command discovers and runs the test
+
+  - name: Create tests in the repository-defined verification layout
+    tags:
+      feature: repository-overlay
+    prompt: |
+      Create the first xUnit v3 test project for ProductCode in this Catalog
+      repository. Add one test proving that `new ProductCode(" ab-12 ").Normalize()`
+      has the value `AB-12`, register the project in Catalog.slnx, and verify it
+      through the solution.
+    environment:
+      files:
+        - src: fixtures/slnx-project
+          dest: .
+        - src: fixtures/repository-overlay/overlay.md
+          dest: .agents/skill-overlays/dotnet-test/scaffold-dotnet-test-project.md
+    graders:
+      - type: run-command
+        config:
+          command: sh -c "test -f verification/unit/Catalog.UnitTests/Catalog.UnitTests.csproj && test -f verification/unit/Catalog.UnitTests/ProductCodeSpec.cs && test ! -d tests"
+          expected_exit_code: 0
+          timeout: 1m
+      - type: run-command
+        config:
+          command: sh -c "grep -q 'verification/unit/Catalog.UnitTests/Catalog.UnitTests.csproj' Catalog.slnx && dotnet test Catalog.slnx"
+          expected_exit_code: 0
+          timeout: 10m
+      - type: prompt
+    rubric:
+      - Created the test project under the repository's verification/unit layout
+      - Used the repository's required Catalog.UnitTests project name and Spec.cs source suffix
+      - Added only the requested ProductCode normalization behavior with central package management intact
+      - Registered the project in Catalog.slnx and verified the solution-level test run

--- a/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
+++ b/tests/dotnet-test/scaffold-dotnet-test-project/eval.yaml
@@ -295,7 +295,7 @@ stimuli:
           timeout: 1m
       - type: run-command
         config:
-          command: sh -c "grep -q 'verification/unit/Catalog.UnitTests/Catalog.UnitTests.csproj' Catalog.slnx && dotnet test Catalog.slnx"
+          command: sh -c "grep -Fq 'verification/unit/Catalog.UnitTests/Catalog.UnitTests.csproj' Catalog.slnx && dotnet test Catalog.slnx"
           expected_exit_code: 0
           timeout: 10m
       - type: prompt

--- a/tests/dotnet-test/scaffold-dotnet-test-project/fixtures/repository-overlay/overlay.md
+++ b/tests/dotnet-test/scaffold-dotnet-test-project/fixtures/repository-overlay/overlay.md
@@ -1,0 +1,11 @@
+---
+core: dotnet-test/scaffold-dotnet-test-project
+binding-revision: "1"
+mode: extend
+---
+
+# Repository test project layout
+
+- Put new unit-test projects under `verification/unit/`.
+- Name the Catalog test project `Catalog.UnitTests`.
+- Name test source files after the behavior subject with the `Spec.cs` suffix.

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -518,3 +518,53 @@ stimuli:
         - bash
         - edit
         - create
+  - name: Apply checked-in MSTest naming and category conventions
+    tags:
+      feature: repository-overlay
+    prompt: |
+      Fix the supplied MSTest code in PriceCalculatorTests.cs. Apply the
+      applicable repository naming and TestCategory conventions while
+      preserving the calculation, assertion behavior, and installed
+      dependencies.
+    environment:
+      files:
+        - src: fixtures/modern-mstest/TestProject.csproj
+          dest: TestProject.csproj
+        - src: fixtures/modern-mstest/global.json
+          dest: global.json
+        - src: fixtures/repository-overlay/AGENTS.md
+          dest: AGENTS.md
+        - src: fixtures/repository-overlay/PriceCalculatorTests.cs
+          dest: PriceCalculatorTests.cs
+        - src: fixtures/repository-overlay/PriceCalculator.cs
+          dest: PriceCalculator.cs
+        - src: fixtures/repository-overlay/overlay.md
+          dest: .agents/skill-overlays/dotnet-test/writing-mstest-tests.md
+    graders:
+      - type: file-contains
+        config:
+          path: PriceCalculatorTests.cs
+          value: public void Should_
+      - type: file-contains
+        config:
+          path: PriceCalculatorTests.cs
+          value: _When_
+      - type: file-contains
+        config:
+          path: PriceCalculatorTests.cs
+          value: '[TestCategory("Fast")]'
+      - type: file-not-contains
+        config:
+          path: PriceCalculatorTests.cs
+          value: sealed class
+      - type: run-command
+        config:
+          command: dotnet test TestProject.csproj
+          expected_exit_code: 0
+          timeout: 10m
+      - type: prompt
+    rubric:
+      - The updated test uses the component-specific method naming convention rather than the general repository default
+      - The test uses the component-specific Fast category rather than the general Unit category
+      - The class remains inheritable under the component-specific fixture-generation exception
+      - The calculation and assertion behavior remain unchanged

--- a/tests/dotnet-test/writing-mstest-tests/eval.yaml
+++ b/tests/dotnet-test/writing-mstest-tests/eval.yaml
@@ -556,6 +556,14 @@ stimuli:
       - type: file-not-contains
         config:
           path: PriceCalculatorTests.cs
+          value: CalculateDiscount_ValidCoupon_ReturnsDiscountedTotal
+      - type: file-not-contains
+        config:
+          path: PriceCalculatorTests.cs
+          value: '[TestCategory("Unit")]'
+      - type: file-not-contains
+        config:
+          path: PriceCalculatorTests.cs
           value: sealed class
       - type: run-command
         config:

--- a/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/AGENTS.md
+++ b/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/AGENTS.md
@@ -1,0 +1,7 @@
+# General test defaults
+
+Unless a component-specific test policy applies:
+
+- Name tests `<Method>_<Scenario>_<Expected>`.
+- Mark unit tests with `[TestCategory("Unit")]`.
+- Seal concrete test classes.

--- a/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/PriceCalculator.cs
+++ b/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/PriceCalculator.cs
@@ -1,0 +1,5 @@
+public sealed class PriceCalculator
+{
+    public decimal CalculateDiscount(decimal price, decimal discountPercent)
+        => price * (1 - discountPercent / 100);
+}

--- a/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/PriceCalculatorTests.cs
+++ b/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/PriceCalculatorTests.cs
@@ -1,0 +1,12 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class PriceCalculatorTests
+{
+    [TestMethod]
+    public void CalculateDiscount_ValidCoupon_ReturnsDiscountedTotal()
+    {
+        var result = new PriceCalculator().CalculateDiscount(100m, 10);
+        Assert.AreEqual(90m, result);
+    }
+}

--- a/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/overlay.md
+++ b/tests/dotnet-test/writing-mstest-tests/fixtures/repository-overlay/overlay.md
@@ -1,0 +1,11 @@
+---
+core: dotnet-test/writing-mstest-tests
+binding-revision: "1"
+mode: extend
+---
+
+# Repository MSTest conventions
+
+- Name tests `Should_<ExpectedBehavior>_When_<Condition>`.
+- Mark tests handled by this component with `[TestCategory("Fast")]`.
+- Do not seal test classes; this repository generates partial derived fixtures.


### PR DESCRIPTION
## Summary

Portable skills need a way to consume repository-specific test conventions without baking those conventions into shared guidance or requiring a local fork. This pilots the overlay strategy proposed by @JeremyKuhne for three `dotnet-test` skills.

The pilot adds revisioned, per-skill bindings under `.agents/skill-overlays/dotnet-test/` for `run-tests`, `writing-mstest-tests`, and `scaffold-dotnet-test-project`. Each skill validates the overlay's core identity, binding revision, and `extend` mode before applying it. Explicit user instructions and verified project constraints remain higher precedence, and missing overlays preserve current portable behavior.

The evals cover valid repository commands, scoped conventions, custom project layout, compilation, and stale-binding rejection. The strongest comparative result is `run-tests`: the no-skill baseline passed 0/2 tagged overlay stimuli while the skilled arm passed 2/2.

## Related issue

Addresses #1112

## Validation

- `python eng/eval-quality/check_eval_quality.py` - passed (98 eval specs; pre-existing warnings only)
- `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-test --known-domains ./eng/known-domains.txt` - passed (22 skills, 10 agents, 0 reference errors)
- Tagged `run-tests` overlay evals - baseline 0/2, skilled 2/2
- Tagged `writing-mstest-tests` treatment - 6/6 graders, including `dotnet test TestProject.csproj`
- Tagged `scaffold-dotnet-test-project` treatment - 3/3 graders, including `dotnet test Catalog.slnx`

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [x] I updated CODEOWNERS when adding or moving owned content. Existing `/plugins/dotnet-test/` and `/tests/dotnet-test/` ownership already covers these files, so no edit was required.
- [x] I updated all marketplace manifests when plugin metadata changed. No plugin manifest metadata changed.
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.