### PR TITLE
Remove duplicate Skill Value sample column

### DIFF
--- a/eng/dashboard/skill-value.js
+++ b/eng/dashboard/skill-value.js
@@ -247,8 +247,8 @@
       `<span class="sv-sub">${row.activationFired}/${row.activationExpected}</span></td>`;
   }
 
-  function metricCell(base, treat, fmt) {
-    // Delta cell already shows both arms; this is the paired-n column.
+  function metricCell(base, treat) {
+    // Both delta cells use the same paired observations, so show one shared count.
     const n = Math.min(base ? base.n : 0, treat ? treat.n : 0);
     const cls = gated(n) ? 'neutral' : 'sv-insufficient';
     return `<td class="num"><span class="${cls}">n=${n}</span></td>`;
@@ -340,7 +340,7 @@
       return `<tr class="level-${level}${childCls} expandable" data-toggle="${toggleId}"${style}>` +
         `<td><span class="expand-icon" id="icon-${toggleId}">▶</span>${label}` +
         (rollup ? ` <span class="sv-sub">${rollup}</span>` : '') +
-        `</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>`;
+        `</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>`;
     }
 
     function collapseChildren(parentId) {
@@ -408,7 +408,7 @@
       }
 
       let html = `<table class="token-table sv-table"><thead><tr>` +
-        `<th>Plugin / Skill / Model</th><th class="num">Activation</th><th class="num">Tokens Δ</th><th class="num">n</th>` +
+        `<th>Plugin / Skill / Model</th><th class="num">Activation</th><th class="num">Tokens Δ</th>` +
         `<th class="num">Time Δ</th><th class="num">n</th><th class="num" title="Share of counted trials whose pass check was false, baseline → treatment. Aggregate pass telemetry — may include judge-scored graders, not a purely objective gate.">Not-passed (base→treat)</th><th>Value</th></tr></thead><tbody>`;
 
       let uid = 0;
@@ -442,12 +442,11 @@
               `<td><span class="expand-icon" id="icon-${mid}">▶</span>${label}</td>` +
               activationCell(row) +
               deltaCell(row.baseline ? row.baseline.tokens : null, row.treatment ? row.treatment.tokens : null, fmtK, diluted) +
-              metricCell(row.baseline, row.treatment, fmtK) +
               deltaCell(row.baseline ? row.baseline.timeMs : null, row.treatment ? row.treatment.timeMs : null, fmtSecs, diluted) +
-              metricCell(row.baseline, row.treatment, fmtSecs) +
+              metricCell(row.baseline, row.treatment) +
               failureCell(row) +
               `<td class="${v.cls}">${v.text}</td></tr>` +
-              `<tr class="sv-detail child-of-${mid}" style="display:none"><td colspan="8">${drilldown(row)}</td></tr>`;
+              `<tr class="sv-detail child-of-${mid}" style="display:none"><td colspan="7">${drilldown(row)}</td></tr>`;
           }
         }
       }

--- a/eng/dashboard/skill-value.test.js
+++ b/eng/dashboard/skill-value.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('skill value table shows one shared sample-count column', async () => {
+  const elements = new Map();
+  const wrap = {
+    innerHTML: '',
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+  const container = {
+    innerHTML: '',
+    querySelector(selector) {
+      if (selector === '#sv-table-wrap') return wrap;
+      if (!elements.has(selector)) {
+        elements.set(selector, {
+          value: '',
+          addEventListener: () => {},
+        });
+      }
+      return elements.get(selector);
+    },
+  };
+
+  globalThis.document = {
+    createElement: () => ({
+      set textContent(value) { this.innerHTML = String(value); },
+      innerHTML: '',
+    }),
+    getElementById: () => container,
+  };
+  globalThis.window = {};
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      entries: [{
+        plugin: 'plugin',
+        model: 'executor',
+        judgeModel: 'judge',
+        date: 1,
+        skills: [{
+          skill: 'skill',
+          baseline: { n: 6, timeMs: 1000, tokens: 100 },
+          treatment: { n: 6, timeMs: 800, tokens: 80 },
+          activationExpected: 6,
+          activationFired: 6,
+          passTotal: 6,
+          baselineFail: 2,
+          treatmentFail: 1,
+          hasPassData: true,
+        }],
+      }],
+    }),
+  });
+
+  require('./skill-value.js');
+  await window.initSkillValue();
+
+  const header = wrap.innerHTML.match(/<thead><tr>(.*?)<\/tr><\/thead>/s)[1];
+  assert.equal((header.match(/<th/g) || []).length, 7);
+  assert.equal((header.match(/>n<\/th>/g) || []).length, 1);
+  assert.match(wrap.innerHTML, /colspan="7"/);
+});

--- a/eng/dashboard/skill-value.test.js
+++ b/eng/dashboard/skill-value.test.js
@@ -1,7 +1,29 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-test('skill value table shows one shared sample-count column', async () => {
+test('skill value table shows one shared sample-count column', async (t) => {
+  const previousGlobals = {
+    document: globalThis.document,
+    window: globalThis.window,
+    fetch: globalThis.fetch,
+  };
+  const hadGlobal = {
+    document: Object.hasOwn(globalThis, 'document'),
+    window: Object.hasOwn(globalThis, 'window'),
+    fetch: Object.hasOwn(globalThis, 'fetch'),
+  };
+  const modulePath = require.resolve('./skill-value.js');
+  t.after(() => {
+    for (const name of Object.keys(previousGlobals)) {
+      if (hadGlobal[name]) {
+        globalThis[name] = previousGlobals[name];
+      } else {
+        delete globalThis[name];
+      }
+    }
+    delete require.cache[modulePath];
+  });
+
   const elements = new Map();
   const wrap = {
     innerHTML: '',
@@ -53,10 +75,12 @@ test('skill value table shows one shared sample-count column', async () => {
     }),
   });
 
-  require('./skill-value.js');
+  require(modulePath);
   await window.initSkillValue();
 
-  const header = wrap.innerHTML.match(/<thead><tr>(.*?)<\/tr><\/thead>/s)[1];
+  const headerMatch = wrap.innerHTML.match(/<thead><tr>(.*?)<\/tr><\/thead>/s);
+  assert.ok(headerMatch, 'rendered table contains a header row');
+  const header = headerMatch[1];
   assert.equal((header.match(/<th/g) || []).length, 7);
   assert.equal((header.match(/>n<\/th>/g) || []).length, 1);
   assert.match(wrap.innerHTML, /colspan="7"/);


### PR DESCRIPTION
## Summary

- show one shared sample-count column for token and time deltas
- keep group rows and drill-down spans aligned with the seven-column table
- add a regression test for the Skill Value table structure

## Before

Two identical **N** columns appear after the token and time deltas.

![Skill Value dashboard before](https://github.com/user-attachments/assets/d95f98fb-28dd-4d82-b387-e03f0b2dbd99)

## After

One shared **N** column reports the paired observation count used by both deltas.

![Skill Value dashboard after](https://github.com/user-attachments/assets/6f7b02d4-a1ae-476d-a49b-b377637e3eff)

## Validation

- `node --test eng\dashboard\*.test.js`
- `node --check eng\dashboard\skill-value.js`
- `node --check eng\dashboard\skill-value.test.js`
- `git diff --check`