### PR TITLE
Expand static test pairing to more languages

### DIFF
--- a/plugins/dotnet-test/.claude-plugin/plugin.json
+++ b/plugins/dotnet-test/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/.claude-plugin/plugin.json
+++ b/plugins/dotnet-test/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/.codex-plugin/plugin.json
+++ b/plugins/dotnet-test/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/.codex-plugin/plugin.json
+++ b/plugins/dotnet-test/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/agents/code-testing-researcher.agent.md
+++ b/plugins/dotnet-test/agents/code-testing-researcher.agent.md
@@ -65,7 +65,7 @@ Based on files found:
 ### 4. Use the cheapest discovery path
 
 - Prefer project manifests, language-server references, and deterministic pairing tools over whole-tree text searches.
-- For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, or Ruby, invoke `find-untested-sources` once and consume its JSON instead of manually walking source and test trees.
+- For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, or C++, invoke `find-untested-sources` once and consume its JSON instead of manually walking source and test trees.
 - Do not spawn sub-agents for discovery that can be completed with one bounded search.
 - Use parallel sub-agents only when the requested scope contains independent projects or languages that need separate context.
 
@@ -117,7 +117,7 @@ Locate tests paired to the bounded target inventory:
   - Whether tests cover only happy paths or also edge cases and error paths
 - Do not invent numeric coverage percentages without a coverage report.
 
-Before manually pairing source ↔ test files in C#, Python, TypeScript/JavaScript, Go, Java, Rust, or Ruby, invoke the `find-untested-sources` skill when available. It returns a deterministic JSON pairing map, an untested list ordered by declared API surface, and suggested test paths. For .NET-only repositories, prefer its namespace-aware Roslyn engine; otherwise use its tree-sitter engine. Use the untested list as the prioritized worklist and do not repeat the same discovery manually. Fall back to bounded manual discovery only when the skill is unavailable or the language is unsupported.
+Before manually pairing source ↔ test files in C#, Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, or C++, invoke the `find-untested-sources` skill when available. It returns a deterministic JSON pairing map, an untested list ordered by declared API surface, and suggested test paths. For .NET-only repositories, prefer its namespace-aware Roslyn engine; otherwise use its tree-sitter engine. Use the untested list as the prioritized worklist and do not repeat the same discovery manually. Fall back to bounded manual discovery only when the skill is unavailable or the language is unsupported.
 
 ### 8. Generate Research Document
 

--- a/plugins/dotnet-test/plugin.json
+++ b/plugins/dotnet-test/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/plugin.json
+++ b/plugins/dotnet-test/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-test",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Skills for running, generating, analyzing, and improving .NET tests: test execution, filtering, platform detection, coverage, testability, and MSTest workflows.",
   "skills": ["./skills/"],
   "agents": [

--- a/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
+++ b/plugins/dotnet-test/skills/code-testing-agent/SKILL.md
@@ -184,7 +184,7 @@ For multi-file requests:
 1. Turn every explicit user requirement into a checklist before implementation. Include requested layers, collaborators to mock, boundary cases, integrations, coverage thresholds, and report artifacts. Copy multi-condition requirements verbatim — they must each map to one test that exercises the whole combination.
 2. Research only the requested module or project and write the checklist plus a compact target inventory to `<TESTAGENT_DIR>/research.md`.
 3. Reuse manifests, symbol references, and deterministic pairing tools instead of reading every source and test file.
-4. For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, or Ruby, run `find-untested-sources` once and consume its pairing and suggested-path output; do not repeat that discovery manually.
+4. For multi-file scopes in C#, Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, or C++, run `find-untested-sources` once and consume its pairing and suggested-path output; do not repeat that discovery manually.
 5. Plan each target file once, then implement phases sequentially. Map every checklist item to at least one concrete test or explain why it is blocked.
 6. Build and test the narrow target during fix cycles; run workspace-level validation once at the end.
 7. Before reporting success, re-open the generated tests and verify every checklist item against concrete test names and assertions. Coverage alone is not evidence that a requested mock seam, boundary, state transition, or property combination was tested.

--- a/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
@@ -4,9 +4,10 @@ description: >
   MANDATORY for static source-to-test pairing: find or list source files/modules
   without corresponding tests, or suggest test locations from repository
   structure. Invoke even for a tiny package; do not substitute manual globbing.
-  Uses Roslyn for C#/.NET and tree-sitter for Python, TS/JS, Go, Java, Rust, and
-  Ruby. DO NOT USE FOR: real line/branch/Cobertura data, coverage-backed test
-  priorities, CRAP risk, or grading existing tests.
+  Uses Roslyn for C#/.NET and tree-sitter for Python, TS/JS, Go, Java, Rust,
+  Ruby, Kotlin, Swift, PowerShell, and C++. DO NOT USE FOR: real
+  line/branch/Cobertura data, coverage-backed test priorities, CRAP risk, or
+  grading existing tests.
 license: MIT
 ---
 
@@ -34,7 +35,7 @@ This skill ships two interchangeable analyzers with a compatible JSON contract:
 | Engine | Script | Use when |
 |--------|--------|----------|
 | **Roslyn (C#)** | `scripts/Find-UntestedSources.cs` | The repo is **.NET-only**. Parses every `.cs` file with the Roslyn syntax API and does strict **namespace disambiguation**, so it is materially more accurate on duplicated short names like `Settings` or `Context`. |
-| **tree-sitter (polyglot)** | `scripts/find_untested_sources.py` | The repo is **not exclusively C#**, or you want one tool across Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, and C#. |
+| **tree-sitter (polyglot)** | `scripts/find_untested_sources.py` | The repo is **not exclusively C#**, or you want one tool across Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, and C++. |
 
 For a .NET-only repository, **prefer the Roslyn engine** — its namespace-aware
 pairing beats the polyglot engine's identifier overlap.
@@ -238,6 +239,10 @@ stderr; JSON goes to stdout.
    | Rust | path contains `tests/`/`benches/`. |
    | C# | path contains `tests/`; or project segment ends `.Tests`/`.Test`/`.UnitTests`/`.IntegrationTests`; or filename ends `Tests`/`Test`. |
    | Ruby | path contains `spec/`/`test/`; or filename ends `_spec.rb`/`_test.rb`. |
+   | Kotlin | path contains `test/`/`tests/`/`spec/`; or filename ends `Test.kt`/`Tests.kt`/`Spec.kt`. |
+   | Swift | path contains `Tests/`/`UITests/`/`IntegrationTests/`; or filename ends `Test.swift`/`Tests.swift`. |
+   | PowerShell | path contains `test/`/`tests/`/`pester/`; or filename ends `.Tests.ps1`/`.Test.ps1`. |
+   | C++ | path contains `test/`/`tests/`/`testing/`; or filename starts `test_` or ends `_test.cpp`/`_tests.cpp`. |
 
 4. **Per-file extraction** — `process(text, ProcessConfig(structure, imports,
    symbols))` returns declared items, raw import statements, and a flat declared

--- a/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
+++ b/plugins/dotnet-test/skills/find-untested-sources/SKILL.md
@@ -35,7 +35,7 @@ This skill ships two interchangeable analyzers with a compatible JSON contract:
 | Engine | Script | Use when |
 |--------|--------|----------|
 | **Roslyn (C#)** | `scripts/Find-UntestedSources.cs` | The repo is **.NET-only**. Parses every `.cs` file with the Roslyn syntax API and does strict **namespace disambiguation**, so it is materially more accurate on duplicated short names like `Settings` or `Context`. |
-| **tree-sitter (polyglot)** | `scripts/find_untested_sources.py` | The repo is **not exclusively C#**, or you want one tool across Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, and C++. |
+| **tree-sitter (polyglot)** | `scripts/find_untested_sources.py` | The repo is **not exclusively C#**, or you want one tool across C#, Python, TypeScript/JavaScript, Go, Java, Rust, Ruby, Kotlin, Swift, PowerShell, and C++. |
 
 For a .NET-only repository, **prefer the Roslyn engine** — its namespace-aware
 pairing beats the polyglot engine's identifier overlap.
@@ -240,7 +240,7 @@ stderr; JSON goes to stdout.
    | C# | path contains `tests/`; or project segment ends `.Tests`/`.Test`/`.UnitTests`/`.IntegrationTests`; or filename ends `Tests`/`Test`. |
    | Ruby | path contains `spec/`/`test/`; or filename ends `_spec.rb`/`_test.rb`. |
    | Kotlin | path contains `test/`/`tests/`/`spec/`; or filename ends `Test.kt`/`Tests.kt`/`Spec.kt`. |
-   | Swift | path contains `Tests/`/`UITests/`/`IntegrationTests/`; or filename ends `Test.swift`/`Tests.swift`. |
+   | Swift | path contains `test/`/`tests/`/`uitests/`/`integrationtests/` (case-insensitive); or filename ends `Test.swift`/`Tests.swift`. |
    | PowerShell | path contains `test/`/`tests/`/`pester/`; or filename ends `.Tests.ps1`/`.Test.ps1`. |
    | C++ | path contains `test/`/`tests/`/`testing/`; or filename starts `test_` or ends `_test.cpp`/`_tests.cpp`. |
 

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
@@ -9,7 +9,8 @@ file via two complementary heuristics:
      source file.
 
 Supports any language tree-sitter-language-pack can parse and classify (Python,
-TypeScript, JavaScript, Go, Java, Rust, C#, Ruby, ...).
+TypeScript, JavaScript, Go, Java, Rust, C#, Ruby, Kotlin, Swift, PowerShell,
+C++, ...).
 
 Output: JSON to stdout matching the schema used by the C# `find-untested-sources`
 skill, so the same prompt patterns can consume both tools.
@@ -55,6 +56,10 @@ SUPPORTED_LANGUAGES = {
     "rust",
     "csharp",
     "ruby",
+    "kotlin",
+    "swift",
+    "powershell",
+    "cpp",
 }
 
 # Directories we never descend into. Lowercase match on segment name.
@@ -168,6 +173,30 @@ def is_test_path(rel: PurePosixPath, lang: str) -> bool:
             return True
         return stem.endswith("_spec") or stem.endswith("_test")
 
+    if lang == "kotlin":
+        if any(p in ("test", "tests", "spec", "specs") for p in parts):
+            return True
+        return stem.endswith("test") or stem.endswith("tests") or stem.endswith("spec")
+
+    if lang == "swift":
+        if any(p in ("test", "tests", "uitests", "integrationtests") for p in parts):
+            return True
+        return stem.endswith("test") or stem.endswith("tests")
+
+    if lang == "powershell":
+        if any(p in ("test", "tests", "pester") for p in parts):
+            return True
+        return name.endswith(".tests.ps1") or name.endswith(".test.ps1")
+
+    if lang == "cpp":
+        if any(p in ("test", "tests", "testing") for p in parts):
+            return True
+        return (
+            stem.startswith("test_")
+            or stem.endswith("_test")
+            or stem.endswith("_tests")
+        )
+
     return False
 
 
@@ -233,8 +262,24 @@ def walk_files(root: Path, lang_filter: set[str] | None = None) -> Iterable[Path
 IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
-def harvest_identifiers(text: str) -> set[str]:
+def harvest_identifiers(text: str, lang: str) -> set[str]:
+    if lang == "powershell":
+        return set(re.findall(r"[A-Za-z_][A-Za-z0-9-]*", text))
     return set(IDENTIFIER_RE.findall(text))
+
+
+def harvest_declarations(text: str, lang: str) -> set[str]:
+    """Recover common declarations when the language-pack symbol view is sparse."""
+    if lang == "powershell":
+        return set(re.findall(r"(?im)^\s*function\s+([A-Za-z_][A-Za-z0-9-]*)", text))
+    if lang == "cpp":
+        return set(
+            re.findall(
+                r"\b(?:class|struct|enum(?:\s+class)?)\s+([A-Za-z_][A-Za-z0-9_]*)",
+                text,
+            )
+        )
+    return set()
 
 
 def parse_file(path: Path, root: Path) -> FileInfo | None:
@@ -284,6 +329,7 @@ def parse_file(path: Path, root: Path) -> FileInfo | None:
         name = getattr(sym, "name", None)
         if name:
             info.declarations.add(name)
+    info.declarations.update(harvest_declarations(text, lang))
 
     # Imports: keep the raw `source` field; we'll normalize per language.
     if getattr(result, "imports", None):
@@ -295,7 +341,7 @@ def parse_file(path: Path, root: Path) -> FileInfo | None:
     # For test files only, scan all identifier-like tokens — caller uses these
     # to pair with source declarations by name.
     if is_test:
-        info.referenced_identifiers = harvest_identifiers(text)
+        info.referenced_identifiers = harvest_identifiers(text, lang)
 
     return info
 
@@ -521,6 +567,15 @@ def _resolve_test_imports(test: FileInfo, indexes: dict, lang: str) -> set[FileI
             target = _strip_quoted(raw)
             if target:
                 add_candidate(PurePosixPath(target + ".rb"))
+        elif lang == "kotlin":
+            target = _strip_quoted(raw)
+            if target:
+                add_candidate(PurePosixPath(target.replace(".", "/") + ".kt"))
+        elif lang in ("swift", "powershell", "cpp"):
+            # These ecosystems commonly import modules, dot-source scripts, or
+            # include headers rather than source files. Identifier overlap is
+            # the reliable cross-project fallback for this analyzer.
+            pass
 
     return found
 
@@ -601,6 +656,14 @@ def _test_filename(source: FileInfo) -> str:
         return f"{stem}Tests.cs"
     if lang == "ruby":
         return f"{stem}_spec.rb"
+    if lang == "kotlin":
+        return f"{stem}Test.kt"
+    if lang == "swift":
+        return f"{stem}Tests.swift"
+    if lang == "powershell":
+        return f"{stem}.Tests.ps1"
+    if lang == "cpp":
+        return f"{stem}_test.cpp"
     return ""
 
 

--- a/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
+++ b/plugins/dotnet-test/skills/find-untested-sources/scripts/find_untested_sources.py
@@ -176,12 +176,14 @@ def is_test_path(rel: PurePosixPath, lang: str) -> bool:
     if lang == "kotlin":
         if any(p in ("test", "tests", "spec", "specs") for p in parts):
             return True
-        return stem.endswith("test") or stem.endswith("tests") or stem.endswith("spec")
+        words = re.findall(r"[A-Z][a-z]*|[a-z]+|[0-9]+", rel.stem)
+        return bool(words and words[-1] in ("Test", "Tests", "Spec", "Specs"))
 
     if lang == "swift":
         if any(p in ("test", "tests", "uitests", "integrationtests") for p in parts):
             return True
-        return stem.endswith("test") or stem.endswith("tests")
+        words = re.findall(r"[A-Z][a-z]*|[a-z]+|[0-9]+", rel.stem)
+        return bool(words and words[-1] in ("Test", "Tests"))
 
     if lang == "powershell":
         if any(p in ("test", "tests", "pester") for p in parts):

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -382,7 +382,7 @@ stimuli:
           pattern: Receipt_test\.cpp
       - type: output-matches
         config:
-          pattern: Invoice\.Tests\.ps1
+          pattern: tests[\\/]powershell[\\/]Discount\.Tests\.ps1
       - type: output-not-matches
         config:
           pattern: (?im)^\s*(?:[$>]\s*)?(?:dotnet|mvn|gradle|swift|pwsh|cmake|ctest)\b

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -367,7 +367,7 @@ stimuli:
           pattern: tests[\\/]swift[\\/]TaxPolicyTests\.swift
       - type: output-matches
         config:
-          pattern: src[\\/]powershell[\\/]Invoice\.Tests\.ps1
+          pattern: tests[\\/]powershell[\\/]Invoice\.Tests\.ps1
       - type: output-matches
         config:
           pattern: tests[\\/]cpp[\\/]TaxPolicy_test\.cpp

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -333,3 +333,67 @@ stimuli:
       - Suggested packages/billing/src/discount.test.ts for the missing test
       - Did not report packages/shipping/src/label.ts because the caller excluded sibling packages
       - Did not run a package manager or claim that the result proves line or branch coverage
+
+  - name: Pair Kotlin Swift PowerShell and C++ sources
+    prompt: |
+      Run the shipped static source-to-test pairing analyzer over the
+      PolyglotPairing fixture. Which four source files are unpaired, and which
+      existing tests cover the other four? Include the analyzer's suggested
+      test paths. Do not build or run any language test runner.
+    environment:
+      files:
+        - src: fixtures/polyglot-pairing
+          dest: PolyglotPairing
+      commands:
+        - python -m pip install --quiet tree-sitter-language-pack==1.8.1
+    graders:
+      - type: output-matches
+        config:
+          pattern: src[\\/]kotlin[\\/]DiscountRules\.kt
+      - type: output-matches
+        config:
+          pattern: src[\\/]swift[\\/]TaxPolicy\.swift
+      - type: output-matches
+        config:
+          pattern: src[\\/]powershell[\\/]Discount\.ps1
+      - type: output-matches
+        config:
+          pattern: src[\\/]cpp[\\/]TaxPolicy\.cpp
+      - type: output-matches
+        config:
+          pattern: tests[\\/]kotlin[\\/]DiscountRulesTest\.kt
+      - type: output-matches
+        config:
+          pattern: tests[\\/]swift[\\/]TaxPolicyTests\.swift
+      - type: output-matches
+        config:
+          pattern: src[\\/]powershell[\\/]Invoice\.Tests\.ps1
+      - type: output-matches
+        config:
+          pattern: tests[\\/]cpp[\\/]TaxPolicy_test\.cpp
+      - type: output-matches
+        config:
+          pattern: InvoiceCalculatorTest\.kt
+      - type: output-matches
+        config:
+          pattern: ReceiptTests\.swift
+      - type: output-matches
+        config:
+          pattern: Receipt_test\.cpp
+      - type: output-matches
+        config:
+          pattern: Invoice\.Tests\.ps1
+      - type: output-not-matches
+        config:
+          pattern: (?im)^\s*(?:[$>]\s*)?(?:dotnet|mvn|gradle|swift|pwsh|cmake|ctest)\b
+      - type: output-matches
+        config:
+          pattern: (?is)(?=.*\bstatic\b)(?=.*\b(?:pairing|heuristic)\b)(?=.*\b(?:line|branch)\b)(?=.*\bcoverage\b)(?=.*\b(?:not|isn't|doesn't|unknown|unverified|cannot)\b)
+      - type: exit-success
+      - type: prompt
+    rubric:
+      - Recognized Kotlin, Swift, PowerShell, and C++ as supported polyglot languages in one analyzer pass
+      - Identified exactly one unpaired source in each language and preserved each suggested test path
+      - Named the paired test files for the other source in each language
+      - Did not build or run any language-specific test command
+      - Distinguished static source-to-test pairing from line or branch coverage

--- a/tests/dotnet-test/find-untested-sources/eval.yaml
+++ b/tests/dotnet-test/find-untested-sources/eval.yaml
@@ -385,7 +385,7 @@ stimuli:
           pattern: tests[\\/]powershell[\\/]Discount\.Tests\.ps1
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*(?:[$>]\s*)?(?:dotnet|mvn|gradle|swift|pwsh|cmake|ctest)\b
+          pattern: (?im)^\s*(?:[$>]\s*)?(?:dotnet|mvn|gradle|swift|pwsh|cmake|ctest)\s+
       - type: output-matches
         config:
           pattern: (?is)(?=.*\bstatic\b)(?=.*\b(?:pairing|heuristic)\b)(?=.*\b(?:line|branch)\b)(?=.*\bcoverage\b)(?=.*\b(?:not|isn't|doesn't|unknown|unverified|cannot)\b)

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/cpp/Receipt.cpp
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/cpp/Receipt.cpp
@@ -1,0 +1,4 @@
+class Receipt {
+public:
+    int total() const { return 0; }
+};

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/cpp/TaxPolicy.cpp
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/cpp/TaxPolicy.cpp
@@ -1,0 +1,4 @@
+class TaxPolicy {
+public:
+    int rate() const { return 20; }
+};

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/kotlin/DiscountRules.kt
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/kotlin/DiscountRules.kt
@@ -1,0 +1,5 @@
+package billing
+
+class DiscountRules {
+    fun apply(total: Int): Int = total
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/kotlin/InvoiceCalculator.kt
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/kotlin/InvoiceCalculator.kt
@@ -1,0 +1,5 @@
+package billing
+
+class InvoiceCalculator {
+    fun total(subtotal: Int, tax: Int): Int = subtotal + tax
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/powershell/Discount.ps1
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/powershell/Discount.ps1
@@ -1,0 +1,4 @@
+function Get-DiscountedTotal {
+    param([int]$Total)
+    return $Total
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/powershell/Invoice.ps1
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/powershell/Invoice.ps1
@@ -1,0 +1,4 @@
+function Get-InvoiceTotal {
+    param([int]$Subtotal, [int]$Tax)
+    return $Subtotal + $Tax
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/swift/Receipt.swift
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/swift/Receipt.swift
@@ -1,0 +1,3 @@
+struct Receipt {
+    let total: Int
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/swift/TaxPolicy.swift
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/src/swift/TaxPolicy.swift
@@ -1,0 +1,3 @@
+struct TaxPolicy {
+    func rate() -> Int { 20 }
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/cpp/Receipt_test.cpp
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/cpp/Receipt_test.cpp
@@ -1,0 +1,4 @@
+void receipt_test() {
+    Receipt receipt;
+    (void)receipt.total();
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/kotlin/InvoiceCalculatorTest.kt
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/kotlin/InvoiceCalculatorTest.kt
@@ -1,0 +1,5 @@
+package billing
+
+class InvoiceCalculatorTest {
+    fun total_is_sum() = InvoiceCalculator().total(2, 3) == 5
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/powershell/Invoice.Tests.ps1
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/powershell/Invoice.Tests.ps1
@@ -1,0 +1,5 @@
+Describe "Invoice" {
+    It "calculates the total" {
+        Get-InvoiceTotal -Subtotal 2 -Tax 3 | Should -Be 5
+    }
+}

--- a/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/swift/ReceiptTests.swift
+++ b/tests/dotnet-test/find-untested-sources/fixtures/polyglot-pairing/tests/swift/ReceiptTests.swift
@@ -1,0 +1,2 @@
+let receipt = Receipt(total: 5)
+_ = receipt.total


### PR DESCRIPTION
## Summary

The static source-to-test pairing analyzer previously covered only part of the languages supported by the test-generation and quality-analysis workflows. This change extends the polyglot path to Kotlin, Swift, PowerShell, and C++, including language-specific test discovery, suggested test paths, and declaration fallbacks where the parser symbol data is sparse. It also updates the consuming researcher/generator guidance and adds a representative four-language evaluation fixture.

## Related issue

N/A

## Validation

- `python -m py_compile .\plugins\dotnet-test\skills\find-untested-sources\scripts\find_untested_sources.py`
- Ran the analyzer against the new PolyglotPairing fixture and confirmed paired/unpaired results and suggested paths for all four languages.
- `python eng/eval-quality/check_eval_quality.py` completed with no errors.
- `git diff --check` passed.

## Checklist

- [x] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [ ] I updated CODEOWNERS when adding or moving owned content. N/A - no owned content was added or moved.
- [x] I updated all marketplace manifests when plugin metadata changed.
- [x] I updated `eng/known-domains.txt` for any new external domains referenced by skill content. N/A - no new external domains were referenced.