### PR TITLE
fix(ci): restore Vally 0.14 compatibility

### DIFF
--- a/eng/evaluation-tools/package-lock.json
+++ b/eng/evaluation-tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@github/copilot": "1.0.75",
-        "@microsoft/vally-cli": "0.15.0"
+        "@microsoft/vally-cli": "0.14.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -255,181 +255,132 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.9.tgz",
-      "integrity": "sha512-ZQJYbKhQTvpiUOU4rtPjppzVQv41gGymaD+AuWDbiZPYvSMSB4jZ/epvCrDs7jgqWa52r+j2D9eOQoSzdUMO6Q==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.13.tgz",
+      "integrity": "sha512-/j6/tGc9HOtcupuYFloOKk0fpScdpy65EVF1LKg2Z2VQOojCGPgBGkhgVGVDaqW7UB6TV2qbQZa9rKJimJ0wWQ==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.78",
         "koffi": "^3.1.0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.83.tgz",
-      "integrity": "sha512-M8uZI0V0dahYV1KZij3nGDxaXEGG7I7YUZzQPI7NEZkL/83Nl/tNTbPdxKtdWZbOmWoXsPKXty/eEYoj6RHDhA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "detect-libc": "^2.1.2"
-      },
-      "bin": {
-        "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.83",
-        "@github/copilot-darwin-x64": "1.0.83",
-        "@github/copilot-linux-arm64": "1.0.83",
-        "@github/copilot-linux-x64": "1.0.83",
-        "@github/copilot-linuxmusl-arm64": "1.0.83",
-        "@github/copilot-linuxmusl-x64": "1.0.83",
-        "@github/copilot-win32-arm64": "1.0.83",
-        "@github/copilot-win32-x64": "1.0.83"
+        "@github/copilot-sdk-darwin-arm64": "1.0.13",
+        "@github/copilot-sdk-darwin-x64": "1.0.13",
+        "@github/copilot-sdk-linux-arm64": "1.0.13",
+        "@github/copilot-sdk-linux-x64": "1.0.13",
+        "@github/copilot-sdk-linuxmusl-arm64": "1.0.13",
+        "@github/copilot-sdk-linuxmusl-x64": "1.0.13",
+        "@github/copilot-sdk-win32-arm64": "1.0.13",
+        "@github/copilot-sdk-win32-x64": "1.0.13"
       }
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.83.tgz",
-      "integrity": "sha512-gv+SZRhxlQCmKOlzCCP6B2SOAaAPPc+VYGd6iC9va06wXNlmigYSCBhQeOSQoSeZ0mK2KR7RTM+AbiXLytBUfA==",
+    "node_modules/@github/copilot-sdk-darwin-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-darwin-arm64/-/copilot-sdk-darwin-arm64-1.0.13.tgz",
+      "integrity": "sha512-AvBV5dzjNWpGwgoCnttrETnt7rLI4pTFQsRSM7GU5TK+YqShauffdMU06Bn/d+IDX2fj1Z4ThH7yl/gHCDvoNQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-arm64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.83.tgz",
-      "integrity": "sha512-f3oQxclEd/HUunTIMTriRIm883ONYPVOETGlEYF6fYWVkllPINMXnlKpM/b6h7fJEjZy8JFDhqqoZ60ezRNuUQ==",
+    "node_modules/@github/copilot-sdk-darwin-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-darwin-x64/-/copilot-sdk-darwin-x64-1.0.13.tgz",
+      "integrity": "sha512-ZNQmTnHwk8bO/E514k0sFBsuCVNpFj8jMH4jeLncASQM4RRdOqYhXlYLW7H/ts7ANjdfMJjJY29NUqzEWaADOA==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-x64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.83.tgz",
-      "integrity": "sha512-pgVS60eX1mVJ8MFo9SDsalM2X5Eaywq6/rWJg6roHEY4GHNuIx3rHFIdnoQfbcIHcuGYpHuQ/wBbWiSgMKdNEQ==",
+    "node_modules/@github/copilot-sdk-linux-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-linux-arm64/-/copilot-sdk-linux-arm64-1.0.13.tgz",
+      "integrity": "sha512-km1jvveDwlJbht8luFyBurz0wUxPHSzdkZRMJEJgVHYfMn03gi0gdnZ6fC6JWgkiffNZpukSxRPJmPfRobw6Aw==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "copilot-linux-arm64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.83.tgz",
-      "integrity": "sha512-G4pe5/4axjULMFpJBU7ran69++7RIn5wlFn8XMhXaFECB18cPVOfU7B9xgoCFbHGFAT4kATl45Fa9dtshKUNmg==",
+    "node_modules/@github/copilot-sdk-linux-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-linux-x64/-/copilot-sdk-linux-x64-1.0.13.tgz",
+      "integrity": "sha512-4AbzC8Nb1dWYQ1uxbHGAh0ZAoOJeL3Ms1oe3byZLn8ENP1PfoyD8DJZUSsyXGYHxL7oLJyUqd3wyt18ifIg8iw==",
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "copilot-linux-x64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.83.tgz",
-      "integrity": "sha512-CkRdANpMLQUIw+qqhg4wtoxeAUDYtdxS3kMuDc23L/tl4zdTYSVPtzDAjXouXNTJTTsjzDeR6k4tP6cIyymPzQ==",
+    "node_modules/@github/copilot-sdk-linuxmusl-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-linuxmusl-arm64/-/copilot-sdk-linuxmusl-arm64-1.0.13.tgz",
+      "integrity": "sha512-pCUjly1nXcNpYDZNnKrglFIFejbb+QDkloilldu+0tTbSzb8gEmVsbGwpfwyZXfNQf5Je5FFjsOfQR9PXH1NDQ==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "copilot-linuxmusl-arm64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.83.tgz",
-      "integrity": "sha512-riB8hgJuFJYk6xAZjdQ01K8NclTE7xh8DQkmaI+1c7aMK4VqxW1TMYkWNRxWXotZyeFRv2+LqfBXYJvvITuKjw==",
+    "node_modules/@github/copilot-sdk-linuxmusl-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-linuxmusl-x64/-/copilot-sdk-linuxmusl-x64-1.0.13.tgz",
+      "integrity": "sha512-y5RmqAbKSYHt+OwQdILIiiMSibXdd7/0kO7kFoTZCN2gn2eGRA8wJbXlf6KZh+yYgWSJGUL8677LDJd3WnIHbA==",
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "bin": {
-        "copilot-linuxmusl-x64": "copilot"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.83.tgz",
-      "integrity": "sha512-uzgmjDwjf3iVfzwrHJF8BOb39hewXpC60v/pm/Mvbd2LPqm38bq3Ky10fC50M+jpOu6t/YGW8qYtioEQQusHVQ==",
+    "node_modules/@github/copilot-sdk-win32-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-win32-arm64/-/copilot-sdk-win32-arm64-1.0.13.tgz",
+      "integrity": "sha512-azISXh4pEVfX0hPzu58wZTYg3tdWG4L1nNpiRa/wdBxhcovbxw+eZVkI4C6FZMx0tiNYFkqWzVTV7oKskNybcw==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "bin": {
-        "copilot-win32-arm64": "copilot.exe"
-      }
+      ]
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.83.tgz",
-      "integrity": "sha512-pau+THyevc9oTmtQNyWF2RSIM4aMo9DNO1gE8Fkg9OqCExmuoKTtYOnfxJHcCB2X1HHsGOrChq0+eRgiDAumoA==",
+    "node_modules/@github/copilot-sdk-win32-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk-win32-x64/-/copilot-sdk-win32-x64-1.0.13.tgz",
+      "integrity": "sha512-lvS7kMbuuxydBQxPDHCkuUwbC858Rvcz3Q3vv0mxnLKuWJ75lAcqERefqA2p4beaPdez+ifZOA5heUT0rx3GnA==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "bin": {
-        "copilot-win32-x64": "copilot.exe"
-      }
+      ]
     },
     "node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.75",
@@ -764,13 +715,12 @@
       }
     },
     "node_modules/@microsoft/vally": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.15.0.tgz",
-      "integrity": "sha512-GVC8cBiDxUx+qWCKwNkBaDhRYvNubb2xunfK3vYqZa4VclcaVkcLcibSVxW2KSlfg9bYZjWEkJn1QGgCGnUOXA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.14.0.tgz",
+      "integrity": "sha512-a3Xhj5PUSp6vv38ViSOocrYneMuBu9HpJQ2/VAyoIAHYhWklm/IGmGCylOMv+4brMX2aZSEiX3sW2dMIy3q7vA==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "1.0.80",
-        "@github/copilot-sdk": "1.0.9",
+        "@github/copilot-sdk": "^1.0.7",
         "@opentelemetry/api": "^1.9.1",
         "js-tiktoken": "^1.0.21",
         "mdast-util-from-markdown": "^2.0.3",
@@ -783,14 +733,14 @@
       }
     },
     "node_modules/@microsoft/vally-cli": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.15.0.tgz",
-      "integrity": "sha512-ZxonkrwSOP3HGKz6GmLA9vM6UnBlz4Jdp45Pg2ui/d/TRnDDtT4xnoHO9V++2lufD133/i+MUaNquklxhP5SYQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.14.0.tgz",
+      "integrity": "sha512-jN9ap1aiuRJQDkiPecrFUp3v5r4Lm+l7154CPY+22cdySGl+XfaOAY5Eh9YqkfwFcya5X+U3pJmBBpFMzHuVlg==",
       "license": "MIT",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
-        "@microsoft/vally": "^0.15.0",
-        "@microsoft/vally-server": "^0.15.0",
+        "@microsoft/vally": "^0.14.0",
+        "@microsoft/vally-server": "^0.14.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
         "@opentelemetry/resources": "^2.10.0",
@@ -809,180 +759,18 @@
       }
     },
     "node_modules/@microsoft/vally-server": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally-server/-/vally-server-0.15.0.tgz",
-      "integrity": "sha512-NxmKmaKUtO7vCOVt77Ym43FwNFtVqgD2sXJHadOkU2tehb2ZJ5eLchshJ1zEUbfIGXtol05+5fa6D3jlk1uuQQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-server/-/vally-server-0.14.0.tgz",
+      "integrity": "sha512-uFyeR8s1oHopjWK0GhRRRFbI+hm4BqHWFUTdgA2GdFRiz+xJfhxjMvTDi69WC0tJoq4WuDEglraEg0CG07LodA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^2.1.0",
-        "@microsoft/vally": "^0.15.0",
-        "better-sqlite3": "^13.0.3",
+        "@hono/node-server": "^2.0.12",
+        "@microsoft/vally": "^0.14.0",
+        "better-sqlite3": "^13.0.2",
         "hono": "^4.13.1"
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.80.tgz",
-      "integrity": "sha512-6tf93ZF56KOiTTAjK/UhLZkl1W543IzaTQly288kockJZFswpRTnQEI00Yvacpb39DTvTYu3/ha9SeKpo/pgZQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "detect-libc": "^2.1.2"
-      },
-      "bin": {
-        "copilot": "npm-loader.js"
-      },
-      "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.80",
-        "@github/copilot-darwin-x64": "1.0.80",
-        "@github/copilot-linux-arm64": "1.0.80",
-        "@github/copilot-linux-x64": "1.0.80",
-        "@github/copilot-linuxmusl-arm64": "1.0.80",
-        "@github/copilot-linuxmusl-x64": "1.0.80",
-        "@github/copilot-win32-arm64": "1.0.80",
-        "@github/copilot-win32-x64": "1.0.80"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.80.tgz",
-      "integrity": "sha512-fzn4PnSx3+O/a3ip72KVsjnzORsEygK+0i21bFAnFBYS+0Wi1Pk+o/CmNsJ7aRbf1enSJrcH8UDVkyc9pMGEBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-arm64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.80.tgz",
-      "integrity": "sha512-PKsyGk5DccNzR3bYXcYTGB9N6sHzhzGqEwq/2t1qBwqPbrC98Zo2dOT2G40/QYpJ4XdrGmTmdmfPJQ9PJknlIQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-x64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.80.tgz",
-      "integrity": "sha512-8oXwN2luyHEjIoSk8AkATBjXDhRoQtuiUvC93GpfQKFHI+I1eoOVwIsAq5fKP8jNCF2rOrYFIcTjwmRt38kCcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linux-arm64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.80.tgz",
-      "integrity": "sha512-qv1ytVNwA3IDK7kcQow+fAikD67t42+AQ8X42bK/7oudNiv4frVZMO0yh1DYIebVRcmEhmPvbVPY/ptVUK3cbA==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linux-x64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.80.tgz",
-      "integrity": "sha512-Qjyi+OlVnPC4Lkuy7blDMMwMUQI/yELl7gDnqQlaN8TEbhZqZueuf3p0a+kEjXcNsw4XtNYQc0eMJqSIYy/Pjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linuxmusl-arm64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.80.tgz",
-      "integrity": "sha512-rBg8pugf+5FhiZxi2zkOr+rlcOVF6Xg63j1FvryfwPT4DJ2w5Na7O3lpS4sgu8QmsP5H+dAqjlXYLYsvSoVQ0g==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linuxmusl-x64": "copilot"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.80.tgz",
-      "integrity": "sha512-+f7Vkd3vt2DYOxRnS8dStvYu3DY638N/AuLuIjxZp1F9GgwCUZK69wspqIxg2L59PmRRQcH4AGTrRDR60ENIZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "copilot-win32-arm64": "copilot.exe"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.80.tgz",
-      "integrity": "sha512-PO0kPqhRTWQfsqGaj4UN3cj8ttkcJYy4wmXiArtFm+03AIFu8xTvuhQDPn2xEOsUome7m7t2XomKoavcrCcRsw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/eng/evaluation-tools/package.json
+++ b/eng/evaluation-tools/package.json
@@ -5,6 +5,6 @@
   "description": "Pinned command-line tools used by the skill evaluation workflow.",
   "dependencies": {
     "@github/copilot": "1.0.75",
-    "@microsoft/vally-cli": "0.15.0"
+    "@microsoft/vally-cli": "0.14.0"
   }
 }


### PR DESCRIPTION
## Summary

Restore the evaluation CI tool pin from `@microsoft/vally-cli` 0.15.0 to exact 0.14.0.

## Root cause and proof

Vally 0.15 rejects the repository-specific top-level `executionShard` field during static spec loading:

```text
error [eval-load-error] ... eval spec: unknown top-level field 'executionShard'
```

This was reproduced with both representative specs:

- `tests/dotnet-msbuild/build-parallelism/eval.yaml`
- `tests/dotnet-test/grade-tests/eval.yaml`

The installed Vally 0.14 CLI loaded and linted both specs successfully with exit code 0. No agents or models were invoked.

`npm ci` resolves Vally 0.14 with `@github/copilot-sdk@1.0.13`. Importing the SDK succeeded and loaded the installed Windows `runtime.node`. A dry-run package inspection of `@github/copilot-sdk-linux-x64@1.0.13` confirmed that it contains `prebuilds/linux-x64/runtime.node` and `copilot-runtime`.

## Scope

Only these files change:

- `eng/evaluation-tools/package.json`
- `eng/evaluation-tools/package-lock.json`

No workflow files changed. No evaluation runs, Copilot model trials, or model traffic were started.