### PR TITLE
Add MTP hot reload coverage evaluations

### DIFF
--- a/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
+++ b/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: mtp-hot-reload
 description: >
-  Set up or recover MTP hot reload for a long-lived edit/re-run loop. Use for
-  "hot reload tests", "dotnet run or dotnet test for hot reload", a host that
-  keeps running, unsupported/rude edits, or a watch-based VSTest fallback.
-  Covers setup, run/watch, restarts, filters, and the VSTest no-mutation
-  fallback. Never mutate VSTest for hot reload. For one-time runs, exact
-  commands, filter errors, TRX/dumps, or merely a failing test, use run-tests.
-  Excludes writing/debugging tests, CI, and Test Explorer hot reload.
+  Set up or recover MTP hot reload for a long-lived console-host edit/re-run
+  loop in a Microsoft Testing Platform project. Use for explicit MTP console
+  requests such as "enable hot reload", "dotnet run to rerun on edit",
+  "unsupported/rude edits", a persistent host that stays running, or a watch-
+  based VSTest fallback. Covers setup, run/watch, restarts, filters, and the
+  VSTest no-mutation fallback. Never mutate VSTest for hot reload. For one-time
+  runs, exact commands, filter errors, TRX/dumps, or merely a failing test, use
+  run-tests. Excludes editor/IDE integration, Visual Studio/Test Explorer hot
+  reload, CI configuration, and writing/debugging tests.
 license: MIT
 ---
 
@@ -26,7 +28,8 @@ edits and automatically reruns tests.
 
 - User needs to write new tests from scratch (use general coding assistance)
 - User needs to diagnose why a test is failing (use diagnostic skills)
-- User wants Visual Studio Test Explorer hot reload (different feature, built into VS)
+- User asks about Visual Studio or VS Code Test Explorer hot reload or an IDE-integrated rerun experience (different feature, not MTP console-host hot reload)
+- User asks whether the editor can auto-rerun affected tests after source edits without using an MTP console host
 - User wants one normal run without rebuilding (use `run-tests`)
 - User needs CI/CD pipeline configuration
 

--- a/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
+++ b/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Set up or recover MTP hot reload for a long-lived console-host edit/re-run
   loop in a Microsoft Testing Platform project. Use for explicit MTP console
   requests such as "enable hot reload", "dotnet run to rerun on edit",
-  "unsupported/rude edits", a persistent host that stays running, or a watch-
-  based VSTest fallback. Covers setup, run/watch, restarts, filters, and the
+  "unsupported/rude edits", a persistent host that stays running, or a
+  watch-based VSTest fallback. Covers setup, run/watch, restarts, filters, and the
   VSTest no-mutation fallback. Never mutate VSTest for hot reload. For one-time
   runs, exact commands, filter errors, TRX/dumps, or merely a failing test, use
   run-tests. Excludes editor/IDE integration, Visual Studio/Test Explorer hot

--- a/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
+++ b/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
@@ -8,8 +8,11 @@ description: >
   watch-based VSTest fallback. Covers setup, run/watch, restarts, filters, and the
   VSTest no-mutation fallback. Never mutate VSTest for hot reload. For one-time
   runs, exact commands, filter errors, TRX/dumps, or merely a failing test, use
-  run-tests. Excludes editor/IDE integration, Visual Studio/Test Explorer hot
-  reload, CI configuration, and writing/debugging tests.
+  run-tests. Do not use when the user asks whether Test Explorer or an IDE can
+  rerun tests without using or configuring an MTP console host; keep that
+  editor-integration question dormant. Excludes editor/IDE integration,
+  Visual Studio/Test Explorer hot reload, CI configuration, and
+  writing/debugging tests.
 license: MIT
 ---
 

--- a/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
+++ b/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md
@@ -3,16 +3,12 @@ name: mtp-hot-reload
 description: >
   Set up or recover MTP hot reload for a long-lived console-host edit/re-run
   loop in a Microsoft Testing Platform project. Use for explicit MTP console
-  requests such as "enable hot reload", "dotnet run to rerun on edit",
-  "unsupported/rude edits", a persistent host that stays running, or a
-  watch-based VSTest fallback. Covers setup, run/watch, restarts, filters, and the
-  VSTest no-mutation fallback. Never mutate VSTest for hot reload. For one-time
-  runs, exact commands, filter errors, TRX/dumps, or merely a failing test, use
-  run-tests. Do not use when the user asks whether Test Explorer or an IDE can
-  rerun tests without using or configuring an MTP console host; keep that
-  editor-integration question dormant. Excludes editor/IDE integration,
-  Visual Studio/Test Explorer hot reload, CI configuration, and
-  writing/debugging tests.
+  requests such as "enable hot reload", "dotnet run to rerun on edit", or
+  unsupported/rude edits. Covers setup, run/watch, restarts, filters, and the
+  VSTest no-mutation fallback. For one-time runs, exact commands, filter
+  errors, TRX/dumps, or merely a failing test, use run-tests. Do not use when
+  Test Explorer or an IDE should rerun tests without an MTP console host.
+  Excludes editor integration, CI, and writing/debugging tests.
 license: MIT
 ---
 

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -322,7 +322,7 @@ stimuli:
           pattern: '(?is)(?:TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d).{0,500}dotnet\s+run|dotnet\s+run.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d))'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -322,13 +322,13 @@ stimuli:
           pattern: Microsoft\.Testing\.Extensions\.HotReload
       - type: output-matches
         config:
-          pattern: (?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["']?1["']?
+          pattern: '(?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)'
       - type: output-matches
         config:
           pattern: dotnet run
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -325,7 +325,7 @@ stimuli:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:configure\s+(?:the\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED|(?:(?:don''t|do not)(?:\s+need\s+to)?|(?:can''t|cannot)|(?:no need(?: to)?|not needed|not necessary)|unsupported\s+(?:to\s+)?)(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?|(?:can''t|cannot)|(?:no need(?: to)?|not needed|not necessary)|unsupported\s+(?:to\s+)?)(?:create|update|add|configure|edit|set up|use)\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -328,7 +328,7 @@ stimuli:
           pattern: dotnet run
       - type: output-not-matches
         config:
-          pattern: '(?im)(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -358,7 +358,7 @@ stimuli:
           pattern: (?is)(?=.*Test Explorer.{0,120}(not supported|does not support|no support))(?=.*(?:console(?:-based| mode| host)|supported console))
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -319,10 +319,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: TESTINGPLATFORM_HOTRELOAD_ENABLED
-      - type: output-matches
-        config:
-          pattern: (?i)(=|to)\s*["']?1["']?
+          pattern: (?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["']?1["']?
       - type: output-matches
         config:
           pattern: dotnet run

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*(?:[-*]\s*)?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b
+          pattern: (?im)^(?![^\r\n]*\b(?:don't|do not|not|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -361,7 +361,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: (?im)^\s*(?:[-*]\s*)?(?:(?:you\s+(?:can|should|need\s+to)\s+)|(?:please\s+))?(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
+          pattern: (?im)^(?![^\r\n]*\b(?:don't|do not|can't|cannot|unsupported|not)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -319,10 +319,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: '(?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)'
-      - type: output-matches
-        config:
-          pattern: dotnet run
+          pattern: '(?is)(?:TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d).{0,500}dotnet\s+run|dotnet\s+run.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d))'
       - type: output-not-matches
         config:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -322,10 +322,10 @@ stimuli:
           pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary|unsupported\s+(?:to\s+)?)(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up
@@ -358,7 +358,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot)\s+(?:create|update|add|configure|edit|set up)\b|(?:(?:no need(?: to)?|not needed|not necessary|unsupported\s+(?:to\s+)?))\s+(?:create|update|add|configure|edit|set up)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:don''t|do not|no need(?: to)?|not needed|not necessary|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -328,7 +328,7 @@ stimuli:
           pattern: dotnet run
       - type: output-not-matches
         config:
-          pattern: '(?im)(?![^\r\n]*\b(?:don''t|do not|no need(?: to)?|not needed|not necessary|already installed)\b)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)'
+          pattern: '(?im)(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary|already installed)\b)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up
@@ -361,7 +361,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:don''t|do not|can''t|cannot|no need(?: to)?|not needed|not necessary|unsupported)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot|no need(?: to)?\s+(?:create|update|add|configure|edit|set up)|not needed|not necessary|unsupported)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -342,10 +342,10 @@ stimuli:
 
   - name: Decline Test Explorer hot reload integration
     prompt: |
-      The test project is configured for a persistent hot-reload loop. Can you
-      make Visual Studio Code Test Explorer automatically rerun the affected
-      tests after every source edit instead of using the console? Do not modify
-      the project.
+      I only want Visual Studio Code Test Explorer to automatically rerun the
+      affected tests after every source edit. Is that an editor feature, and
+      can it be enabled without using or configuring an MTP console host?
+      Do not modify the project.
     expect_activation: false
     environment:
       files:

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -355,7 +355,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot|no need(?: to)?\s+(?:create|update|add|configure|edit|set up)|not needed|not necessary|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up))\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot)\s+(?:create|update|add|configure|edit|set up)\b|(?:(?:no need(?: to)?|not needed|not necessary|unsupported\s+(?:to\s+)?))\s+(?:create|update|add|configure|edit|set up)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -319,13 +319,13 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b)'
+          pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+|set\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:create|update|add|configure|edit|set up|use)|(?:can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: (?im)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)
+          pattern: (?im)^\s*(?:[-*]\s*)?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -358,10 +358,10 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (?i)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
+          pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: (?is)(create|update|add|configure|edit|set up).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
+          pattern: (?im)^\s*(?:[-*]\s*)?(?:(?:you\s+(?:can|should|need\s+to)\s+)|(?:please\s+))?(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable
@@ -370,5 +370,6 @@ stimuli:
       - Directs the user to the supported console-based persistent test-host workflow
     constraints:
       reject_tools:
+        - bash
         - edit
         - create

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -325,7 +325,7 @@ stimuli:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:create|update|add|configure|edit|set up|use)|(?:can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:configure\s+(?:the\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED|(?:(?:don''t|do not)(?:\s+need\s+to)?|(?:can''t|cannot)|(?:no need(?: to)?|not needed|not necessary)|unsupported\s+(?:to\s+)?)(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up
@@ -355,7 +355,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
+          pattern: (?is)(?=.*Test Explorer.{0,120}(not supported|does not support|no support))(?=.*(?:console(?:-based| mode| host)|supported console))
       - type: output-not-matches
         config:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -319,13 +319,13 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+|set\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b)'
+          pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+|set\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?\s+`?dotnet\s+run\b)'
       - type: output-not-matches
         config:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:create|update|add|configure|edit|set up|use)|(?:can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)(?:\s+need\s+to)?\s+(?:create|update|add|configure|edit|set up|use)|(?:can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary)\s+(?:create|update|add|configure|edit|set up|use)|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*(?:create|update|add|configure|edit|set up|use)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -361,7 +361,7 @@ stimuli:
           pattern: (?i)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: (?is)(created|updated|added|configured|edited).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
+          pattern: (?is)(create|update|add|configure|edit|set up).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -323,6 +323,9 @@ stimuli:
       - type: output-not-matches
         config:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'
+      - type: output-not-matches
+        config:
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not|can''t|cannot)\s+(?:create|update|add|configure|edit|set up|use)|(?:no need(?: to)?|not needed|not necessary|unsupported\s+(?:to\s+)?)(?:create|update|add|configure|edit|set up|use))\b)[^\r\n]*\blaunchSettings\.json\b'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -319,7 +319,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: '(?is)(?:TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d).{0,500}dotnet\s+run|dotnet\s+run.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d))'
+          pattern: '(?is)(?:(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b.{0,500}TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)|(?m)^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?(?:`?(?:\$env:|export\s+)?TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?).{0,500}^[ \t]*(?:[-*]\s*)?(?:[$>]\s*)?`?dotnet\s+run\b)'
       - type: output-not-matches
         config:
           pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*(?:\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b)'

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -300,3 +300,76 @@ stimuli:
       - Gives a safe recovery sequence that preserves the same persistent workflow
       - Offers a valid watch-managed restart fallback for future unsupported edits
       - Preserves existing setup and does not reinstall present dependencies
+
+  - name: Enable a configured host that does not react to edits
+    prompt: |
+      My test project already references the hot-reload extension. I started it
+      with `dotnet run --project TestProject.csproj`, and the console stays
+      open, but test or production-code edits never cause another run. I have
+      not configured any environment variables. What is missing, and how should
+      I relaunch the same long-lived loop? Do not modify the project.
+    environment:
+      files:
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/EmailValidatorTests.cs
+          dest: EmailValidatorTests.cs
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/global.json
+          dest: global.json
+    graders:
+      - type: output-matches
+        config:
+          pattern: TESTINGPLATFORM_HOTRELOAD_ENABLED
+      - type: output-matches
+        config:
+          pattern: (?i)(=|to)\s*["']?1["']?
+      - type: output-matches
+        config:
+          pattern: dotnet run
+      - type: output-not-matches
+        config:
+          pattern: (?im)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)
+      - type: prompt
+    rubric:
+      - Identifies the missing activation setting as the reason edits are not picked up
+      - Gives a valid way to set the activation setting before restarting the existing persistent host
+      - Preserves the already installed dependency and the requested no-mutation workflow
+    constraints:
+      expect_tools:
+        - bash
+      reject_tools:
+        - edit
+        - create
+
+  - name: Decline Test Explorer hot reload integration
+    prompt: |
+      The test project is configured for a persistent hot-reload loop. Can you
+      make Visual Studio Code Test Explorer automatically rerun the affected
+      tests after every source edit instead of using the console? Do not modify
+      the project.
+    expect_activation: false
+    environment:
+      files:
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/TestProject.csproj
+          dest: TestProject.csproj
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/EmailValidatorTests.cs
+          dest: EmailValidatorTests.cs
+        - src: ./fixtures/enable-hot-reload-when-package-already-installed/global.json
+          dest: global.json
+    graders:
+      - type: output-matches
+        config:
+          pattern: (?i)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
+      - type: output-not-matches
+        config:
+          pattern: (?is)(created|updated|added).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload)
+      - type: prompt
+    rubric:
+      - Clearly explains that the requested Test Explorer integration is unavailable
+      - The hot-reload setup workflow stayed dormant rather than treating the editor-integration request as setup work
+      - Does not claim to have configured unsupported editor integration or alter project setup
+      - Directs the user to the supported console-based persistent test-host workflow
+    constraints:
+      reject_tools:
+        - edit
+        - create

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -332,8 +332,6 @@ stimuli:
       - Gives a valid way to set the activation setting before restarting the existing persistent host
       - Preserves the already installed dependency and the requested no-mutation workflow
     constraints:
-      expect_tools:
-        - bash
       reject_tools:
         - edit
         - create
@@ -359,7 +357,7 @@ stimuli:
           pattern: (?i)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: (?is)(created|updated|added).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload)
+          pattern: (?is)(created|updated|added|configured|edited).{0,80}(launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -319,6 +319,9 @@ stimuli:
     graders:
       - type: output-matches
         config:
+          pattern: Microsoft\.Testing\.Extensions\.HotReload
+      - type: output-matches
+        config:
           pattern: (?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["']?1["']?
       - type: output-matches
         config:
@@ -333,6 +336,7 @@ stimuli:
       - Preserves the already installed dependency and the requested no-mutation workflow
     constraints:
       reject_tools:
+        - bash
         - edit
         - create
 

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:(?:re)?install|add(?:\s+\S+)?\s+package|run\s+`?dotnet\s+add)|no need(?: to)?\s+(?:(?:re)?install|add)|not needed|not necessary)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -317,9 +317,6 @@ stimuli:
         - src: ./fixtures/enable-hot-reload-when-package-already-installed/global.json
           dest: global.json
     graders:
-      - type: output-matches
-        config:
-          pattern: Microsoft\.Testing\.Extensions\.HotReload
       - type: output-matches
         config:
           pattern: '(?i)TESTINGPLATFORM_HOTRELOAD_ENABLED\s*=\s*["'']?1["'']?(?!\d)'

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -293,7 +293,7 @@ stimuli:
           pattern: DOTNET_WATCH_RESTART_ON_RUDE_EDIT|Ctrl\+R|restart prompt
       - type: output-not-matches
         config:
-          pattern: (?im)^(?![^\r\n]*\b(?:don't|do not|not|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b
+          pattern: '(?im)^(?![^\r\n]*\b(?:don''t|do not|no need(?: to)?|not needed|not necessary|already installed)\b)[^\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b'
       - type: prompt
     rubric:
       - Correctly distinguishes changes the active session can apply from changes that require a rebuild
@@ -328,7 +328,7 @@ stimuli:
           pattern: dotnet run
       - type: output-not-matches
         config:
-          pattern: (?im)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)
+          pattern: '(?im)(?![^\r\n]*\b(?:don''t|do not|no need(?: to)?|not needed|not necessary|already installed)\b)(?:^\s*(?:[-*]\s*)?`?(?:[$>]\s*)?dotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b|`[^`\r\n]*\bdotnet\s+add(?:\s+\S+)?\s+package\s+\S*HotReload\b[^`\r\n]*`)'
       - type: prompt
     rubric:
       - Identifies the missing activation setting as the reason edits are not picked up
@@ -361,7 +361,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: (?im)^(?![^\r\n]*\b(?:don't|do not|can't|cannot|unsupported|not)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)
+          pattern: '(?im)^(?![^\r\n]*\b(?:don''t|do not|can''t|cannot|no need(?: to)?|not needed|not necessary|unsupported)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable

--- a/tests/dotnet-test/mtp-hot-reload/eval.yaml
+++ b/tests/dotnet-test/mtp-hot-reload/eval.yaml
@@ -355,7 +355,7 @@ stimuli:
           pattern: (?is)(Test Explorer.{0,80}(not supported|does not support|no support)|console mode only|console.{0,80}instead)
       - type: output-not-matches
         config:
-          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot|no need(?: to)?\s+(?:create|update|add|configure|edit|set up)|not needed|not necessary|unsupported)\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
+          pattern: '(?im)^(?![^\r\n]*\b(?:(?:don''t|do not)\s+(?:create|update|add|configure|edit|set up)|can''t|cannot|no need(?: to)?\s+(?:create|update|add|configure|edit|set up)|not needed|not necessary|unsupported\s+(?:to\s+)?(?:create|update|add|configure|edit|set up))\b)[^\r\n]*(?:create|update|add|configure|edit|set up)\b[^\r\n]*(?:launchSettings\.json|TESTINGPLATFORM_HOTRELOAD_ENABLED|Microsoft\.Testing\.Extensions\.HotReload|\.vscode[\\/](?:settings|launch)\.json)'
       - type: prompt
     rubric:
       - Clearly explains that the requested Test Explorer integration is unavailable


### PR DESCRIPTION
## Summary

Extends the MTP hot reload evaluation suite to cover two important troubleshooting boundaries: an installed extension that is inactive because its environment setting was omitted, and the unsupported Test Explorer integration path. This ensures the skill directs users to the persistent console host without reinstalling dependencies or attempting unsupported editor configuration.

## Related issue

N/A

## Validation

- `python eng/eval-quality/check_eval_quality.py`
- `dotnet run --project eng/skill-validator/src/SkillValidator.csproj -- check --plugin ./plugins/dotnet-test`

## Checklist

- [ ] I searched existing issues and pull requests to avoid duplicates.
- [x] I kept this pull request focused and avoided unrelated refactors.
- [x] I added or updated tests, evals, or documentation when changing skill or agent behavior.
- [ ] I updated CODEOWNERS when adding or moving owned content.
- [ ] I updated all marketplace manifests when plugin metadata changed.
- [ ] I updated `eng/known-domains.txt` for any new external domains referenced by skill content.